### PR TITLE
feat: slot assign accepts --pair/--coder/--reviewer/--plan directly; slot start errors on missing t3code args

### DIFF
--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -262,6 +262,33 @@ describe("slot assign — direct orchestration flags", () => {
     await expect(runSlot(["1", "assign", "My task", "-a", "manual", "-A", "--pair --coder foo"])).resolves.toBeUndefined();
     expect(readAdapterArgs()).toBe("--pair --coder foo");
   });
+
+  test("does not inject --pair when -A already contains a mode flag (--duo)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    await runSlot(["1", "assign", "My task", "-a", "t3code", "-A", "--duo --agent coder:claude-code", "--plan"]);
+    // --plan is a direct shorthand, but --duo already set a mode in the raw fragment
+    expect(readAdapterArgs()).toBe("--duo --agent coder:claude-code --plan");
+  });
+
+  test("does not inject --pair when -A already contains --pair", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    await runSlot(["1", "assign", "My task", "-a", "t3code", "-A", "--pair --coder existing", "--plan"]);
+    expect(readAdapterArgs()).toBe("--pair --coder existing --plan");
+  });
+
+  test("errors when --coder value looks like a flag", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    await expect(runSlot(["1", "assign", "My task", "-a", "t3code", "--coder", "--reviewer"])).rejects.toThrow("got a flag instead");
+  });
+
+  test("errors when --reviewer value looks like a flag", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    await expect(runSlot(["1", "assign", "My task", "-a", "t3code", "--reviewer", "--plan"])).rejects.toThrow("got a flag instead");
+  });
 });
 
 describe("slotStart — t3code empty-args guard", () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -858,7 +858,7 @@ export async function runSlot(args: string[]): Promise<void> {
             break;
           case "--coder": {
             const val = args[++i];
-            if (!val) throw new Error("--coder requires a provider value");
+            if (!val || val.startsWith("-")) throw new Error("--coder requires a provider value (got a flag instead)");
             hasDirectOrchFlags = true;
             if (firstDirectOrchFlagIdx === -1) firstDirectOrchFlagIdx = adapterArgFragments.length;
             adapterArgFragments.push(`--coder ${val}`);
@@ -866,7 +866,7 @@ export async function runSlot(args: string[]): Promise<void> {
           }
           case "--reviewer": {
             const val = args[++i];
-            if (!val) throw new Error("--reviewer requires a provider value");
+            if (!val || val.startsWith("-")) throw new Error("--reviewer requires a provider value (got a flag instead)");
             hasDirectOrchFlags = true;
             if (firstDirectOrchFlagIdx === -1) firstDirectOrchFlagIdx = adapterArgFragments.length;
             adapterArgFragments.push(`--reviewer ${val}`);
@@ -891,8 +891,13 @@ export async function runSlot(args: string[]): Promise<void> {
       // Auto-prepend --pair when any direct orchestration shorthand is present without an
       // explicit mode flag. Splice at the position of the first such shorthand to preserve
       // fragment ordering (raw -A fragments that precede it are left undisturbed).
-      const hasPairFragment = adapterArgFragments.includes("--pair");
-      if (hasDirectOrchFlags && !hasPairFragment && firstDirectOrchFlagIdx !== -1) {
+      // Also scan raw -A fragments for an existing mode word (--pair or --duo) so we don't
+      // clobber an intentional duo-mode config passed via --adapter-args.
+      const hasModeDirectFlag = adapterArgFragments.includes("--pair");
+      const hasModeInRawFragments = adapterArgFragments.some(
+        f => /(?:^|\s)--(?:pair|duo)(?:\s|$)/.test(f)
+      );
+      if (hasDirectOrchFlags && !hasModeDirectFlag && !hasModeInRawFragments && firstDirectOrchFlagIdx !== -1) {
         adapterArgFragments.splice(firstDirectOrchFlagIdx, 0, "--pair");
       }
 


### PR DESCRIPTION
## Summary

- `slot assign` now accepts `--pair`, `--coder <provider>`, `--reviewer <provider>`, and `--plan` as direct CLI flags, forwarding them into adapter args via a fragment-accumulation approach that preserves CLI order.
- `--adapter-args` (`-A`) still works as the escape hatch and can be combined with the new shorthands.
- `--pair` is auto-prepended when `--coder`, `--reviewer`, or `--plan` is used without an explicit mode flag.
- Using shorthand orchestration flags with a non-`t3code` adapter now fails immediately with a clear error.
- `slot start` now fails with a descriptive error when a `t3code` slot has empty/null adapter args, instead of silently falling through to single-thread mode.

## Test plan

- [x] `bun run typecheck` — pre-existing error at line 679 (unrelated); no new errors
- [x] `bun test src/slots/index.test.ts` — 19 tests pass (13 new)
- [ ] Smoke: `ludics slot N assign <task> -a t3code --pair --coder claude-code --reviewer codex --plan` → check `Adapter Args`
- [ ] Smoke: `ludics slot N assign <task> -a t3code --plan` → `Adapter Args: --pair --plan`
- [ ] Smoke: `ludics slot N assign <task> -a t3code -A "--gather" --plan` → `--gather --pair --plan`
- [ ] Smoke: `ludics slot N assign <task> -a manual --pair` → immediate error
- [ ] Smoke: empty-args t3code slot `slot start` → descriptive error with reassign hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)