### PR TITLE
Implement Mayor System for pai-lite

### DIFF
--- a/bin/pai-lite
+++ b/bin/pai-lite
@@ -25,6 +25,8 @@ source "$root_dir/lib/flow.sh"
 source "$root_dir/lib/notify.sh"
 # shellcheck source=lib/dashboard.sh
 source "$root_dir/lib/dashboard.sh"
+# shellcheck source=lib/mayor.sh
+source "$root_dir/lib/mayor.sh"
 
 usage() {
   cat <<'USAGE'
@@ -54,11 +56,18 @@ Commands:
   flow context                 Context distribution across slots
   flow check-cycle             Check for dependency cycles
 
+  mayor start                  Start Mayor tmux session
+  mayor stop                   Stop Mayor tmux session
+  mayor status                 Show Mayor status
+  mayor attach                 Attach to Mayor tmux session
+  mayor logs [n]               Show recent Mayor activity
+  mayor doctor                 Health check for Mayor setup
   mayor briefing               Request morning briefing
   mayor suggest                Get task suggestions
   mayor analyze <issue>        Analyze GitHub issue
   mayor elaborate <id>         Elaborate task into detailed spec
   mayor health-check           Check for stalled work, deadlines
+  mayor queue                  Show pending queue requests
 
   notify pai <msg>             Send strategic notification
   notify agents <msg>          Send operational notification
@@ -98,9 +107,9 @@ case "$cmd" in
     local_install="$HOME/.local/pai-lite"
     local_bin="$HOME/.local/bin"
 
-    # Copy entire directory structure
+    # Copy entire directory structure (including skills for Mayor)
     mkdir -p "$local_install"
-    cp -r "$root_dir"/{bin,lib,adapters,templates} "$local_install/"
+    cp -r "$root_dir"/{bin,lib,adapters,templates,skills} "$local_install/"
 
     # Create symlink in ~/.local/bin
     mkdir -p "$local_bin"
@@ -140,8 +149,66 @@ case "$cmd" in
         if [[ ! -f "$harness_dir/slots.md" ]]; then
           cp "$root_dir/templates/harness/slots.md" "$harness_dir/slots.md"
         fi
+
+        # Create Mayor directory structure
+        mayor_dir="$harness_dir/mayor"
+        mkdir -p "$mayor_dir/memory/projects"
+        if [[ ! -f "$mayor_dir/context.md" ]]; then
+          cp "$root_dir/templates/mayor/context.md" "$mayor_dir/context.md" 2>/dev/null || \
+            echo "# Mayor Context" > "$mayor_dir/context.md"
+        fi
+        if [[ ! -f "$mayor_dir/memory/corrections.md" ]]; then
+          cp "$root_dir/templates/mayor/memory/corrections.md" "$mayor_dir/memory/corrections.md" 2>/dev/null || \
+            echo "# Corrections" > "$mayor_dir/memory/corrections.md"
+        fi
+        if [[ ! -f "$mayor_dir/memory/tools.md" ]]; then
+          cp "$root_dir/templates/mayor/memory/tools.md" "$mayor_dir/memory/tools.md" 2>/dev/null || \
+            echo "# Tools Knowledge" > "$mayor_dir/memory/tools.md"
+        fi
+        if [[ ! -f "$mayor_dir/memory/workflows.md" ]]; then
+          cp "$root_dir/templates/mayor/memory/workflows.md" "$mayor_dir/memory/workflows.md" 2>/dev/null || \
+            echo "# Workflows" > "$mayor_dir/memory/workflows.md"
+        fi
+        echo "Initialized Mayor memory in: $mayor_dir"
+
         echo "Initialized harness in: $harness_dir"
       fi
+    fi
+
+    # Install stop hook if --hooks flag is provided
+    install_hooks="${2:-}"
+    if [[ "$install_hooks" == "--hooks" ]]; then
+      hooks_dir="$HOME/.claude/hooks"
+      mkdir -p "$hooks_dir"
+
+      hook_file="$hooks_dir/pai-lite-on-stop.sh"
+      if [[ -f "$hook_file" ]]; then
+        pai_lite_warn "Stop hook already exists: $hook_file"
+        echo "To reinstall, remove it first: rm $hook_file"
+      else
+        cp "$root_dir/templates/hooks/pai-lite-on-stop.sh" "$hook_file"
+        chmod +x "$hook_file"
+        echo "Installed stop hook: $hook_file"
+        echo "Note: You may need to configure Claude Code to use this hook"
+      fi
+
+      # Print guidance about skills installation
+      echo ""
+      echo "=== Skills Setup ==="
+      echo "The Mayor skills are in: $root_dir/skills/"
+      echo ""
+      echo "To use skills like /briefing, /suggest, etc. in Claude Code:"
+      echo "1. Copy skills to Claude Code's skills directory:"
+      echo "   cp -r $root_dir/skills/*.md ~/.claude/skills/"
+      echo ""
+      echo "2. Or symlink them:"
+      echo "   mkdir -p ~/.claude/skills"
+      echo "   ln -sf $root_dir/skills/*.md ~/.claude/skills/"
+      echo ""
+      echo "3. Ensure Claude Code is configured to load skills from ~/.claude/skills/"
+    else
+      echo ""
+      echo "To install the Mayor stop hook and skills, run: pai-lite init --hooks"
     fi
     ;;
   slots)
@@ -220,6 +287,25 @@ case "$cmd" in
     ;;
   status)
     require_config
+    echo "=== pai-lite status - $(date) ==="
+    echo ""
+
+    # Mayor status (brief)
+    echo "Mayor:"
+    if mayor_is_running; then
+      echo "  Session: $MAYOR_SESSION_NAME (running)"
+      _queue_file="$(pai_lite_queue_file)"
+      if [[ -f "$_queue_file" ]] && [[ -s "$_queue_file" ]]; then
+        _pending_count=$(wc -l < "$_queue_file" | tr -d ' ')
+        echo "  Pending requests: $_pending_count"
+      else
+        echo "  Pending requests: 0"
+      fi
+    else
+      echo "  Session: not running"
+    fi
+    echo ""
+
     echo "Slots:"
     slots_list || true
     echo ""
@@ -232,16 +318,36 @@ case "$cmd" in
     ;;
   briefing)
     require_config
-    echo "pai-lite briefing - $(date)"
+    echo "=== pai-lite briefing - $(date) ==="
     echo ""
+
+    # Quick status first
     echo "Slots:"
     slots_list || true
     echo ""
-    if [[ -f "$(tasks_file_path)" ]]; then
-      echo "Tasks:"
-      tasks_list
+
+    # Check if Mayor is running and queue a briefing
+    if mayor_is_running; then
+      echo "Requesting strategic briefing from Mayor..."
+      echo ""
+      mayor_briefing true 300
     else
-      echo "Tasks: (run 'pai-lite tasks sync')"
+      # Fallback to basic briefing without Mayor
+      echo "Mayor not running - showing basic briefing"
+      echo "(Start Mayor with: pai-lite mayor start)"
+      echo ""
+
+      if [[ -f "$(tasks_file_path)" ]]; then
+        echo "Tasks:"
+        tasks_list
+      else
+        echo "Tasks: (run 'pai-lite tasks sync')"
+      fi
+
+      # Show flow critical if available
+      echo ""
+      echo "Critical items:"
+      flow_main critical 2>/dev/null || echo "  (flow engine not initialized)"
     fi
     ;;
   triggers)
@@ -271,10 +377,35 @@ case "$cmd" in
     require_config
     sub="${2:-}"
     case "$sub" in
+      start)
+        mayor_start
+        ;;
+      stop)
+        mayor_stop
+        ;;
+      status)
+        mayor_status
+        ;;
+      attach)
+        mayor_attach
+        ;;
+      logs)
+        lines="${3:-100}"
+        mayor_logs "$lines"
+        ;;
+      doctor)
+        mayor_doctor
+        ;;
       briefing)
-        request_id=$(pai_lite_queue_request "briefing")
-        echo "Queued briefing request: $request_id"
-        echo "Mayor will process when ready (check ~/.claude/hooks/on-stop.sh)"
+        # Queue and optionally wait for briefing
+        wait_flag="${3:-}"
+        if [[ "$wait_flag" == "--no-wait" ]]; then
+          request_id=$(pai_lite_queue_request "briefing")
+          echo "Queued briefing request: $request_id"
+          echo "Mayor will process when ready"
+        else
+          mayor_briefing true
+        fi
         ;;
       suggest)
         request_id=$(pai_lite_queue_request "suggest")
@@ -296,6 +427,22 @@ case "$cmd" in
         request_id=$(pai_lite_queue_request "health-check")
         echo "Queued health check: $request_id"
         ;;
