### PR TITLE
Wire workerReportStatus into orchestration runner completion path

### DIFF
--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -18,6 +18,8 @@ import { fetchNewPrCommentCount, getPrVerification, hasCodexSubmittedReview, isP
 import { updateFrontmatterField } from "../tasks/markdown.ts";
 import { findProjectConfig, globalAdapter, harnessDir } from "../config.ts";
 import { notifyAgents } from "../notify.ts";
+import { workerReportStatus } from "../worker-signal.ts";
+import { federationRole } from "../federation.ts";
 import { autoCommitWorktree, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 
@@ -1200,6 +1202,21 @@ export async function runOrchestration(
         3,
         `Slot ${state.slot}: task done`,
       );
+
+      // On worker machines, write a signal file so the controller discovers
+      // completion quickly via controllerPollWorkers() instead of waiting
+      // for the slower state-repo sync path (maybeClearDoneSlots).
+      if (federationRole() === "worker") {
+        try {
+          workerReportStatus(state.slot, {
+            taskId: state.taskId,
+            status: "done",
+            message: `orchestration completed for ${state.taskId}`,
+          });
+        } catch (err) {
+          console.error(`ludics: worker signal write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
 
       // Collect retrospective data before threads are cleaned up
       try {


### PR DESCRIPTION
## Summary

- When orchestration completes on a worker machine, write a worker signal file so the controller discovers task completion quickly via `controllerPollWorkers()` instead of relying on the slower state-repo sync path (`maybeClearDoneSlots`)
- Guarded by `federationRole() === "worker"` — no-op on standalone/controller machines
- Wrapped in try/catch so signal write failure doesn't break orchestration completion

## Test plan

- [ ] Verify `bun run typecheck` passes
- [ ] On a worker machine, run orchestration to completion and confirm `worker-signals/slot-N.json` is created
- [ ] On a standalone machine, confirm no signal file is written
- [ ] Verify controller picks up the signal via `controllerPollWorkers()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)