### PR TITLE
feat: auto-commit uncommitted changes at end of each agent turn

### DIFF
--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "path";
 import { tmpdir } from "os";
 import { isAgentDone, pairReviewVerdict } from "./phases.ts";
-import { updateTurnLifecycle, refreshAgentStatuses, maybePostCodexReviewRequests } from "./runner.ts";
+import { updateTurnLifecycle, refreshAgentStatuses, maybePostCodexReviewRequests, autoCommitAgent, autoCommitAllAgents } from "./runner.ts";
 import * as github from "./github.ts";
 import { orchOnStop } from "./index.ts";
 import { readStopHookRecord, writeStopHookRecord, writeAgentMarkerFiles, readAgentMarkerFile } from "./peer-sync.ts";
@@ -1426,5 +1426,195 @@ describe("maybePostCodexReviewRequests", () => {
     });
     maybePostCodexReviewRequests(state, "pr-create", "pr-comments");
     expect(postSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoCommitAgent / autoCommitAllAgents
+// ---------------------------------------------------------------------------
+
+function initGitRepo(dir: string): void {
+  const { mkdirSync, writeFileSync } = require("fs");
+  mkdirSync(dir, { recursive: true });
+  Bun.spawnSync(["git", "init", "-b", "main"], { cwd: dir, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "config", "user.email", "test@example.com"], { cwd: dir, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "config", "user.name", "Test User"], { cwd: dir, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  writeFileSync(join(dir, "README.md"), "init\n");
+  Bun.spawnSync(["git", "add", "README.md"], { cwd: dir, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: dir, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+}
+
+function gitLastCommitMsg(dir: string): string {
+  return Bun.spawnSync(["git", "log", "--format=%s", "-1"], {
+    cwd: dir, stdout: "pipe", stderr: "pipe",
+    env: process.env as Record<string, string>,
+  }).stdout.toString().trim();
+}
+
+function gitCommitCount(dir: string): number {
+  const out = Bun.spawnSync(["git", "rev-list", "--count", "HEAD"], {
+    cwd: dir, stdout: "pipe", stderr: "pipe",
+    env: process.env as Record<string, string>,
+  }).stdout.toString().trim();
+  return parseInt(out, 10);
+}
+
+describe("autoCommitAgent", () => {
+  afterEach(() => {
+    rmSync(join(import.meta.dir, ".test-tmp-autocommit"), { recursive: true, force: true });
+  });
+
+  test("commit message format: '<agent> <phase>: <statusMessage>'", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "msg-fmt");
+    initGitRepo(repo);
+    writeFileSync(join(repo, "code.ts"), "export const x = 1;\n");
+
+    const state = makeState({
+      phase: "work",
+      agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo }],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 100, statusMessage: "implemented tensor syntax", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAgent(state, state.agents[0]!, false);
+    expect(gitLastCommitMsg(repo)).toBe("coder work: implemented tensor syntax");
+  });
+
+  test("falls back to WIP when statusMessage is empty", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "wip-fallback");
+    initGitRepo(repo);
+    writeFileSync(join(repo, "code.ts"), "export const x = 1;\n");
+
+    const state = makeState({
+      phase: "review",
+      agents: [{ name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: repo }],
+      agentStates: {
+        reviewer: { status: "done", statusEpoch: 100, statusMessage: "", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAgent(state, state.agents[0]!, false);
+    expect(gitLastCommitMsg(repo)).toBe("reviewer review: WIP");
+  });
+
+  test("collapses multiline statusMessage to single line", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "multiline");
+    initGitRepo(repo);
+    writeFileSync(join(repo, "code.ts"), "export const x = 1;\n");
+
+    const state = makeState({
+      phase: "work",
+      agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo }],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 100, statusMessage: "line1\nline2\n  line3", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAgent(state, state.agents[0]!, false);
+    expect(gitLastCommitMsg(repo)).toBe("coder work: line1 line2 line3");
+  });
+
+  test("no-op on clean worktree", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "clean");
+    initGitRepo(repo);
+
+    const state = makeState({
+      phase: "work",
+      agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo }],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 100, statusMessage: "done", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAgent(state, state.agents[0]!, false);
+    expect(gitCommitCount(repo)).toBe(1); // only the init commit
+  });
+});
+
+describe("autoCommitAllAgents", () => {
+  afterEach(() => {
+    rmSync(join(import.meta.dir, ".test-tmp-autocommit"), { recursive: true, force: true });
+  });
+
+  test("pair mode: commits once for shared worktree", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "pair-dedup");
+    initGitRepo(repo);
+    writeFileSync(join(repo, "code.ts"), "export const x = 1;\n");
+
+    const state = makeState({
+      phase: "work",
+      mode: "pair",
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: repo },
+      ],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 200, statusMessage: "coded it", prUrl: null, interrupted: false },
+        reviewer: { status: "done", statusEpoch: 100, statusMessage: "reviewed", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAllAgents(state, state.agents, false);
+    // Only 1 new commit (init + auto-commit = 2 total), not 2 new commits
+    expect(gitCommitCount(repo)).toBe(2);
+  });
+
+  test("pair mode: attributes to agent with newest statusEpoch", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(import.meta.dir, ".test-tmp-autocommit", "pair-attr");
+    initGitRepo(repo);
+    writeFileSync(join(repo, "code.ts"), "export const x = 1;\n");
+
+    const state = makeState({
+      phase: "work",
+      mode: "pair",
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: repo },
+      ],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 100, statusMessage: "coded", prUrl: null, interrupted: false },
+        reviewer: { status: "done", statusEpoch: 200, statusMessage: "reviewed it", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAllAgents(state, state.agents, false);
+    // Reviewer has higher epoch → commit attributed to reviewer
+    expect(gitLastCommitMsg(repo)).toBe("reviewer work: reviewed it");
+  });
+
+  test("duo mode: commits independently per worktree", () => {
+    if (!Bun.which("git")) return;
+    const repo1 = join(import.meta.dir, ".test-tmp-autocommit", "duo-1");
+    const repo2 = join(import.meta.dir, ".test-tmp-autocommit", "duo-2");
+    initGitRepo(repo1);
+    initGitRepo(repo2);
+    writeFileSync(join(repo1, "code.ts"), "coder work\n");
+    writeFileSync(join(repo2, "review.md"), "reviewer notes\n");
+
+    const state = makeState({
+      phase: "work",
+      mode: "duo",
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo1 },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: repo2 },
+      ],
+      agentStates: {
+        coder: { status: "done", statusEpoch: 100, statusMessage: "coded", prUrl: null, interrupted: false },
+        reviewer: { status: "done", statusEpoch: 100, statusMessage: "reviewed", prUrl: null, interrupted: false },
+      },
+    });
+
+    autoCommitAllAgents(state, state.agents, false);
+    expect(gitCommitCount(repo1)).toBe(2);
+    expect(gitCommitCount(repo2)).toBe(2);
+    expect(gitLastCommitMsg(repo1)).toBe("coder work: coded");
+    expect(gitLastCommitMsg(repo2)).toBe("reviewer work: reviewed");
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -22,6 +22,7 @@ import { fetchNewPrCommentCount, hasPrApprovalReaction, isPrMerged, postCodexRev
 import { updateFrontmatterField } from "../tasks/markdown.ts";
 import { findProjectConfig, harnessDir } from "../config.ts";
 import { notifyAgents } from "../notify.ts";
+import { autoCommitWorktree, pushBranch } from "./worktrees.ts";
 
 async function withClient<T>(
   record: T3CodeServerRecord,
@@ -608,6 +609,95 @@ async function handleTimeout(state: OrchestrationState): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Auto-commit helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-commit any uncommitted changes for an agent and optionally push.
+ * Logs events for commits, warnings for failures. No-op on clean worktree.
+ */
+export function autoCommitAgent(
+  state: OrchestrationState,
+  agent: AgentConfig,
+  push: boolean = false,
+): void {
+  const runtime = state.agentStates[agent.name];
+  if (!runtime) return;
+
+  // Build commit message: "<agent> <phase>: <status message or WIP>"
+  const statusMsg = runtime.statusMessage?.replace(/\s+/g, " ").trim() || "WIP";
+  const commitMessage = `${agent.name} ${state.phase}: ${statusMsg}`;
+
+  const result = autoCommitWorktree(agent.worktreePath, commitMessage);
+
+  if (result.committed) {
+    emitEvent({
+      event_type: "auto_commit",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.feature,
+      message: `auto-committed ${result.commitSha ?? ""} in ${agent.worktreePath}: ${commitMessage}`,
+    });
+  } else if (result.error) {
+    emitEvent({
+      event_type: "orchestration_warning",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.feature,
+      message: `auto-commit failed for ${agent.name}: ${result.error}`,
+    });
+  }
+  // dirty===false && !error → clean tree, silent no-op
+
+  if (result.committed && push) {
+    try {
+      pushBranch(agent.worktreePath, agent.branch);
+    } catch (err) {
+      // Best-effort push — warn but don't block phase transition
+      emitEvent({
+        event_type: "orchestration_warning",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.feature,
+        message: `auto-commit push failed for ${agent.name}: ${err}`,
+      });
+    }
+  }
+}
+
+/**
+ * Auto-commit all agents, deduplicating by worktreePath (pair mode: both
+ * agents share rootWorktree). Attributes the commit to the agent with
+ * the newest statusEpoch for deterministic pair-mode attribution.
+ */
+export function autoCommitAllAgents(
+  state: OrchestrationState,
+  agents: AgentConfig[],
+  push: boolean,
+): void {
+  // Deduplicate by worktreePath → pick the agent with the newest status.
+  const byPath = new Map<string, AgentConfig>();
+  for (const agent of agents) {
+    const existing = byPath.get(agent.worktreePath);
+    if (!existing) {
+      byPath.set(agent.worktreePath, agent);
+    } else {
+      const existingEpoch = state.agentStates[existing.name]?.statusEpoch ?? 0;
+      const candidateEpoch = state.agentStates[agent.name]?.statusEpoch ?? 0;
+      if (candidateEpoch > existingEpoch) {
+        byPath.set(agent.worktreePath, agent);
+      }
+    }
+  }
+  for (const agent of byPath.values()) {
+    autoCommitAgent(state, agent, push);
+  }
+}
+
 async function pollUntilDone(state: OrchestrationState): Promise<void> {
   const timeout = state.config.timeouts[state.phase] ?? 600;
   const deadline = state.phaseStartedAt + timeout;
@@ -791,12 +881,29 @@ export async function runOrchestration(
     persistState(state);
 
     await pollUntilDone(state);
+
+    // Auto-commit any uncommitted work after agents finish their turn.
+    // Push=false here; push happens before PR-related phases below.
+    const participating = state.agents.filter(a => agentParticipatesInPhase(state, a));
+    autoCommitAllAgents(state, participating, /* push */ false);
+
     const evaluated = evaluateTransition(state);
     const next = maybeOverrideTransition(state, evaluated);
 
     if (!next) {
       await sleep(state.config.pollInterval * 1000);
       continue;
+    }
+
+    // Before phases that require committed+pushed code, ensure nothing is lost.
+    // Iterate ALL agents: non-participating agents may have leftover uncommitted
+    // work from a previous phase that needs to be pushed before PR creation.
+    const pushBeforePhases = new Set([
+      "pr-create", "forward-pr", "final-merge",
+      "merge-execute", "merge-review",
+    ]);
+    if (pushBeforePhases.has(next)) {
+      autoCommitAllAgents(state, state.agents, /* push */ true);
     }
 
     applyPhaseSideEffects(state, next);

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { cleanupWorktrees, createWorktrees, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, cleanupWorktrees, createWorktrees, symlinkPeerSync } from "./worktrees.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -45,5 +45,160 @@ describe("worktrees", () => {
     expect(lstatSync(link).isSymbolicLink()).toBe(true);
 
     cleanupWorktrees(repo, "feat", [{ name: "agent1" }, { name: "agent2" }], 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoCommitWorktree
+// ---------------------------------------------------------------------------
+
+function initRepo(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  run(["git", "init", "-b", "main"], dir);
+  run(["git", "config", "user.email", "test@example.com"], dir);
+  run(["git", "config", "user.name", "Test User"], dir);
+  writeFileSync(join(dir, "README.md"), "init\n");
+  run(["git", "add", "README.md"], dir);
+  run(["git", "commit", "-m", "init"], dir);
+}
+
+function gitLog(dir: string, format: string = "%s"): string {
+  const result = Bun.spawnSync(["git", "log", `--format=${format}`], {
+    cwd: dir, stdout: "pipe", stderr: "pipe",
+    env: process.env as Record<string, string>,
+  });
+  return result.stdout.toString().trim();
+}
+
+function gitLogCount(dir: string): number {
+  return gitLog(dir, "%H").split("\n").filter(Boolean).length;
+}
+
+describe("autoCommitWorktree", () => {
+  test("commits when worktree has uncommitted tracked changes", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-dirty");
+    initRepo(repo);
+    writeFileSync(join(repo, "README.md"), "modified\n");
+
+    const result = autoCommitWorktree(repo, "test: dirty commit");
+    expect(result.dirty).toBe(true);
+    expect(result.committed).toBe(true);
+    expect(result.commitSha).toMatch(/^[a-f0-9]+$/);
+    expect(result.error).toBeUndefined();
+    expect(gitLog(repo, "%s").split("\n")[0]).toBe("test: dirty commit");
+    expect(gitLogCount(repo)).toBe(2);
+  });
+
+  test("commits untracked files", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-untracked");
+    initRepo(repo);
+    writeFileSync(join(repo, "newfile.ts"), "export const x = 1;\n");
+
+    const result = autoCommitWorktree(repo, "test: untracked");
+    expect(result.dirty).toBe(true);
+    expect(result.committed).toBe(true);
+    // Verify the new file is in the commit
+    const showStat = Bun.spawnSync(["git", "show", "--stat", "--format=", "HEAD"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(showStat).toContain("newfile.ts");
+  });
+
+  test("no-op when worktree is clean", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-clean");
+    initRepo(repo);
+
+    const result = autoCommitWorktree(repo, "should not appear");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+    expect(result.error).toBeUndefined();
+    expect(gitLogCount(repo)).toBe(1);
+  });
+
+  test("excludes .peer-sync from staging and dirty check", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-exclude-peer-sync");
+    initRepo(repo);
+    mkdirSync(join(repo, ".peer-sync"), { recursive: true });
+    writeFileSync(join(repo, ".peer-sync", "coder.status"), "done|123|finished\n");
+
+    const result = autoCommitWorktree(repo, "should not commit");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+  });
+
+  test("excludes .ludics-orchestration.json from staging", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-exclude-marker");
+    initRepo(repo);
+    writeFileSync(join(repo, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
+
+    const result = autoCommitWorktree(repo, "should not commit");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+  });
+
+  test("excludes .claude/ from staging", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-exclude-claude");
+    initRepo(repo);
+    mkdirSync(join(repo, ".claude"), { recursive: true });
+    writeFileSync(join(repo, ".claude", "settings.local.json"), '{"hooks":{}}\n');
+
+    const result = autoCommitWorktree(repo, "should not commit");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+  });
+
+  test("commits real files while excluding orchestration files", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-mixed");
+    initRepo(repo);
+    // Real code change
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "main.ts"), "export const y = 2;\n");
+    // Orchestration files that should be excluded
+    mkdirSync(join(repo, ".peer-sync"), { recursive: true });
+    writeFileSync(join(repo, ".peer-sync", "coder.status"), "done|123|ok\n");
+    writeFileSync(join(repo, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
+
+    const result = autoCommitWorktree(repo, "mixed changes");
+    expect(result.dirty).toBe(true);
+    expect(result.committed).toBe(true);
+
+    // Verify the real file is in the commit
+    const showStat = Bun.spawnSync(["git", "show", "--stat", "--format=", "HEAD"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(showStat).toContain("src/main.ts");
+    expect(showStat).not.toContain(".peer-sync");
+    expect(showStat).not.toContain(".ludics-orchestration.json");
+  });
+
+  test("returns error on invalid directory", () => {
+    const result = autoCommitWorktree("/nonexistent/path/xxxxx", "msg");
+    expect(result.committed).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("failed");
+  });
+
+  test("idempotent: second call on clean tree is no-op", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-idempotent");
+    initRepo(repo);
+    writeFileSync(join(repo, "file.ts"), "content\n");
+
+    const r1 = autoCommitWorktree(repo, "first");
+    expect(r1.committed).toBe(true);
+
+    const r2 = autoCommitWorktree(repo, "second");
+    expect(r2.dirty).toBe(false);
+    expect(r2.committed).toBe(false);
+    expect(gitLogCount(repo)).toBe(2); // init + first, no second
   });
 });

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -9,7 +9,7 @@ export interface WorktreeSetup {
   branches: Record<string, string>;
 }
 
-function runGit(projectDir: string, args: string[]): string {
+export function runGit(projectDir: string, args: string[]): string {
   const result = Bun.spawnSync(["git", ...args], {
     cwd: projectDir,
     stdout: "pipe",
@@ -169,4 +169,67 @@ export function cleanupWorktrees(
       removeIfRegistered(projectDir, join(parentDir, `${stem}-${slugify(agent.name)}`));
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-commit helpers
+// ---------------------------------------------------------------------------
+
+/** Paths that the orchestrator writes into worktrees but must never be committed. */
+const ORCHESTRATION_EXCLUDES = [
+  ":!.peer-sync",
+  ":!.ludics-orchestration.json",
+  ":!.claude",
+];
+
+export interface AutoCommitResult {
+  /** Whether the worktree had eligible uncommitted changes. */
+  dirty: boolean;
+  /** Whether a commit was created. */
+  committed: boolean;
+  /** SHA of the created commit, if any. */
+  commitSha?: string;
+  /** Error message if something went wrong. */
+  error?: string;
+}
+
+/**
+ * Auto-commit any uncommitted changes in the given directory, excluding
+ * orchestration-internal paths (.peer-sync, .ludics-orchestration.json, .claude).
+ * Returns a structured result. Safe to call on clean worktrees (no-op).
+ */
+export function autoCommitWorktree(
+  worktreePath: string,
+  commitMessage: string,
+): AutoCommitResult {
+  // Use runGit (throws on failure) in try/catch so we can distinguish
+  // "clean tree" from "git command failed". maybeGit collapses both to "".
+  let status: string;
+  try {
+    status = runGit(worktreePath, [
+      "status", "--porcelain", "--", ".", ...ORCHESTRATION_EXCLUDES,
+    ]);
+  } catch (err) {
+    return { dirty: false, committed: false, error: `status check failed: ${err}` };
+  }
+
+  if (!status) return { dirty: false, committed: false }; // clean tree
+
+  try {
+    runGit(worktreePath, ["add", "-A", "--", ".", ...ORCHESTRATION_EXCLUDES]);
+    runGit(worktreePath, ["commit", "-m", commitMessage]);
+    const sha = maybeGit(worktreePath, ["rev-parse", "--short", "HEAD"]);
+    return { dirty: true, committed: true, commitSha: sha || undefined };
+  } catch (err) {
+    return { dirty: true, committed: false, error: String(err) };
+  }
+}
+
+/**
+ * Push the current branch, setting upstream tracking if needed.
+ * Freshly-created worktree branches may not have an upstream, so
+ * we use `git push -u origin <branch>`.
+ */
+export function pushBranch(worktreePath: string, branch: string): void {
+  runGit(worktreePath, ["push", "-u", "origin", branch]);
 }


### PR DESCRIPTION
## Summary
- Adds `autoCommitWorktree()` helper in `worktrees.ts` and `autoCommitAgent()`/`autoCommitAllAgents()` in `runner.ts`
- Auto-commits after each agent turn completion and before PR-related phase transitions (with push)
- Excludes orchestration-internal files, deduplicates by worktree path in pair mode
- 16 new tests covering commit logic and integration

## Test plan
- [x] `bun run typecheck` passes
- [x] 151 orchestration tests pass
- [x] Manual verification of commit message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)