### PR TITLE
Limit preemption by project

### DIFF
--- a/skills/ludics-preempt.md
+++ b/skills/ludics-preempt.md
@@ -26,11 +26,15 @@ This skill is invoked when:
    ```
 
 3. **Check for existing preemptions**:
-   Look in `harness/mag/preempted/` for any existing stash files.
-   Never preempt a slot that already has a stash (no double preemption).
+   Look in `harness/mag/preempted/` for existing stash files.
+   Never preempt a slot that already has a stash (no double preemption for that slot).
+   Treat the effective cap as **one active preemption per project**, not one globally.
+   A priority task from project A must not block preempting a slot for project B.
 
 4. **Evaluate each slot** using these criteria:
-   - **Never preempt another priority project task** — check if the slot's current task belongs to a priority project
+   - **Never create a second active preemption for the same project** — if the incoming task's project already has a queued or stashed preemption, stop and reset the task to `ready`
+   - **Avoid preempting another priority task from the same project** — check whether the slot's current task belongs to the incoming task's project
+   - **A different priority project is not a global blocker** — if project A already has a preempted slot, project B may still preempt one of its own
    - **Prefer lower-priority tasks** — tasks with priority C over B over A
    - **Prefer tasks with less time invested** — recently started tasks are cheaper to pause
    - **Consider context** — prefer preempting tasks in unrelated contexts
@@ -53,7 +57,7 @@ This skill is invoked when:
    ```
 
    ### On failure / no suitable slot
-   If no slot can be preempted (e.g., all run priority project tasks), reset the task status so it can be reconsidered later. The task status was set to `preempt-queued` when the request was queued; update the task file's `status:` field back to `ready` if preemption doesn't happen.
+   If no slot can be preempted (e.g., every candidate would create a second preemption for the same project, or every slot already has a stash), reset the task status so it can be reconsidered later. The task status was set to `preempt-queued` when the request was queued; update the task file's `status:` field back to `ready` if preemption doesn't happen.
 
 ## Output Format
 

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tasksQueuePreemptions } from "./sync.ts";
+import { emptyBlock, writeSlotFile } from "../slots/markdown.ts";
+
+const TMP = join(import.meta.dir, ".test-tmp-sync");
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: alpha
+    repo: owner/alpha
+    priority: true
+  - name: beta
+    repo: owner/beta
+    priority: true
+mag:
+  autonomy_level:
+    preempt_slots: auto
+`);
+  return configPath;
+}
+
+function writeTask(tasksDir: string, id: string, project: string, status: string): void {
+  writeFileSync(join(tasksDir, `${id}.md`), `---
+id: ${id}
+title: "${id}"
+project: ${project}
+status: ${status}
+priority: A
+elaborated: true
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+}
+
+function readQueueTasks(queueFile: string): string[] {
+  return readFileSync(queueFile, "utf-8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { task?: string })
+    .map((entry) => entry.task ?? "");
+}
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  mkdirSync(TMP, { recursive: true });
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+
+  if (ORIGINAL_CONFIG === undefined) {
+    delete process.env.LUDICS_CONFIG;
+  } else {
+    process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  }
+
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("tasksQueuePreemptions", () => {
+  test("queues one preemption per priority project even when those projects already occupy slots", () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+
+    writeTask(tasksDir, "task-alpha-active", "alpha", "in-progress");
+    writeTask(tasksDir, "task-beta-active", "beta", "in-progress");
+    writeTask(tasksDir, "task-alpha-ready", "alpha", "ready");
+    writeTask(tasksDir, "task-beta-ready", "beta", "ready");
+
+    const slots = new Map<number, string>();
+    slots.set(1, emptyBlock(1).replace("**Process:** (empty)", "**Process:** alpha active").replace("**Task:** null", "**Task:** task-alpha-active"));
+    slots.set(2, emptyBlock(2).replace("**Process:** (empty)", "**Process:** beta active").replace("**Task:** null", "**Task:** task-beta-active"));
+    writeSlotFile(join(harness, "slots.md"), slots, 2);
+
+    tasksQueuePreemptions();
+
+    const queuedTasks = readQueueTasks(join(harness, "mag", "queue.jsonl"));
+    expect(queuedTasks).toEqual(["task-alpha-ready", "task-beta-ready"]);
+    expect(readFileSync(join(tasksDir, "task-alpha-ready.md"), "utf-8")).toContain("status: preempt-queued");
+    expect(readFileSync(join(tasksDir, "task-beta-ready.md"), "utf-8")).toContain("status: preempt-queued");
+  });
+
+  test("keeps the limit per project when one project already has a stashed preemption", () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const preemptDir = join(harness, "mag", "preempted");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(preemptDir, { recursive: true });
+
+    writeTask(tasksDir, "task-alpha-current", "alpha", "in-progress");
+    writeTask(tasksDir, "task-alpha-next", "alpha", "ready");
+    writeTask(tasksDir, "task-beta-next", "beta", "ready");
+
+    const slots = new Map<number, string>();
+    slots.set(1, emptyBlock(1).replace("**Process:** (empty)", "**Process:** alpha current").replace("**Task:** null", "**Task:** task-alpha-current"));
+    slots.set(2, emptyBlock(2).replace("**Process:** (empty)", "**Process:** something else").replace("**Task:** null", "**Task:** task-other"));
+    writeSlotFile(join(harness, "slots.md"), slots, 2);
+
+    writeFileSync(join(preemptDir, "slot-1.json"), JSON.stringify({
+      slotNum: 1,
+      previousTask: "task-old",
+      previousProcess: "old task",
+      previousMode: "manual",
+      previousSession: "1",
+      previousPath: "/tmp",
+      previousStarted: "2026-03-06T10:00:00Z",
+      previousAdapterArgs: "",
+      preemptedAt: "2026-03-06T10:01:00Z",
+      preemptingTask: "task-alpha-current",
+    }) + "\n");
+
+    tasksQueuePreemptions();
+
+    const queuedTasks = readQueueTasks(join(harness, "mag", "queue.jsonl"));
+    expect(queuedTasks).toEqual(["task-beta-next"]);
+    expect(readFileSync(join(tasksDir, "task-alpha-next.md"), "utf-8")).toContain("status: ready");
+    expect(readFileSync(join(tasksDir, "task-beta-next.md"), "utf-8")).toContain("status: preempt-queued");
+  });
+});

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { loadConfigSync, harnessDir, priorityProjects, preemptAutonomy, slotsCount } from "../config.ts";
 import { slotsFilePath } from "../config.ts";
 import { parseSlotBlocks, getProcess, getTask } from "../slots/markdown.ts";
