### PR TITLE
feat: process-suggestions skill and needs-confirmation status

### DIFF
--- a/skills/ludics-briefing.md
+++ b/skills/ludics-briefing.md
@@ -57,8 +57,8 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      - Run a lightweight slot reassignment (only newly-empty slots
        or newly-ready high-priority tasks)
      - Do not re-elaborate tasks or redo the full analysis
-     - Still run step 6 (Nudge stalled slotted tasks)
-     - Then skip to step 8 (Write result)
+     - Still run step 7 (Nudge stalled slotted tasks)
+     - Then skip to step 9 (Write result)
    - If `Status: new`: proceed with the full process below
 
 3. **Elaborate unprocessed tasks**:
@@ -66,7 +66,12 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
    - For tasks that appear in the ready queue or are high-priority:
      - Use the Task tool to invoke `/ludics-elaborate <task-id>` (parallel)
 
-4. **Analyze, merge, and split work**:
+4. **Scan for needs-confirmation tasks**:
+   - Check task files for `status: needs-confirmation`
+   - For each, note the task ID, title, priority, and `relates_to` source task
+   - These will be included in a dedicated "Needs Confirmation" section
+
+5. **Analyze, merge, and split work**:
    - Identify high-priority ready tasks, approaching deadlines (7 days),
      slot utilization
    - Factor in recent incoming messages as high-priority context
@@ -81,7 +86,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      - Sub-tasks: `ludics tasks create "<title>" <project> <priority>` or
        `/ludics-elaborate <task-id>` to break into children
 
-5. **(Re)Assign slots**:
+6. **(Re)Assign slots**:
 
    Slot states: **Empty** (available), **Project-reserved** (path+mode, no task),
    **Task-assigned** (active work).
@@ -116,7 +121,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
    - **suggest**: include ready-to-run commands in the briefing
    - **manual**: include observations only
 
-6. **Nudge stalled slotted tasks**:
+7. **Nudge stalled slotted tasks**:
    - Read the `## Active Unconcluded Agent-Duo Slots` section first.
      - Treat listed slots as **Case A** (active, unconcluded): do **not** re-send
        launch buttons for those slots.