+      learn)
+        request_id=$(pai_lite_queue_request "learn")
+        echo "Queued learn request: $request_id"
+        ;;
+      sync-learnings)
+        request_id=$(pai_lite_queue_request "sync-learnings")
+        echo "Queued sync-learnings request: $request_id"
+        ;;
+      techdebt)
+        request_id=$(pai_lite_queue_request "techdebt")
+        echo "Queued techdebt review: $request_id"
+        ;;
+      context-sync)
+        request_id=$(pai_lite_queue_request "context-sync")
+        echo "Queued context-sync: $request_id"
+        ;;
       queue)
         # Show pending queue
         queue_file="$(pai_lite_queue_file)"
@@ -306,8 +453,12 @@ case "$cmd" in
           echo "No pending requests in queue"
         fi
         ;;
+      "")
+        # No subcommand - show status
+        mayor_status
+        ;;
       *)
-        pai_lite_die "unknown mayor subcommand: $sub (use: briefing, suggest, analyze, elaborate, health-check, queue)"
+        pai_lite_die "unknown mayor subcommand: $sub (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, health-check, learn, sync-learnings, techdebt, context-sync, queue)"
         ;;
     esac
     ;;

--- a/lib/mayor.sh
+++ b/lib/mayor.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# pai-lite/lib/mayor.sh - Mayor session management
+# The Mayor is a persistent Claude Code instance running in a dedicated tmux session
+
+#------------------------------------------------------------------------------
+# Constants
+#------------------------------------------------------------------------------
+
+MAYOR_SESSION_NAME="${PAI_LITE_MAYOR_SESSION:-pai-mayor}"
+MAYOR_DEFAULT_PORT="${PAI_LITE_MAYOR_PORT:-7690}"
+
+#------------------------------------------------------------------------------
+# Helper: Get Mayor state directory
+#------------------------------------------------------------------------------
+
+mayor_state_dir() {
+  local harness_dir
+  harness_dir="$(pai_lite_state_harness_dir)"
+  echo "$harness_dir/mayor"
+}
+
+#------------------------------------------------------------------------------
+# Helper: Get Mayor state file
+#------------------------------------------------------------------------------
+
+mayor_state_file() {
+  echo "$(mayor_state_dir)/session.state"
+}
+
+#------------------------------------------------------------------------------
+# Helper: Get Mayor status file
+#------------------------------------------------------------------------------
+
+mayor_status_file() {
+  echo "$(mayor_state_dir)/session.status"
+}
+
+#------------------------------------------------------------------------------
+# Helper: Check if Mayor session is running
+#------------------------------------------------------------------------------
+
+mayor_is_running() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    return 1
+  fi
+  tmux has-session -t "$MAYOR_SESSION_NAME" 2>/dev/null
+}
+
+#------------------------------------------------------------------------------
+# Mayor start: Create/restart the Mayor tmux session
+#------------------------------------------------------------------------------
+
+mayor_start() {
+  local state_dir working_dir state_file
+
+  if ! command -v tmux >/dev/null 2>&1; then
+    pai_lite_die "mayor start: tmux is required but not installed"
+  fi
+
+  # Check if session already exists
+  if mayor_is_running; then
+    pai_lite_warn "Mayor session '$MAYOR_SESSION_NAME' is already running"
+    echo "Attach with: tmux attach -t $MAYOR_SESSION_NAME"
+    echo "Or view status with: pai-lite mayor status"
+    return 0
+  fi
+
+  # Ensure state directory exists
+  state_dir="$(mayor_state_dir)"
+  mkdir -p "$state_dir"
+  mkdir -p "$state_dir/memory"
+  mkdir -p "$state_dir/memory/projects"
+
+  # Get working directory (harness dir by default)
+  working_dir="$(pai_lite_state_harness_dir)"
+
+  # Create state file
+  state_file="$(mayor_state_file)"
+  cat > "$state_file" <<EOF
+session=$MAYOR_SESSION_NAME
+started=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+working_dir=$working_dir
+status=starting
+EOF
+
+  # Create tmux session
+  pai_lite_info "Creating Mayor tmux session '$MAYOR_SESSION_NAME' in $working_dir"
+  tmux new-session -d -s "$MAYOR_SESSION_NAME" -c "$working_dir"
+
+  # Update status
+  mayor_signal "running" "session started"
+
+  # Start Claude Code CLI if available
+  if command -v claude >/dev/null 2>&1; then
+    tmux send-keys -t "$MAYOR_SESSION_NAME" "claude" C-m
+    pai_lite_info "Started Claude Code in Mayor session"
+  else
+    pai_lite_warn "claude CLI not found; session started without Claude Code"
+  fi
+
+  echo "Mayor session started. Attach with: tmux attach -t $MAYOR_SESSION_NAME"
+
+  # Optionally start ttyd if configured
+  local ttyd_port
+  ttyd_port=$(pai_lite_config_get_nested "mayor" "ttyd_port" 2>/dev/null || echo "")
+  if [[ -n "$ttyd_port" ]] && command -v ttyd >/dev/null 2>&1; then
+    pai_lite_info "Starting ttyd on port $ttyd_port..."
+    # Note: ttyd would need to be started separately to connect to the session
+    echo "To enable web access: ttyd -p $ttyd_port tmux attach -t $MAYOR_SESSION_NAME"
+  fi
+
+  return 0
+}
+
+#------------------------------------------------------------------------------
+# Mayor stop: Gracefully stop the Mayor session
+#------------------------------------------------------------------------------
+
+mayor_stop() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    pai_lite_die "mayor stop: tmux is not available"
+  fi
+
+  if ! mayor_is_running; then
+    pai_lite_warn "Mayor session '$MAYOR_SESSION_NAME' is not running"
+    return 0
+  fi
+
+  # Update status before stopping
+  mayor_signal "stopped" "session stopped by user"
+
+  pai_lite_info "Stopping Mayor tmux session '$MAYOR_SESSION_NAME'..."
+  tmux kill-session -t "$MAYOR_SESSION_NAME"
+
+  # Update state file
+  local state_file
+  state_file="$(mayor_state_file)"
+  if [[ -f "$state_file" ]]; then
+    # Append stopped timestamp
+    echo "stopped=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$state_file"
+  fi
+
+  echo "Mayor session stopped."
+  return 0
+}
+
+#------------------------------------------------------------------------------
+# Mayor status: Show Mayor session status
+#------------------------------------------------------------------------------
+
+mayor_status() {
+  local state_dir state_file status_file
+
+  state_dir="$(mayor_state_dir)"
+  state_file="$(mayor_state_file)"
+  status_file="$(mayor_status_file)"
+
+  echo "=== Mayor Status ==="
+  echo ""
+
+  # Check if session is running
+  if mayor_is_running; then
+    echo "Session: $MAYOR_SESSION_NAME (running)"
+  else
+    echo "Session: $MAYOR_SESSION_NAME (not running)"
+    if [[ -f "$state_file" ]] && grep -q '^stopped=' "$state_file" 2>/dev/null; then
+      local stopped
+      stopped=$(grep '^stopped=' "$state_file" | tail -n1 | cut -d= -f2-)
+      echo "Last stopped: $stopped"
+    fi
+    echo ""
+    echo "Start with: pai-lite mayor start"
+    return 0
+  fi
+
+  echo ""
+
+  # Show state file info
+  if [[ -f "$state_file" ]]; then
+    if grep -q '^started=' "$state_file" 2>/dev/null; then
+      echo "Started: $(grep '^started=' "$state_file" | cut -d= -f2-)"
+    fi
+    if grep -q '^working_dir=' "$state_file" 2>/dev/null; then
+      echo "Working directory: $(grep '^working_dir=' "$state_file" | cut -d= -f2-)"
+    fi
+  fi
+
+  # Show status
+  if [[ -f "$status_file" ]]; then
+    local status_line status_text status_epoch status_msg
+    status_line=$(cat "$status_file")
+    status_text=$(echo "$status_line" | cut -d'|' -f1)
+    status_epoch=$(echo "$status_line" | cut -d'|' -f2)
+    status_msg=$(echo "$status_line" | cut -d'|' -f3-)
+
+    echo ""
+    echo "Status: $status_text"
+    if [[ -n "$status_msg" ]]; then
+      echo "Message: $status_msg"
+    fi
+    if [[ -n "$status_epoch" ]]; then
+      local now diff mins
+      now=$(date +%s)
+      diff=$((now - status_epoch))
+      mins=$((diff / 60))
+      if [[ $mins -lt 60 ]]; then
+        echo "Last activity: ${mins}m ago"
+      else
+        local hours=$((mins / 60))
+        echo "Last activity: ${hours}h ago"
+      fi
+    fi
+  fi
+
+  # Show queue status
+  echo ""
+  local queue_file
+  queue_file="$(pai_lite_queue_file)"
+  if [[ -f "$queue_file" ]] && [[ -s "$queue_file" ]]; then
+    local pending_count
+    pending_count=$(wc -l < "$queue_file" | tr -d ' ')
+    echo "Pending requests: $pending_count"
+  else
+    echo "Pending requests: 0"
+  fi
+
+  # Show memory status
+  echo ""
+  local memory_dir="$state_dir/memory"
+  if [[ -d "$memory_dir" ]]; then
+    echo "Memory:"
+    if [[ -f "$memory_dir/corrections.md" ]]; then
+      local corrections_count
+      corrections_count=$(grep -c '^-' "$memory_dir/corrections.md" 2>/dev/null || echo "0")
+      echo "  - Corrections: $corrections_count entries"
+    fi
+    if [[ -f "$memory_dir/tools.md" ]]; then
+      echo "  - Tools: present"
+    fi
+    if [[ -f "$memory_dir/workflows.md" ]]; then
+      echo "  - Workflows: present"
+    fi
+    local projects_count
+    projects_count=$(find "$memory_dir/projects" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$projects_count" -gt 0 ]]; then
+      echo "  - Projects: $projects_count"
+    fi
+  fi
+
+  # Show context file if present
+  if [[ -f "$state_dir/context.md" ]]; then
+    echo ""
+    echo "Context file: present"
+  fi
+
+  return 0
+}
+
+#------------------------------------------------------------------------------
+# Mayor attach: Attach to the Mayor tmux session
+#------------------------------------------------------------------------------
+
+mayor_attach() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    pai_lite_die "mayor attach: tmux is not available"
+  fi
+
+  if ! mayor_is_running; then
+    pai_lite_die "Mayor session '$MAYOR_SESSION_NAME' is not running. Start with: pai-lite mayor start"
+  fi
+
+  exec tmux attach -t "$MAYOR_SESSION_NAME"
+}
+
+#------------------------------------------------------------------------------
+# Mayor logs: Show recent Mayor activity from tmux pane
+#------------------------------------------------------------------------------
+
+mayor_logs() {
+  local lines="${1:-100}"
+
+  if ! command -v tmux >/dev/null 2>&1; then
+    pai_lite_die "mayor logs: tmux is not available"
+  fi
+
+  if ! mayor_is_running; then
+    pai_lite_warn "Mayor session '$MAYOR_SESSION_NAME' is not running"
+
+    # Show results from completed requests if available
+    local results_dir
+    results_dir="$(pai_lite_results_dir)"
+    if [[ -d "$results_dir" ]]; then
+      echo "Recent results:"
+      find "$results_dir" -name "*.json" -type f -mtime -1 | \
+        xargs -I {} sh -c 'echo "---"; cat "{}"' 2>/dev/null | head -n 50
+    fi
+    return 0
+  fi
+
+  echo "=== Mayor Session Logs (last $lines lines) ==="
+  echo ""
+  tmux capture-pane -t "$MAYOR_SESSION_NAME" -p -S "-$lines"
+}
+
+#------------------------------------------------------------------------------
+# Mayor signal: Update Mayor status
+#------------------------------------------------------------------------------
+
+mayor_signal() {
+  local status="$1"
+  local message="${2:-}"
+
+  local status_file state_dir
+  state_dir="$(mayor_state_dir)"
+  status_file="$(mayor_status_file)"
+
+  # Ensure state directory exists
+  mkdir -p "$state_dir"
+
+  # Write status in format: status|epoch|message
+  local epoch
+  epoch=$(date +%s)
+  echo "${status}|${epoch}|${message}" > "$status_file"
+}
+
+#------------------------------------------------------------------------------
+# Mayor send: Send a command to the Mayor (for automation)
+#------------------------------------------------------------------------------
+
+mayor_send() {
+  local command="$1"
+
+  if ! mayor_is_running; then
+    pai_lite_die "Mayor session is not running. Start with: pai-lite mayor start"
+  fi
+
+  tmux send-keys -t "$MAYOR_SESSION_NAME" "$command" C-m
+  pai_lite_info "Sent command to Mayor: $command"
+}
+
+#------------------------------------------------------------------------------
+# Mayor doctor: Health check for Mayor setup
+#------------------------------------------------------------------------------
+
+mayor_doctor() {
+  local all_ok=true
+
+  echo "=== Mayor Health Check ==="
+  echo ""
+
+  # Check tmux
+  if command -v tmux >/dev/null 2>&1; then
+    echo "tmux: $(tmux -V)"
+  else
+    echo "tmux: NOT FOUND (required)"
+    all_ok=false
+  fi
+
+  # Check claude CLI
+  if command -v claude >/dev/null 2>&1; then
+    echo "claude: found at $(command -v claude)"
+  else
+    echo "claude: NOT FOUND"
+    echo "  Install: npm install -g @anthropic-ai/claude-code"
+    all_ok=false
+  fi
+
+  # Check jq (for queue processing)
+  if command -v jq >/dev/null 2>&1; then
+    echo "jq: found"
+  else
+    echo "jq: NOT FOUND (required for queue processing)"
+    all_ok=false
+  fi
+
+  echo ""
+
+  # Check session status
+  if mayor_is_running; then
+    echo "Mayor session: running"
+  else
+    echo "Mayor session: not running"
+  fi
+
+  # Check state directory
+  local state_dir
+  state_dir="$(mayor_state_dir)"
+  if [[ -d "$state_dir" ]]; then
+    echo "State directory: $state_dir"
+  else
+    echo "State directory: $state_dir (not created yet)"
+  fi
+
+  # Check queue file
+  local queue_file
+  queue_file="$(pai_lite_queue_file)"
+  if [[ -f "$queue_file" ]]; then
+    local pending
+    pending=$(wc -l < "$queue_file" | tr -d ' ')
+    echo "Queue: $queue_file ($pending pending)"
+  else
+    echo "Queue: not initialized"
+  fi
+
+  # Check stop hook
+  echo ""
+  echo "Stop hook locations to check:"
+  echo "  - ~/.claude/hooks/pai-lite-on-stop.sh"
+  echo "  - ~/.config/claude-code/hooks/pai-lite-on-stop.sh"
+
+  if [[ -f "$HOME/.claude/hooks/pai-lite-on-stop.sh" ]]; then
+    echo "  Found: ~/.claude/hooks/pai-lite-on-stop.sh"
+  elif [[ -f "$HOME/.config/claude-code/hooks/pai-lite-on-stop.sh" ]]; then
+    echo "  Found: ~/.config/claude-code/hooks/pai-lite-on-stop.sh"
+  else
+    echo "  Not found - install with: pai-lite init --hooks"
+    all_ok=false
+  fi
+
+  echo ""
+
+  if $all_ok; then
+    echo "All checks passed"
+    return 0
+  else
+    echo "Some checks failed"
+    return 1
+  fi
+}
+
+#------------------------------------------------------------------------------
+# Mayor briefing: Request a briefing and wait for result
+#------------------------------------------------------------------------------
+
+mayor_briefing() {
+  local wait="${1:-true}"
+  local timeout="${2:-300}"
+
+  # Queue the briefing request
+  local request_id
+  request_id=$(pai_lite_queue_request "briefing")
+  echo "Queued briefing request: $request_id"
+
+  if [[ "$wait" != "true" ]]; then
+    echo "Mayor will process when ready"
+    return 0
+  fi
+
+  # Check if Mayor is running
+  if ! mayor_is_running; then
+    pai_lite_warn "Mayor session is not running. Start with: pai-lite mayor start"
+    pai_lite_warn "Or process manually: the request is queued"
+    return 1
+  fi
+
+  echo "Waiting for Mayor to process (timeout: ${timeout}s)..."
+
+  # Wait for result
+  local result
+  if result=$(pai_lite_wait_for_result "$request_id" "$timeout"); then
+    echo ""
+    echo "=== Briefing Result ==="
+    echo "$result" | jq -r '.output // "No output"' 2>/dev/null || echo "$result"
+
+    # Send notification
+    if command -v notify_pai >/dev/null 2>&1; then
+      local summary
+      summary=$(echo "$result" | jq -r '.output // ""' 2>/dev/null | head -n 5)
+      notify_pai "Briefing ready" 3 "pai-lite briefing"
+    fi
+
+    return 0
+  else
+    pai_lite_warn "Timeout waiting for briefing result"
+    return 1
+  fi
+}

