### PR TITLE
feat: add git info/exclude setup to prevent committing workflow infrastructure

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { autoCommitWorktree, cleanupWorktrees, createWorktrees, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, cleanupWorktrees, createWorktrees, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, symlinkPeerSync } from "./worktrees.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -200,5 +200,167 @@ describe("autoCommitWorktree", () => {
     expect(r2.dirty).toBe(false);
     expect(r2.committed).toBe(false);
     expect(gitLogCount(repo)).toBe(2); // init + first, no second
+  });
+
+  test("ignores .agents and node_modules (expanded ORCHESTRATION_EXCLUDES)", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-expanded-excludes");
+    initRepo(repo);
+    ensureGitExcludes(repo);
+    mkdirSync(join(repo, ".agents"), { recursive: true });
+    writeFileSync(join(repo, ".agents", "marker"), "1\n");
+    mkdirSync(join(repo, ".agent-sessions"), { recursive: true });
+    writeFileSync(join(repo, ".agent-sessions", "s1"), "data\n");
+    // Create a node_modules symlink (like createWorktrees does)
+    try { symlinkSync("/tmp", join(repo, "node_modules")); } catch { /* */ }
+
+    const result = autoCommitWorktree(repo, "should not commit");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureGitExcludes
+// ---------------------------------------------------------------------------
+
+function readExcludeFile(repoPath: string): string {
+  const result = Bun.spawnSync(["git", "rev-parse", "--git-common-dir"], {
+    cwd: repoPath, stdout: "pipe", stderr: "pipe",
+    env: process.env as Record<string, string>,
+  });
+  const gitDir = result.stdout.toString().trim();
+  const resolved = gitDir.startsWith("/") ? gitDir : join(repoPath, gitDir);
+  const excludePath = join(resolved, "info", "exclude");
+  try { return readFileSync(excludePath, "utf-8"); } catch { return ""; }
+}
+
+describe("ensureGitExcludes", () => {
+  test("writes all entries to a repo's info/exclude", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "exclude-basic");
+    initRepo(repo);
+
+    ensureGitExcludes(repo);
+
+    const content = readExcludeFile(repo);
+    for (const entry of GIT_EXCLUDE_ENTRIES) {
+      expect(content).toContain(entry);
+    }
+  });
+
+  test("idempotent: calling twice does not duplicate entries", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "exclude-idempotent");
+    initRepo(repo);
+
+    ensureGitExcludes(repo);
+    ensureGitExcludes(repo);
+
+    const content = readExcludeFile(repo);
+    for (const entry of GIT_EXCLUDE_ENTRIES) {
+      const count = content.split("\n").filter((l: string) => l === entry).length;
+      expect(count).toBe(1);
+    }
+  });
+
+  test("preserves existing exclude content", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "exclude-preserve");
+    initRepo(repo);
+    writeFileSync(join(repo, ".git", "info", "exclude"), "my-custom-ignore\n");
+
+    ensureGitExcludes(repo);
+
+    const content = readExcludeFile(repo);
+    expect(content).toContain("my-custom-ignore");
+    for (const entry of GIT_EXCLUDE_ENTRIES) {
+      expect(content).toContain(entry);
+    }
+  });
+
+  test("createWorktrees writes excludes to projectDir and all worktrees", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "repo-excludes");
+    mkdirSync(repo, { recursive: true });
+    run(["git", "init", "-b", "main"], repo);
+    run(["git", "config", "user.email", "test@example.com"], repo);
+    run(["git", "config", "user.name", "Test User"], repo);
+    writeFileSync(join(repo, "README.md"), "hello\n");
+    run(["git", "add", "README.md"], repo);
+    run(["git", "commit", "-m", "init"], repo);
+
+    const setup = createWorktrees(repo, "excl", [{ name: "a1" }, { name: "a2" }], "main", 7);
+
+    // Check projectDir
+    const mainContent = readExcludeFile(repo);
+    for (const entry of GIT_EXCLUDE_ENTRIES) {
+      expect(mainContent).toContain(entry);
+    }
+
+    // Check root worktree
+    const rootContent = readExcludeFile(setup.rootWorktree);
+    for (const entry of GIT_EXCLUDE_ENTRIES) {
+      expect(rootContent).toContain(entry);
+    }
+
+    // Check agent worktrees
+    for (const wt of Object.values(setup.agentWorktrees)) {
+      const content = readExcludeFile(wt);
+      for (const entry of GIT_EXCLUDE_ENTRIES) {
+        expect(content).toContain(entry);
+      }
+    }
+
+    cleanupWorktrees(repo, "excl", [{ name: "a1" }, { name: "a2" }], 7);
+  });
+
+  test("git add -A in a worktree ignores orchestration files", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "repo-gitadd");
+    mkdirSync(repo, { recursive: true });
+    run(["git", "init", "-b", "main"], repo);
+    run(["git", "config", "user.email", "test@example.com"], repo);
+    run(["git", "config", "user.name", "Test User"], repo);
+    writeFileSync(join(repo, "README.md"), "hello\n");
+    run(["git", "add", "README.md"], repo);
+    run(["git", "commit", "-m", "init"], repo);
+
+    const setup = createWorktrees(repo, "ga", [{ name: "c1" }], "main", 8);
+    const wt = setup.agentWorktrees.c1!;
+
+    // Create orchestration files
+    writeFileSync(join(wt, ".ludics-orchestration.json"), "{}");
+    mkdirSync(join(wt, ".peer-sync"), { recursive: true });
+    writeFileSync(join(wt, ".peer-sync", "foo"), "x");
+    mkdirSync(join(wt, ".claude"), { recursive: true });
+    writeFileSync(join(wt, ".claude", "settings.json"), "{}");
+    mkdirSync(join(wt, ".agents"), { recursive: true });
+    writeFileSync(join(wt, ".agents", "marker"), "1");
+    mkdirSync(join(wt, ".agent-sessions"), { recursive: true });
+    writeFileSync(join(wt, ".agent-sessions", "s1"), "1");
+    try { symlinkSync("/tmp", join(wt, "node_modules")); } catch { /* */ }
+
+    // Create a real source file
+    mkdirSync(join(wt, "src"), { recursive: true });
+    writeFileSync(join(wt, "src", "main.ts"), "export const x = 1;\n");
+
+    run(["git", "add", "-A"], wt);
+    const status = Bun.spawnSync(["git", "status", "--porcelain"], {
+      cwd: wt, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+
+    expect(status).toContain("src/main.ts");
+    expect(status).not.toContain(".peer-sync");
+    expect(status).not.toContain(".ludics-orchestration.json");
+    expect(status).not.toContain(".claude");
+    expect(status).not.toContain(".agents");
+    expect(status).not.toContain(".agent-sessions");
+    expect(status).not.toContain("node_modules");
+
+    cleanupWorktrees(repo, "ga", [{ name: "c1" }], 8);
   });
 });

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdirSync, readlinkSync, rmSync, symlinkSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { slugify } from "./util.ts";
 
