### PR TITLE
feat: attach review artifacts to retrospective file

### DIFF
--- a/src/retrospective.test.ts
+++ b/src/retrospective.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { extractReviews } from "./retrospective.ts";
+import type { RetrospectiveVerdict } from "./retrospective.ts";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "ludics-retro-test-"));
+}
+
+describe("extractReviews", () => {
+  let tmp: string;
+
+  afterEach(() => {
+    try { rmSync(tmp, { recursive: true }); } catch { /* ignore */ }
+  });
+
+  test("mixed files sorted: plan-review before review, then by round", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "round-1-reviewer.md"), "**Verdict**: REQUEST_CHANGES\n\nFix the bug.\n");
+    writeFileSync(join(reviewsDir, "plan-merge-0-reviewer.md"), "**Verdict**: APPROVE\n\nLooks good!\n");
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(2);
+
+    // plan-merge-0 first (round 0 < round 1)
+    expect(reviews[0]!.round).toBe(0);
+    expect(reviews[0]!.type).toBe("plan-review");
+    expect(reviews[0]!.reviewer).toBe("reviewer");
+    expect(reviews[0]!.verdict).toBe("approve");
+    expect(reviews[0]!.content).toContain("Looks good!");
+
+    expect(reviews[1]!.round).toBe(1);
+    expect(reviews[1]!.type).toBe("review");
+    expect(reviews[1]!.verdict).toBe("request_changes");
+    expect(reviews[1]!.content).toContain("Fix the bug.");
+  });
+
+  test("hyphenated reviewer name captured correctly", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "round-2-codex-reviews-claude.md"), "APPROVE\n");
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]!.reviewer).toBe("codex-reviews-claude");
+  });
+
+  test("unrecognized filename ignored", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "notes.md"), "some notes");
+    writeFileSync(join(reviewsDir, "round-1-coder.md"), "APPROVE\n");
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]!.reviewer).toBe("coder");
+  });
+
+  test("empty/missing reviews directory returns empty array", () => {
+    tmp = makeTmpDir();
+    // No reviews/ subdirectory
+    const reviews = extractReviews(tmp);
+    expect(reviews).toEqual([]);
+  });
+
+  test("verdict-less content falls back to timeout", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    const body = "This review has no verdict keyword.\n";
+    writeFileSync(join(reviewsDir, "round-1-reviewer.md"), body);
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]!.verdict).toBe("timeout");
+    expect(reviews[0]!.content).toBe(body);
+  });
+
+  test("multiple reviewers same round sorted alphabetically", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "round-1-bob.md"), "APPROVE\n");
+    writeFileSync(join(reviewsDir, "round-1-alice.md"), "APPROVE\n");
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0]!.reviewer).toBe("alice");
+    expect(reviews[1]!.reviewer).toBe("bob");
+  });
+
+  test("plan-review before review at same round number", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "round-1-reviewer.md"), "APPROVE\n");
+    writeFileSync(join(reviewsDir, "plan-merge-1-reviewer.md"), "APPROVE\n");
+
+    const reviews = extractReviews(tmp);
+    expect(reviews).toHaveLength(2);
+    expect(reviews[0]!.type).toBe("plan-review");
+    expect(reviews[1]!.type).toBe("review");
+  });
+
+  test("derived verdicts match reviews", () => {
+    tmp = makeTmpDir();
+    const reviewsDir = join(tmp, "reviews");
+    mkdirSync(reviewsDir, { recursive: true });
+
+    writeFileSync(join(reviewsDir, "plan-merge-0-reviewer.md"), "APPROVE\n");
+    writeFileSync(join(reviewsDir, "round-1-codex-reviews-claude.md"), "REQUEST_CHANGES\n\nFix it.\n");
+    writeFileSync(join(reviewsDir, "round-2-coder.md"), "APPROVE\n");
+
+    const reviews = extractReviews(tmp);
+    // Derive verdicts the same way the collector does
+    const verdicts: RetrospectiveVerdict[] = reviews.map((r) => ({
+      round: r.round,
+      type: r.type,
+      verdict: r.verdict,
+      reviewer: r.reviewer,
+    }));
+
+    expect(verdicts).toHaveLength(reviews.length);
+    for (let i = 0; i < reviews.length; i++) {
+      expect(verdicts[i]!.round).toBe(reviews[i]!.round);
+      expect(verdicts[i]!.type).toBe(reviews[i]!.type);
+      expect(verdicts[i]!.verdict).toBe(reviews[i]!.verdict);
+      expect(verdicts[i]!.reviewer).toBe(reviews[i]!.reviewer);
+    }
+
+    // Verify hyphenated name is in both
+    expect(verdicts[1]!.reviewer).toBe("codex-reviews-claude");
+  });
+});

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -20,6 +20,14 @@ export interface RetrospectiveVerdict {
   reviewer: string | null;
 }
 