+import { listStashes } from "../slots/preempt.ts";
 import { writeTaskFile, updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter } from "./markdown.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
@@ -234,6 +235,54 @@ function normalizeState(value: string | null | undefined): string {
 
 function normalizeStateReason(value: string | null | undefined): string {
   return normalizeState(value).replace(/-/g, "_");
+}
+
+function readTaskProjectName(tasksDir: string, taskId: string): string {
+  if (!taskId) return "";
+  const taskFile = join(tasksDir, `${taskId}.md`);
+  if (!existsSync(taskFile)) return "";
+  const taskContent = readFileSync(taskFile, "utf-8");
+  const projectMatch = taskContent.match(/^project:\s*(.+)$/m);
+  return projectMatch ? projectMatch[1]!.trim() : "";
+}
+
+function collectProjectsWithQueuedPreemption(tasksDir: string, queueContent: string, priProjects: string[]): Set<string> {
+  const projects = new Set<string>();
+
+  for (const stash of listStashes()) {
+    const project = readTaskProjectName(tasksDir, stash.preemptingTask);
+    if (project && priProjects.includes(project)) {
+      projects.add(project);
+    }
+  }
+
+  for (const line of queueContent.split("\n")) {
+    if (!line.includes('"action":"preempt"')) continue;
+    try {
+      const req = JSON.parse(line) as Record<string, unknown>;
+      const qTask = String(req.task ?? "");
+      const project = readTaskProjectName(tasksDir, qTask);
+      if (project && priProjects.includes(project)) {
+        projects.add(project);
+      }
+    } catch {
+      // skip malformed queue lines
+    }
+  }
+
+  const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
+  for (const file of files) {
+    const content = readFileSync(join(tasksDir, file), "utf-8");
+    const statusMatch = content.match(/^status:\s*(.+)$/m);
+    if (!statusMatch || statusMatch[1]!.trim() !== "preempt-queued") continue;
+    const projectMatch = content.match(/^project:\s*(.+)$/m);
+    const project = projectMatch ? projectMatch[1]!.trim() : "";
+    if (project && priProjects.includes(project)) {
+      projects.add(project);
+    }
+  }
+
+  return projects;
 }
 
 function closedStatusFromIssue(issue: GhIssueState): "done" | "abandoned" | null {
@@ -678,39 +727,10 @@ function tasksQueuePreemptions(): void {
     alreadyQueued = readFileSync(queueFile, "utf-8");
   }
 
-  // Collect projects that already have a task in-flight (in-progress or preempted in a slot)
-  // to avoid thrashing with multiple preemptions for the same project
-  const projectsInFlight = new Set<string>();
-  for (let i = 1; i <= count; i++) {
-    const block = blocks.get(i);
-    if (!block) continue;
-    const slotTaskId = getTask(block).trim();
-    if (!slotTaskId || slotTaskId === "null") continue;
-    const taskFile = join(tasksDir, `${slotTaskId}.md`);
-    if (!existsSync(taskFile)) continue;
-    const taskContent = readFileSync(taskFile, "utf-8");
-    const pm = taskContent.match(/^project:\s*(.+)$/m);
-    if (pm && priProjects.includes(pm[1]!.trim())) {
-      projectsInFlight.add(pm[1]!.trim());
-    }
-  }
-
-  // Also count projects already queued for preemption
-  const queuedLines = alreadyQueued.split("\n").filter((l) => l.includes('"action":"preempt"'));
-  for (const line of queuedLines) {
-    try {
-      const req = JSON.parse(line) as Record<string, unknown>;
-      const qTask = String(req.task ?? "");
-      if (!qTask) continue;
-      const taskFile = join(tasksDir, `${qTask}.md`);
-      if (!existsSync(taskFile)) continue;
-      const taskContent = readFileSync(taskFile, "utf-8");
-      const pm = taskContent.match(/^project:\s*(.+)$/m);
-      if (pm && priProjects.includes(pm[1]!.trim())) {
-        projectsInFlight.add(pm[1]!.trim());
-      }
-    } catch { /* skip */ }
-  }
+  // Limit active preemptions per project, not globally. A priority project already
+  // occupying a normal slot should not block another project from getting one
+  // preempted slot of its own.
+  const projectsInFlight = collectProjectsWithQueuedPreemption(tasksDir, alreadyQueued, priProjects);
 
   const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
   let queued = 0;


### PR DESCRIPTION
Track active slot preemptions per project instead of treating any priority project already in a slot as globally blocking.

Align the /ludics-preempt skill with the same policy and add regression coverage for cross-project and same-project preemption limits.

Co-Authored-By: Codex <noreply@openai.com>