--- a/skills/analyze-issue.md
+++ b/skills/analyze-issue.md
@@ -1,0 +1,122 @@
+# /analyze-issue - GitHub Issue Analysis
+
+Analyze a GitHub issue and create a task file with inferred dependencies.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor analyze <issue>`
+- Automation detects a new issue in watched repos
+
+## Arguments
+
+- `<issue>`: Issue number (e.g., `127`) or URL (e.g., `https://github.com/org/repo/issues/127`)
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Fetch issue**:
+   ```bash
+   gh issue view <issue> --json title,body,labels,assignees,milestone
+   ```
+
+2. **Assess actionability**:
+   - Is this a feature request, bug report, or discussion?
+   - Is it clear enough to act on?
+   - Does it need clarification?
+
+3. **Extract dependencies** (delegate to Haiku for speed):
+   ```
+   Task → Haiku: "Extract dependencies from this issue.
+   Return JSON: {blocks: [...], blocked_by: [...], related: [...]}"
+   ```
+
+4. **Validate dependencies**:
+   - Check that referenced tasks exist
+   - Run `tsort` to verify no cycles are introduced
+   ```bash
+   echo "existing deps + new deps" | tsort
+   ```
+
+5. **Infer metadata**:
+   - Priority (A/B/C) based on labels, milestone, urgency
+   - Effort (small/medium/large) based on scope
+   - Context tag based on repository/area
+
+6. **Create task file**:
+   Write `$PAI_LITE_STATE_PATH/tasks/task-<next_id>.md`
+
+## Output Format
+
+### Task File
+
+```yaml
+---
+id: task-143
+title: "Implement tensor concatenation with ^ operator"
+project: ocannl
+status: ready
+priority: B
+deadline: null
+dependencies:
+  blocks: []
+  blocked_by: [task-042]
+effort: medium
+context: einsum
+slot: null
+adapter: null
+created: 2026-02-01
+started: null
+completed: null
+github_issue: 127
+---
+
+# Context
+
+From GitHub issue #127:
+[Summary of the issue in your own words]
+
+# Acceptance Criteria
+
+- [ ] Parse `^` in einsum expressions
+- [ ] Implement projection inference for concatenation
+- [ ] Add tests for edge cases
+- [ ] Update documentation
+
+# Technical Notes
+
+[Any code pointers, relevant files, or implementation hints]
+
+# Dependencies
+
+- Blocked by task-042 (einsum parser refactoring)
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "output": "Created task-143.md from issue #127",
+  "task_id": "task-143",
+  "github_issue": 127
+}
+```
+
+## Delegation Strategy
+
+- **Haiku** (via Task tool): Extract structured data (dependencies, effort estimate)
+- **CLI**: Validate dependencies with tsort
+- **Opus**: Write the task file with context and acceptance criteria
+
+## Error Handling
+
+- Issue not found: Write result with status "error"
+- Cycle detected: Warn but still create task, note dependency issue
+- Ambiguous issue: Create task with status "blocked" and note clarification needed