@@ -130,23 +135,23 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
        ```
      - Note the nudge in the briefing under Slot Assignments (e.g.,
        "Slot 3: re-sent launch buttons for task-101 (no active session)")
-   - Skip tasks whose slot was just assigned in step 5 (fresh assignments will
+   - Skip tasks whose slot was just assigned in step 6 (fresh assignments will
      get their own proposal via the normal draft-proposal flow)
    - Skip if `start_sessions` autonomy is `manual`
 
-7. **Surface ambiguities**:
+8. **Surface ambiguities**:
    - Review the full briefing for information gaps that would change your next
      autonomous actions (conflicting priorities, unclear task scope, suspiciously elaborated tasks,
      dependency tangles, missing context from the user)
    - Formulate 1-5 specific questions (see Questions Guidelines in the output format)
    - If no genuine ambiguities exist, note "No blocking ambiguities."
 
-8. **Write result**:
+9. **Write result**:
    - Write briefing to `$LUDICS_STATE_PATH/briefing.md`
    - Read request ID: `REQ_ID=$(cat "$LUDICS_STATE_PATH/mag/current-request-id")`
    - Write result JSON to `$LUDICS_RESULTS_DIR/$REQ_ID.json`
 
-9. **Send questions notification**:
+10. **Send questions notification**:
    - Extract the `## Questions` section from the briefing you just wrote
    - If there are questions (not just "No blocking ambiguities"), send them:
      ```bash
@@ -155,7 +160,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      Use the briefing date as the title, e.g., "Briefing questions — 2026-02-27"
    - Keep the message concise: just the numbered questions, no preamble
 
-10. **Commit and push state**:
+11. **Commit and push state**:
     - Run `ludics sync` to commit and push to remote
 
 ## Output Format
@@ -181,6 +186,14 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
 1. **task-101** (A): [title] - [reason this is high priority]
 2. **task-067** (A): [title]
 3. **task-128** (B): [title]
+
+## Needs Confirmation
+- **task-abc123** (C): "Refactor tensor allocation path" -- from task-xyz789 retrospective
+- **task-def456** (C): "Add missing edge-case tests for parser" -- from task-xyz789 retrospective
+
+_(Confirm or dismiss these in the dashboard)_
+
+[Omit this section if no needs-confirmation tasks exist]
 
 ## Urgent Attention
 - **Deadline**: task-042 due in 3 days (POPL submission)

--- a/skills/ludics-process-suggestions.md
+++ b/skills/ludics-process-suggestions.md
@@ -1,0 +1,134 @@
+---
+name: ludics-process-suggestions
+description: Process retrospective suggestions into needs-confirmation tasks
+---
+
+# /ludics-process-suggestions - Process Retrospective Suggestions
+
+Process a completed task's retrospective to create follow-up tasks from
+substantive suggestions. Nitpicky suggestions are skipped with reasoning.
+
+## Trigger
+
+Auto-queued after retrospective collection for a completed task.
+Manual: `ludics mag process-suggestions <task-id>`
+
+## Arguments
+
+- `$ARGUMENTS`: `<task-id>` -- the completed task whose retrospective to process
+
+## Inputs
+
+- `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
+- **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id`
+
+## Process
+
+1. Read the request ID:
+   ```bash
+   LUDICS_REQUEST_ID=$(cat "$LUDICS_STATE_PATH/mag/current-request-id" 2>/dev/null || echo "unknown")
+   ```
+
+2. Read retrospective file:
+   ```bash
+   cat "$LUDICS_STATE_PATH/retrospectives/$ARGUMENTS.json"
+   ```
+   If file is missing, write an error result and stop.
+
+3. Parse JSON and extract `suggestRefactorSummary` (string or null) and
+   `workflowFeedback` (object keyed by agent name, values are strings).
+
+4. If both fields are empty/null, write an empty result and stop.
+
+5. Read the source task file to recover project name:
+   ```bash
+   cat "$LUDICS_STATE_PATH/tasks/$ARGUMENTS.md"
+   ```
+   Extract the `project` field from frontmatter.
+
+6. **Normalize and dedupe**: Split unstructured text into individual suggestion
+   items. The `suggestRefactorSummary` may be a single text blob -- split by
+   logical suggestion boundaries (numbered items, bullet points, paragraph
+   breaks). Each `workflowFeedback` entry may also contain multiple
+   suggestions -- split those too. Merge near-duplicate items.
+
+7. **Idempotency guard**: Before creating any tasks, scan existing task files
+   for follow-ups already created from this source task:
+   ```bash
+   grep -l "relates_to:.*$ARGUMENTS" "$LUDICS_STATE_PATH/tasks/"*.md 2>/dev/null || true
+   ```
+   For each existing follow-up, read its title. Skip any new suggestion that
+   substantially overlaps with an existing follow-up title or theme.
+
+8. For each distinct suggestion, classify:
+   - **Substantive** -- create a task
+   - **Nitpicky** -- skip with logged reasoning
+
+9. For substantive suggestions:
+   a. Run: `ludics tasks create "<title>" <project> C`
+   b. Check stdout:
+      - If `"Task already exists"`: read the existing task file. If its
+        `relates_to` includes the current source task-id OR the title clearly
+        matches this suggestion, skip (true duplicate). Otherwise the collision
+        is accidental -- append the source task-id suffix to the title
+        (e.g., "Refactor X (from task-abc123)") and retry creation.
+      - If `"ID: task-..."`: parse the new task ID.
+   c. Rewrite the new task file to set:
+      - `status: needs-confirmation` (replace `status: ready`)
+      - `effort: small` (replace `effort: medium`)
+      - `relates_to: [$ARGUMENTS]` (replace `relates_to: []`)
+      - Replace Context section body with:
+        "Auto-generated from retrospective of `<source-task-id>`.
+         Original suggestion: <brief summary>"
+
+10. Write result JSON:
+    ```bash
+    cat > "$LUDICS_RESULTS_DIR/$LUDICS_REQUEST_ID.json" << 'RESULT_EOF'
+    {
+      "id": "<request-id>",
+      "status": "completed",
+      "timestamp": "<ISO timestamp>",
+      "created": <count>,
+      "skipped": <count>,
+      "tasks": ["task-xxx", ...],
+      "skipReasons": [{"suggestion": "...", "reason": "..."}]
+    }
+    RESULT_EOF
+    ```
+
+## Judgment Criteria
+
+**Create task (substantive)**:
+- Architectural refactoring that affects multiple modules
+- Missing error handling or edge cases
+- Performance improvements with measurable impact
+- API design improvements that affect downstream consumers
+- Missing test coverage for important code paths
+- Security or correctness concerns
+- Workflow improvements that reduce friction across multiple tasks
+
+**Skip (nitpicky)**:
+- Variable/function renaming for style preference
+- Comment rewording or documentation formatting
+- Import reordering or minor code organization
+- Minor formatting changes (whitespace, bracket style)
+- Suggestions already covered by existing tasks (check relates_to overlap)
+- Cosmetic UI tweaks with no functional impact
+
+## Error Handling
+
+- Missing retrospective file: write `{"status": "error", "message": "retrospective not found"}`
+- Empty suggestions: write `{"status": "empty"}`
+- Partial failure during batch creation: report partial success in result JSON
+  with the tasks created so far and error details
+
+## Output
+
+Report a summary after processing:
+
+```
+STATUS: completed | empty | error
+CREATED: <count>
+SKIPPED: <count>
+TASKS: [list of created task IDs]
+```

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -8,6 +8,7 @@ import { resolve, extname, join } from "path";
 import YAML from "yaml";
 import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, slotsFilePath, loadConfigSync } from "./config.ts";
+import { updateFrontmatterField } from "./tasks/markdown.ts";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -325,6 +326,74 @@ export function startDashboardServer(
           }
           lastGenerated = 0;
           return new Response(JSON.stringify({ priority: newPriority }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        } catch (e) {
+          return new Response(String(e), { status: 500 });
+        }
+      }
+
+      // API: confirm a needs-confirmation task (set status to ready)
+      if (pathname === "/api/task-confirm") {
+        const taskParam = url.searchParams.get("task");
+        if (!taskParam || !/^[A-Za-z0-9._-]+$/.test(taskParam)) {
+          return new Response("Bad Request: invalid task id", { status: 400 });
+        }
+        try {
+          const hDir = harnessDir();
+          const taskFile = resolve(hDir, "tasks", `${taskParam}.md`);
+          const safeTasksRoot = resolve(hDir, "tasks") + "/";
+          if (!taskFile.startsWith(safeTasksRoot)) {
+            return new Response("Forbidden", { status: 403 });
+          }
+          if (!existsSync(taskFile) || statSync(taskFile).isDirectory()) {
+            return new Response("Not Found", { status: 404 });
+          }
+          const content = readFileSync(taskFile, "utf-8");
+          const statusMatch = content.match(/^status:\s*(.+)$/m);
+          const currentStatus = statusMatch ? statusMatch[1]!.trim() : "";
+          if (currentStatus !== "needs-confirmation") {
+            return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
+              status: 409, headers: { "Content-Type": "application/json" },
+            });
+          }
+          updateFrontmatterField(taskFile, "status", "ready");
+          lastGenerated = 0;
+          return new Response(JSON.stringify({ status: "ready" }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        } catch (e) {
+          return new Response(String(e), { status: 500 });
+        }
+      }
+
+      // API: dismiss a needs-confirmation task (set status to abandoned)
+      if (pathname === "/api/task-dismiss") {
+        const taskParam = url.searchParams.get("task");
+        if (!taskParam || !/^[A-Za-z0-9._-]+$/.test(taskParam)) {
+          return new Response("Bad Request: invalid task id", { status: 400 });
+        }
+        try {
+          const hDir = harnessDir();
+          const taskFile = resolve(hDir, "tasks", `${taskParam}.md`);
+          const safeTasksRoot = resolve(hDir, "tasks") + "/";
+          if (!taskFile.startsWith(safeTasksRoot)) {
+            return new Response("Forbidden", { status: 403 });
+          }
+          if (!existsSync(taskFile) || statSync(taskFile).isDirectory()) {
+            return new Response("Not Found", { status: 404 });
+          }
+          const content = readFileSync(taskFile, "utf-8");
+          const statusMatch = content.match(/^status:\s*(.+)$/m);
+          const currentStatus = statusMatch ? statusMatch[1]!.trim() : "";
+          if (currentStatus !== "needs-confirmation") {
+            return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
+              status: 409, headers: { "Content-Type": "application/json" },
+            });
+          }
+          updateFrontmatterField(taskFile, "status", "abandoned");
+          lastGenerated = 0;
+          return new Response(JSON.stringify({ status: "abandoned" }), {
             headers: { "Content-Type": "application/json" },
           });
         } catch (e) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -283,6 +283,7 @@ interface DashboardTask {
   context: string;
   deadline: string | null;
   milestone: string | null;
+  created: string | null;
   completed: string | null;
   isCompleted: boolean;
   url: string | null;
@@ -291,8 +292,18 @@ interface DashboardTask {
   dependencies: {
     blocks: string[];
     blocked_by: string[];
+    relates_to: string[];
     subtask_of: string | null;
   };
+}
+
+interface NeedsConfirmationTask {
+  id: string;
+  title: string;
+  project: string;
+  priority: string;
+  created: string | null;
+  relatesTo: string[];
 }
 
 interface TasksTreeNode {
@@ -360,6 +371,7 @@ function readDashboardTasks(): DashboardTask[] {
         context: String(data.context ?? ""),
         deadline: data.deadline ? String(data.deadline) : null,
         milestone: isNonNullValue(data.milestone) ? String(data.milestone).trim() : null,
+        created: isNonNullValue(data.created) ? String(data.created) : null,
         completed: isNonNullValue(data.completed) ? String(data.completed) : null,
         isCompleted: isNonNullValue(data.completed),
         url: data.url ? String(data.url) : null,
@@ -368,6 +380,7 @@ function readDashboardTasks(): DashboardTask[] {
         dependencies: {
           blocks: Array.isArray(deps.blocks) ? (deps.blocks as string[]) : [],
           blocked_by: Array.isArray(deps.blocked_by) ? (deps.blocked_by as string[]) : [],
+          relates_to: Array.isArray(deps.relates_to) ? (deps.relates_to as string[]) : [],
           subtask_of: deps.subtask_of ? String(deps.subtask_of) : null,
         },
       });
@@ -427,6 +440,19 @@ function generateReady(tasks: DashboardTask[]): ReadyTask[] {
   });
 
   return ready;
+}
+
+function generateNeedsConfirmation(tasks: DashboardTask[]): NeedsConfirmationTask[] {
+  return tasks
+    .filter((task) => task.status === "needs-confirmation")
+    .map((task) => ({
+      id: task.id,
+      title: task.title,
+      project: task.project,
+      priority: task.priority,
+      created: task.created,
+      relatesTo: task.dependencies.relates_to,
+    }));
 }
 
 function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
@@ -810,6 +836,9 @@ export function dashboardGenerate(): void {
 
   writeFileSync(join(dataDir, "ready.json"), JSON.stringify(generateReady(tasks), null, 2));
   console.error("  ready.json");
+
+  writeFileSync(join(dataDir, "needs-confirmation.json"), JSON.stringify(generateNeedsConfirmation(tasks), null, 2));
+  console.error("  needs-confirmation.json");
 
   writeFileSync(join(dataDir, "tasks-tree.json"), JSON.stringify(generateTasksTree(tasks), null, 2));
   console.error("  tasks-tree.json");

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ Commands:
   mag verify-completion <id>   Deep-inspect task completion, create follow-ups
   mag health-check             Check for deadlines, issues
   mag adopt-sessions [--force] Discover sessions and queue adoption for Mag
+  mag process-suggestions <id> Queue suggestion processing for completed task
   mag message "text"           Send async message to Mag
   mag queue                    Show pending queue requests
   mag context                  Pre-compute briefing context file

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -159,4 +159,20 @@ describe("resolveQueueRequestCommand — backward compat parsing", () => {
     );
     expect(result).toBe("/ludics-draft-proposal task-042");
   });
+
+  test("process-suggestions action routes to skill command", async () => {
+    const result = await resolveQueueRequestCommand(
+      { action: "process-suggestions", task: "task-042" },
+      false,
+    );
+    expect(result).toBe("/ludics-process-suggestions task-042");
+  });
+
+  test("process-suggestions without task returns null", async () => {
+    const result = await resolveQueueRequestCommand(
+      { action: "process-suggestions" },
+      false,
+    );
+    expect(result).toBeNull();
+  });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1211,6 +1211,11 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
     case "adopt-sessions":
       adoptSessionsPrecomputeContext();
       return "/ludics-adopt-sessions";
+    case "process-suggestions": {
+      const task = String(request.task ?? "");
+      if (!task) return null;
+      return `/ludics-process-suggestions ${task}`;
+    }
     default:
       if (executeProgrammatic) {
         console.error(`ludics: mag queue-pop: unknown action: ${action}`);
@@ -2864,6 +2869,13 @@ export async function runMag(args: string[]): Promise<void> {
       console.log(`Queued adopt-sessions request (${fingerprint.unclassifiedCount} unclassified session(s))`);
       break;
     }
+    case "process-suggestions": {
+      const taskId = args[1];
+      if (!taskId) throw new Error("task id required");
+      queueRequest("process-suggestions", `"task":"${taskId}"`);
+      console.log(`Queued process-suggestions request for ${taskId}`);
+      break;
+    }
     case "completed": {
       const proposalName = args[1];
       if (!proposalName) throw new Error("proposal name required (without .md extension)");
@@ -2894,6 +2906,6 @@ export async function runMag(args: string[]): Promise<void> {
       break;
     }
     default:
-      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, health-check, adopt-sessions, completed, message, queue, queue-pop, context, feedback-digest)`);
+      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue-pop, context, feedback-digest)`);
   }
 }

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -6,6 +6,7 @@ import { basename, join } from "path";
 import YAML from "yaml";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
+import { queueRequest } from "./queue.ts";
 import type { OrchestrationState } from "./orchestration/state.ts";
 import type { T3Thread, T3ThreadMessage } from "./t3code/types.ts";
 import { threadModel } from "./t3code/types.ts";
@@ -416,6 +417,15 @@ function writeRetrospective(data: RetrospectiveData): void {
     slot: data.slot ?? undefined,
     message: `retrospective written for ${data.taskId} (${data.turns.length} turns, ${data.threads.length} threads)`,
   });
+
+  // Auto-queue suggestion processing if retrospective contains suggestions
+  if (data.suggestRefactorSummary || Object.keys(data.workflowFeedback).length > 0) {
+    try {
+      queueRequest("process-suggestions", `"task":"${data.taskId}"`);
+    } catch {
+      // Non-critical: don't fail retrospective write if queue append fails
+    }
+  }
 }
 
 // --- Primary collector ---

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -4,7 +4,7 @@ export interface TaskFrontmatter {
   id: string;
   title: string;
   project: string;
-  status: string; // ready, in-progress, preempted, done, abandoned, merged
+  status: string; // ready, in-progress, preempted, done, abandoned, merged, needs-confirmation
   priority: string; // A, B, C
   deadline: string | null;
   dependencies: {

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -42,6 +42,7 @@ async function fetchAllData() {
         await Promise.all([
             fetchSlots(),
             fetchReadyQueue(),
+            fetchNeedsConfirmation(),
             fetchQueueHoldState(),
             fetchNotifications(),
             fetchMagStatus(),
@@ -485,6 +486,88 @@ async function promoteTask(taskId) {
         setTimeout(() => li.classList.remove('promote-error'), 1500);
     } finally {
         setTimeout(() => li.classList.remove('promoting'), 300);
+    }
+}
+
+// Fetch needs-confirmation tasks
+async function fetchNeedsConfirmation() {
+    try {
+        const response = await fetch(CONFIG.dataPath + 'needs-confirmation.json');
+        if (!response.ok) throw new Error('Failed to fetch needs-confirmation');
+        const tasks = await response.json();
+        renderNeedsConfirmation(tasks);
+    } catch (error) {
+        console.warn('Using placeholder needs-confirmation');
+        renderNeedsConfirmation([]);
+    }
+}
+
+// Render needs-confirmation tasks
+function renderNeedsConfirmation(tasks) {
+    const list = document.getElementById('needs-confirmation-list');
+    if (!list) return;
+
+    let newHtml;
+    if (tasks.length === 0) {
+        newHtml = '<li class="empty">No tasks need confirmation</li>';
+    } else {
+        const items = tasks.map(task => {
+            const priority = task.priority || '-';
+            const priorityClass = `priority-${priority}`;
+            const source = task.relatesTo?.length ? ` (from ${escapeHtml(task.relatesTo[0])})` : '';
+            return `
+            <li class="needs-confirm-item">
+                <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
+                <span class="task-title">${escapeHtml(task.title || task.id)}${source}</span>
+                <span class="confirm-actions">
+                    <button class="confirm-btn" onclick="confirmTask('${escapeHtml(task.id)}')" title="Confirm: move to ready">&#x2713;</button>
+                    <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
+                </span>
+            </li>`;
+        });
+        newHtml = items.join('');
+    }
+
+    if (list.innerHTML !== newHtml) {
+        list.innerHTML = newHtml;
+    }
+}
+
+// Confirm a needs-confirmation task (move to ready)
+async function confirmTask(taskId) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = '\u2026';
+    try {
+        const response = await fetch(`/api/task-confirm?task=${encodeURIComponent(taskId)}`);
+        if (response.ok) {
+            fetchAllData();
+        } else {
+            btn.textContent = '\u2713';
+            setTimeout(() => { btn.disabled = false; }, 2000);
+        }
+    } catch {
+        btn.textContent = '\u2713';
+        setTimeout(() => { btn.disabled = false; }, 2000);
+    }
+}
+
+// Dismiss a needs-confirmation task (move to abandoned)
+async function dismissTask(taskId) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = '\u2026';
+    try {
+        const response = await fetch(`/api/task-dismiss?task=${encodeURIComponent(taskId)}`);
+        if (response.ok) {
+            fetchAllData();
+        } else {
+            btn.textContent = '\u2715';
+            setTimeout(() => { btn.disabled = false; }, 2000);
+        }
+    } catch {
+        btn.textContent = '\u2715';
+        setTimeout(() => { btn.disabled = false; }, 2000);
     }
 }
 

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -103,6 +103,14 @@
                     <a href="tasks.html" class="view-all" id="view-all-ready">View all</a>
                 </section>
 
+                <!-- Needs Confirmation -->
+                <section class="needs-confirmation panel">
+                    <h2>Needs Confirmation</h2>
+                    <ul id="needs-confirmation-list">
+                        <li class="loading">Loading...</li>
+                    </ul>
+                </section>
+
                 <!-- Recent Notifications -->
                 <section class="notifications panel">
                     <h2>Recent Notifications</h2>

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -693,6 +693,42 @@ main {
     background-color: rgba(233, 69, 96, 0.15);
 }
 
+/* Needs Confirmation */
+.needs-confirm-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.3em 0.5em;
+    cursor: default;
+}
+
+.confirm-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 0.25em;
+}
+
+.confirm-btn, .dismiss-btn {
+    border: 1px solid;
+    border-radius: 4px;
+    padding: 0.15em 0.4em;
+    cursor: pointer;
+    font-size: 0.85em;
+    background: transparent;
+}
+
+.confirm-btn {
+    border-color: #4a9;
+    color: #4a9;
+}
+.confirm-btn:hover { background: #4a9; color: #fff; }
+
+.dismiss-btn {
+    border-color: #c55;
+    color: #c55;
+}
+.dismiss-btn:hover { background: #c55; color: #fff; }
+
 /* Notifications */
 .notifications li {
     display: flex;


### PR DESCRIPTION
## Summary
- Add `ludics-process-suggestions` Mag skill that reads retrospective suggest-refactor/workflow-feedback content and auto-creates follow-up tasks with `status: needs-confirmation`
- Auto-queue the skill after `writeRetrospective()` when suggestions exist
- Add dashboard panel, API endpoints (`/api/task-confirm`, `/api/task-dismiss`), and briefing section for needs-confirmation tasks

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/mag.test.ts` passes (26 tests, including 2 new routing tests)
- [ ] Manual: `ludics mag process-suggestions <task-id>` queues and Mag picks up skill
- [ ] Manual: Dashboard confirm/dismiss buttons change task status correctly
- [ ] Manual: `ludics flow ready` excludes needs-confirmation tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)