### PR TITLE
Add relation-affinity tie-breaking to task sorting

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import YAML from "yaml";
 import { harnessDir, slotsFilePath, focusProject, effectivePriority, effectivePriorityValue, milestonesEnabledProjects, milestoneKey } from "./config.ts";
+import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
 
 interface TaskData {
   id: string;
@@ -12,6 +13,7 @@ interface TaskData {
   priority: string;
   deadline: string | null;
   started: string | null;
+  completed: string | null;
   modified: string | null;
   project: string;
   context: string;
@@ -47,6 +49,7 @@ function collectTasks(): TaskData[] {
         priority: String(data.priority ?? "B"),
         deadline: data.deadline ? String(data.deadline) : null,
         started: data.started ? String(data.started) : null,
+        completed: data.completed ? String(data.completed) : null,
         modified: data.modified ? String(data.modified) : null,
         project: String(data.project ?? ""),
         context: String(data.context ?? ""),
@@ -121,6 +124,20 @@ function checkCycle(tasks: TaskData[]): boolean {
   return visited < allNodes.size; // cycle exists if not all visited
 }
 
+function readSlottedTaskIds(): Set<string> {
+  const sFile = slotsFilePath();
+  if (!existsSync(sFile)) return new Set();
+  const content = readFileSync(sFile, "utf-8");
+  const ids = new Set<string>();
+  const re = /^\*\*Task:\*\*\s*(.+)$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const id = m[1]!.trim();
+    if (id && id !== "(empty)" && id !== "null") ids.add(id);
+  }
+  return ids;
+}
+
 export function flowReady(): void {
   const tasks = collectTasks();
 
@@ -132,6 +149,20 @@ export function flowReady(): void {
   // Pre-compute milestones-enabled project set to avoid repeated config reads
   const milestonesProjects = milestonesEnabledProjects();
   const anyMilestones = milestonesProjects.size > 0;
+
+  // Build affinity lookup once for tie-breaking
+  const slottedIds = readSlottedTaskIds();
+  const affinityInputs: AffinityInput[] = tasks.map((t) => ({
+    id: t.id,
+    status: t.status,
+    completed: t.completed,
+    dependencies: {
+      blocks: t.dependencies.blocks ?? [],
+      blocked_by: t.dependencies.blocked_by ?? [],
+      relates_to: t.dependencies.relates_to ?? [],
+    },
+  }));
+  const affinity = buildAffinityLookup(affinityInputs, slottedIds);
 
   const ready = tasks
     .filter(
@@ -150,6 +181,8 @@ export function flowReady(): void {
       // Pass pre-computed fp to avoid O(n log n) config reads during sorting
       const pDiff = effectivePriorityValue(a.priority, a.project, fp) - effectivePriorityValue(b.priority, b.project, fp);
       if (pDiff !== 0) return pDiff;
+      const tDiff = affinity.getTier(a.id) - affinity.getTier(b.id);
+      if (tDiff !== 0) return tDiff;
       const aHas = a.deadline ? 1 : 2;
       const bHas = b.deadline ? 1 : 2;
       if (aHas !== bHas) return aHas - bHas;

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -11,6 +11,7 @@ import { federationShouldRunMag } from "./federation.ts";
 import { journalAppend } from "./journal.ts";
 import { emitEvent } from "./events.ts";
 import { isElaborated } from "./tasks/elaboration.ts";
+import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
 import {
   notifyOutgoing,
   expirePendingRevises,
@@ -1862,57 +1863,61 @@ function maybeFillEmptySlots(): void {
 
   interface Candidate { id: string; priority: string; project: string; milestone?: string; hasDeadline: boolean; deadline: string; effort: string }
   const candidates: Candidate[] = [];
+  const allTasksForAffinity: AffinityInput[] = [];
 
   for (const f of files) {
     const content = readFileSync(join(tasksDir, f), "utf-8");
-    const idMatch = content.match(/^id:\s*(.+)$/m);
-    if (!idMatch) continue;
-    const id = idMatch[1]!.trim();
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fmMatch) continue;
 
+    let fm: Record<string, unknown>;
+    try { fm = YAML.parse(fmMatch[1]!) as Record<string, unknown>; } catch { continue; }
+
+    const id = String(fm.id ?? "").trim();
+    if (!id) continue;
+
+    const status = String(fm.status ?? "ready").trim();
+    const deps = (fm.dependencies as Record<string, unknown>) ?? {};
+
+    // Collect affinity data for ALL tasks (needed for graph construction)
+    allTasksForAffinity.push({
+      id,
+      status,
+      completed: fm.completed ? String(fm.completed) : null,
+      dependencies: {
+        blocks: Array.isArray(deps.blocks) ? deps.blocks as string[] : [],
+        blocked_by: Array.isArray(deps.blocked_by) ? deps.blocked_by as string[] : [],
+        relates_to: Array.isArray(deps.relates_to) ? deps.relates_to as string[] : [],
+      },
+    });
+
+    // Filter for candidates: ready, elaborated, unblocked, not already slotted
     if (tasksInSlots.has(id)) continue;
-
-    const statusMatch = content.match(/^status:\s*(.+)$/m);
-    if (!statusMatch || statusMatch[1]!.trim() !== "ready") continue;
-
+    if (status !== "ready") continue;
     if (!isElaborated(content)) continue;
 
-    // Must not have blocked_by dependencies
-    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-    if (fmMatch) {
-      try {
-        const fm = YAML.parse(fmMatch[1]!) as Record<string, unknown>;
-        const deps = fm.dependencies as Record<string, unknown> | undefined;
-        const blockedBy = deps?.blocked_by;
-        if (Array.isArray(blockedBy) && blockedBy.length > 0) continue;
-      } catch { /* skip parse errors */ }
-    }
+    const blockedBy = deps.blocked_by;
+    if (Array.isArray(blockedBy) && blockedBy.length > 0) continue;
 
-    const priorityMatch = content.match(/^priority:\s*(.+)$/m);
-    const priority = priorityMatch ? priorityMatch[1]!.trim() : "B";
+    const priority = String(fm.priority ?? "B").trim();
+    const project = String(fm.project ?? "").trim();
+    const milestone = fm.milestone ? String(fm.milestone).trim() : undefined;
+    const deadlineRaw = fm.deadline ? String(fm.deadline).trim() : "";
+    const deadline = deadlineRaw && deadlineRaw !== "null" ? deadlineRaw : "";
+    const effort = String(fm.effort ?? "small").trim();
 
-    const projectMatch = content.match(/^project:\s*(.+)$/m);
-    const project = projectMatch ? projectMatch[1]!.trim() : "";
-
-    const milestoneMatch = content.match(/^milestone:\s*(.+)$/m);
-    const milestone = milestoneMatch ? milestoneMatch[1]!.trim() : undefined;
-
-    const deadlineMatch = content.match(/^deadline:\s*(.+)$/m);
-    const deadline = deadlineMatch ? deadlineMatch[1]!.trim() : "";
-
-    const effortMatch = content.match(/^effort:\s*(.+)$/m);
-    const effort = effortMatch ? effortMatch[1]!.trim() : "small";
-
-    candidates.push({ id, priority, project, milestone, hasDeadline: !!deadline && deadline !== "null", deadline, effort });
+    candidates.push({ id, priority, project, milestone, hasDeadline: !!deadline, deadline, effort });
   }
 
   if (candidates.length === 0) return;
 
-  // Sort by: milestone (when enabled) > effective (virtual) priority > deadline presence > deadline date.
-  // Focus-project tasks receive a one-level virtual boost via effectivePriorityValue().
+  // Sort by: milestone (when enabled) > effective (virtual) priority > affinity tier > deadline.
   // Pre-compute fp and milestonesProjects once to avoid repeated config reads inside the sort comparator.
   const fp = focusProject();
   const milestonesProjects = milestonesEnabledProjects();
   const anyMilestones = milestonesProjects.size > 0;
+  // Build affinity lookup once for tie-breaking
+  const affinity = buildAffinityLookup(allTasksForAffinity, tasksInSlots);
   candidates.sort((a, b) => {
     if (anyMilestones) {
       const aMKey = milestoneKey(a.milestone, a.project, milestonesProjects);
@@ -1922,6 +1927,8 @@ function maybeFillEmptySlots(): void {
     }
     const pd = effectivePriorityValue(a.priority, a.project, fp) - effectivePriorityValue(b.priority, b.project, fp);
     if (pd !== 0) return pd;
+    const td = affinity.getTier(a.id) - affinity.getTier(b.id);
+    if (td !== 0) return td;
     if (a.hasDeadline !== b.hasDeadline) return a.hasDeadline ? -1 : 1;
     return (a.deadline || "9999").localeCompare(b.deadline || "9999");
   });

--- a/src/tasks/affinity.test.ts
+++ b/src/tasks/affinity.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect } from "bun:test";
+import { buildAffinityLookup, type AffinityInput } from "./affinity.ts";
+
+function task(id: string, overrides: Partial<AffinityInput> = {}): AffinityInput {
+  return {
+    id,
+    status: "ready",
+    completed: null,
+    dependencies: { blocks: [], blocked_by: [], relates_to: [] },
+    ...overrides,
+  };
+}
+
+describe("buildAffinityLookup", () => {
+  test("chained relates_to closure — slotted propagates through chain", () => {
+    const tasks = [
+      task("A", { dependencies: { blocks: [], blocked_by: [], relates_to: ["B"] } }),
+      task("B", { dependencies: { blocks: [], blocked_by: [], relates_to: ["C"] } }),
+      task("C"),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set(["A"]));
+    expect(lookup.getTier("A")).toBe(1);
+    expect(lookup.getTier("B")).toBe(1);
+    expect(lookup.getTier("C")).toBe(1);
+  });
+
+  test("blocks and blocked_by contribute to components", () => {
+    const tasks = [
+      task("done-task", { status: "done", dependencies: { blocks: ["ready-task"], blocked_by: [], relates_to: [] } }),
+      task("ready-task"),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set());
+    expect(lookup.getTier("ready-task")).toBe(2);
+  });
+
+  test("tier precedence — slotted wins over completed in same component", () => {
+    const tasks = [
+      task("slotted"),
+      task("completed", { status: "done", dependencies: { blocks: [], blocked_by: [], relates_to: ["slotted"] } }),
+      task("related", { dependencies: { blocks: [], blocked_by: [], relates_to: ["completed"] } }),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set(["slotted"]));
+    expect(lookup.getTier("related")).toBe(1);
+    expect(lookup.getTier("completed")).toBe(1);
+  });
+
+  test("no affinity — isolated task is Tier 3", () => {
+    const tasks = [
+      task("isolated"),
+      task("slotted"),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set(["slotted"]));
+    expect(lookup.getTier("isolated")).toBe(3);
+    expect(lookup.getTier("slotted")).toBe(1);
+  });
+
+  test("unknown relation targets tolerated", () => {
+    const tasks = [
+      task("A", { dependencies: { blocks: [], blocked_by: [], relates_to: ["nonexistent"] } }),
+      task("B"),
+    ];
+    // Should not throw
+    const lookup = buildAffinityLookup(tasks, new Set());
+    expect(lookup.getTier("A")).toBe(3);
+    expect(lookup.getTier("B")).toBe(3);
+  });
+
+  test("multiple components — each classified independently", () => {
+    const tasks = [
+      task("slotted", { dependencies: { blocks: [], blocked_by: [], relates_to: ["s-friend"] } }),
+      task("s-friend"),
+      task("done-task", { status: "done", dependencies: { blocks: [], blocked_by: [], relates_to: ["d-friend"] } }),
+      task("d-friend"),
+      task("alone"),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set(["slotted"]));
+    expect(lookup.getTier("s-friend")).toBe(1);
+    expect(lookup.getTier("d-friend")).toBe(2);
+    expect(lookup.getTier("alone")).toBe(3);
+  });
+
+  test("completed via completed field (not status)", () => {
+    const tasks = [
+      task("finished", { completed: "2026-03-20T10:00Z", dependencies: { blocks: [], blocked_by: [], relates_to: ["neighbor"] } }),
+      task("neighbor"),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set());
+    expect(lookup.getTier("neighbor")).toBe(2);
+  });
+
+  test("blocked_by edges connect tasks", () => {
+    const tasks = [
+      task("blocker", { status: "done" }),
+      task("blocked", { dependencies: { blocks: [], blocked_by: ["blocker"], relates_to: [] } }),
+    ];
+    const lookup = buildAffinityLookup(tasks, new Set());
+    expect(lookup.getTier("blocked")).toBe(2);
+  });
+});

--- a/src/tasks/affinity.ts
+++ b/src/tasks/affinity.ts
@@ -1,0 +1,103 @@
+// Relation-affinity helper — computes connected components over task relation
+// edges and classifies each task into affinity tiers based on whether its
+// component contains a slotted or completed task.
+
+export interface AffinityInput {
+  id: string;
+  status: string;
+  completed: string | null;
+  dependencies: {
+    blocks: string[];
+    blocked_by: string[];
+    relates_to: string[];
+  };
+}
+
+export interface AffinityLookup {
+  getTier(taskId: string): 1 | 2 | 3;
+}
+
+// --- Union-Find with path compression and union-by-rank ---
+
+function makeUnionFind() {
+  const parent = new Map<string, string>();
+  const rank = new Map<string, number>();
+
+  function find(x: string): string {
+    if (!parent.has(x)) { parent.set(x, x); rank.set(x, 0); }
+    let root = x;
+    while (parent.get(root) !== root) root = parent.get(root)!;
+    // path compression
+    let cur = x;
+    while (cur !== root) { const next = parent.get(cur)!; parent.set(cur, root); cur = next; }
+    return root;
+  }
+
+  function union(a: string, b: string): void {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) return;
+    const rA = rank.get(ra) ?? 0;
+    const rB = rank.get(rb) ?? 0;
+    if (rA < rB) { parent.set(ra, rb); }
+    else if (rA > rB) { parent.set(rb, ra); }
+    else { parent.set(rb, ra); rank.set(ra, rA + 1); }
+  }
+
+  return { find, union };
+}
+
+function isCompletedTask(t: AffinityInput): boolean {
+  if (t.status === "done" || t.status === "abandoned") return true;
+  const c = (t.completed ?? "").trim().toLowerCase();
+  return !!c && c !== "null";
+}
+
+/**
+ * Build an affinity lookup from all tasks and the set of currently slotted task IDs.
+ *
+ * The undirected relation graph includes edges from `relates_to`, `blocks`, and
+ * `blocked_by`. Connected components are computed via union-find, and each
+ * component is classified:
+ *   - Tier 1 if it contains any slotted task
+ *   - Tier 2 if it contains any completed/abandoned task (but no slotted task)
+ *   - Tier 3 otherwise
+ */
+export function buildAffinityLookup(
+  tasks: AffinityInput[],
+  slottedTaskIds: Set<string>,
+): AffinityLookup {
+  const uf = makeUnionFind();
+
+  // Build undirected graph via union-find
+  for (const t of tasks) {
+    for (const other of t.dependencies.relates_to) { uf.union(t.id, other); }
+    for (const other of t.dependencies.blocks) { uf.union(t.id, other); }
+    for (const other of t.dependencies.blocked_by) { uf.union(t.id, other); }
+  }
+
+  // Classify each component root
+  const componentHasSlotted = new Set<string>();
+  const componentHasCompleted = new Set<string>();
+
+  for (const t of tasks) {
+    const root = uf.find(t.id);
+    if (slottedTaskIds.has(t.id)) componentHasSlotted.add(root);
+    if (isCompletedTask(t)) componentHasCompleted.add(root);
+  }
+
+  // Also check slotted IDs that may not be in the tasks array (e.g. unknown IDs)
+  for (const sid of slottedTaskIds) {
+    const root = uf.find(sid);
+    componentHasSlotted.add(root);
+  }
+
+  return {
+    getTier(taskId: string): 1 | 2 | 3 {
+      const root = uf.find(taskId);
+      if (componentHasSlotted.has(root)) return 1;
+      if (componentHasCompleted.has(root)) return 2;
+      return 3;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `src/tasks/affinity.ts` — union-find based connected component computation over task relation edges (`relates_to`, `blocks`, `blocked_by`) to classify tasks into affinity tiers
- Update `flowReady()` in `src/flow.ts` to sort by priority → affinity tier → deadline
- Update `maybeFillEmptySlots()` in `src/mag.ts` to use the same sort order
- 8 unit tests in `src/tasks/affinity.test.ts`

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 120 tests, 0 failures
- [x] Affinity tests cover: chained closures, blocks/blocked_by, tier precedence, isolation, unknown targets, multiple components

🤖 Generated with [Claude Code](https://claude.com/claude-code)