### PR TITLE
fix: require coder agents to read proposal before implementing (gh-ludics-139)

### DIFF
--- a/skills/orchestration/pair-coder-plan-merge.md
+++ b/skills/orchestration/pair-coder-plan-merge.md
@@ -1,5 +1,9 @@
 # Pair Plan Merge (Coder)
 
+{{#IF PROPOSAL_PATH}}
+**Step 0**: Reference the proposal file at `{{PROPOSAL_PATH}}` in the project repo while merging. The proposal contains the authoritative scope and acceptance criteria for resolving conflicts between the two plans.
+{{/IF}}
+
 Merge the two independent plans for `{{TASK_ID}}` into one at `{{MERGED_PLAN_FILE}}`.
 
 **Your plan**: `{{PLAN_FILE}}`

--- a/skills/orchestration/pair-coder-plan.md
+++ b/skills/orchestration/pair-coder-plan.md
@@ -1,5 +1,9 @@
 # Pair Plan (Coder)
 
+{{#IF PROPOSAL_PATH}}
+**Step 0**: Read the proposal file at `{{PROPOSAL_PATH}}` in the project repo before starting. The proposal contains the authoritative acceptance criteria and full scope.
+{{/IF}}
+
 Write an implementation plan for `{{TASK_ID}}` to `{{PLAN_FILE}}` from `{{WORKTREE_PATH}}`.
 
 {{TASK_SPEC}}

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -1,5 +1,9 @@
 # Pair Work (Coder)
 
+{{#IF PROPOSAL_PATH}}
+**Step 0**: Read the proposal file at `{{PROPOSAL_PATH}}` in the project repo before starting. The proposal contains the authoritative acceptance criteria and full scope.
+{{/IF}}
+
 Implement the task in `{{WORKTREE_PATH}}`.
 
 {{TASK_SPEC}}

--- a/skills/orchestration/plan.md
+++ b/skills/orchestration/plan.md
@@ -1,5 +1,9 @@
 # Plan
 
+{{#IF PROPOSAL_PATH}}
+**Step 0**: Read the proposal file at `{{PROPOSAL_PATH}}` in the project repo before starting. The proposal contains the authoritative acceptance criteria and full scope.
+{{/IF}}
+
 Produce an implementation plan for `{{TASK_ID}}` from `{{WORKTREE_PATH}}`.
 
 Task spec:

--- a/skills/orchestration/work.md
+++ b/skills/orchestration/work.md
@@ -1,5 +1,9 @@
 # Work
 
+{{#IF PROPOSAL_PATH}}
+**Step 0**: Read the proposal file at `{{PROPOSAL_PATH}}` in the project repo before starting. The proposal contains the authoritative acceptance criteria and full scope.
+{{/IF}}
+
 Implement the task in `{{WORKTREE_PATH}}`.
 
 {{TASK_SPEC}}

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -375,7 +375,7 @@ describe("skills", () => {
       expect(ctxR2["TASK_SPEC"]).toContain("task-r2");
       expect(ctxR2["TASK_SPEC"]).toContain("Round Two Task");
       expect(ctxR2["TASK_SPEC"]).toContain("docs/proposals/round2.md");
-      expect(ctxR2["TASK_SPEC"]).toContain("round 1");
+      expect(ctxR2["TASK_SPEC"]).toContain("re-read if you need to verify");
       expect(ctxR2["TASK_SPEC"]).not.toContain("Acceptance Criteria"); // full body not included
 
       // Round 3: still brief
@@ -578,6 +578,51 @@ describe("skills", () => {
     } finally {
       unlinkFs(overridePath);
     }
+  });
+
+  test("work template includes proposal instruction when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/work.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+    });
+    expect(withProposal).toContain("Step 0");
+    expect(withProposal).toContain("docs/proposals/my-feature.md");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+    });
+    expect(withoutProposal).not.toContain("Step 0");
+  });
+
+  test("pair-coder-plan template includes proposal instruction when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-plan.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+    });
+    expect(withProposal).toContain("Step 0");
+    expect(withProposal).toContain("docs/proposals/my-feature.md");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+    });
+    expect(withoutProposal).not.toContain("Step 0");
+  });
+
+  test("pair-coder-plan-merge template uses merge-specific proposal wording", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-plan-merge.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+    });
+    expect(rendered).toContain("Reference the proposal file");
+    expect(rendered).toContain("resolving conflicts between the two plans");
   });
 
   test("substituteTemplate renders pr-conflict-resolve.md correctly", () => {

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -100,7 +100,7 @@ function taskSpecBriefText(state: OrchestrationState): string {
       ? proposalValue
       : "";
   const proposalLine = proposalRef
-    ? `\nProposal file: \`${proposalRef}\` (already read in round 1)`
+    ? `\nProposal file: \`${proposalRef}\` — re-read if you need to verify scope or acceptance criteria.`
     : "";
   return `**Task** ${taskId}: ${title}${proposalLine}\n(Full task spec was provided in round 1 — refer to earlier context.)`;
 }


### PR DESCRIPTION
## Summary

- Add `{{#IF PROPOSAL_PATH}}` conditional blocks to 5 orchestration templates (work, pair-coder-work, plan, pair-coder-plan, pair-coder-plan-merge) so agents are explicitly told to read the proposal file before starting
- Update `taskSpecBriefText()` round 2+ wording from "already read in round 1" to "re-read if you need to verify scope or acceptance criteria"
- Add 3 new template-render tests and update 1 existing assertion

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test src/orchestration/skills.test.ts` — all 36 tests pass
- [x] `grep PROPOSAL_PATH skills/orchestration/` shows 7 template files (5 new + 2 existing review)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)