### PR TITLE
Dashboard: remove Quick Links tile, fix View All buttons, add effort to slot tiles

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -34,6 +34,7 @@ interface SlotJson {
   prUrl: string | null;
   githubUrl: string | null;
   t3codeThreadLinks: Record<string, string> | null;
+  effort: string | null;
 }
 
 function lookupTaskContent(taskId: string): string | null {
@@ -87,6 +88,23 @@ function lookupTaskGithubUrl(taskId: string): string | null {
     const url = data.url;
     if (!url || typeof url !== "string" || url.trim() === "" || url.trim().toLowerCase() === "null") return null;
     return url.trim();
+  } catch {
+    return null;
+  }
+}
+
+function lookupTaskEffort(taskId: string): string | null {
+  const tasksDir = join(harnessDir(), "tasks");
+  const taskFile = join(tasksDir, taskId + ".md");
+  if (!existsSync(taskFile)) return null;
+  try {
+    const content = readFileSync(taskFile, "utf-8");
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fmMatch) return null;
+    const data = (YAML.parse(fmMatch[1]!) ?? {}) as Record<string, unknown>;
+    const effort = data.effort;
+    if (!effort || typeof effort !== "string" || effort.trim() === "" || effort.trim().toLowerCase() === "null") return null;
+    return effort.trim();
   } catch {
     return null;
   }
@@ -193,6 +211,7 @@ function generateSlots(): SlotJson[] {
 
     const taskId = empty ? null : getTask(block).trim() || null;
     const taskContent = taskId && taskId !== "null" ? lookupTaskContent(taskId) : null;
+    const taskEffort = taskId && taskId !== "null" ? lookupTaskEffort(taskId) : null;
     const slotHasProposal = taskId && taskId !== "null" ? lookupTaskHasProposal(taskId) : false;
     const slotProposalLink = slotHasProposal && taskId ? `/proposal.html?task=${encodeURIComponent(taskId)}` : null;
     const githubUrl = taskId && taskId !== "null" ? lookupTaskGithubUrl(taskId) : null;
@@ -223,6 +242,7 @@ function generateSlots(): SlotJson[] {
       prUrl: empty ? null : orchLinks.prUrl,
       githubUrl: empty ? null : githubUrl,
       t3codeThreadLinks: empty ? null : orchLinks.t3codeThreadLinks,
+      effort: taskEffort,
     });
   }
 

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -108,6 +108,7 @@ function renderSlots(slots) {
             let html = `<p class="process" title="${escapeHtml(slot.process)}">${escapeHtml(slot.process)}</p>`;
             const meta = [];
             if (hasTask) meta.push(`<span class="task-id">${escapeHtml(slot.task)}</span>`);
+            if (slot.effort) meta.push(`<span class="effort">${escapeHtml(slot.effort)}</span>`);
             if (slot.mode) meta.push(escapeHtml(slot.mode));
             if (slot.started) meta.push(formatTime(slot.started));
             if (meta.length > 0) html += `<p class="slot-meta">${meta.join(' · ')}</p>`;
@@ -298,13 +299,6 @@ function setConnectionStatus(connected) {
         el.className = connected ? 'connected' : 'disconnected';
         el.textContent = connected ? 'Connected' : 'Disconnected';
     }
-}
-
-// Scroll to the ready queue panel (used by quick links)
-function scrollToReadyQueue(event) {
-    event.preventDefault();
-    const el = document.querySelector('.ready-queue');
-    if (el) el.scrollIntoView({ behavior: 'smooth' });
 }
 
 // Helper: set innerHTML only if changed, preserving scroll of scrollable descendants

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -96,7 +96,7 @@
                     <ul id="ready-list">
                         <li class="loading">Loading...</li>
                     </ul>
-                    <a href="#" class="view-all" id="view-all-ready">View all</a>
+                    <a href="tasks.html" class="view-all" id="view-all-ready">View all</a>
                 </section>
 
                 <!-- Recent Notifications -->
@@ -105,7 +105,7 @@
                     <ul id="notifications-list">
                         <li class="loading">Loading...</li>
                     </ul>
-                    <a href="#" class="view-all" id="view-all-notifications">View all</a>
+                    <a href="ntfy.html" class="view-all" id="view-all-notifications">View all</a>
                 </section>
 
                 <!-- Mag Status -->
@@ -120,16 +120,7 @@
                     </div>
                 </section>
 
-                <!-- Quick Links -->
-                <section class="quick-links panel">
-                    <h2>Quick Links</h2>
-                    <ul>
-                        <li><a href="#" onclick="scrollToReadyQueue(event)">Flow Ready</a></li>
-                        <li><a href="tasks.html">Flow Blocked</a></li>
-                        <li><a href="tasks.html">Flow Critical</a></li>
-                        <li><a href="tasks.html">All Tasks</a></li>
-                    </ul>
-                </section>
+
             </aside>
         </div>
     </main>

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -302,6 +302,16 @@ main {
     font-family: monospace;
 }
 
+.slot-details .effort {
+    font-size: 0.7rem;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    background-color: var(--bg-secondary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    text-transform: lowercase;
+}
+
 .slot-details .task-content {
     background-color: var(--bg-secondary);
     border: 1px solid var(--border);
@@ -559,20 +569,6 @@ main {
 
 .mag-links a:hover {
     text-decoration: underline;
-}
-
-/* Quick Links */
-.quick-links li {
-    padding: 0.375rem 0;
-}
-
-.quick-links a {
-    color: var(--text-primary);
-    text-decoration: none;
-}
-
-.quick-links a:hover {
-    color: var(--accent);
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary

- Remove the Quick Links sidebar tile from the dashboard (HTML, JS, CSS)
- Fix "View all" on Ready Queue panel: links to `tasks.html`
- Fix "View all" on Recent Notifications panel: links to `ntfy.html`
- Add task effort estimate (small/medium/large) display in slot tile meta area, sourced from task frontmatter via `slots.json`

## Test plan

- [ ] Dashboard loads without JS errors
- [ ] Quick Links section no longer appears in the sidebar
- [ ] "View all" on Ready Queue navigates to tasks.html
- [ ] "View all" on Recent Notifications navigates to ntfy.html
- [ ] Slot tiles with an assigned task show the effort badge in the meta row
- [ ] `bun run typecheck` passes
- [ ] `bun run build` produces a clean binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)