### PR TITLE
refactor: computeSlotLiveness takes SlotLivenessContext struct

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -67,7 +67,7 @@ describe("computeSlotLiveness", () => {
   // Dynamic import to pick up env changes
   async function getLiveness(slot: number, mode: string | null) {
     const { computeSlotLiveness } = await import("./dashboard.ts");
-    return computeSlotLiveness(slot, mode);
+    return computeSlotLiveness({ slotNum: slot, mode });
   }
 
   test("t3code slot with alive PID returns 'alive'", async () => {
@@ -130,13 +130,13 @@ describe("computeSlotLiveness", () => {
   test("explicit Liveness field 'interrupted' in slot block returns 'interrupted'", async () => {
     const { computeSlotLiveness } = await import("./dashboard.ts");
     const block = `## Slot 1\n\n**Process:** test\n**Liveness:** interrupted\n`;
-    expect(computeSlotLiveness(1, null, block)).toBe("interrupted");
+    expect(computeSlotLiveness({ slotNum: 1, mode: null, slotBlock: block })).toBe("interrupted");
   });
 
   test("explicit Liveness field 'null' in slot block falls through to PID check", async () => {
     const { computeSlotLiveness } = await import("./dashboard.ts");
     const block = `## Slot 1\n\n**Process:** test\n**Liveness:** null\n`;
-    expect(computeSlotLiveness(1, null, block)).toBe(null);
+    expect(computeSlotLiveness({ slotNum: 1, mode: null, slotBlock: block })).toBe(null);
   });
 });
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -45,11 +45,14 @@ interface SlotJson {
   liveness: "alive" | "interrupted" | null;
 }
 
-export function computeSlotLiveness(
-  slotNum: number,
-  mode: string | null,
-  slotBlock?: string,
-): "alive" | "interrupted" | null {
+export interface SlotLivenessContext {
+  slotNum: number;
+  mode: string | null;
+  slotBlock?: string;
+}
+
+export function computeSlotLiveness(ctx: SlotLivenessContext): "alive" | "interrupted" | null {
+  const { slotNum, mode, slotBlock } = ctx;
   // Check explicit Liveness field from slot block (set by markSlotSetupFailed)
   if (slotBlock) {
     const explicit = getLiveness(slotBlock).trim();
@@ -275,7 +278,7 @@ function generateSlots(): SlotJson[] {
       const explicitLiveness = getLiveness(block).trim();
       const shouldCheck = (phase && phase !== "done") || explicitLiveness === "interrupted";
       if (shouldCheck && (!machineName || machineName === "null" || !isRemoteMachine(machineName))) {
-        liveness = computeSlotLiveness(num, getMode(block).trim() || null, block);
+        liveness = computeSlotLiveness({ slotNum: num, mode: getMode(block).trim() || null, slotBlock: block });
       }
     }
 


### PR DESCRIPTION
## Summary
- Introduce exported `SlotLivenessContext` interface in `src/dashboard.ts`
- Change `computeSlotLiveness` to accept a single struct parameter instead of positional primitives
- Update the single call site and all tests

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/dashboard.test.ts` — all 7 tests pass
- [x] Pure refactor, no behavior change

Resolves task-54b564a2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)