--- a/skills/briefing.md
+++ b/skills/briefing.md
@@ -1,0 +1,96 @@
+# /briefing - Strategic Morning Briefing
+
+Generate a comprehensive strategic briefing for the user.
+
+## Trigger
+
+This skill is invoked by the pai-lite automation when:
+- The user runs `pai-lite briefing` or `pai-lite mayor briefing`
+- A morning trigger fires (e.g., 08:00 via launchd)
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+- `$PAI_LITE_RESULTS_DIR`: Directory for writing result JSON
+
+## Process
+
+1. **Gather context**:
+   - Read `slots.md` to understand active work
+   - Read `tasks/*.md` to understand task inventory
+   - Use flow engine to compute ready queue: `pai-lite flow ready`
+   - Check for critical items: `pai-lite flow critical`
+   - Read recent journal entries: `journal/*.md`
+
+2. **Analyze state**:
+   - Identify high-priority ready tasks (A-priority, empty blocked_by)
+   - Detect approaching deadlines (within 7 days)
+   - Identify stalled work (in-progress > 7 days without updates)
+   - Check slot utilization (X/6 slots active)
+
+3. **Generate briefing**:
+   Write a strategic briefing covering:
+   - **Current state**: Active slots, ongoing work
+   - **Ready tasks**: Priority-sorted list of what can start
+   - **Urgent items**: Deadlines, stalled work, blockers
+   - **Suggestions**: What to work on today and why
+   - **Context switches**: Note if changing context is expensive
+
+4. **Write result**:
+   - Write briefing to `$PAI_LITE_STATE_PATH/briefing.md`
+   - Write result JSON to `$PAI_LITE_RESULTS_DIR/$PAI_LITE_REQUEST_ID.json`
+
+## Output Format
+
+### briefing.md
+
+```markdown
+# Briefing - YYYY-MM-DD
+
+## Current State
+- Slot 1: [task] (agent-duo, phase)
+- Slot 2: empty
+- ...
+
+## Ready to Start (Priority Order)
+1. **task-101** (A): [title] - [reason this is high priority]
+2. **task-067** (A): [title]
+3. **task-128** (B): [title]
+
+## Urgent Attention
+- **Deadline**: task-042 due in 3 days (POPL submission)
+- **Stalled**: task-089 has been in-progress for 12 days
+
+## Today's Suggestion
+Start with task-101 because [reasoning]. If blocked, switch to task-067.
+
+Current context focus: [einsum/ocannl] - switching to [other] would incur context cost.
+
+## Notes
+- [Any other strategic observations]
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "2026-02-01T08:00:00Z",
+  "output": "[briefing content]"
+}
+```
+
+## Delegation Strategy
+
+- **CLI tools** for ready queue computation (yq, jq, tsort)
+- **Direct Opus analysis** for strategic suggestions
+- No subagent delegation needed for briefings
+
+## Error Handling
+
+If state files are missing or malformed:
+- Write partial briefing with warnings
+- Include "run pai-lite tasks sync" suggestion
+- Still write result JSON with status "partial"

--- a/skills/context-sync.md
+++ b/skills/context-sync.md
@@ -1,0 +1,153 @@
+# /context-sync - Pre-Briefing Context Aggregation
+
+Aggregate recent activity across sources for richer briefings.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor context-sync`
+- Before `/briefing` (can be chained)
+- On demand for catching up after being away
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Fetch GitHub activity**:
+   ```bash
+   # Recent issue comments across watched repos
+   for repo in $(pai-lite config projects --repos); do
+     gh api "repos/$repo/issues/comments?since=$(date -d '1 day ago' -Iseconds)" \
+       --jq '.[] | {repo: "'$repo'", body: .body, user: .user.login, created: .created_at}'
+   done
+
+   # Recent PR reviews
+   for repo in $(pai-lite config projects --repos); do
+     gh pr list --repo "$repo" --state all --json number,title,updatedAt --jq '.[] | select(.updatedAt > "'$(date -d '1 day ago' -Iseconds)'")'
+   done
+   ```
+
+2. **Fetch git commits**:
+   ```bash
+   for project_dir in $(pai-lite config projects --dirs); do
+     git -C "$project_dir" log --since="1 day ago" --oneline --all
+   done
+   ```
+
+3. **Read recent notifications**:
+   ```bash
+   cat "$PAI_LITE_STATE_PATH/journal/notifications.jsonl" | \
+     jq -s '[.[] | select(.timestamp > "'$(date -d '1 day ago' -Iseconds)'")]'
+   ```
+
+4. **Aggregate external sources** (if configured):
+   - Slack via MCP (if available)
+   - Email summaries (if integrated)
+
+5. **Generate context document**:
+   Write to `$PAI_LITE_STATE_PATH/context-sync.md`
+
+## Output Format
+
+### context-sync.md
+
+```markdown
+# Context Sync - 2026-02-01 08:00
+
+## GitHub Activity (Last 24h)
+
+### Issue Comments
+
+**ocannl#127** - "Tensor concatenation"
+- @contributor1: "Have you considered using ^ for the operator?"
+- @contributor2: "That aligns with the mathematical notation"
+
+**ppx-minidebug#45** - "Performance regression"
+- @user: "Still seeing slow output on large traces"
+- Needs attention - may need investigation
+
+### PR Updates
+
+**ocannl#134** - "Einsum parser refactoring"
+- Status: Approved, ready to merge
+- Last update: 2h ago
+
+### New Issues
+
+- ocannl#129: "Support for complex tensors" (needs triage)
+
+---
+
+## Git Activity
+
+### ocannl
+- `a1b2c3d` Fix dimension broadcasting edge case
+- `e4f5g6h` Add einsum concatenation tests
+
+### ppx-minidebug
+- `i7j8k9l` Update changelog for 3.0 release
+
+---
+
+## Notifications (Last 24h)
+
+- 14:30: Slot 1 PR ready
+- 18:00: Health check - task-089 stalled warning
+- 22:00: Build failed on ppx-minidebug main
+
+---
+
+## Items Requiring Attention
+
+1. **ocannl#129**: New issue needs triage
+2. **ppx-minidebug#45**: Performance complaint - investigate?
+3. **ocannl#134**: PR ready to merge
+
+## Suggested Follow-ups
+
+- Review and merge ocannl#134
+- Triage ocannl#129
+- Investigate ppx-minidebug performance complaint
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "github_comments": 4,
+  "pr_updates": 1,
+  "new_issues": 1,
+  "commits": 3,
+  "notifications": 3,
+  "attention_items": 3
+}
+```
+
+## Integration with /briefing
+
+The `/briefing` skill can read `context-sync.md` to provide richer context:
+
+```markdown
+# Briefing - 2026-02-01
+
+## External Context
+[Summary from context-sync.md]
+
+## Current State
+[slot status]
+
+## Ready Tasks
+[flow ready output]
+```
+
+## Delegation Strategy
+
+- **CLI**: gh CLI for GitHub data, git for commits
+- **Haiku** (via Task tool): Parse and summarize large volumes of comments
+- **Opus**: Identify items requiring attention, write summary

--- a/skills/elaborate.md
+++ b/skills/elaborate.md
@@ -1,0 +1,124 @@
+# /elaborate - Task Elaboration
+
+Elaborate a high-level task into a detailed specification.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor elaborate <task_id>`
+- Before assigning a task to a slot
+
+## Arguments
+
+- `<task_id>`: Task identifier (e.g., `task-042`)
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Read task file**:
+   ```bash
+   cat "$PAI_LITE_STATE_PATH/tasks/<task_id>.md"
+   ```
+
+2. **Gather context**:
+   - Read related task files (dependencies)
+   - Check GitHub issue if linked
+   - Read project-specific memory: `mayor/memory/projects/<project>.md`
+   - Identify relevant code files in the repository
+
+3. **Elaborate**:
+   - Break down into subtasks
+   - Identify specific files to modify
+   - Note edge cases and potential blockers
+   - Add implementation hints
+   - Define test cases
+
+4. **Update task file**:
+   Expand the task with detailed specification
+
+## Output Format
+
+### Updated Task File
+
+The task file should be updated with additional sections:
+
+```markdown
+---
+[existing frontmatter]
+elaborated: 2026-02-01
+---
+
+# Context
+[existing context]
+
+# Acceptance Criteria
+[refined criteria]
+
+# Implementation Plan
+
+## Phase 1: Parser Changes
+- [ ] Modify `lib/einsum/parser.ml` to recognize `^` operator
+- [ ] Add AST node for concatenation
+- [ ] Update precedence rules (same as `,`)
+
+## Phase 2: Inference
+- [ ] Extend `lib/einsum/infer.ml` for concatenation projections
+- [ ] Handle dimension alignment
+
+## Phase 3: Codegen
+- [ ] Update `lib/einsum/codegen.ml`
+- [ ] Add runtime concatenation implementation
+
+## Phase 4: Testing
+- [ ] Add unit tests in `test/einsum_test.ml`
+- [ ] Add integration test with existing benchmarks
+
+# Technical Notes
+
+## Code Pointers
+- Parser entry point: `lib/einsum/parser.ml:142`
+- Inference main: `lib/einsum/infer.ml:87`
+- Similar feature: tensor product implementation at line 203
+
+## Edge Cases
+- Empty tensors
+- Mismatched dimensions
+- Broadcasting behavior
+
+## Dependencies
+- Requires task-041 (parser refactoring) to be complete
+
+# Estimated Effort
+Medium (2-3 days)
+- Day 1: Parser + AST
+- Day 2: Inference + Codegen
+- Day 3: Testing + edge cases
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "output": "Elaborated task-042 with implementation plan",
+  "task_id": "task-042"
+}
+```
+
+## Delegation Strategy
+
+- **Sonnet** (via Task tool): Generate structured subtasks
+- **CLI**: File navigation, code search
+- **Opus**: Write detailed specification with judgment calls
+
+## Error Handling
+
+- Task not found: Write result with status "error"
+- Already elaborated: Ask if re-elaboration is wanted
+- Missing context: Note gaps and proceed with available information

