### PR TITLE
Move waitForNewTurn to t3code/client.ts

### DIFF
--- a/src/t3code/client.ts
+++ b/src/t3code/client.ts
@@ -12,6 +12,14 @@ import {
 
 export { threadModel, projectModel } from "./types.ts";
 
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 type PushListener = (data: unknown) => void;
 
 interface PendingRequest {
@@ -259,6 +267,68 @@ export class T3CodeClient {
 
     pending.resolve(parsed.result);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Polling utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Poll `getSnapshot` until a turn with a different ID than `preDispatchTurnId`
+ * AND a `requestedAt` timestamp not earlier than `minRequestedAt` reaches a
+ * terminal state ("completed", "error", or "interrupted").
+ *
+ * The two filters together guard against stale pre-existing turns AND unrelated
+ * concurrent turns dispatched by other actors before our command was processed.
+ *
+ * Returns the terminal result, or null on timeout.
+ */
+export async function waitForNewTurn(
+  getSnapshot: () => Promise<T3Snapshot | null>,
+  threadId: string,
+  preDispatchTurnId: string | null,
+  options: {
+    pollIntervalMs: number;
+    maxWaitMs: number;
+    /**
+     * ISO timestamp captured just before the dispatch command was sent.
+     * Turns whose `requestedAt` is strictly before this value are ignored,
+     * filtering out concurrent turns created by other actors before our command
+     * reached the server.
+     */
+    minRequestedAt?: string;
+  },
+): Promise<{ state: "completed" | "error" | "interrupted"; turnId: string } | null> {
+  const deadline = Date.now() + options.maxWaitMs;
+
+  while (Date.now() < deadline) {
+    await sleep(options.pollIntervalMs);
+    try {
+      const snap = await getSnapshot();
+      if (!snap) continue;
+
+      const t = snap.threads.find((x) => x.id === threadId);
+      if (!t) return null; // thread gone
+
+      const lt = t.latestTurn;
+      if (!lt) continue;
+
+      // Skip the pre-dispatch turn — it was already there before we sent.
+      if (lt.turnId === preDispatchTurnId) continue;
+
+      // Skip turns requested before our dispatch — they belong to concurrent actors.
+      if (options.minRequestedAt && lt.requestedAt < options.minRequestedAt) continue;
+
+      if (lt.state === "completed" || lt.state === "error" || lt.state === "interrupted") {
+        return { state: lt.state, turnId: lt.turnId };
+      }
+      // else "running" or "starting" — keep polling
+    } catch {
+      // transient error — keep polling
+    }
+  }
+
+  return null; // timed out
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/t3code/index.ts
+++ b/src/t3code/index.ts
@@ -1,9 +1,9 @@
 import { harnessDir } from "../config.ts";
 import { readOrchestrationState } from "../orchestration/state.ts";
 import type { AgentConfig } from "../orchestration/state.ts";
-import { T3CodeClient } from "./client.ts";
+import { T3CodeClient, waitForNewTurn } from "./client.ts";
 import { doctorServer, ensureServer, readServerRecord, serverStatus, stopServer, t3codeServerPath } from "./server.ts";
-import type { T3Snapshot, T3ThreadMessage } from "./types.ts";
+import type { T3ThreadMessage } from "./types.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -15,10 +15,6 @@ function isoNow(): string {
 
 function makeId(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}`;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function withClient<T>(
@@ -115,65 +111,6 @@ async function threadLog(
     harness,
   );
   formatMessages(messages);
-}
-
-/**
- * Poll `getSnapshot` until a turn with a different ID than `preDispatchTurnId`
- * AND a `requestedAt` timestamp not earlier than `minRequestedAt` reaches a
- * terminal state ("completed", "error", or "interrupted").
- *
- * The two filters together guard against stale pre-existing turns AND unrelated
- * concurrent turns dispatched by other actors before our command was processed.
- *
- * Returns the terminal result, or null on timeout.
- * Exported for testing.
- */
-export async function waitForNewTurn(
-  getSnapshot: () => Promise<T3Snapshot | null>,
-  threadId: string,
-  preDispatchTurnId: string | null,
-  options: {
-    pollIntervalMs: number;
-    maxWaitMs: number;
-    /**
-     * ISO timestamp captured just before the dispatch command was sent.
-     * Turns whose `requestedAt` is strictly before this value are ignored,
-     * filtering out concurrent turns created by other actors before our command
-     * reached the server.
-     */
-    minRequestedAt?: string;
-  },
-): Promise<{ state: "completed" | "error" | "interrupted"; turnId: string } | null> {
-  const deadline = Date.now() + options.maxWaitMs;
-
-  while (Date.now() < deadline) {
-    await sleep(options.pollIntervalMs);
-    try {
-      const snap = await getSnapshot();
-      if (!snap) continue;
-
-      const t = snap.threads.find((x) => x.id === threadId);
-      if (!t) return null; // thread gone
-
-      const lt = t.latestTurn;
-      if (!lt) continue;
-
-      // Skip the pre-dispatch turn — it was already there before we sent.
-      if (lt.turnId === preDispatchTurnId) continue;
-
-      // Skip turns requested before our dispatch — they belong to concurrent actors.
-      if (options.minRequestedAt && lt.requestedAt < options.minRequestedAt) continue;
-
-      if (lt.state === "completed" || lt.state === "error" || lt.state === "interrupted") {
-        return { state: lt.state, turnId: lt.turnId };
-      }
-      // else "running" or "starting" — keep polling
-    } catch {
-      // transient error — keep polling
-    }
-  }
-
-  return null; // timed out
 }
 
 async function threadSend(

--- a/src/t3code/thread-send.test.ts
+++ b/src/t3code/thread-send.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { waitForNewTurn } from "./index.ts";
+import { waitForNewTurn } from "./client.ts";
 import type { T3LatestTurn, T3Snapshot } from "./types.ts";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Moves `waitForNewTurn` from `src/t3code/index.ts` to `src/t3code/client.ts` where it belongs as a reusable t3code client primitive
- Adds a local `sleep` helper to `client.ts` (required by the moved function)
- Updates the import in `src/t3code/index.ts` to pull from `./client.ts`
- Updates `src/t3code/thread-send.test.ts` to import from `./client.ts`

`pollUntilDone` in `src/orchestration/runner.ts` uses a broader, multi-agent phase-polling mechanism (peer-sync status + turn lifecycle state machine + event-driven wakeup) that does not overlap cleanly with `waitForNewTurn`'s single-thread, snapshot-only polling approach, so no runner changes are needed.

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun test src/t3code/` — 98 tests pass (including all 9 `waitForNewTurn` tests now running against `client.ts`)
- [x] `bun run build` — binary compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)