### PR TITLE
fix: orchestration runners survive parent exit via setsid

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -88,6 +88,15 @@ describe("computeSlotLiveness", () => {
     expect(await getLiveness(1, "t3code")).toBe("interrupted");
   });
 
+  test("tmux slot with alive PID returns 'alive'", async () => {
+    writeTmuxSlotState(1, {
+      slot: 1,
+      ttydPids: {},
+      orchestration: { stateFile: "orch.json", mode: "duo", pid: process.pid },
+    });
+    expect(await getLiveness(1, "tmux")).toBe("alive");
+  });
+
   test("tmux slot with dead PID returns 'interrupted'", async () => {
     writeTmuxSlotState(1, {
       slot: 1,

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand } from "./mag.ts";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode } from "./mag.ts";
 
 describe("normalizeLaunchAdapter", () => {
   test("t3code passes through unchanged", () => {
@@ -192,5 +195,75 @@ describe("resolveQueueRequestCommand — backward compat parsing", () => {
       false,
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("orchPidForSlotMode", () => {
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  let TMP = "";
+
+  function writeConfig(homeDir: string): string {
+    const configDir = join(homeDir, ".config", "ludics");
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state\nstate_path: harness\nslots:\n  count: 2\n`);
+    return configPath;
+  }
+
+  function testHarnessDir(): string {
+    return join(TMP, "harness");
+  }
+
+  function writeT3codeSlotState(slot: number, state: object): void {
+    const dir = join(testHarnessDir(), "t3code");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `slot-${slot}.json`), JSON.stringify(state));
+  }
+
+  function writeTmuxSlotState(slot: number, state: object): void {
+    const dir = join(testHarnessDir(), "orchestration");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `tmux-slot-${slot}.json`), JSON.stringify(state));
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-mag-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_CONFIG = writeConfig(TMP);
+    process.env.LUDICS_HARNESS_DIR = testHarnessDir();
+    mkdirSync(testHarnessDir(), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("tmux mode reads PID from tmux slot state", () => {
+    writeTmuxSlotState(1, {
+      slot: 1, ttydPids: {},
+      orchestration: { stateFile: "orch.json", mode: "duo", pid: 12345 },
+    });
+    expect(orchPidForSlotMode(1, "tmux")).toBe(12345);
+  });
+
+  test("t3code mode reads PID from t3code slot state", () => {
+    writeT3codeSlotState(1, {
+      slot: 1, threads: [],
+      orchestration: { stateFile: "orch.json", mode: "pair", pid: 67890 },
+    });
+    expect(orchPidForSlotMode(1, "t3code")).toBe(67890);
+  });
+
+  test("unknown mode returns undefined", () => {
+    expect(orchPidForSlotMode(1, "manual")).toBeUndefined();
+  });
+
+  test("missing state file returns undefined", () => {
+    expect(orchPidForSlotMode(99, "tmux")).toBeUndefined();
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -21,6 +21,7 @@ import {
 } from "./notify.ts";
 import { slotAssign, slotClear, slotResume, slotStart, taskCompleteDirectly } from "./slots/index.ts";
 import { readSlotState } from "./t3code/server.ts";
+import { readTmuxSlotState } from "./adapters/tmux-adapter.ts";
 import { resolveSkillCommand, hasRegisteredAction } from "./skill-queue-registry.ts";
 import { selectOrchestrationFlags } from "./adapters/t3code.ts";
 import YAML from "yaml";
@@ -2271,6 +2272,19 @@ function maybeFillEmptySlots(): void {
  * Follows the maybeClearDoneSlots() pattern.
  * Rate-limited: at most 1 resume per keepalive invocation.
  */
+export function orchPidForSlotMode(
+  slotNum: number,
+  mode: string,
+): number | undefined {
+  if (mode === "t3code") {
+    return readSlotState(slotNum)?.orchestration?.pid;
+  }
+  if (mode === "tmux") {
+    return readTmuxSlotState(slotNum, harnessDir())?.orchestration?.pid;
+  }
+  return undefined;
+}
+
 async function maybeResumeDeadOrchestrators(): Promise<void> {
   if (startSessionsAutonomy() === "manual") return;
 
@@ -2288,7 +2302,7 @@ async function maybeResumeDeadOrchestrators(): Promise<void> {
     if (!slotProcess || slotProcess === "(empty)") continue;
 
     const mode = getMode(block).trim();
-    if (mode !== "t3code") continue;
+    if (mode !== "t3code" && mode !== "tmux") continue;
 
     const taskId = getTask(block).trim();
     if (!taskId || taskId === "null") continue;
@@ -2300,10 +2314,9 @@ async function maybeResumeDeadOrchestrators(): Promise<void> {
     // Guard: orchestration state must match slot's current task
     if (orchState.taskId && orchState.taskId !== taskId) continue;
 
-    const slotState = readSlotState(slotNum);
-    if (!slotState?.orchestration?.pid) continue;
-
-    const pid = slotState.orchestration.pid;
+    const orchPid = orchPidForSlotMode(slotNum, mode);
+    if (!orchPid || orchPid <= 0) continue;
+    const pid = orchPid;
     let alive = true;
     try {
       process.kill(pid, 0); // global process — PID liveness check

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -82,6 +82,7 @@ export async function runOrchestrationCli(args: string[]): Promise<void> {
       orchLog(requireSlot(args[1]));
       return;
     case "run-internal": {
+      console.error(`ludics: orchestration runner starting — slot ${args[1]}, pid ${process.pid}, ${new Date().toISOString()}`);
       // Catch crashes and unhandled rejections — orchestrator runs detached,
       // stderr goes to log file, silent deaths are unacceptable.
       const crashHandler = (err: unknown) => {

--- a/src/orchestration/process.ts
+++ b/src/orchestration/process.ts
@@ -3,7 +3,7 @@
 
 import { openSync, readFileSync } from "fs";
 import { join } from "path";
-import { ludicsSelfCommand } from "./util.ts";
+import { ludicsSelfCommand, setsidWrap } from "./util.ts";
 
 /**
  * Spawn the orchestration runner as a detached background process for a slot.
@@ -12,7 +12,7 @@ import { ludicsSelfCommand } from "./util.ts";
 export async function startOrchestrationProcess(slot: number, harnessDir: string, taskId: string): Promise<number> {
   const logPath = join(harnessDir, "orchestration", `slot-${slot}-${taskId}.log`);
   const logFd = openSync(logPath, "a");
-  const proc = Bun.spawn(ludicsSelfCommand(["orch", "run-internal", String(slot)]), {
+  const proc = Bun.spawn(setsidWrap(ludicsSelfCommand(["orch", "run-internal", String(slot)])), {
     stdin: "ignore",
     stdout: "ignore",
     stderr: logFd,

--- a/src/orchestration/util.test.ts
+++ b/src/orchestration/util.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { setsidWrap } from "./util.ts";
+
+describe("setsidWrap", () => {
+  const cmd = ["ludics", "orch", "run-internal", "1"];
+
+  test("prepends setsid binary when resolved path is provided", () => {
+    const wrapped = setsidWrap(cmd, "/usr/bin/setsid");
+    expect(wrapped).toEqual(["/usr/bin/setsid", ...cmd]);
+  });
+
+  test("uses perl POSIX fallback when resolved path is null", () => {
+    const wrapped = setsidWrap(cmd, null);
+    expect(wrapped[0]).toBe("perl");
+    expect(wrapped[1]).toBe("-e");
+    expect(wrapped[2]).toBe("use POSIX qw(setsid); setsid(); exec @ARGV");
+    expect(wrapped[3]).toBe("--");
+    expect(wrapped.slice(4)).toEqual(cmd);
+  });
+
+  test("uses perl POSIX fallback when resolved path is empty string", () => {
+    const wrapped = setsidWrap(cmd, "");
+    expect(wrapped[0]).toBe("perl");
+  });
+
+  test("default (no resolvedSetsid arg) picks platform-appropriate wrapper", () => {
+    const wrapped = setsidWrap(cmd);
+    expect(wrapped.length).toBeGreaterThan(cmd.length);
+    // Original command args always appear at the tail
+    expect(wrapped.slice(-cmd.length)).toEqual(cmd);
+  });
+});

--- a/src/orchestration/util.ts
+++ b/src/orchestration/util.ts
@@ -55,3 +55,29 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Build a command array that runs in its own session, immune to SIGHUP
+ * when the parent exits.  Accepts an optional resolved setsid path so
+ * callers (and tests) can control which branch is taken.
+ *
+ * - Linux: prepend the setsid binary.
+ * - macOS (no setsid binary): use perl POSIX::setsid as a fallback.
+ */
+export function setsidWrap(
+  command: string[],
+  resolvedSetsid?: string | null,
+): string[] {
+  const setsidBin = resolvedSetsid !== undefined
+    ? resolvedSetsid
+    : (Bun.which("setsid") ?? null);
+  if (setsidBin) {
+    return [setsidBin, ...command];
+  }
+  return [
+    "perl", "-e",
+    "use POSIX qw(setsid); setsid(); exec @ARGV",
+    "--",
+    ...command,
+  ];
+}
+

--- a/src/t3code/server.ts
+++ b/src/t3code/server.ts
@@ -2,6 +2,7 @@ import { appendFileSync, copyFileSync, existsSync, mkdirSync, readFileSync, rena
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "path";
 import { Database } from "bun:sqlite";
+import { setsidWrap } from "../orchestration/util.ts";
 
 /**
  * Migrate legacy `<t3codeDir>/state/` → `<t3codeDir>/userdata/`.
@@ -308,14 +309,8 @@ export async function ensureServer(
       } catch { /* ignore */ }
     }
     try {
-      // Wrap in setsid to isolate the server in its own process group.
-      // This prevents SIGINT from parent terminals or sibling processes
-      // (e.g., ludics CLI invocations) from killing the server.
-      const setsidBin = Bun.which("setsid");
-      const wrappedCommand = setsidBin
-        ? [setsidBin, ...command]  // Linux: setsid binary available
-        : ["perl", "-e", `use POSIX qw(setsid); setsid(); exec @ARGV`, "--", ...command]; // macOS: use perl
-      proc = Bun.spawn(wrappedCommand, {
+      // Wrap in setsid to isolate the server in its own session/process group.
+      proc = Bun.spawn(setsidWrap(command), {
         stdin: "ignore",
         stdout: "ignore",
         stderr: Bun.file(stderrPath),


### PR DESCRIPTION
(no PR created yet — changes are local, not pushed)