### PR TITLE
fix: add --paginate to gh api list-endpoint calls

### DIFF
--- a/skills/orchestration/pr-comments.md
+++ b/skills/orchestration/pr-comments.md
@@ -5,7 +5,7 @@ Address reviewer feedback on the PR in `{{PR_FILE}}` from `{{WORKTREE_PATH}}`.
 Fetch both top-level reviews and inline file comments:
 ```sh
 gh pr view --json reviews,comments --jq '.reviews,.comments'
-gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {path, line, body}'
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {path, line, body}'
 ```
 
 For each actionable comment, make the change, commit, and push.

--- a/src/orchestration/github.ts
+++ b/src/orchestration/github.ts
@@ -21,13 +21,15 @@ export function fetchNewPrCommentCount(prUrl: string, sinceEpoch: number): numbe
 
   function countViaGhApi(args: string[]): number {
     try {
-      const result = Bun.spawnSync(["gh", "api", ...args], {
+      const result = Bun.spawnSync(["gh", "api", "--paginate", ...args], {
         stdout: "pipe",
         stderr: "ignore",
         env: process.env as Record<string, string>,
       });
       if (result.exitCode !== 0) return 0;
-      return parseInt(result.stdout.toString().trim(), 10) || 0;
+      // --paginate + --jq outputs one number per page; sum them
+      return result.stdout.toString().trim().split("\n")
+        .reduce((sum, line) => sum + (parseInt(line, 10) || 0), 0);
     } catch {
       return 0;
     }

--- a/templates/mag/memory/tools.md
+++ b/templates/mag/memory/tools.md
@@ -77,7 +77,7 @@ gh pr list --repo owner/repo
 gh pr view 123 --json state,reviews
 
 # API
-gh api repos/owner/repo/issues/123/comments
+gh api --paginate repos/owner/repo/issues/123/comments
 ```
 
 ### Gotchas


### PR DESCRIPTION
## Summary

- Add `--paginate` flag to `countViaGhApi()` in `src/orchestration/github.ts` so `fetchNewPrCommentCount()` correctly counts all comments/reviews on PRs with >30 items per endpoint
- Fix result parsing to sum per-page jq output (matching the existing pattern in `hasCodexSubmittedReview()`)
- Update `--paginate` in example commands in `skills/orchestration/pr-comments.md` and `templates/mag/memory/tools.md`

Closes: task-983a1079

## Test plan

- [ ] `bun run typecheck` passes
- [ ] On a PR with <30 comments, behavior is unchanged (--paginate is a no-op for single-page results)
- [ ] On a PR with >30 comments on any endpoint, all comments are now counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)