### PR TITLE
feat: detect stalled slots and auto-nudge or restart agents

### DIFF
--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -46,6 +46,12 @@ This skill is invoked when:
      flag as warning: "Active [agent] session on [project] has no slot (all slots occupied)"
    - If unmatched sessions exist:
      flag as info: "Unrecognized session at [cwd] — not matched to any configured project"
+   - For each active `Mode=t3code` slot, read orchestration state:
+     `cat "$LUDICS_STATE_PATH/orchestration/slot-<N>.json" 2>/dev/null`
+     - Check each agent's `turnLifecycle.stallDetectedAt`
+     - If non-null, report: slot number, agent name, phase, stall age, nudge count
+     - Build stable issue key: `slot-stall:<slot>:<agent>`
+     - Severity: warning if nudgeAttempts < 2, critical if >= 2
 
 3. **Check queue health**:
    - Read `mag/queue.jsonl`

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -18,7 +18,8 @@ import {
   expirePendingRevises,
   expirePendingFollowupRevises,
 } from "./notify.ts";
-import { slotAssign, slotClear, slotStart, taskCompleteDirectly } from "./slots/index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, taskCompleteDirectly } from "./slots/index.ts";
+import { readSlotState } from "./t3code/server.ts";
 import { resolveSkillCommand, hasRegisteredAction } from "./skill-queue-registry.ts";
 import { selectOrchestrationFlags } from "./adapters/t3code.ts";
 import YAML from "yaml";
@@ -2123,6 +2124,88 @@ function maybeFillEmptySlots(): void {
   }
 }
 