@@ -31,6 +31,47 @@ function maybeGit(projectDir: string, args: string[]): string {
   });
   if (result.exitCode !== 0) return "";
   return result.stdout.toString().trim();
+}
+
+/** Paths that the orchestrator manages inside worktrees and must never be committed. */
+export const GIT_EXCLUDE_ENTRIES = [
+  ".peer-sync",
+  ".ludics-orchestration.json",
+  ".claude",
+  ".agents",
+  ".agent-sessions",
+  "node_modules",
+];
+
+/**
+ * Ensure that all {@link GIT_EXCLUDE_ENTRIES} are present in the local
+ * `.git/info/exclude` for the given repo or worktree path.
+ * Uses `--git-common-dir` so that worktrees write to the shared exclude
+ * file that git actually reads (not the per-worktree git dir).
+ * Idempotent: only appends entries that are not already present.
+ * Throws on failure — this is required setup, not best-effort.
+ */
+export function ensureGitExcludes(repoPath: string): void {
+  const commonDir = runGit(repoPath, ["rev-parse", "--git-common-dir"]);
+  const resolvedGitDir = resolve(repoPath, commonDir);
+  const infoDir = join(resolvedGitDir, "info");
+  const excludePath = join(infoDir, "exclude");
+
+  mkdirSync(infoDir, { recursive: true });
+
+  let existing = "";
+  try {
+    existing = readFileSync(excludePath, "utf-8");
+  } catch {
+    // File doesn't exist yet — will be created.
+  }
+
+  const existingLines = new Set(existing.split("\n"));
+  const missing = GIT_EXCLUDE_ENTRIES.filter((e) => !existingLines.has(e));
+  if (missing.length === 0) return;
+
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  writeFileSync(excludePath, existing + prefix + missing.join("\n") + "\n");
 }
 
 function worktreeExists(projectDir: string, path: string): boolean {
@@ -123,6 +164,14 @@ export function createWorktrees(
     }
   }
 
+  // Write .git/info/exclude so orchestration files are never committed,
+  // even if agents run their own git add / git commit -a.
+  ensureGitExcludes(resolve(projectDir));
+  const allWorktrees = new Set([rootWorktree, ...Object.values(agentWorktrees)]);
+  for (const wt of allWorktrees) {
+    ensureGitExcludes(wt);
+  }
+
   return { rootWorktree, peerSyncDir, agentWorktrees, branches };
 }
 
@@ -175,12 +224,8 @@ export function cleanupWorktrees(
 // Auto-commit helpers
 // ---------------------------------------------------------------------------
 
-/** Paths that the orchestrator writes into worktrees but must never be committed. */
-const ORCHESTRATION_EXCLUDES = [
-  ":!.peer-sync",
-  ":!.ludics-orchestration.json",
-  ":!.claude",
-];
+/** Pathspec exclusions derived from {@link GIT_EXCLUDE_ENTRIES} for autoCommitWorktree. */
+const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.map((e) => `:!${e}`);
 
 export interface AutoCommitResult {
   /** Whether the worktree had eligible uncommitted changes. */
@@ -195,7 +240,7 @@ export interface AutoCommitResult {
 
 /**
  * Auto-commit any uncommitted changes in the given directory, excluding
- * orchestration-internal paths (.peer-sync, .ludics-orchestration.json, .claude).
+ * orchestration-internal paths listed in {@link GIT_EXCLUDE_ENTRIES}.
  * Returns a structured result. Safe to call on clean worktrees (no-op).
  */
 export function autoCommitWorktree(


### PR DESCRIPTION
## Summary

- Add `ensureGitExcludes()` helper that writes local `.git/info/exclude` entries at worktree creation time, using `--git-common-dir` for correct worktree support
- Derive `ORCHESTRATION_EXCLUDES` pathspecs from shared `GIT_EXCLUDE_ENTRIES` constant (single source of truth)
- Protect against agent-initiated `git add -A` / `git commit -a` bypassing pathspec exclusions
- Fix `node_modules` symlink not being ignored (`.gitignore` has `node_modules/` with trailing slash, which doesn't match symlinks)

## Test plan

- [x] `bun run typecheck` passes
- [x] 6 new tests: exclude file writing, idempotency, content preservation, `createWorktrees` coverage, `git add -A` behavior, expanded pathspec coverage
- [x] All 404 tests pass (`bun test`)
- [ ] Manual verification: create worktrees, confirm `git status --ignored` shows orchestration files as ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)