### PR TITLE
Add proposal viewer page and link from dashboard

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -28,6 +28,8 @@ interface SlotJson {
   terminals: Record<string, string> | null;
   preempted: boolean;
   preemptedTask: string | null;
+  hasProposal: boolean;
+  proposalLink: string | null;
 }
 
 function lookupTaskContent(taskId: string): string | null {
@@ -67,6 +69,21 @@ function discoverTtydUrls(): Map<string, string> {
     // ignore — pgrep may not be available or ttyd may not be running
   }
   return result;
+}
+
+function lookupTaskHasProposal(taskId: string): boolean {
+  const tasksDir = join(harnessDir(), "tasks");
+  const taskFile = join(tasksDir, taskId + ".md");
+  if (!existsSync(taskFile)) return false;
+  try {
+    const content = readFileSync(taskFile, "utf-8");
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fmMatch) return false;
+    const data = (YAML.parse(fmMatch[1]!) ?? {}) as Record<string, unknown>;
+    return hasNonNullProposal(data.proposal);
+  } catch {
+    return false;
+  }
 }
 
 function generateSlots(): SlotJson[] {
@@ -117,6 +134,8 @@ function generateSlots(): SlotJson[] {
 
     const taskId = empty ? null : getTask(block).trim() || null;
     const taskContent = taskId && taskId !== "null" ? lookupTaskContent(taskId) : null;
+    const slotHasProposal = taskId && taskId !== "null" ? lookupTaskHasProposal(taskId) : false;
+    const slotProposalLink = slotHasProposal && taskId ? `/proposal.html?task=${encodeURIComponent(taskId)}` : null;
 
     // Check for preemption stash
     const stash = readStash(num);
@@ -133,6 +152,8 @@ function generateSlots(): SlotJson[] {
       terminals: empty ? null : Object.keys(terminals).length > 0 ? terminals : null,
       preempted: stash !== null,
       preemptedTask: stash?.previousTask ?? null,
+      hasProposal: slotHasProposal,
+      proposalLink: slotProposalLink,
     });
   }
 
@@ -358,7 +379,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
     const subtreeHasActiveProposal = hasActiveProposal || descendantHasActiveProposal;
     const highlighted = !task.isCompleted && subtreeHasActiveProposal;
     const taskFileLink = `/task-files/${encodeURIComponent(task.id)}.md`;
