### PR TITLE
refactor: extract shared tile abstraction for dashboard tiles

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -355,20 +355,9 @@ interface DashboardTask {
   hasQuestions: boolean;
 }
 
-interface NeedsConfirmationTask {
-  id: string;
-  title: string;
-  project: string;
-  priority: string;
-  created: string | null;
-  relatesTo: string[];
-}
-
-interface UnansweredQuestionsTask {
-  id: string;
-  title: string;
-  project: string;
-  priority: string;
+interface FilteredTaskTileConfig {
+  filter: (task: DashboardTask) => boolean;
+  extraFields: (task: DashboardTask) => Record<string, unknown>;
 }
 
 interface TasksTreeNode {
@@ -511,29 +500,27 @@ function generateReady(tasks: DashboardTask[]): ReadyTask[] {
   return ready;
 }
 
-function generateNeedsConfirmation(tasks: DashboardTask[]): NeedsConfirmationTask[] {
+function generateFilteredTaskList(tasks: DashboardTask[], config: FilteredTaskTileConfig): Record<string, unknown>[] {
   return tasks
-    .filter((task) => task.status === "needs-confirmation")
+    .filter(config.filter)
     .map((task) => ({
       id: task.id,
       title: task.title,
       project: task.project,
       priority: task.priority,
-      created: task.created,
-      relatesTo: task.dependencies.relates_to,
+      ...config.extraFields(task),
     }));
 }
 
-function generateUnansweredQuestions(tasks: DashboardTask[]): UnansweredQuestionsTask[] {
-  return tasks
-    .filter((task) => task.hasQuestions && !task.isCompleted)
-    .map((task) => ({
-      id: task.id,
-      title: task.title,
-      project: task.project,
-      priority: task.priority,
-    }));
-}
+const needsConfirmationConfig: FilteredTaskTileConfig = {
+  filter: (task) => task.status === "needs-confirmation",
+  extraFields: (task) => ({ created: task.created, relatesTo: task.dependencies.relates_to }),
+};
+
+const unansweredQuestionsConfig: FilteredTaskTileConfig = {
+  filter: (task) => task.hasQuestions && !task.isCompleted,
+  extraFields: () => ({}),
+};
 
 function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
   if (tasks.length === 0) return [];
@@ -979,10 +966,10 @@ export function dashboardGenerate(): void {
   writeFileSync(join(dataDir, "ready.json"), JSON.stringify(generateReady(tasks), null, 2));
   console.error("  ready.json");
 
-  writeFileSync(join(dataDir, "needs-confirmation.json"), JSON.stringify(generateNeedsConfirmation(tasks), null, 2));
+  writeFileSync(join(dataDir, "needs-confirmation.json"), JSON.stringify(generateFilteredTaskList(tasks, needsConfirmationConfig), null, 2));
   console.error("  needs-confirmation.json");
 
-  writeFileSync(join(dataDir, "unanswered-questions.json"), JSON.stringify(generateUnansweredQuestions(tasks), null, 2));
+  writeFileSync(join(dataDir, "unanswered-questions.json"), JSON.stringify(generateFilteredTaskList(tasks, unansweredQuestionsConfig), null, 2));
   console.error("  unanswered-questions.json");
 
   writeFileSync(join(dataDir, "tasks-tree.json"), JSON.stringify(generateTasksTree(tasks), null, 2));

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -518,29 +518,38 @@ async function promoteTask(taskId) {
     }
 }
 
-// Fetch needs-confirmation tasks
-async function fetchNeedsConfirmation() {
+// Shared fetch-and-render for filtered task list tiles
+async function fetchAndRenderTaskList({ jsonFile, listId, emptyText, renderItem }) {
+    let tasks = [];
     try {
-        const response = await fetch(CONFIG.dataPath + 'needs-confirmation.json');
-        if (!response.ok) throw new Error('Failed to fetch needs-confirmation');
-        const tasks = await response.json();
-        renderNeedsConfirmation(tasks);
+        const response = await fetch(CONFIG.dataPath + jsonFile);
+        if (!response.ok) throw new Error('Failed to fetch ' + jsonFile);
+        tasks = await response.json();
     } catch (error) {
-        console.warn('Using placeholder needs-confirmation');
-        renderNeedsConfirmation([]);
+        console.warn('Using placeholder ' + jsonFile);
     }
-}
 
-// Render needs-confirmation tasks
-function renderNeedsConfirmation(tasks) {
-    const list = document.getElementById('needs-confirmation-list');
+    const list = document.getElementById(listId);
     if (!list) return;
 
     let newHtml;
     if (tasks.length === 0) {
-        newHtml = '<li class="empty">No tasks need confirmation</li>';
+        newHtml = `<li class="empty">${emptyText}</li>`;
     } else {
-        const items = tasks.map(task => {
+        newHtml = tasks.map(renderItem).join('');
+    }
+
+    if (list.innerHTML !== newHtml) {
+        list.innerHTML = newHtml;
+    }
+}
+
+function fetchNeedsConfirmation() {
+    return fetchAndRenderTaskList({
+        jsonFile: 'needs-confirmation.json',
+        listId: 'needs-confirmation-list',
+        emptyText: 'No tasks need confirmation',
+        renderItem(task) {
             const priority = task.priority || '-';
             const priorityClass = `priority-${priority}`;
             const source = task.relatesTo?.length ? ` (from ${escapeHtml(task.relatesTo[0])})` : '';
@@ -553,38 +562,16 @@ function renderNeedsConfirmation(tasks) {
                     <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
                 </span>
             </li>`;
-        });
-        newHtml = items.join('');
-    }
-
-    if (list.innerHTML !== newHtml) {
-        list.innerHTML = newHtml;
-    }
+        },
+    });
 }
 
-// Fetch unanswered-questions tasks
-async function fetchUnansweredQuestions() {
-    try {
-        const response = await fetch(CONFIG.dataPath + 'unanswered-questions.json');
-        if (!response.ok) throw new Error('Failed to fetch unanswered-questions');
-        const tasks = await response.json();
-        renderUnansweredQuestions(tasks);
-    } catch (error) {
-        console.warn('Using placeholder unanswered-questions');
-        renderUnansweredQuestions([]);
-    }
-}
-
-// Render unanswered-questions tasks
-function renderUnansweredQuestions(tasks) {
-    const list = document.getElementById('unanswered-questions-list');
-    if (!list) return;
-
-    let newHtml;
-    if (tasks.length === 0) {
-        newHtml = '<li class="empty">No unanswered questions</li>';
-    } else {
-        const items = tasks.map(task => {
+function fetchUnansweredQuestions() {
+    return fetchAndRenderTaskList({
+        jsonFile: 'unanswered-questions.json',
+        listId: 'unanswered-questions-list',
+        emptyText: 'No unanswered questions',
+        renderItem(task) {
             const priority = task.priority || '-';
             const priorityClass = `priority-${priority}`;
             return `
@@ -592,13 +579,8 @@ function renderUnansweredQuestions(tasks) {
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
                 <a class="task-title unanswered-q-link" href="task-files/${escapeHtml(task.id)}.md" target="_blank">${escapeHtml(task.title || task.id)}</a>
             </li>`;
-        });
-        newHtml = items.join('');
-    }
-
-    if (list.innerHTML !== newHtml) {
-        list.innerHTML = newHtml;
-    }
+        },
+    });
 }
 
 // Confirm a needs-confirmation task (move to ready)


### PR DESCRIPTION
## Summary
- Extract `generateFilteredTaskList(tasks, config)` in backend replacing two near-identical generator functions and two interfaces (`NeedsConfirmationTask`, `UnansweredQuestionsTask`)
- Extract `fetchAndRenderTaskList({jsonFile, listId, emptyText, renderItem})` in frontend replacing four duplicated fetch/render functions
- Net reduction of 31 lines with no behavioral change

Closes #136

## Test plan
- [ ] Run `bun run typecheck` — passes
- [ ] Run `bun run build` — passes
- [ ] Verify dashboard loads both tiles identically (needs-confirmation + unanswered-questions)
- [ ] Verify confirm/dismiss buttons still work on needs-confirmation tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)