--- a/skills/health-check.md
+++ b/skills/health-check.md
@@ -1,0 +1,99 @@
+# /health-check - System Health Check
+
+Detect stalled work, approaching deadlines, and other issues requiring attention.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor health-check`
+- Periodic automation (every 4h via launchd)
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Check for stalled tasks**:
+   - Find tasks with `status: in-progress`
+   - Calculate time since `started` date
+   - Flag if > 7 days without updates
+
+2. **Check approaching deadlines**:
+   - Find tasks with `deadline` field
+   - Calculate days remaining
+   - Flag if <= 7 days (warning) or <= 3 days (critical)
+
+3. **Check slot health**:
+   - Read `slots.md`
+   - Identify slots that have been active > 24h without status update
+   - Check for orphaned sessions (tmux sessions without slot assignment)
+
+4. **Check queue health**:
+   - Read `tasks/queue.jsonl`
+   - Flag if requests have been pending > 1h
+
+5. **Generate report**:
+   - Categorize issues by severity
+   - Include actionable recommendations
+
+6. **Send notifications** for critical issues:
+   ```bash
+   pai-lite notify pai "Critical: task-042 deadline in 2 days" 5 "Health Check"
+   ```
+
+## Output Format
+
+### Health Report
+
+```markdown
+# Health Check - YYYY-MM-DD HH:MM
+
+## Critical Issues
+- **DEADLINE**: task-042 "POPL submission" due in 2 days
+- **STALLED**: task-089 in-progress for 14 days
+
+## Warnings
+- **DEADLINE**: task-101 due in 6 days
+- **SLOT**: Slot 3 has been active for 28 hours without update
+
+## Info
+- Active slots: 2/6
+- Ready tasks: 8
+- Blocked tasks: 3
+- Queue pending: 0
+
+## Recommendations
+1. Prioritize task-042 - deadline is imminent
+2. Review task-089 - consider abandoning or breaking into smaller pieces
+3. Slot 3 may need attention - check tmux session
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "critical": 2,
+  "warnings": 2,
+  "output": "[health report content]"
+}
+```
+
+## Notification Triggers
+
+| Condition | Topic | Priority |
+|-----------|-------|----------|
+| Deadline <= 3 days | pai | 5 (critical) |
+| Deadline <= 7 days | pai | 4 (high) |
+| Stalled > 14 days | pai | 4 (high) |
+| Stalled > 7 days | pai | 3 (normal) |
+| Queue stuck > 1h | agents | 4 (high) |
+
+## Delegation Strategy
+
+- **CLI tools**: Date calculations, file parsing
+- **Opus**: Judgment on severity, recommendations

--- a/skills/learn.md
+++ b/skills/learn.md
@@ -1,0 +1,114 @@
+# /learn - Institutional Learning
+
+Update Mayor's memory from user corrections and feedback.
+
+## Trigger
+
+This skill is invoked when:
+- The user provides a correction and says `/learn`
+- Example: "Don't use yq -s on single files, it expects multiple" then `/learn`
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- Previous message context (the correction)
+
+## Process
+
+1. **Identify the correction**:
+   - Parse the user's previous message
+   - Understand what was wrong and what's correct
+
+2. **Categorize the learning**:
+   - **Tool gotcha**: CLI tool behavior, flags, quirks
+   - **Workflow pattern**: Process or procedure improvement
+   - **Project-specific**: Knowledge about a specific codebase
+   - **Preference**: User's preferred style or approach
+
+3. **Write to corrections log**:
+   Append to `$PAI_LITE_STATE_PATH/mayor/memory/corrections.md`
+
+4. **Update structured memory** (if pattern is clear):
+   - Tools: `mayor/memory/tools.md`
+   - Workflows: `mayor/memory/workflows.md`
+   - Project: `mayor/memory/projects/<project>.md`
+
+5. **Acknowledge the learning**
+
+## Output Format
+
+### Corrections Entry
+
+Append to `mayor/memory/corrections.md`:
+
+```markdown
+## 2026-02-01: yq usage
+
+**Context**: Using yq for YAML parsing
+
+**Correction**: `yq -s` (slurp) expects multiple files as input. For single file operations, use `yq eval` or `yq e` instead.
+
+**Before** (wrong):
+```bash
+yq -s '.' single-file.yaml
+```
+
+**After** (correct):
+```bash
+yq eval '.' single-file.yaml
+```
+
+**Source**: User feedback
+
+---
+```
+
+### Tools Memory Update
+
+If this is a tool-related learning, also update `mayor/memory/tools.md`:
+
+```markdown
+## yq
+
+### Gotchas
+- `yq -s` (slurp) expects multiple files; use `yq eval` for single files
+- [other gotchas...]
+```
+
+### Acknowledgment
+
+```
+Learned: yq -s expects multiple files, use yq eval for single files.
+Added to: corrections.md, tools.md
+```
+
+## Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "category": "tool",
+  "summary": "yq -s expects multiple files",
+  "files_updated": ["corrections.md", "tools.md"]
+}
+```
+
+## Memory Structure
+
+```
+mayor/
+├── context.md           # Current understanding, project focus
+└── memory/
+    ├── corrections.md   # Raw correction log (append-only)
+    ├── tools.md         # CLI tool knowledge
+    ├── workflows.md     # Process patterns
+    └── projects/
+        ├── ocannl.md
+        └── ppx-minidebug.md
+```
+
+## Delegation Strategy
+
+- **Opus only**: Requires understanding context and making judgment calls about categorization

