### PR TITLE
fix: gate pr-create → pr-comments on prUrl

### DIFF
--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -64,6 +64,21 @@ describe("evaluateTransition", () => {
     expect(evaluateTransition(state)).toBe("pr-comments");
   });
 
+  test("pr-create blocks advancement when no prUrl is set", () => {
+    const state = makeState({ phase: "pr-create" });
+    state.agentStates.agent1.status = "pr-create-done";
+    state.agentStates.agent2.status = "pr-create-done";
+    expect(evaluateTransition(state)).toBeNull();
+  });
+
+  test("pr-create advances to pr-comments when prUrl is set", () => {
+    const state = makeState({ phase: "pr-create" });
+    state.agentStates.agent1.status = "pr-create-done";
+    state.agentStates.agent2.status = "pr-create-done";
+    state.agentStates.agent1.prUrl = "https://github.com/owner/repo/pull/1";
+    expect(evaluateTransition(state)).toBe("pr-comments");
+  });
+
   test("pr-comments stays null when no PR and quiet period not set", () => {
     const state = makeState({ phase: "pr-comments" });
     expect(evaluateTransition(state)).toBeNull();

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -475,8 +475,9 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
     case "pr-create":
       // NOTE: Runner verifies PR exists on GitHub before agents reach done state here.
       // See verifyPrCreateOutcome() in runner.ts.
-      if (allAgentsDone(state) || phaseTimeoutExpired(state)) return "pr-comments";
-      return null;
+      if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (!hasAnyPr(state)) return null; // Block advancement without a PR URL (defense in depth)
+      return "pr-comments";
 
     case "pr-comments": {
       if (isMerged(state)) return "suggest-refactor";

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -184,6 +184,7 @@ function preparePhaseRedispatch(state: OrchestrationState): void {
   }
   state.phaseDispatched = false;
   state.currentPhaseToken = undefined;
+  state.phaseStartedAt = nowEpoch(); // Reset timer so retries get a fresh timeout window
 }
 /** Force-settle via interruptAgent() after this many failed nudges. */
 /** Force-settle a hung agent after this many failed nudges. */
@@ -850,6 +851,8 @@ async function handleTimeout(state: OrchestrationState, transport: Orchestration
   if (
     state.phase === "work"
     || state.phase === "review"
+    || state.phase === "update-docs"
+    || state.phase === "pr-create"
     || state.phase === "pr-comments"
     || state.phase === "final-merge"
     || state.phase === "forward-pr"


### PR DESCRIPTION
## Summary
- Add `hasAnyPr()` guard in `evaluateTransition()` so pr-create → pr-comments requires a PR URL (defense in depth)
- Reset `phaseStartedAt` in `preparePhaseRedispatch()` so retry attempts get a fresh timeout window
- Add `pr-create` and `update-docs` to `handleTimeout()` interrupt list so agents are interrupted on timeout

## Test plan
- [x] `bun run typecheck` passes
- [x] All 150 tests pass (`bun test src/orchestration/phases.test.ts src/orchestration/runner.test.ts`)
- [x] Added 2 new tests for pr-create prUrl guard in evaluateTransition

Closes task-5011342a

🤖 Generated with [Claude Code](https://claude.com/claude-code)