### PR TITLE
feat: add --restart-t3code flag to ludics init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ Commands:
 
   status                       Overview of slots + tasks
   briefing                     Morning briefing
-  init [--no-hooks] [--no-dashboard] [--no-triggers]
+  init [--no-hooks] [--no-dashboard] [--no-triggers] [--restart-t3code]
                                Initialize config, harness, hooks, dashboard, and triggers
   stop [pause|uninstall]       Stop scheduled activity (default: pause)
   triggers install             Install launchd/systemd triggers

--- a/src/init.ts
+++ b/src/init.ts
@@ -6,6 +6,7 @@ import YAML from "yaml";
 import { ludicsRoot, pointerConfigPath, harnessDir } from "./config.ts";
 import { dashboardInstall, dashboardStop, dashboardServe } from "./dashboard.ts";
 import { triggersInstall } from "./triggers.ts";
+import { stopServer, ensureServer } from "./t3code/server.ts";
 
 const POINTER_CONFIG_TEMPLATE = `# ludics pointer config — edit state_repo, then run: ludics init
 state_repo: your-username/your-private-repo
@@ -20,6 +21,7 @@ export async function runInit(args: string[]): Promise<void> {
   const noHooks = args.includes("--no-hooks");
   const noDashboard = args.includes("--no-dashboard");
   const noTriggers = args.includes("--no-triggers");
+  const restartT3code = args.includes("--restart-t3code");
 
   const root = ludicsRoot();
 
@@ -74,6 +76,22 @@ export async function runInit(args: string[]): Promise<void> {
     } catch (err) {
       console.warn(`warning: dashboard install failed: ${err instanceof Error ? err.message : String(err)}`);
     }
+  }
+
+  // 8b. t3code restart (opt-in)
+  if (restartT3code && repoDir) {
+    const resolvedHarnessDir = join(repoDir, statePath);
+    console.log("\n--- t3code server restart ---");
+    try {
+      const stopped = await stopServer({ harnessDir: resolvedHarnessDir });
+      console.log(stopped ? "  stopped existing server" : "  no running server found");
+      const record = await ensureServer({ harnessDir: resolvedHarnessDir });
+      console.log(`  started t3code server on ${record.webUrl} (pid ${record.pid})`);
+    } catch (err) {
+      console.warn(`warning: t3code restart failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else if (restartT3code && !repoDir) {
+    console.warn("warning: --restart-t3code skipped — state repo not configured");
   }
 
   // 9. Triggers


### PR DESCRIPTION
## Summary

- Adds `--restart-t3code` opt-in flag to `ludics init`
- Calls `stopServer()` then `ensureServer()` with the harness dir resolved during init (guarded by `repoDir` being valid — skips gracefully with a warning when the state repo is not yet configured)
- Updates CLI help text so the flag appears alongside the other `--no-*` flags and is discoverable via `ludics help`

## Test plan

- [ ] `ludics help` shows `--restart-t3code` in the `init` flags line
- [ ] `ludics init --restart-t3code` with a configured state repo stops any running t3code server and starts a fresh one, printing the URL and PID
- [ ] `ludics init --restart-t3code` without the flag leaves t3code untouched
- [ ] `ludics init --restart-t3code` when state repo is a placeholder logs a warning and skips (does not attempt to start t3code under `~/your-private-repo/harness`)
- [ ] `bun run typecheck` passes
- [ ] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)