+export interface RetrospectiveReview {
+  round: number;
+  type: "review" | "plan-review";
+  reviewer: string;
+  verdict: "approve" | "request_changes" | "timeout";
+  content: string;
+}
+
 export interface RetrospectiveThread {
   threadId: string;
   agentName: string;
@@ -63,6 +71,7 @@ export interface RetrospectiveData {
   planMergeRound: number;
   agents: string[];
   verdicts: RetrospectiveVerdict[];
+  reviews: RetrospectiveReview[];
   threads: RetrospectiveThread[];
   turns: RetrospectiveTurn[];
   missingThreads: MissingThread[];
@@ -291,6 +300,60 @@ function extractVerdicts(peerSyncDir: string): RetrospectiveVerdict[] {
   return verdicts;
 }
 
+export function extractReviews(peerSyncDir: string): RetrospectiveReview[] {
+  const reviewsDir = join(peerSyncDir, "reviews");
+  if (!existsSync(reviewsDir)) return [];
+
+  const reviews: RetrospectiveReview[] = [];
+
+  try {
+    const files = readdirSync(reviewsDir).filter((f: string) => f.endsWith(".md"));
+
+    for (const f of files) {
+      // Normal review: round-N-<reviewer>.md
+      const roundMatch = f.match(/^round-(\d+)-(.+)\.md$/);
+      if (roundMatch) {
+        const round = parseInt(roundMatch[1]!, 10);
+        const reviewer = roundMatch[2]!;
+        try {
+          const content = readFileSync(join(reviewsDir, f), "utf-8");
+          const verdict = parseVerdictFromContent(content);
+          reviews.push({ round, type: "review", reviewer, verdict, content });
+        } catch {
+          // skip unreadable file
+        }
+        continue;
+      }
+
+      // Plan-review: plan-merge-N-<reviewer>.md
+      const planMatch = f.match(/^plan-merge-(\d+)-(.+)\.md$/);
+      if (planMatch) {
+        const round = parseInt(planMatch[1]!, 10);
+        const reviewer = planMatch[2]!;
+        try {
+          const content = readFileSync(join(reviewsDir, f), "utf-8");
+          const verdict = parseVerdictFromContent(content);
+          reviews.push({ round, type: "plan-review", reviewer, verdict, content });
+        } catch {
+          // skip unreadable file
+        }
+      }
+      // Unrecognized filenames silently skipped
+    }
+  } catch {
+    // directory read error — return empty
+  }
+
+  // Sort: round ASC, plan-review before review at same round, reviewer alpha
+  reviews.sort((a, b) => {
+    if (a.round !== b.round) return a.round - b.round;
+    if (a.type !== b.type) return a.type === "plan-review" ? -1 : 1;
+    return a.reviewer.localeCompare(b.reviewer);
+  });
+
+  return reviews;
+}
+
 function parseVerdictFromContent(content: string): "approve" | "request_changes" | "timeout" {
   const upper = content.toUpperCase();
   if (upper.includes("APPROVE") && !upper.includes("REQUEST_CHANGES")) return "approve";
@@ -486,8 +549,14 @@ export async function collectAndWriteRetrospective(state: OrchestrationState): P
   // Sort turns chronologically
   allTurns.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
-  // Extract review verdicts
-  const verdicts = extractVerdicts(state.peerSyncDir);
+  // Extract full reviews and derive verdicts for backward compatibility
+  const reviews = extractReviews(state.peerSyncDir);
+  const verdicts: RetrospectiveVerdict[] = reviews.map((r) => ({
+    round: r.round,
+    type: r.type,
+    verdict: r.verdict,
+    reviewer: r.reviewer,
+  }));
 
   // Extract artifact summaries
   const suggestRefactorSummary = extractArtifactSummary(state.peerSyncDir, /^suggest-refactor.*\.md$/);
@@ -514,6 +583,7 @@ export async function collectAndWriteRetrospective(state: OrchestrationState): P
     planMergeRound: state.planMergeRound ?? 0,
     agents: state.agents.map((a) => a.name),
     verdicts,
+    reviews,
     threads: allThreads,
     turns: allTurns,
     missingThreads: allMissing,
@@ -597,6 +667,7 @@ export async function collectRetrospectiveFallback(taskId: string): Promise<void
     planMergeRound: 0,
     agents: [],
     verdicts: [],
+    reviews: [],
     threads: allThreads,
     turns: allTurns,
     missingThreads: allMissing,


### PR DESCRIPTION
## Summary
- Add `RetrospectiveReview` interface and `reviews: RetrospectiveReview[]` field to `RetrospectiveData` in `src/retrospective.ts`
- New `extractReviews()` reads all `.peer-sync/reviews/*.md` files, preserving full markdown content, and sorts chronologically (round ASC, plan-review before review, reviewer alpha)
- Derive `verdicts` from `reviews` in the primary collector so both fields stay consistent (fixes narrow `\w+` regex that missed hyphenated reviewer names)
- Add 8 focused tests in `src/retrospective.test.ts` covering sort order, hyphenated names, unrecognized filenames, missing directory, verdict fallback, and verdicts-reviews consistency

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/retrospective.test.ts` — 8 tests pass
- [x] `bun test` — full suite 421 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)