+// --- Auto-resume dead orchestrator processes ---
+
+/**
+ * Detect dead orchestrator processes and auto-resume via slotResume().
+ * Follows the maybeClearDoneSlots() pattern.
+ * Rate-limited: at most 1 resume per keepalive invocation.
+ */
+async function maybeResumeDeadOrchestrators(): Promise<void> {
+  if (startSessionsAutonomy() === "manual") return;
+
+  const sFile = slotsFilePath();
+  if (!existsSync(sFile)) return;
+
+  const blocks = parseSlotBlocks(readFileSync(sFile, "utf-8"));
+  let resumed = 0;
+
+  for (const [slotNum, block] of blocks) {
+    if (resumed >= 1) break; // rate-limit: at most 1 per invocation
+
+    // IMPORTANT: use `slotProcess` not `process` to avoid shadowing the global
+    const slotProcess = getProcess(block).trim();
+    if (!slotProcess || slotProcess === "(empty)") continue;
+
+    const mode = getMode(block).trim();
+    if (mode !== "t3code") continue;
+
+    const taskId = getTask(block).trim();
+    if (!taskId || taskId === "null") continue;
+
+    const orchState = readOrchestrationState(slotNum);
+    if (!orchState) continue;
+    if (orchState.phase === "done") continue;
+
+    // Guard: orchestration state must match slot's current task
+    if (orchState.taskId && orchState.taskId !== taskId) continue;
+
+    const slotState = readSlotState(slotNum);
+    if (!slotState?.orchestration?.pid) continue;
+
+    const pid = slotState.orchestration.pid;
+    let alive = true;
+    try {
+      process.kill(pid, 0); // global process — PID liveness check
+    } catch {
+      alive = false;
+    }
+    if (alive) continue;
+
+    console.error(
+      `ludics: detected dead orchestrator for slot ${slotNum} ` +
+      `(pid ${pid}, task ${taskId}, phase ${orchState.phase}) — auto-resuming`,
+    );
+    try {
+      await slotResume(slotNum);
+      resumed += 1;
+      emitEvent({
+        event_type: "orchestration_auto_resume",
+        source: "keepalive",
+        scope: "slot",
+        slot: slotNum,
+        task: taskId,
+        deadPid: pid,
+        message: `auto-resumed dead orchestrator (pid ${pid}, phase=${orchState.phase})`,
+      });
+    } catch (err) {
+      console.error(
+        `ludics: failed to auto-resume slot ${slotNum}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+      );
+      emitEvent({
+        event_type: "orchestration_auto_resume_failed",
+        source: "keepalive",
+        scope: "slot",
+        slot: slotNum,
+        task: taskId,
+        status: "failed",
+        message: `auto-resume failed for slot ${slotNum}: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+}
+
 // --- Auto-clear slots whose task reached done status ---
 
 function maybeClearDoneSlots(): void {
@@ -2206,6 +2289,9 @@ export async function magStart(args: string[]): Promise<void> {
 
     // Auto-clear slots whose task reached done status
     maybeClearDoneSlots();
+
+    // Auto-resume dead orchestrator processes
+    await maybeResumeDeadOrchestrators();
 
     // Auto-fill empty slots with ready elaborated tasks
     maybeFillEmptySlots();

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -26,8 +26,11 @@ function orchStatus(slot: number): void {
     const effort = agent.thinkingEffort ? ` thinking=${agent.thinkingEffort}` : "";
     const lc = runtime?.turnLifecycle;
     const lcInfo = lc ? ` turn=${lc.state}${lc.observedTurnId ? ` id=${lc.observedTurnId.slice(0, 8)}` : ""}` : "";
+    const stallInfo = lc?.stallDetectedAt
+      ? ` STALL(nudges=${lc.nudgeAttempts ?? 0}, since=${lc.stallDetectedAt})`
+      : "";
     console.log(
-      `${agent.name}: status=${runtime?.status ?? "unknown"} provider=${agent.provider} model=${agent.model}${effort} pr=${runtime?.prUrl ?? "-"}${lcInfo}`,
+      `${agent.name}: status=${runtime?.status ?? "unknown"} provider=${agent.provider} model=${agent.model}${effort} pr=${runtime?.prUrl ?? "-"}${lcInfo}${stallInfo}`,
     );
   }
   console.log("timeouts:");

--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -3,7 +3,9 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { join } from "path";
 import { tmpdir } from "os";
 import { isAgentDone, pairReviewVerdict } from "./phases.ts";
-import { updateTurnLifecycle, refreshAgentStatuses, maybePostCodexReviewRequests, autoCommitAgent, autoCommitAllAgents } from "./runner.ts";
+import { updateTurnLifecycle, refreshAgentStatuses, maybePostCodexReviewRequests, autoCommitAgent, autoCommitAllAgents, detectAndNudgeStalls, interruptAgent } from "./runner.ts";
+import * as events from "../events.ts";
+import * as t3codeServer from "../t3code/server.ts";
 import * as github from "./github.ts";
 import { orchOnStop } from "./index.ts";
 import { readStopHookRecord, writeStopHookRecord, writeAgentMarkerFiles, readAgentMarkerFile } from "./peer-sync.ts";
@@ -30,6 +32,10 @@ function makeLifecycle(overrides: Partial<AgentTurnLifecycle> = {}): AgentTurnLi
     completionSource: null,
     statusFileFingerprint: null,
     lastStopHookAt: null,
+    stallDetectedAt: null,
+    nudgeAttempts: 0,
+    lastNudgeAt: null,
+    preNudgeAssistantMessageId: null,
     ...overrides,
   };
 }
@@ -640,15 +646,23 @@ describe("refreshAgentStatuses", () => {
       hookEventName: "Stop",
     });
 
+    // Use a requestedAt BEFORE the dispatch time to simulate a turn from a prior
+    // phase/dispatch. This ensures the snapshot reconciliation guard (which checks
+    // requestedAt >= dispatchedAt) correctly rejects this stale turn.
     const snapshot = makeSnapshot([{
       id: "t1",
       session: { status: "ready", activeTurnId: null },
-      latestTurn: { turnId: "turn-x", state: "completed", completedAt: new Date().toISOString() },
+      latestTurn: {
+        turnId: "turn-x",
+        state: "completed",
+        completedAt: new Date().toISOString(),
+        requestedAt: new Date(Date.now() - 120_000).toISOString(), // before dispatchedAt
+      },
     }]);
 
     refreshAgentStatuses(state, snapshot);
 
-    // Stale phaseToken — lifecycle stays dispatched.
+    // Stale phaseToken AND stale requestedAt — lifecycle stays dispatched.
     expect(state.agentStates.coder.turnLifecycle!.state).toBe("dispatched");
   });
 
@@ -1616,5 +1630,416 @@ describe("autoCommitAllAgents", () => {
     expect(gitCommitCount(repo2)).toBe(2);
     expect(gitLastCommitMsg(repo1)).toBe("coder work: coded");
     expect(gitLastCommitMsg(repo2)).toBe("reviewer work: reviewed");
+  });
+});
+
+// ===========================================================================
+// Snapshot reconciliation for stuck dispatched lifecycles
+// ===========================================================================
+
+describe("snapshot reconciliation for stuck dispatched", () => {
+  let tmpDir: string;
+  let origHarnessDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = join(tmpDir, "harness");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+  });
+
+  test("dispatched + completed latestTurn with requestedAt >= dispatchedAt → settled", () => {
+    const dispatchedAt = new Date(Date.now() - 60_000).toISOString();
+    const requestedAt = new Date(Date.now() - 30_000).toISOString();
+    const completedAt = new Date(Date.now() - 10_000).toISOString();
+
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "work-active|0|coding" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "dispatched",
+      dispatchedAt,
+    });
+
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: { turnId: "turn-reconcile", state: "completed", requestedAt, completedAt },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.state).toBe("settled");
+    expect(lc.observedTurnId).toBe("turn-reconcile");
+    expect(lc.completionSource).toBe("snapshot");
+  });
+
+  test("dispatched + completed latestTurn with requestedAt < dispatchedAt → stays dispatched", () => {
+    const dispatchedAt = new Date(Date.now() - 10_000).toISOString();
+    const requestedAt = new Date(Date.now() - 60_000).toISOString(); // before dispatch
+
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "work-active|0|coding" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "dispatched",
+      dispatchedAt,
+    });
+
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: { turnId: "turn-old", state: "completed", requestedAt, completedAt: new Date().toISOString() },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    expect(state.agentStates.coder.turnLifecycle!.state).toBe("dispatched");
+  });
+
+  test("dispatched + null sessionStatus (snapshot fetch failure) → stays dispatched", () => {
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "work-active|0|coding" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({ state: "dispatched" });
+
+    // null snapshot → sessionStatus will be undefined/null
+    refreshAgentStatuses(state, null);
+
+    expect(state.agentStates.coder.turnLifecycle!.state).toBe("dispatched");
+  });
+
+  test("dispatched + error latestTurn with requestedAt >= dispatchedAt → error", () => {
+    const dispatchedAt = new Date(Date.now() - 60_000).toISOString();
+    const requestedAt = new Date(Date.now() - 30_000).toISOString();
+
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "work-active|0|coding" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "dispatched",
+      dispatchedAt,
+    });
+
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: { turnId: "turn-err", state: "error", requestedAt },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.state).toBe("error");
+    expect(lc.observedTurnId).toBe("turn-err");
+    expect(lc.completionSource).toBe("snapshot");
+  });
+});
+
+// ===========================================================================
+// detectAndNudgeStalls — stall detection and nudge logic
+// ===========================================================================
+
+describe("detectAndNudgeStalls", () => {
+  let tmpDir: string;
+  let serverRecordSpy: ReturnType<typeof spyOn>;
+  let emitSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, "plans"), { recursive: true });
+    mkdirSync(join(tmpDir, "reviews"), { recursive: true });
+    // Mock readServerRecord to return null (prevents actual WebSocket)
+    serverRecordSpy = spyOn(t3codeServer, "readServerRecord").mockReturnValue(null);
+    emitSpy = spyOn(events, "emitEvent");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    serverRecordSpy.mockRestore();
+    emitSpy.mockRestore();
+  });
+
+  test("running stall: done status + running lifecycle + age > threshold → stall detected", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(), // 200s ago > 180s threshold
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.stallDetectedAt).not.toBeNull();
+    // Nudge attempt won't succeed (readServerRecord returns null) so nudgeAttempts stays 0
+    // but stall is detected
+    const stallEvent = emitSpy.mock.calls.find(
+      (c: unknown[]) => (c[0] as { event_type?: string }).event_type === "orchestration_stall_detected",
+    );
+    expect(stallEvent).toBeDefined();
+  });
+
+  test("dispatch stall: dispatched lifecycle + age > threshold → stall detected", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "dispatched",
+      dispatchedAt: new Date(Date.now() - 400_000).toISOString(), // 400s > 300s threshold
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.stallDetectedAt).not.toBeNull();
+  });
+
+  test("below threshold: no stall detected", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 60_000).toISOString(), // 60s < 180s threshold
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.stallDetectedAt).toBeNull();
+  });
+
+  test("nudge cooldown respected: recent lastNudgeAt → no nudge", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 100_000).toISOString(),
+      nudgeAttempts: 1,
+      lastNudgeAt: new Date(Date.now() - 30_000).toISOString(), // 30s ago < 120s cooldown
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    // nudgeAttempts should stay at 1 (cooldown prevented another nudge)
+    expect(state.agentStates.coder.turnLifecycle!.nudgeAttempts).toBe(1);
+  });
+
+  test("force-settle after MAX_NUDGE_ATTEMPTS: interruptAgent called", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 600_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 500_000).toISOString(),
+      nudgeAttempts: 2, // >= MAX_NUDGE_ATTEMPTS
+      lastNudgeAt: new Date(Date.now() - 200_000).toISOString(),
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    // interruptAgent sets interrupted = true and status = "interrupted"
+    expect(state.agentStates.coder.interrupted).toBe(true);
+    expect(state.agentStates.coder.status).toBe("interrupted");
+    const forceEvent = emitSpy.mock.calls.find(
+      (c: unknown[]) => (c[0] as { event_type?: string }).event_type === "orchestration_force_settle",
+    );
+    expect(forceEvent).toBeDefined();
+  });
+
+  test("pre-nudge snapshot guard: settled session → no nudge", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 100_000).toISOString(),
+      nudgeAttempts: 0,
+    });
+
+    // Snapshot shows session is idle (already settled)
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+    }]);
+
+    await detectAndNudgeStalls(state, snapshot);
+
+    // nudgeAttempts should stay 0 because the snapshot guard skipped the nudge
+    expect(state.agentStates.coder.turnLifecycle!.nudgeAttempts).toBe(0);
+  });
+
+  test("settled lifecycle is skipped", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "settled",
+      observedTurnId: "turn-1",
+      turnCompletedAt: new Date().toISOString(),
+      completionSource: "snapshot",
+    });
+
+    await detectAndNudgeStalls(state, null);
+
+    expect(state.agentStates.coder.turnLifecycle!.stallDetectedAt).toBeNull();
+  });
+
+  test("interrupted agent is skipped", async () => {
+    const state = makeState({ phase: "work" }, tmpDir);
+    state.agentStates.coder.interrupted = true;
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+    });
+    state.agentStates.coder.status = "done";
+
+    await detectAndNudgeStalls(state, null);
+
+    expect(state.agentStates.coder.turnLifecycle!.stallDetectedAt).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Post-nudge outcome classification
+// ===========================================================================
+
+describe("post-nudge outcome classification", () => {
+  let tmpDir: string;
+  let origHarnessDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = join(tmpDir, "harness");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+  });
+
+  test("settlement after nudge with changed assistantMessageId → alive", () => {
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "done|1|done" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 100_000).toISOString(),
+      nudgeAttempts: 1,
+      lastNudgeAt: new Date(Date.now() - 50_000).toISOString(),
+      preNudgeAssistantMessageId: "msg-old",
+    });
+
+    // Snapshot shows settled session with new assistant message
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: {
+        turnId: "turn-1",
+        state: "completed",
+        completedAt: new Date().toISOString(),
+        assistantMessageId: "msg-new", // changed
+      },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    // Stall should be cleared after settlement
+    expect(lc.stallDetectedAt).toBeNull();
+    expect(lc.nudgeAttempts).toBe(0);
+
+    // Check events journal
+    const eventsPath = join(tmpDir, "harness", "journal", "events.jsonl");
+    if (existsSync(eventsPath)) {
+      const evts = readFileSync(eventsPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+      const aliveEvent = evts.find((e: { event_type?: string }) => e.event_type === "orchestration_nudge_settled_alive");
+      expect(aliveEvent).toBeDefined();
+    }
+  });
+
+  test("settlement after nudge with unchanged assistantMessageId → dead", () => {
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "done|1|done" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 100_000).toISOString(),
+      nudgeAttempts: 1,
+      lastNudgeAt: new Date(Date.now() - 50_000).toISOString(),
+      preNudgeAssistantMessageId: "msg-same",
+    });
+
+    // Snapshot shows settled with same assistant message
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: {
+        turnId: "turn-1",
+        state: "completed",
+        completedAt: new Date().toISOString(),
+        assistantMessageId: "msg-same", // unchanged
+      },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.stallDetectedAt).toBeNull();
+    expect(lc.nudgeAttempts).toBe(0);
+
+    const eventsPath = join(tmpDir, "harness", "journal", "events.jsonl");
+    if (existsSync(eventsPath)) {
+      const evts = readFileSync(eventsPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+      const deadEvent = evts.find((e: { event_type?: string }) => e.event_type === "orchestration_nudge_settled_dead");
+      expect(deadEvent).toBeDefined();
+    }
+  });
+
+  test("settlement without any nudge (nudgeAttempts=0) → no outcome event, stall cleared", () => {
+    const peerSyncDir = makePeerSyncDir({ root: tmpDir, coder: tmpDir }, { coder: "done|1|done" });
+    const state = makeState({ phase: "work" }, peerSyncDir);
+    state.agentStates.coder.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-1",
+      turnStartedAt: new Date(Date.now() - 200_000).toISOString(),
+      stallDetectedAt: new Date(Date.now() - 100_000).toISOString(),
+      nudgeAttempts: 0, // no nudge was sent
+    });
+
+    const snapshot = makeSnapshot([{
+      id: "t1",
+      session: { status: "idle", activeTurnId: null },
+      latestTurn: {
+        turnId: "turn-1",
+        state: "completed",
+        completedAt: new Date().toISOString(),
+      },
+    }]);
+
+    refreshAgentStatuses(state, snapshot);
+
+    const lc = state.agentStates.coder.turnLifecycle!;
+    expect(lc.stallDetectedAt).toBeNull();
+    expect(lc.nudgeAttempts).toBe(0);
+
+    // No nudge outcome event should be emitted
+    const eventsPath = join(tmpDir, "harness", "journal", "events.jsonl");
+    if (existsSync(eventsPath)) {
+      const evts = readFileSync(eventsPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+      const outcomeEvent = evts.find((e: { event_type?: string }) =>
+        e.event_type === "orchestration_nudge_settled_alive" || e.event_type === "orchestration_nudge_settled_dead",
+      );
+      expect(outcomeEvent).toBeUndefined();
+    }
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -24,6 +24,16 @@ import { findProjectConfig, harnessDir } from "../config.ts";
 import { notifyAgents } from "../notify.ts";
 import { autoCommitWorktree, pushBranch } from "./worktrees.ts";
 
+// --- Stall detection constants ---
+/** Seconds after turnStartedAt before a running-but-done-status agent is stalled. */
+const STALL_THRESHOLD_S = 180;
+/** Seconds after dispatchedAt before a never-started dispatch is stalled. */
+const DISPATCH_STALL_THRESHOLD_S = 300;
+/** Minimum seconds between nudge attempts per agent. */
+const NUDGE_COOLDOWN_S = 120;
+/** Force-settle via interruptAgent() after this many failed nudges. */
+const MAX_NUDGE_ATTEMPTS = 2;
+
 async function withClient<T>(
   record: T3CodeServerRecord,
   fn: (client: T3CodeClient) => Promise<T>,
@@ -97,8 +107,69 @@ export function refreshAgentStatuses(state: OrchestrationState, snapshot: T3Snap
       }
     }
 
+    // --- 3c. Snapshot reconciliation for stuck dispatched lifecycles ---
+    // If lifecycle is still "dispatched", no stop-hook arrived, but the snapshot
+    // shows a terminal latestTurn that was requested AFTER our dispatch, settle
+    // the lifecycle. This handles the case where t3code processed the turn but
+    // the orchestrator never observed it running (e.g. very fast completion,
+    // snapshot polling gap).
+    if (lc && lc.state === "dispatched" && !activeTurnId && latestTurn
+        && (latestTurn.state === "completed" || latestTurn.state === "error")
+        && sessionStatus !== null && sessionStatus !== undefined) {
+      const turnRequested = latestTurn.requestedAt
+        ? new Date(latestTurn.requestedAt).getTime()
+        : 0;
+      const dispatched = new Date(lc.dispatchedAt).getTime();
+      if (turnRequested >= dispatched) {
+        lc.observedTurnId = latestTurn.turnId;
+        lc.state = latestTurn.state === "error" ? "error" : "settled";
+        lc.turnCompletedAt = latestTurn.completedAt ?? isoNow();
+        lc.completionSource = "snapshot";
+        emitEvent({
+          event_type: "orchestration_snapshot_reconcile",
+          source: "orchestration",
+          scope: "slot",
+          slot: state.slot,
+          task: state.feature,
+          agent: agent.name,
+          message: `${agent.name}: reconciled stuck dispatched lifecycle via snapshot (latestTurn.requestedAt >= dispatchedAt)`,
+        });
+      }
+    }
+
     // --- 4. Detect inconsistencies ---
     detectAgentInconsistencies(state, agent, runtime);
+
+    // --- 5. Post-nudge outcome classification ---
+    if (lc && (lc.stallDetectedAt ?? null) !== null && lc.state === "settled") {
+      const nudgeAttempts = lc.nudgeAttempts ?? 0;
+      if (nudgeAttempts > 0) {
+        // Deterministic classification via assistantMessageId comparison.
+        const currentAMId = thread?.latestTurn?.assistantMessageId ?? null;
+        const preAMId = lc.preNudgeAssistantMessageId ?? null;
+        // If the assistantMessageId changed (or appeared), agent responded to nudge.
+        // If unchanged (or both null), session was dead / settled without response.
+        const agentResponded = currentAMId !== null && currentAMId !== preAMId;
+        const eventType = agentResponded
+          ? "orchestration_nudge_settled_alive"
+          : "orchestration_nudge_settled_dead";
+        emitEvent({
+          event_type: eventType,
+          source: "orchestration",
+          scope: "slot",
+          slot: state.slot,
+          task: state.feature,
+          agent: agent.name,
+          nudgeAttempts,
+          message: `${agent.name}: stall resolved (${agentResponded ? "alive" : "dead"}) after ${nudgeAttempts} nudge(s)`,
+        });
+      }
+      // Clear stall bookkeeping
+      lc.stallDetectedAt = null;
+      lc.nudgeAttempts = 0;
+      lc.lastNudgeAt = null;
+      lc.preNudgeAssistantMessageId = null;
+    }
   }
 }
 
