### PR TITLE
feat: add Unanswered Questions dashboard tile

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -300,6 +300,7 @@ interface DashboardTask {
     relates_to: string[];
     subtask_of: string | null;
   };
+  hasQuestions: boolean;
 }
 
 interface NeedsConfirmationTask {
@@ -309,6 +310,13 @@ interface NeedsConfirmationTask {
   priority: string;
   created: string | null;
   relatesTo: string[];
+}
+
+interface UnansweredQuestionsTask {
+  id: string;
+  title: string;
+  project: string;
+  priority: string;
 }
 
 interface TasksTreeNode {
@@ -388,8 +396,9 @@ function readDashboardTasks(): DashboardTask[] {
           blocks: Array.isArray(deps.blocks) ? (deps.blocks as string[]) : [],
           blocked_by: Array.isArray(deps.blocked_by) ? (deps.blocked_by as string[]) : [],
           relates_to: Array.isArray(deps.relates_to) ? (deps.relates_to as string[]) : [],
-          subtask_of: deps.subtask_of ? String(deps.subtask_of) : null,
+          subtask_of: isNonNullValue(deps.subtask_of) ? String(deps.subtask_of) : null,
         },
+        hasQuestions: !!data.has_questions,
       });
     } catch {
       // skip
@@ -460,6 +469,17 @@ function generateNeedsConfirmation(tasks: DashboardTask[]): NeedsConfirmationTas
       priority: task.priority,
       created: task.created,
       relatesTo: task.dependencies.relates_to,
+    }));
+}
+
+function generateUnansweredQuestions(tasks: DashboardTask[]): UnansweredQuestionsTask[] {
+  return tasks
+    .filter((task) => task.hasQuestions && !task.isCompleted)
+    .map((task) => ({
+      id: task.id,
+      title: task.title,
+      project: task.project,
+      priority: task.priority,
     }));
 }
 
@@ -901,6 +921,9 @@ export function dashboardGenerate(): void {
 
   writeFileSync(join(dataDir, "needs-confirmation.json"), JSON.stringify(generateNeedsConfirmation(tasks), null, 2));
   console.error("  needs-confirmation.json");
+
+  writeFileSync(join(dataDir, "unanswered-questions.json"), JSON.stringify(generateUnansweredQuestions(tasks), null, 2));
+  console.error("  unanswered-questions.json");
 
   writeFileSync(join(dataDir, "tasks-tree.json"), JSON.stringify(generateTasksTree(tasks), null, 2));
   console.error("  tasks-tree.json");

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -43,6 +43,7 @@ async function fetchAllData() {
             fetchSlots(),
             fetchReadyQueue(),
             fetchNeedsConfirmation(),
+            fetchUnansweredQuestions(),
             fetchQueueHoldState(),
             fetchNotifications(),
             fetchMagStatus(),
@@ -531,6 +532,45 @@ function renderNeedsConfirmation(tasks) {
                     <button class="confirm-btn" onclick="confirmTask('${escapeHtml(task.id)}')" title="Confirm: move to ready">&#x2713;</button>
                     <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
                 </span>
+            </li>`;
+        });
+        newHtml = items.join('');
+    }
+
+    if (list.innerHTML !== newHtml) {
+        list.innerHTML = newHtml;
+    }
+}
+
+// Fetch unanswered-questions tasks
+async function fetchUnansweredQuestions() {
+    try {
+        const response = await fetch(CONFIG.dataPath + 'unanswered-questions.json');
+        if (!response.ok) throw new Error('Failed to fetch unanswered-questions');
+        const tasks = await response.json();
+        renderUnansweredQuestions(tasks);
+    } catch (error) {
+        console.warn('Using placeholder unanswered-questions');
+        renderUnansweredQuestions([]);
+    }
+}
+
+// Render unanswered-questions tasks
+function renderUnansweredQuestions(tasks) {
+    const list = document.getElementById('unanswered-questions-list');
+    if (!list) return;
+
+    let newHtml;
+    if (tasks.length === 0) {
+        newHtml = '<li class="empty">No unanswered questions</li>';
+    } else {
+        const items = tasks.map(task => {
+            const priority = task.priority || '-';
+            const priorityClass = `priority-${priority}`;
+            return `
+            <li class="unanswered-q-item">
+                <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
+                <a class="task-title unanswered-q-link" href="task-files/${escapeHtml(task.id)}.md" target="_blank">${escapeHtml(task.title || task.id)}</a>
             </li>`;
         });
         newHtml = items.join('');

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -113,6 +113,14 @@
                     </ul>
                 </section>
 
+                <!-- Unanswered Questions -->
+                <section class="unanswered-questions panel">
+                    <h2>Unanswered Questions</h2>
+                    <ul id="unanswered-questions-list">
+                        <li class="loading">Loading...</li>
+                    </ul>
+                </section>
+
                 <!-- Recent Notifications -->
                 <section class="notifications panel">
                     <h2>Recent Notifications</h2>

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -749,6 +749,24 @@ main {
     text-decoration: underline;
 }
 
+/* Unanswered Questions */
+.unanswered-q-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.3em 0.5em;
+    cursor: default;
+}
+
+.unanswered-q-link {
+    color: #e0e0e0;
+    text-decoration: none;
+}
+.unanswered-q-link:hover {
+    color: #fff;
+    text-decoration: underline;
+}
+
 .confirm-btn {
     border-color: #4a9;
     color: #4a9;


### PR DESCRIPTION
## Summary
- Add new "Unanswered Questions" tile to the dashboard, placed between Needs Confirmation and Recent Notifications
- Backend: new `generateUnansweredQuestions()` in `src/dashboard.ts` filters tasks with `has_questions: true` and writes `unanswered-questions.json`
- Frontend: fetch/render functions in `dashboard.js`, HTML section in `index.html`, CSS styles in `style.css`
- Follows the exact pattern of the existing Needs Confirmation tile (no action buttons needed)

Closes task-ed2be1ba

## Test plan
- [ ] Run `bun run typecheck` — passes
- [ ] Run `ludics dashboard generate` and verify `unanswered-questions.json` is created
- [ ] Create a task with `has_questions: true`, regenerate, confirm it appears in the tile
- [ ] Verify completed tasks with `has_questions` are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)