-    const proposalLink = task.proposalPath ? `/proposal-files/${encodeURIComponent(task.id)}.md` : null;
+    const proposalLink = task.proposalPath ? `/proposal.html?task=${encodeURIComponent(task.id)}` : null;
 
     return {
       node: {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -9,6 +9,7 @@ import { parseSlotBlocks, getTask, getPath } from "./slots/markdown.ts";
 import { listSessions, type SessionInfo } from "./adapters/peer-sync.ts";
 import { readSingleFile, readStatusFile, resolveProjectDir, isGitWorktree, getMainRepoFromWorktree } from "./adapters/base.ts";
 import type { AdapterContext } from "./adapters/types.ts";
+import { getUrl } from "./network.ts";
 
 function notificationLogFile(): string {
   return join(harnessDir(), "journal", "notifications.jsonl");
@@ -851,6 +852,13 @@ export function notifyProposal(
 
   const token = getToken();
   const project = taskId.split("-").slice(0, -1).join("-") || "unknown";
+
+  // Compute dashboard view URL for the proposal
+  const config = loadConfigSync();
+  const dashboardPort = config.dashboard?.port ?? 7678;
+  const dashboardBaseUrl = getUrl(dashboardPort);
+  const proposalViewUrl = `${dashboardBaseUrl}/proposal.html?task=${encodeURIComponent(taskId)}`;
+
   const resolvedPath = resolveProposalFilePath(taskId, filePath);
   if (!resolvedPath) {
     console.error(`ludics: proposal file not found for attachment (${filePath}); sending notification without attachment`);
@@ -864,37 +872,54 @@ export function notifyProposal(
       proposalText = "";
     }
   }
-  const inlineMessage = proposalInlineMessage(summary, proposalText, attachmentName);
-  const inlineHeaderMessage = inlineMessage.replace(/\r?\n/g, " ").trim();
   const tagsHeader = `memo,${taskId}`;
 
   const headers: Record<string, string> = {};
   if (token) headers["Authorization"] = `Bearer ${token}`;
-  const actions = inTopic
+
+  // Build "view" action as first action (opens proposal in browser)
+  const viewAction: NtfyAction = {
+    action: "view",
+    label: "view",
+    url: proposalViewUrl,
+  };
+
+  const launchActions = inTopic
     ? buildProposalNotificationActions(taskId, project, inTopic, headers)
     : [];
-  const actionBatches = chunkNotificationActions(actions, NTFY_MAX_ACTIONS);
+  const allActions = [viewAction, ...launchActions];
+  const actionBatches = chunkNotificationActions(allActions, NTFY_MAX_ACTIONS);
   const firstActionBatch = actionBatches[0] ?? [];
 
+  // When we have a dashboard view URL, use a simpler message body
+  const simpleMessage = summary.trim()
+    ? `Proposal for ${taskId}${slotSuffix}: ${summary.trim()}`
+    : `Proposal for ${taskId}${slotSuffix}`;
+
+  // Use dashboard view URL message when available; file attachment is a fallback
   let first: { httpCode: string; stderr: string; body: string };
-  if (resolvedPath) {
+  first = notifyPublishMessage(
+    outTopic,
+    simpleMessage,
+    token,
+    proposalTitle,
+    3,
+    tagsHeader,
+    firstActionBatch,
+  );
+
+  if (first.httpCode !== "200" && resolvedPath) {
+    // Fallback: attach the file
+    const detail = first.body || first.stderr;
+    console.error(`ludics: ntfy.sh proposal notification failed (HTTP ${first.httpCode})${detail ? `: ${detail}` : ""}, retrying with file attachment`);
+    const fallbackMessage = proposalInlineMessage(summary, proposalText, attachmentName).replace(/\r?\n/g, " ").trim();
     first = notifyPublishFile(
       outTopic,
       resolvedPath,
       attachmentName,
       token,
       proposalTitle,
-      inlineHeaderMessage,
-      3,
-      tagsHeader,
-      firstActionBatch,
-    );
-  } else {
-    first = notifyPublishMessage(
-      outTopic,
-      inlineMessage,
-      token,
-      proposalTitle,
+      fallbackMessage,
       3,
       tagsHeader,
       firstActionBatch,
@@ -903,20 +928,7 @@ export function notifyProposal(
 
   if (first.httpCode !== "200") {
     const detail = first.body || first.stderr;
-    console.error(`ludics: ntfy.sh proposal notification failed (HTTP ${first.httpCode})${detail ? `: ${detail}` : ""}, retrying without attachment`);
-    const fallback = notifyPublishMessage(
-      outTopic,
-      `Proposal for ${taskId}${slotSuffix}\n\n${inlineMessage}`,
-      token,
-      proposalTitle,
-      3,
-      tagsHeader,
-      firstActionBatch,
-    );
-    if (fallback.httpCode !== "200") {
-      const fallbackDetail = fallback.body || fallback.stderr;
-      console.error(`ludics: ntfy.sh proposal fallback failed (HTTP ${fallback.httpCode})${fallbackDetail ? `: ${fallbackDetail}` : ""}, logged locally`);
-    }
+    console.error(`ludics: ntfy.sh proposal notification failed (HTTP ${first.httpCode})${detail ? `: ${detail}` : ""}, logged locally`);
     return;
   }
 

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -127,6 +127,9 @@ function renderSlots(slots) {
                     }
                 }
             }
+            if (slot.proposalLink) {
+                links += `<a href="${slot.proposalLink}">proposal</a>`;
+            }
             setHtmlPreserveScroll(linksDiv, links);
         }
     }

--- a/templates/dashboard/proposal.html
+++ b/templates/dashboard/proposal.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ludics Proposal</title>
+    <link rel="stylesheet" href="style.css">
+    <style>
+        /* Proposal-specific styles (mirrors briefing styles) */
+        .briefing-container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 1.5rem 2rem;
+        }
+
+        .briefing-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+        }
+
+        .briefing-date {
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+        }
+
+        .briefing-content {
+            background-color: var(--bg-panel);
+            border-radius: 8px;
+            border: 1px solid var(--border);
+            padding: 2rem;
+            line-height: 1.7;
+        }
+
+        .briefing-content h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            padding-bottom: 0.75rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .briefing-content h2 {
+            font-size: 1.125rem;
+            font-weight: 600;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+            color: var(--accent);
+        }
+
+        .briefing-content h3 {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-top: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .briefing-content p {
+            margin-bottom: 0.75rem;
+            color: var(--text-primary);
+        }
+
+        .briefing-content ul, .briefing-content ol {
+            margin-bottom: 0.75rem;
+            padding-left: 1.5rem;
+        }
+
+        .briefing-content li {
+            margin-bottom: 0.375rem;
+            color: var(--text-primary);
+        }
+
+        .briefing-content strong {
+            color: var(--text-primary);
+            font-weight: 600;
+        }
+
+        .briefing-content code {
+            background-color: var(--bg-secondary);
+            padding: 0.125rem 0.375rem;
+            border-radius: 3px;
+            font-size: 0.875rem;
+        }
+
+        .briefing-content pre {
+            background-color: var(--bg-secondary);
+            padding: 1rem;
+            border-radius: 6px;
+            overflow-x: auto;
+            margin-bottom: 0.75rem;
+        }
+
+        .briefing-content pre code {
+            background-color: transparent;
+            padding: 0;
+        }
+
+        .briefing-content table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 0.75rem;
+            font-size: 0.875rem;
+        }
+
+        .briefing-content th {
+            background-color: var(--bg-secondary);
+            font-weight: 600;
+            text-align: left;
+            padding: 0.5rem 0.75rem;
+            border: 1px solid var(--border);
+        }
+
+        .briefing-content td {
+            padding: 0.5rem 0.75rem;
+            border: 1px solid var(--border);
+        }
+
+        .briefing-content tr:nth-child(even) td {
+            background-color: rgba(255,255,255,0.03);
+        }
+
+        .briefing-placeholder {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 300px;
+            color: var(--text-secondary);
+        }
+
+        .briefing-placeholder .icon {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+            opacity: 0.5;
+        }
+
+        .briefing-placeholder .text {
+            font-size: 1rem;
+            opacity: 0.7;
+        }
+
+        .briefing-placeholder .hint {
+            font-size: 0.875rem;
+            opacity: 0.5;
+            margin-top: 0.5rem;
+        }
+
+        .proposal-task-id {
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="nav-links">
+            <h1>ludics</h1>
+            <a href="index.html">Dashboard</a>
+            <a href="terminal.html">Mag</a>
+            <a href="#" id="t3code-link">t3code</a>
+            <a href="ntfy.html">ntfy</a>
+            <a href="tasks.html">Tasks</a>
+            <a href="briefing.html">Briefing</a>
+        </div>
+        <div class="status-bar">
+            <span id="last-update">Last update: --</span>
+            <span id="connection-status" class="connected">Connected</span>
+        </div>
+    </header>
+
+    <main class="briefing-container">
+        <div class="briefing-header">
+            <span class="proposal-task-id" id="proposal-task-id"></span>
+        </div>
+        <div class="briefing-content" id="proposal-content">
+            <div class="briefing-placeholder">
+                <span class="icon">&#x1F4C4;</span>
+                <span class="text">Loading proposal...</span>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <p>ludics v0.1 | <a href="https://github.com/lukstafi/ludics">GitHub</a></p>
+    </footer>
+
+    <script>
+        // Read task ID from query parameter
+        const params = new URLSearchParams(window.location.search);
+        const taskId = params.get('task') || '';
+
+        if (taskId) {
+            document.title = `ludics Proposal: ${taskId}`;
+            const taskIdEl = document.getElementById('proposal-task-id');
+            if (taskIdEl) taskIdEl.textContent = taskId;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchProposal();
+        });
+
+        async function fetchProposal() {
+            const container = document.getElementById('proposal-content');
+            if (!container) return;
+
+            if (!taskId) {
+                container.innerHTML = `
+                    <div class="briefing-placeholder">
+                        <span class="icon">&#x1F4C4;</span>
+                        <span class="text">No task specified</span>
+                        <span class="hint">Use ?task=TASK-ID in the URL</span>
+                    </div>
+                `;
+                return;
+            }
+
+            try {
+                const response = await fetch(`/proposal-files/${encodeURIComponent(taskId)}.md`);
+                if (response.status === 404) {
+                    container.innerHTML = `
+                        <div class="briefing-placeholder">
+                            <span class="icon">&#x1F4C4;</span>
+                            <span class="text">Proposal not found</span>
+                            <span class="hint">No proposal file available for task ${escapeHtml(taskId)}</span>
+                        </div>
+                    `;
+                    setConnectionStatus(true);
+                    updateTimestamp();
+                    return;
+                }
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const text = await response.text();
+                container.innerHTML = markdownToHtml(text);
+                updateTimestamp();
+                setConnectionStatus(true);
+            } catch (error) {
+                console.warn('Failed to fetch proposal:', error);
+                container.innerHTML = `
+                    <div class="briefing-placeholder">
+                        <span class="icon">&#x26A0;</span>
+                        <span class="text">Failed to load proposal</span>
+                        <span class="hint">${escapeHtml(String(error))}</span>
+                    </div>
+                `;
+                setConnectionStatus(false);
+            }
+        }
+
+        /**
+         * Simple markdown to HTML converter.
+         * Handles: headings, bold, italic, code, lists, paragraphs, horizontal rules.
+         */
+        function markdownToHtml(md) {
+            if (!md) return '';
+
+            const lines = md.split('\n');
+            let html = '';
+            let inList = null; // 'ul' or 'ol'
+            let inPre = false;
+            let preContent = '';
+
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+
+                // Fenced code blocks
+                if (line.startsWith('```')) {
+                    if (inPre) {
+                        html += '<pre><code>' + escapeHtml(preContent.trimEnd()) + '</code></pre>\n';
+                        preContent = '';
+                        inPre = false;
+                    } else {
+                        if (inList) { html += `</${inList}>\n`; inList = null; }
+                        inPre = true;
+                    }
+                    continue;
+                }
+                if (inPre) {
+                    preContent += line + '\n';
+                    continue;
+                }
+
+                // Tables: detect a pipe-delimited line followed by a separator line
+                if (line.includes('|') && i + 1 < lines.length && lines[i + 1].match(/^\|?[\s-]+\|[\s-|]+$/)) {
+                    if (inList) { html += `</${inList}>\n`; inList = null; }
+                    // Parse header row
+                    const headerCells = parseTableRow(line);
+                    // Skip separator line
+                    i++;
+                    // Collect body rows
+                    const bodyRows = [];
+                    while (i + 1 < lines.length && lines[i + 1].includes('|') && !lines[i + 1].match(/^\s*$/)) {
+                        i++;
+                        bodyRows.push(parseTableRow(lines[i]));
+                    }
+                    // Render table
+                    html += '<table>\n<thead><tr>';
+                    for (const cell of headerCells) {
+                        html += '<th>' + inlineFormat(cell) + '</th>';
+                    }
+                    html += '</tr></thead>\n<tbody>\n';
+                    for (const row of bodyRows) {
+                        html += '<tr>';
+                        for (const cell of row) {
+                            html += '<td>' + inlineFormat(cell) + '</td>';
+                        }
+                        html += '</tr>\n';
+                    }
+                    html += '</tbody></table>\n';
+                    continue;
+                }
+
+                // Close list if current line is not a list item
+                if (inList && !line.match(/^(\s*[-*]|\s*\d+\.)\s/)) {
+                    html += `</${inList}>\n`;
+                    inList = null;
+                }
+
+                // Headings
+                if (line.startsWith('### ')) {
+                    html += '<h3>' + inlineFormat(line.slice(4)) + '</h3>\n';
+                    continue;
+                }
+                if (line.startsWith('## ')) {
+                    html += '<h2>' + inlineFormat(line.slice(3)) + '</h2>\n';
+                    continue;
+                }
+                if (line.startsWith('# ')) {
+                    html += '<h1>' + inlineFormat(line.slice(2)) + '</h1>\n';
+                    continue;
+                }
+
+                // Horizontal rule
+                if (line.match(/^---+$/)) {
+                    html += '<hr>\n';
+                    continue;
+                }
+
+                // Unordered list
+                if (line.match(/^\s*[-*]\s/)) {
+                    if (inList !== 'ul') {
+                        if (inList) html += `</${inList}>\n`;
+                        html += '<ul>\n';
+                        inList = 'ul';
+                    }
+                    html += '<li>' + inlineFormat(line.replace(/^\s*[-*]\s/, '')) + '</li>\n';
+                    continue;
+                }
+
+                // Ordered list
+                if (line.match(/^\s*\d+\.\s/)) {
+                    if (inList !== 'ol') {
+                        if (inList) html += `</${inList}>\n`;
+                        html += '<ol>\n';
+                        inList = 'ol';
+                    }
+                    html += '<li>' + inlineFormat(line.replace(/^\s*\d+\.\s/, '')) + '</li>\n';
+                    continue;
+                }
+
+                // Empty line
+                if (line.trim() === '') {
+                    continue;
+                }
+
+                // Paragraph
+                html += '<p>' + inlineFormat(line) + '</p>\n';
+            }
+
+            // Close any open list
+            if (inList) html += `</${inList}>\n`;
+            if (inPre) html += '<pre><code>' + escapeHtml(preContent.trimEnd()) + '</code></pre>\n';
+
+            return html;
+        }
+
+        // Parse a markdown table row into cells
+        function parseTableRow(line) {
+            let s = line.trim();
+            if (s.startsWith('|')) s = s.slice(1);
+            if (s.endsWith('|')) s = s.slice(0, -1);
+            return s.split('|').map(c => c.trim());
+        }
+
+        // Inline formatting: bold, italic, code, links
+        function inlineFormat(text) {
+            let s = escapeHtml(text);
+            // Code (backticks) - must come before bold/italic
+            s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+            // Bold
+            s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+            // Italic
+            s = s.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+            // Links
+            s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>');
+            return s;
+        }
+
+        function escapeHtml(str) {
+            if (!str) return '';
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
+        }
+
+        function updateTimestamp() {
+            const el = document.getElementById('last-update');
+            if (el) {
+                el.textContent = `Last update: ${new Date().toLocaleTimeString()}`;
+            }
+        }
+
+        function setConnectionStatus(connected) {
+            const el = document.getElementById('connection-status');
+            if (el) {
+                el.className = connected ? 'connected' : 'disconnected';
+                el.textContent = connected ? 'Connected' : 'Disconnected';
+            }
+        }
+        // Resolve t3code link
+        (async function() {
+            try {
+                const resp = await fetch('data/t3code.json');
+                if (!resp.ok) return;
+                const data = await resp.json();
+                const link = document.getElementById('t3code-link');
+                if (link && data.available && data.webUrl) {
+                    link.href = data.webUrl;
+                    link.title = 't3code Web client';
+                } else if (link) {
+                    link.style.opacity = '0.4';
+                    link.style.pointerEvents = 'none';
+                    link.title = 't3code server not running';
+                }
+            } catch { /* ignore */ }
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add `proposal.html` page that fetches `/proposal-files/{taskId}.md` by `?task=` query param, renders markdown to HTML, and displays it with `.briefing-content` styling
- Extend `SlotJson` with `hasProposal` and `proposalLink` fields; `generateSlots()` calls `lookupTaskHasProposal()` to populate them
- In `dashboard.js`, append a "proposal" link in slot tiles when `slot.proposalLink` is set
- In `notifyProposal()` (`notify.ts`): add a "view" ntfy action button linking to the dashboard proposal page; use concise message body

## Test plan

- [ ] Install dashboard (`ludics dashboard install`) and confirm `proposal.html` is copied
- [ ] Open `/proposal.html?task=TASK-ID` — verify markdown renders correctly
- [ ] On main dashboard, verify slot tiles with proposals show a "proposal" link
- [ ] Send `ludics notify proposal ...` — verify ntfy notification has a "view" button
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)