@@ -171,6 +242,145 @@ function detectAgentInconsistencies(
       task: state.feature,
       message: `${agent.name}: peer-sync says "${runtime.status}" but turn lifecycle is "${lc.state}"`,
     });
+  }
+}
+
+/**
+ * Detect stalled agents and send phase-aware nudge messages.
+ * Called from pollUntilDone() after refreshAgentStatuses(), before allAgentsDone().
+ *
+ * Stall conditions (only reached if snapshot reconciliation didn't resolve it):
+ * 1. Running stall: DONE_STATUSES.has(status) && lc.state === "running" && age > STALL_THRESHOLD_S
+ * 2. Dispatch stall: lc.state === "dispatched" && age > DISPATCH_STALL_THRESHOLD_S
+ *
+ * Recovery progression: detect → nudge (up to MAX_NUDGE_ATTEMPTS) → force-settle
+ */
+export async function detectAndNudgeStalls(
+  state: OrchestrationState,
+  snapshot: T3Snapshot | null,
+): Promise<void> {
+  for (const agent of state.agents) {
+    if (!agentParticipatesInPhase(state, agent)) continue;
+    const runtime = state.agentStates[agent.name]!;
+    const lc = runtime.turnLifecycle;
+    if (!lc || lc.state === "settled" || lc.state === "error") continue;
+    if (runtime.interrupted) continue;
+
+    const now = nowEpoch();
+    let isStalled = false;
+    let stallType: "running" | "dispatch" | null = null;
+
+    // Running stall: peer-sync done + turn still running
+    if (DONE_STATUSES.has(runtime.status) && lc.state === "running" && lc.turnStartedAt) {
+      const age = now - Math.floor(new Date(lc.turnStartedAt).getTime() / 1000);
+      if (age > STALL_THRESHOLD_S) {
+        isStalled = true;
+        stallType = "running";
+      }
+    }
+    // Dispatch stall: turn never started (snapshot reconciliation didn't help)
+    else if (lc.state === "dispatched") {
+      const age = now - Math.floor(new Date(lc.dispatchedAt).getTime() / 1000);
+      if (age > DISPATCH_STALL_THRESHOLD_S) {
+        isStalled = true;
+        stallType = "dispatch";
+      }
+    }
+
+    if (!isStalled) continue;
+
+    // --- First detection ---
+    if (!(lc.stallDetectedAt ?? null)) {
+      lc.stallDetectedAt = isoNow();
+      emitEvent({
+        event_type: "orchestration_stall_detected",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.feature,
+        agent: agent.name,
+        phase: state.phase,
+        stallType,
+        message: `${agent.name}: stall detected (${stallType}), lc.state=${lc.state}, status=${runtime.status}`,
+      });
+    }
+
+    const attempts = lc.nudgeAttempts ?? 0;
+
+    // --- Force-settle after MAX_NUDGE_ATTEMPTS ---
+    if (attempts >= MAX_NUDGE_ATTEMPTS) {
+      emitEvent({
+        event_type: "orchestration_force_settle",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.feature,
+        agent: agent.name,
+        phase: state.phase,
+        attempts,
+        message: `${agent.name}: force-settling after ${attempts} nudge attempts`,
+      });
+      await interruptAgent(state, agent);
+      continue;
+    }
+
+    // --- Nudge cooldown ---
+    const lastNudge = lc.lastNudgeAt
+      ? Math.floor(new Date(lc.lastNudgeAt).getTime() / 1000)
+      : 0;
+    if (now - lastNudge < NUDGE_COOLDOWN_S) continue;
+
+    // --- Pre-nudge snapshot guard (avoid nudging a naturally settling turn) ---
+    const thread = snapshot
+      ? threadSnapshot(snapshot, state.threadIds[agent.name])
+      : null;
+    if (snapshot && thread) {
+      const activeTurnId = thread.session?.activeTurnId ?? null;
+      const sessionStatus = thread.session?.status;
+      if (sessionStatus !== "running" || !activeTurnId) {
+        // Turn appears settled in latest snapshot — let the next
+        // refreshAgentStatuses() advance the lifecycle naturally.
+        continue;
+      }
+    }
+
+    // --- Capture pre-nudge assistant message ID for outcome classification ---
+    const preNudgeAMId = thread?.latestTurn?.assistantMessageId ?? null;
+
+    // --- Send phase-aware nudge ---
+    try {
+      const nudgeMessage = stallType === "dispatch"
+        ? `Your session appears stuck. Please respond to confirm you are working on the ${state.phase} phase.`
+        : `Your work for the ${state.phase} phase is complete. Stop and wait for further instructions.`;
+      await sendTurnMessage(state, agent, nudgeMessage);
+      lc.nudgeAttempts = attempts + 1;
+      lc.lastNudgeAt = isoNow();
+      lc.preNudgeAssistantMessageId = preNudgeAMId;
+      emitEvent({
+        event_type: "orchestration_nudge_sent",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.feature,
+        agent: agent.name,
+        phase: state.phase,
+        attempt: attempts + 1,
+        stallType,
+        message: `${agent.name}: nudge #${attempts + 1} sent (${stallType})`,
+      });
+    } catch (err) {
+      // Nudge dispatch failed — log, don't throw. Next cycle retries.
+      emitEvent({
+        event_type: "orchestration_nudge_failed",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.feature,
+        agent: agent.name,
+        message: `${agent.name}: nudge dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      // Do NOT increment nudgeAttempts on failure — the next poll cycle will retry.
+    }
   }
 }
 
@@ -342,6 +552,10 @@ async function enterPhase(state: OrchestrationState): Promise<void> {
       completionSource: null,
       statusFileFingerprint: statusFileFingerprint(state.peerSyncDir, agent.name),
       lastStopHookAt: null,
+      stallDetectedAt: null,
+      nudgeAttempts: 0,
+      lastNudgeAt: null,
+      preNudgeAssistantMessageId: null,
     };
 
     // Persist after each agent dispatch — crash recovery will have lifecycle data
@@ -382,6 +596,10 @@ async function redispatchForPrComments(state: OrchestrationState): Promise<void>
       completionSource: null,
       statusFileFingerprint: statusFileFingerprint(state.peerSyncDir, agent.name),
       lastStopHookAt: null,
+      stallDetectedAt: null,
+      nudgeAttempts: 0,
+      lastNudgeAt: null,
+      preNudgeAssistantMessageId: null,
     };
   }
 }
@@ -734,6 +952,9 @@ async function pollUntilDone(state: OrchestrationState): Promise<void> {
     while (true) {
       const snapshot = await fetchSnapshot(record);
       refreshAgentStatuses(state, snapshot);
+
+      // Detect stalled agents and send nudges / force-settle.
+      await detectAndNudgeStalls(state, snapshot);
 
       // Validate pr files when coder finishes pr-create (auto-create PR from markdown if needed).
       if (state.phase === "pr-create") {

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -53,6 +53,17 @@ export interface AgentTurnLifecycle {
   statusFileFingerprint: string | null;
   /** ISO timestamp of the most recent stop hook for this agent. */
   lastStopHookAt: string | null;
+  // --- Stall detection & nudge fields ---
+  /** ISO timestamp when stall was first detected (null = no active stall). */
+  stallDetectedAt?: string | null;
+  /** Number of nudge messages sent during this stall episode. */
+  nudgeAttempts?: number;
+  /** ISO timestamp of the most recent nudge dispatch. */
+  lastNudgeAt?: string | null;
+  /** assistantMessageId from the thread's latestTurn at the moment a nudge was sent.
+   *  Used to classify post-nudge outcome: if it changes after settlement,
+   *  the agent was alive; if unchanged, the session was dead. */
+  preNudgeAssistantMessageId?: string | null;
 }
 
 export interface AgentRuntimeState {


### PR DESCRIPTION
## Summary
- Adds stall detection in orchestrator poll loop: detects peer-sync/lifecycle divergence
- Sends phase-aware nudge messages via t3code thread API
- Force-settles after max nudge attempts
- Auto-resumes dead orchestrators from keepalive (`maybeResumeDeadOrchestrators()`)
- Health check reports stalled slots
- 14 new tests covering stall detection, nudge cooldown, force-settle, snapshot reconciliation

## Test plan
- [x] `bun run typecheck` passes
- [x] 150 orchestration tests pass
- [x] Addresses the lifecycle stall bugs observed throughout 2026-03-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)