--- a/skills/suggest.md
+++ b/skills/suggest.md
@@ -1,0 +1,75 @@
+# /suggest - Task Suggestions
+
+Provide intelligent task suggestions based on current flow state.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor suggest`
+- The user asks "what should I work on?"
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Analyze flow state**:
+   ```bash
+   pai-lite flow ready      # Get ready tasks
+   pai-lite flow critical   # Get urgent items
+   pai-lite flow context    # Get context distribution
+   ```
+
+2. **Consider factors**:
+   - **Priority**: A-priority tasks first
+   - **Deadlines**: Items with hard deadlines
+   - **Impact**: Tasks that unblock the most downstream work
+   - **Context**: Minimize context switching if already focused
+   - **Effort**: Balance small wins with large projects
+
+3. **Generate suggestions**:
+   - Top 3 recommended tasks with reasoning
+   - Alternative if primary is blocked
+   - Warning about any stalled work
+
+## Output Format
+
+```markdown
+## Suggested Tasks
+
+### Top Recommendation
+**task-101**: Implement einsum concatenation
+
+*Why*: A-priority, unblocks 3 tasks, matches your current einsum context.
+
+### Alternatives
+1. **task-067**: Fix type inference edge case
+   - Same context, smaller scope, quick win
+
+2. **task-128**: Update documentation
+   - Lower priority but deadline in 5 days
+
+### Consider Later
+- task-089 has been stalled for 10 days - need to either restart or abandon
+```
+
+## Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "suggestions": [
+    {"task": "task-101", "priority": 1, "reason": "..."},
+    {"task": "task-067", "priority": 2, "reason": "..."}
+  ]
+}
+```
+
+## Delegation Strategy
+
+- **CLI tools** for flow analysis
+- **Opus** for reasoning about suggestions

--- a/skills/sync-learnings.md
+++ b/skills/sync-learnings.md
@@ -1,0 +1,162 @@
+# /sync-learnings - Knowledge Consolidation
+
+Consolidate scattered learnings from corrections.md into structured memory files.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor sync-learnings`
+- Periodically (weekly) via automation
+- When corrections.md grows beyond a threshold
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Read recent corrections**:
+   ```bash
+   cat "$PAI_LITE_STATE_PATH/mayor/memory/corrections.md"
+   ```
+
+2. **Read journal friction points**:
+   ```bash
+   grep -l "friction\|mistake\|learned" "$PAI_LITE_STATE_PATH/journal/"*.md
+   ```
+
+3. **Group by theme**:
+   - Tool-related → tools.md
+   - Process-related → workflows.md
+   - Project-specific → projects/<project>.md
+
+4. **Update structured files**:
+   - Merge similar learnings
+   - Remove duplicates
+   - Add cross-references
+
+5. **Archive processed corrections**:
+   - Move entries to `corrections-archive.md`
+   - Keep corrections.md for recent items only
+
+6. **Propose CLAUDE.md updates** (if broad patterns detected):
+   - Output suggestions for codebase-wide instructions
+   - Do not auto-update CLAUDE.md
+
+## Output Format
+
+### Sync Report
+
+```markdown
+# Learnings Sync - 2026-02-01
+
+## Processed
+- 12 corrections from corrections.md
+- 3 friction points from journal
+
+## Updates Made
+
+### tools.md
+- Added yq gotchas section
+- Added jq multiline handling note
+
+### workflows.md
+- Added "PR review checklist" pattern
+- Updated "task elaboration" process
+
+### projects/ocannl.md
+- Added einsum parsing notes
+- Added build system quirks
+
+## Archived
+- Moved 8 processed corrections to corrections-archive.md
+
+## Suggested CLAUDE.md Updates
+Consider adding:
+> When using yq, prefer `yq eval` over `yq -s` for single file operations.
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "processed": 12,
+  "updates": {
+    "tools.md": 2,
+    "workflows.md": 2,
+    "projects/ocannl.md": 2
+  },
+  "archived": 8
+}
+```
+
+## Memory File Formats
+
+### tools.md
+
+```markdown
+# CLI Tools Knowledge
+
+## yq
+
+### Usage
+- Single file: `yq eval '.key' file.yaml`
+- Multiple files: `yq -s '.' *.yaml`
+
+### Gotchas
+- `yq -s` expects multiple files
+- Output is JSON by default, use `-o yaml` for YAML
+
+## jq
+
+### Gotchas
+- Use `--slurpfile` for loading JSON files as variables
+- Multiline strings need careful quoting
+```
+
+### workflows.md
+
+```markdown
+# Workflow Patterns
+
+## Task Elaboration
+1. Read task file and linked issue
+2. Check related tasks for context
+3. Identify specific files to modify
+4. Break into subtasks with acceptance criteria
+
+## PR Review Checklist
+- [ ] Tests pass
+- [ ] No new warnings
+- [ ] Documentation updated if needed
+- [ ] Commit message follows convention
+```
+
+### projects/ocannl.md
+
+```markdown
+# OCANNL Project Knowledge
+
+## Build System
+- Uses dune
+- `dune build` from root
+- Tests: `dune test`
+
+## Einsum Module
+- Parser at `lib/einsum/parser.ml`
+- Entry point: `parse_einsum`
+- Uses menhir for parsing
+
+## Common Issues
+- Type inference can be slow on large tensors
+- Watch for dimension broadcasting edge cases
+```
+
+## Delegation Strategy
+
+- **Haiku** (via Task tool): Extract themes and group corrections
+- **Opus**: Write the consolidated memory files with judgment

--- a/skills/techdebt.md
+++ b/skills/techdebt.md
@@ -1,0 +1,132 @@
+# /techdebt - Technical Debt Review
+
+End-of-day or end-of-week technical debt review.
+
+## Trigger
+
+This skill is invoked when:
+- The user runs `pai-lite mayor techdebt`
+- Weekly automation (e.g., Friday 17:00)
+
+## Inputs
+
+- `$PAI_LITE_STATE_PATH`: Path to the harness directory
+- `$PAI_LITE_REQUEST_ID`: Request ID for writing results
+
+## Process
+
+1. **Scan recent commits** (delegate to Haiku for speed):
+   ```bash
+   # Get commits from last 7 days across watched projects
+   for project in $(pai-lite config projects); do
+     git -C "$project" log --since="7 days ago" --oneline
+   done
+   ```
+
+2. **Identify code smells**:
+   - TODO/FIXME comments added recently
+   - Duplicated code blocks (>80% similarity)
+   - Unused imports or dead code
+   - Copy-pasted patterns that could be consolidated
+   - Long functions (>100 lines) added
+
+3. **Categorize by maintenance cost**:
+   - **Low**: Style issues, minor duplication
+   - **Medium**: TODO comments, moderate duplication
+   - **High**: Significant duplication, architectural issues
+
+4. **Generate report**:
+   - Group by project
+   - Include file locations
+   - Suggest consolidation approaches
+
+5. **Optionally create task files**:
+   - For high-cost items, create C-priority tasks
+   - Include in next week's ready queue
+
+## Output Format
+
+### Tech Debt Report
+
+```markdown
+# Technical Debt Review - 2026-02-01
+
+## Summary
+- 3 high-priority items
+- 7 medium-priority items
+- 12 low-priority items
+
+## High Priority
+
+### ocannl: Duplicated einsum parsing
+**Files**:
+- `lib/einsum/parser.ml:142-180`
+- `lib/einsum/legacy_parser.ml:89-127`
+
+**Issue**: 80% code similarity in parsing logic
+
+**Suggestion**: Extract common parsing functions to shared module
+
+**Estimated effort**: Medium
+
+---
+
+### ppx-minidebug: Long function
+**File**: `lib/ppx_minidebug.ml:423-580` (157 lines)
+
+**Issue**: `transform_expr` is too long, hard to maintain
+
+**Suggestion**: Break into helper functions by expression type
+
+---
+
+## Medium Priority
+
+### ocannl: TODO comment
+**File**: `lib/tensor.ml:89`
+**Comment**: `(* TODO: optimize for sparse tensors *)`
+**Added**: 2026-01-28
+
+---
+
+### ppx-minidebug: Unused import
+**File**: `lib/ppx_minidebug.ml:3`
+**Import**: `open Unused_module`
+
+---
+
+## Low Priority
+- Minor style inconsistencies (12 items)
+- See full list in `techdebt-details.md`
+
+## Tasks Created
+- task-201: Consolidate einsum parsing (C-priority)
+- task-202: Refactor transform_expr (C-priority)
+```
+
+### Result JSON
+
+```json
+{
+  "id": "req-...",
+  "status": "completed",
+  "timestamp": "...",
+  "high": 3,
+  "medium": 7,
+  "low": 12,
+  "tasks_created": ["task-201", "task-202"]
+}
+```
+
+## Delegation Strategy
+
+- **Haiku** (via Task tool): Scan for duplicated code, TODOs, long functions
+- **CLI**: Git log, grep for patterns
+- **Opus**: Assess severity, write recommendations
+
+## Notification
+
+If high-priority items found:
+```bash
+pai-lite notify pai "Tech debt review: 3 high-priority items found" 3 "Weekly Review"
+```

--- a/templates/config.example.yaml
+++ b/templates/config.example.yaml
@@ -63,6 +63,7 @@ notifications:
     public: your-username-public     # Public read-only (broadcasts)
 
   # Priority levels by event type (1=min, 5=urgent)
+
   priorities:
     briefing: 3
     health_check: 3

--- a/templates/hooks/pai-lite-on-stop.sh
+++ b/templates/hooks/pai-lite-on-stop.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# pai-lite Mayor Stop Hook
+# Install to: ~/.claude/hooks/pai-lite-on-stop.sh
+#
+# This hook fires when Claude Code finishes a turn and returns to the prompt.
+# It reads queued requests from pai-lite and outputs the appropriate skill command.
+#
+# Setup:
+# 1. Run: pai-lite init --hooks
+#    Or manually copy to ~/.claude/hooks/pai-lite-on-stop.sh
+# 2. Make executable: chmod +x ~/.claude/hooks/pai-lite-on-stop.sh
+# 3. Configure Claude Code to use hooks from ~/.claude/hooks/
+#
+# The hook's stdout becomes the next user prompt for Claude Code.
+
+#------------------------------------------------------------------------------
+# State Path Detection
+#------------------------------------------------------------------------------
+
+# Priority order for finding state path:
+# 1. PAI_LITE_STATE_PATH environment variable (explicit override)
+# 2. Derive from pointer config (~/.config/pai-lite/config.yaml)
+# 3. Fall back to common default
+
+detect_state_path() {
+  # 1. Check environment variable first
+  if [[ -n "${PAI_LITE_STATE_PATH:-}" ]]; then
+    echo "$PAI_LITE_STATE_PATH"
+    return 0
+  fi
+
+  # 2. Try to read from pointer config
+  local pointer_config="$HOME/.config/pai-lite/config.yaml"
+  if [[ -f "$pointer_config" ]]; then
+    local state_repo state_path repo_name
+
+    # Parse state_repo (e.g., "lukstafi/self-improve")
+    state_repo=$(awk '/^state_repo:/ { sub(/^[^:]+:[[:space:]]*/, ""); print; exit }' "$pointer_config")
+
+    # Parse state_path (default: "harness")
+    state_path=$(awk '/^state_path:/ { sub(/^[^:]+:[[:space:]]*/, ""); print; exit }' "$pointer_config")
+    [[ -z "$state_path" ]] && state_path="harness"
+
+    if [[ -n "$state_repo" ]]; then
+      # Extract repo name from slug (e.g., "self-improve" from "lukstafi/self-improve")
+      repo_name="${state_repo##*/}"
+      local derived_path="$HOME/$repo_name/$state_path"
+
+      if [[ -d "$derived_path" ]]; then
+        echo "$derived_path"
+        return 0
+      fi
+    fi
+  fi
+
+  # 3. Fall back to common default
+  local default_path="$HOME/self-improve/harness"
+  if [[ -d "$default_path" ]]; then
+    echo "$default_path"
+    return 0
+  fi
+
+  # Unable to detect - return empty
+  return 1
+}
+
+#------------------------------------------------------------------------------
+# Main Hook Logic
+#------------------------------------------------------------------------------
+
+# Detect state path
+STATE_PATH=$(detect_state_path)
+if [[ -z "$STATE_PATH" ]]; then
+  # No state path found - exit silently
+  exit 0
+fi
+
+QUEUE="$STATE_PATH/tasks/queue.jsonl"
+RESULTS="$STATE_PATH/tasks/results"
+
+# Exit silently if no queue file or empty
+[[ -f "$QUEUE" ]] || exit 0
+[[ -s "$QUEUE" ]] || exit 0
+
+# Check if jq is available (required for parsing)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "pai-lite-on-stop: jq not found, cannot process queue" >&2
+  exit 0
+fi
+
+# Read first request from queue (but don't remove yet)
+request=$(head -n 1 "$QUEUE")
+
+# Parse the action and request ID - validate before dequeuing
+action=$(echo "$request" | jq -r '.action' 2>/dev/null)
+request_id=$(echo "$request" | jq -r '.id' 2>/dev/null)
+
+# Exit without dequeuing if parsing failed or no valid action
+if [[ -z "$action" || "$action" == "null" ]]; then
+  echo "pai-lite-on-stop: invalid request in queue (no action), leaving in queue" >&2
+  exit 0
+fi
+
+# Now that we have a valid action, remove from queue atomically
+tmp="${QUEUE}.tmp"
+tail -n +2 "$QUEUE" > "$tmp" && mv "$tmp" "$QUEUE"
+
+# Ensure results directory exists
+mkdir -p "$RESULTS"
+
+# Export request info for skills to use
+export PAI_LITE_REQUEST_ID="$request_id"
+export PAI_LITE_STATE_PATH="$STATE_PATH"
+export PAI_LITE_RESULTS_DIR="$RESULTS"
+
+# Map action to skill command
+# The output here becomes Claude Code's next input
+case "$action" in
+    briefing)
+        echo "/briefing"
+        ;;
+    suggest)
+        echo "/suggest"
+        ;;
+    analyze-issue)
+        issue=$(echo "$request" | jq -r '.issue' 2>/dev/null)
+        echo "/analyze-issue $issue"
+        ;;
+    elaborate)
+        task=$(echo "$request" | jq -r '.task' 2>/dev/null)
+        echo "/elaborate $task"
+        ;;
+    health-check)
+        echo "/health-check"
+        ;;
+    learn)
+        echo "/learn"
+        ;;
+    sync-learnings)
+        echo "/sync-learnings"
+        ;;
+    techdebt)
+        echo "/techdebt"
+        ;;
+    context-sync)
+        echo "/context-sync"
+        ;;
+    *)
+        # Unknown action - log to stderr and skip
+        echo "pai-lite-on-stop: unknown queue action: $action" >&2
+        exit 0
+        ;;
+esac
+
+# The Mayor skill is responsible for writing results to:
+#   $RESULTS/${request_id}.json
+#
+# Result format:
+# {
+#   "id": "req-1706789012-12345",
+#   "status": "completed",
+#   "timestamp": "2026-02-01T12:30:00Z",
+#   "output": "..."
+# }
+#
+# Skills can use pai_lite_write_result helper if sourcing common.sh,
+# or write the JSON directly.

--- a/templates/mayor/context.md
+++ b/templates/mayor/context.md
@@ -1,0 +1,44 @@
+# Mayor Context
+
+This file contains the Mayor's current understanding and focus areas.
+
+## Current Focus
+
+*Update this section to reflect your current priorities and context.*
+
+- Primary project: [your main project]
+- Current sprint goal: [what you're trying to achieve]
+- Key deadlines: [any hard deadlines]
+
+## Active Workstreams
+
+### [Project 1]
+- **Status**: [in-progress/planning/blocked]
+- **Current phase**: [what's happening now]
+- **Key files**: [important code locations]
+- **Notes**: [anything to remember]
+
+### [Project 2]
+- **Status**: [in-progress/planning/blocked]
+- **Current phase**: [what's happening now]
+- **Notes**: [anything to remember]
+
+## Context Switches
+
+*Track recent context switches to avoid excessive jumping.*
+
+| Date | From | To | Reason |
+|------|------|-----|--------|
+| YYYY-MM-DD | project-a | project-b | deadline pressure |
+
+## User Preferences
+
+*Learned preferences for briefings, suggestions, and communication style.*
+
+- Preferred briefing time: [morning/evening]
+- Notification verbosity: [high/medium/low]
+- Risk tolerance for auto-actions: [conservative/moderate/aggressive]
+
+## Notes
+
+*Anything else the Mayor should remember between sessions.*

--- a/templates/mayor/memory/corrections.md
+++ b/templates/mayor/memory/corrections.md
@@ -1,0 +1,33 @@
+# Corrections Log
+
+This file records corrections and learnings from user feedback. The Mayor updates this file when `/learn` is invoked.
+
+Entries are periodically consolidated into structured memory files via `/sync-learnings`.
+
+---
+
+## Template Entry
+
+```markdown
+## YYYY-MM-DD: [Topic]
+
+**Context**: [What was happening]
+
+**Correction**: [What was wrong and what's correct]
+
+**Before** (wrong):
+[code or approach that was incorrect]
+
+**After** (correct):
+[code or approach that is correct]
+
+**Source**: User feedback / Self-identified / Other
+
+---
+```
+
+## Entries
+
+*New corrections are appended below. Processed entries are moved to corrections-archive.md.*
+
+---

--- a/templates/mayor/memory/projects/example-project.md
+++ b/templates/mayor/memory/projects/example-project.md
@@ -1,0 +1,71 @@
+# [Project Name] Knowledge
+
+*Template for project-specific knowledge. Copy and rename for each project.*
+
+## Overview
+
+- **Repository**: owner/repo
+- **Language**: [OCaml/Python/etc.]
+- **Build system**: [dune/make/npm/etc.]
+
+## Build & Test
+
+```bash
+# Build
+[build command]
+
+# Test
+[test command]
+
+# Lint/Format
+[lint command]
+```
+
+## Directory Structure
+
+```
+repo/
+├── lib/           # [description]
+├── bin/           # [description]
+├── test/          # [description]
+└── ...
+```
+
+## Key Modules
+
+### [Module 1]
+- **Location**: `lib/module1.ml`
+- **Purpose**: [what it does]
+- **Entry points**: [main functions]
+
+### [Module 2]
+- **Location**: `lib/module2.ml`
+- **Purpose**: [what it does]
+
+## Common Issues
+
+*Known gotchas, quirks, and things to watch for.*
+
+- [Issue 1]: [description and how to handle]
+- [Issue 2]: [description and how to handle]
+
+## Dependencies
+
+- [Dependency 1]: [what it's used for]
+- [Dependency 2]: [what it's used for]
+
+## Coding Conventions
+
+- [Convention 1]
+- [Convention 2]
+
+## Related Tasks
+
+*Tasks related to this project.*
+
+- task-XXX: [title]
+- task-YYY: [title]
+
+## Notes
+
+*Project-specific learnings and notes.*

--- a/templates/mayor/memory/tools.md
+++ b/templates/mayor/memory/tools.md
@@ -1,0 +1,125 @@
+# CLI Tools Knowledge
+
+This file contains learned knowledge about CLI tools used in pai-lite workflows.
+
+## yq (YAML processor)
+
+### Usage Patterns
+- Single file: `yq eval '.key' file.yaml` or `yq e '.key' file.yaml`
+- Multiple files slurp: `yq eval-all '.' *.yaml` or `yq ea '.' *.yaml`
+- Output as JSON: `yq -o json file.yaml`
+- Output as YAML (explicit): `yq -o yaml file.yaml`
+
+### Gotchas
+- *Add gotchas learned from corrections here*
+
+### Examples
+```bash
+# Extract frontmatter from task files
+yq eval-all '.' tasks/*.md 2>/dev/null
+
+# Get specific field
+yq e '.status' task-042.md
+```
+
+---
+
+## jq (JSON processor)
+
+### Usage Patterns
+- Basic filter: `jq '.key' file.json`
+- Multiple values: `jq '.key1, .key2' file.json`
+- Raw output: `jq -r '.key' file.json`
+- Slurp array: `jq -s '.' *.json`
+
+### Gotchas
+- *Add gotchas learned from corrections here*
+
+### Examples
+```bash
+# Filter ready tasks
+jq '[.[] | select(.status == "ready")]' tasks.json
+
+# Sort by priority
+jq 'sort_by(.priority)' tasks.json
+```
+
+---
+
+## tsort (Topological sort)
+
+### Usage
+- Input: pairs of dependencies, one per line (format: `A B` means A must come before B)
+- Output: sorted list
+- Detects cycles (exits with error)
+
+### Example
+```bash
+# Check for dependency cycles
+echo "task-1 task-2
+task-2 task-3" | tsort
+
+# Will fail if cycle exists
+```
+
+---
+
+## gh (GitHub CLI)
+
+### Common Commands
+```bash
+# Issues
+gh issue list --repo owner/repo
+gh issue view 123 --json title,body,labels
+
+# PRs
+gh pr list --repo owner/repo
+gh pr view 123 --json state,reviews
+
+# API
+gh api repos/owner/repo/issues/123/comments
+```
+
+### Gotchas
+- *Add gotchas learned from corrections here*
+
+---
+
+## git
+
+### Useful Commands
+```bash
+# Recent commits
+git log --since="1 day ago" --oneline
+
+# Check if in worktree
+test -f .git  # True if worktree (file), false if main repo (directory)
+
+# Get main repo from worktree
+cat .git | grep gitdir | cut -d' ' -f2-
+```
+
+---
+
+## tmux
+
+### Common Commands
+```bash
+# Sessions
+tmux new-session -d -s name -c /path
+tmux has-session -t name
+tmux kill-session -t name
+tmux ls
+
+# Send commands
+tmux send-keys -t session "command" C-m
+
+# Capture output
+tmux capture-pane -t session -p -S -100
+```
+
+---
+
+## Add New Tools
+
+*When learning about a new tool, add a section following the pattern above.*

--- a/templates/mayor/memory/workflows.md
+++ b/templates/mayor/memory/workflows.md
@@ -1,0 +1,122 @@
+# Workflow Patterns
+
+This file contains learned workflow patterns for common pai-lite operations.
+
+## Task Elaboration
+
+When elaborating a task from a high-level description to detailed spec:
+
+1. **Read the task file and linked GitHub issue**
+   - Understand the goal and acceptance criteria
+   - Note any constraints or preferences mentioned
+
+2. **Check related tasks for context**
+   - Read blocking/blocked-by tasks
+   - Understand where this fits in the larger picture
+
+3. **Identify specific files to modify**
+   - Use grep/glob to find relevant code
+   - Note entry points and key functions
+
+4. **Break into subtasks with acceptance criteria**
+   - Each subtask should be independently testable
+   - Include edge cases in criteria
+
+5. **Add implementation hints**
+   - Code pointers (file:line)
+   - Similar existing implementations
+   - Potential gotchas
+
+---
+
+## Issue Analysis
+
+When analyzing a GitHub issue to create a task:
+
+1. **Assess actionability**
+   - Is this a bug, feature, or discussion?
+   - Is there enough information to act?
+   - Does it need clarification first?
+
+2. **Extract dependencies**
+   - What existing tasks does this relate to?
+   - What must be done first?
+   - What does this unblock?
+
+3. **Infer priority**
+   - Check labels and milestone
+   - Consider user impact
+   - Consider technical urgency
+
+4. **Create task with context**
+   - Link back to issue
+   - Summarize in your own words
+   - Add technical notes
+
+---
+
+## Morning Briefing
+
+When generating a morning briefing:
+
+1. **Current state**
+   - What's running in slots?
+   - What phase are active tasks in?
+
+2. **Ready queue**
+   - Priority-sorted tasks with empty blocked_by
+   - Highlight A-priority items
+
+3. **Urgent items**
+   - Deadlines within 7 days
+   - Stalled work (>7 days in-progress)
+   - Blocked high-priority tasks
+
+4. **Suggestion**
+   - What to work on and why
+   - Consider context switching cost
+   - Note alternatives
+
+---
+
+## PR Review Checklist
+
+When reviewing or creating a PR:
+
+- [ ] Tests pass
+- [ ] No new warnings
+- [ ] Documentation updated if needed
+- [ ] Commit messages follow convention
+- [ ] No accidental file inclusions
+- [ ] Changes match the task description
+
+---
+
+## Slot Assignment
+
+When assigning a task to a slot:
+
+1. **Check task readiness**
+   - blocked_by must be empty
+   - Task must have clear acceptance criteria
+
+2. **Choose adapter**
+   - Complex tasks: agent-duo (two agents)
+   - Medium tasks: claude-code (single agent)
+   - Simple tasks: manual or claude-code
+
+3. **Set up context**
+   - Ensure working directory is correct
+   - Create worktree if needed
+   - Note any special setup
+
+4. **Update slot state**
+   - Record task assignment
+   - Set started timestamp
+   - Add initial runtime notes
+
+---
+
+## Add New Workflows
+
+*When a new workflow pattern emerges, document it following the patterns above.*


### PR DESCRIPTION
## Summary
- Add Mayor lifecycle management with session commands (start/stop/status/attach/logs)
- Create queue-driven stop hook with state path detection for automation integration
- Add 9 skill files for Mayor capabilities (briefing, suggest, analyze-issue, elaborate, health-check, learn, sync-learnings, techdebt, context-sync)
- Add Mayor memory templates for institutional learning (context.md, corrections.md, tools.md, workflows.md, projects/)
- Update briefing/status commands to integrate with Mayor
- Add nested YAML config lookup for mayor.ttyd_port configuration

## Test plan
- [ ] Run `pai-lite init --hooks` and verify skills directory is copied
- [ ] Run `pai-lite mayor start` to create tmux session
- [ ] Run `pai-lite mayor status` to verify session status
- [ ] Run `pai-lite mayor stop` to terminate session
- [ ] Verify stop hook can detect state path from config

🤖 Generated with [Claude Code](https://claude.com/claude-code)