### PR TITLE
docs: document worker response contracts (gh-ludics-137)

### DIFF
--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -39,13 +39,13 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
 3. **Check preconditions**:
    - Verify `has_questions` is NOT set in frontmatter. If it is, the task
-     has unanswered questions — report `STATUS: error` with message
+     has unanswered questions — report `status: "error"` with message
      "task has unanswered questions" and stop.
    - If the task is clearly stale (work already done or goal no longer applies),
-     report `STATUS: stale` in your final response and stop.
+     report `status: "stale"` in your final response and stop.
    - If the task covers multiple independent concerns (different modules,
      separable features, could be merged to main independently), report
-     `STATUS: split-needed` and stop.
+     `status: "split-needed"` and stop.
 
 4. **Explore project codebase**:
    - Read relevant source files mentioned in the task elaboration
@@ -110,6 +110,17 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+### Response Contract
+
+1. `status` — string, required. Values: `"completed"`, `"stale"`, `"split-needed"`, `"already-exists"`, `"error"`.
+2. `task_id` — string, required.
+3. `proposal_path` — string, conditional. Present only when `status = "completed"` or `"already-exists"`.
+4. `ambiguities` — string[], required. `"none"` when empty.
+5. `start_confidence` — string, conditional. Present only when `status = "completed"`. Values: `"high"`, `"low"`.
+6. `start_rationale` — string, conditional. Present only when `status = "completed"`.
+7. `title` — string, required.
+8. `summary` — string, required.
+
 ```json
 {
   "status": "completed | stale | split-needed | already-exists | error",
@@ -122,9 +133,6 @@ as the last code block in your response:
   "summary": "<one-line summary of what was proposed>"
 }
 ```
-
-Omit `proposal_path` if status is `"stale"`, `"split-needed"`, or `"error"`. Use
-`"none"` for `ambiguities` when there are none.
 
 **START_CONFIDENCE guidance:**
 - `high`: task is a clear, bounded improvement with specific scope — derived from
@@ -139,7 +147,7 @@ Omit `proposal_path` if status is `"stale"`, `"split-needed"`, or `"error"`. Use
 
 ## Error Handling
 
-- Task not found: Report `STATUS: error` with explanation
-- Project path not found: Report `STATUS: error`
-- Already has proposal: Report `STATUS: already-exists` with the existing path
+- Task not found: Report `status: "error"` with explanation
+- Project path not found: Report `status: "error"`
+- Already has proposal: Report `status: "already-exists"` with the existing path
 - Git push fails: Log warning, continue — the proposal is still written locally

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -67,11 +67,16 @@ Extract the JSON block from the worker's response (the last fenced ` ```json ` b
 Parse the JSON for `status`, `proposal_path`, `ambiguities`, `start_confidence`,
 `start_rationale`, `title`, and `summary`.
 
-If no JSON block is found, fall back to line-based parsing: look for `STATUS: <value>`,
-`PROPOSAL_PATH: <value>`, `AMBIGUITIES: <value>`, `START_CONFIDENCE: <value>`,
-`START_RATIONALE: <value>`, `TITLE: <value>`, and `SUMMARY: <value>` lines. On the
-legacy path, treat `AMBIGUITIES:` content as a pre-formatted string and send as-is
-in the questions notification step.
+### Expected Worker Fields
+
+1. `status` — primary routing. Absent: error (malformed response).
+2. `proposal_path` — notification, result JSON. Expected absent for stale/split-needed/error.
+3. `ambiguities` — questions notification. Absent: treat as `"none"`, skip.
+4. `start_confidence` — auto-start evaluation. Absent: default to `"low"` (defer to user).
+5. `start_rationale` — auto-start evaluation. Absent: default to empty string.
+6. `title` — notification title. Absent: fall back to task_id.
+7. `summary` — notification body, result JSON. Absent: use empty string.
+8. `task_id` — not consumed by orchestrator.
 
 - **status: completed** — proceed to auto-start evaluation (next section)
 - **status: stale** — write result JSON with `"status": "stale"`, stop
@@ -139,8 +144,7 @@ ludics notify proposal "<task_id>" "<title>" "<summary>" "<project_path>/<propos
 ## Skill-Specific: Questions Notification
 
 If `ambiguities` is not `"none"` and is non-empty, send as notification text:
-- JSON array path: format each element as a numbered list
-- Legacy pre-formatted string (fallback path): send as-is
+- Format each element as a numbered list
 
 ```bash
 ludics notify outgoing "<formatted ambiguities>"

--- a/skills/ludics-elaborate-worker.md
+++ b/skills/ludics-elaborate-worker.md
@@ -38,7 +38,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 - If a duplicate is found:
   - Prefer the version that is already elaborated, or has richer context
   - Run `ludics tasks merge <target> <this_task_id>` to merge
-  - Report `STATUS: merged` and stop
+  - Report `status: "merged"` and stop
 
 ### 0b. Milestone-aware blocking (watch tasks)
 
@@ -162,6 +162,16 @@ elaborated: <today's date>
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+### Response Contract
+
+1. `status` — string, required. Values: `"completed"`, `"merged"`, `"already-elaborated"`, `"error"`.
+2. `task_id` — string, required.
+3. `title` — string, required.
+4. `merge_target` — string, conditional. Present only when `status = "merged"`.
+5. `elaborated_date` — string, conditional. Present only when `status = "already-elaborated"`.
+6. `questions` — string[], required. `"none"` when empty.
+7. `summary` — string, required.
+
 ```json
 {
   "status": "completed | merged | already-elaborated | error",
@@ -174,11 +184,8 @@ as the last code block in your response:
 }
 ```
 
-Omit `merge_target` and `elaborated_date` when not applicable. Use `"none"` for
-`questions` when there are no questions.
-
 ## Error Handling
 
-- Task not found: Report `STATUS: error`
-- Already elaborated: Report `STATUS: already-elaborated` with existing date
+- Task not found: Report `status: "error"`
+- Already elaborated: Report `status: "already-elaborated"` with existing date
 - Missing context: Note gaps in elaboration and proceed with available information

--- a/skills/ludics-elaborate.md
+++ b/skills/ludics-elaborate.md
@@ -43,9 +43,15 @@ Worker: `/ludics-elaborate-worker <task_id> <project_path> <context_brief>`
 Extract the JSON block from the worker's response (the last fenced ` ```json ` block).
 Parse the JSON for `status`, `questions`, and `summary`.
 
-If no JSON block is found, fall back to line-based parsing: look for `STATUS: <value>`,
-`QUESTIONS: <value>`, and `SUMMARY: <value>` lines. On the legacy path, treat `QUESTIONS:`
-content as a pre-formatted string and send as-is in the questions notification step.
+### Expected Worker Fields
+
+1. `status` — primary routing. Absent: error (malformed response).
+2. `questions` — questions notification. Absent: treat as `"none"`, skip notification.
+3. `summary` — result context. Absent: use empty string.
+4. `merge_target` — result JSON (merged path). Only expected when `status = "merged"`.
+5. `elaborated_date` — already-elaborated path. Only expected when `status = "already-elaborated"`.
+6. `title` — notification title. Absent: fall back to task_id.
+7. `task_id` — not consumed by orchestrator.
 
 - **status: completed** — proceed to notifications
 - **status: merged** — write result JSON noting the merge, stop
@@ -60,8 +66,7 @@ If `questions` is not `"none"` and is non-empty:
    until the user answers the questions and removes the field).
 
 2. Send as notification text:
-   - JSON array path: format each element as a numbered list (e.g., `1. <q1>\n2. <q2>`)
-   - Legacy pre-formatted string (fallback path): send as-is
+   - Format each element as a numbered list (e.g., `1. <q1>\n2. <q2>`)
 
 ```bash
 ludics notify outgoing "<formatted questions>"

--- a/skills/ludics-feedback-digest-worker.md
+++ b/skills/ludics-feedback-digest-worker.md
@@ -27,7 +27,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
 Read all `.md` files from `$LUDICS_STATE_PATH/feedback/` (skip the `processed/`
 subdirectory). Files are named `<task-id>--workflow-feedback-<agent>.md`.
-If no files exist, report `STATUS: empty` and stop.
+If no files exist, report `status: "empty"` and stop.
 
 ### 2. Extract individual data points
 
@@ -95,6 +95,18 @@ mv "$LUDICS_STATE_PATH/feedback/"*.md "$LUDICS_STATE_PATH/feedback/processed/"
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+### Response Contract
+
+1. `status` — string, required. Values: `"completed"`, `"empty"`, `"error"`.
+2. `issues_created` — number, required. 0 when none created.
+3. `issues_updated` — number, required. 0 when none updated.
+4. `issues_skipped` — number, required. 0 when none skipped.
+5. `files_processed` — number, required. 0 when none processed.
+6. `summary` — string, required.
+
+Note: when `status = "error"`, count fields may be absent. The `summary` or
+`error` field carries the explanation.
+
 ```json
 {
   "status": "completed | empty | error",
@@ -108,6 +120,6 @@ as the last code block in your response:
 
 ## Error Handling
 
-- `gh` not authenticated or repo inaccessible: Report `STATUS: error`
+- `gh` not authenticated or repo inaccessible: Report `status: "error"`
 - Some issues fail to create: Continue with the rest, report partial results
 - Always move processed files even if some issue creation fails

--- a/skills/ludics-feedback-digest.md
+++ b/skills/ludics-feedback-digest.md
@@ -43,9 +43,14 @@ Extract the JSON block from the worker's response (the last fenced ` ```json ` b
 Parse the JSON for `status`, `issues_created`, `issues_updated`, `issues_skipped`,
 `files_processed`, and `summary`.
 
-If no JSON block is found, fall back to line-based parsing: look for `STATUS: <value>`,
-`ISSUES_CREATED: <value>`, `ISSUES_UPDATED: <value>`, `ISSUES_SKIPPED: <value>`,
-`FILES_PROCESSED: <value>`, and `SUMMARY: <value>` lines.
+### Expected Worker Fields
+
+1. `status` — primary routing. Absent: error (malformed response).
+2. `issues_created` — result JSON. Absent: default to 0.
+3. `issues_updated` — result JSON. Absent: default to 0.
+4. `issues_skipped` — result JSON. Absent: default to 0.
+5. `files_processed` — result JSON. Absent: default to 0.
+6. `summary` — result output. Absent: use empty string.
 
 - **status: completed** — write result JSON
 - **status: empty** — write result JSON indicating nothing to process

--- a/skills/ludics-revise-proposal-worker.md
+++ b/skills/ludics-revise-proposal-worker.md
@@ -56,7 +56,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
         "import os; r=os.path.relpath('$proposal_abs','<project_path>'); print(r)")
       ```
       If `$proposal_rel` starts with `..` or equals `..`, the proposal lives outside the
-      project repo and cannot be committed. Report `STATUS: error` with this message and stop:
+      project repo and cannot be committed. Report `status: "error"` with this message and stop:
       ```
       Proposal file is outside the project tree (<proposal_abs>). Cannot revise and commit
       safely. Move the proposal to <project_path>/<proposals_path>/<feature>.md and update
@@ -149,13 +149,23 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
 7. **Assess changes**:
    If after re-examination the proposal is already solid and no meaningful
-   changes were needed, report `STATUS: no-changes` instead of making
+   changes were needed, report `status: "no-changes"` instead of making
    trivial edits.
 
 ## Final Response
 
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
+
+### Response Contract
+
+1. `status` — string, required. Values: `"revised"`, `"no-changes"`, `"error"`.
+2. `task_id` — string, required.
+3. `proposal_path` — string, conditional. Present only when `proposal_mode = "file"`. Omitted for inline.
+4. `proposal_mode` — string, conditional. Required when `status = "revised"` (`"file"` or `"inline"`). Omitted for `"no-changes"`.
+5. `changes_summary` — string, required. What changed, or why nothing changed.
+6. `title` — string, required.
+7. `summary` — string, required.
 
 ```json
 {
@@ -169,15 +179,10 @@ as the last code block in your response:
 }
 ```
 
-For **inline mode**: omit `proposal_path` entirely and set `"proposal_mode": "inline"`.
-For **file-based mode**: include `proposal_path` as the project-relative path and set
-`"proposal_mode": "file"`.
-`proposal_mode` is required when `status` is `"revised"`.
-
 ## Error Handling
 
-- Task not found: Report `STATUS: error` with explanation
-- Proposal file not found: Report `STATUS: error` — orchestrator should not
+- Task not found: Report `status: "error"` with explanation
+- Proposal file not found: Report `status: "error"` — orchestrator should not
   have invoked revision without a proposal
-- Project path not found: Report `STATUS: error`
+- Project path not found: Report `status: "error"`
 - Git push fails: Log warning, continue — edits are still written locally

--- a/skills/ludics-revise-proposal.md
+++ b/skills/ludics-revise-proposal.md
@@ -55,9 +55,15 @@ Extract the JSON block from the worker's response (the last fenced ` ```json ` b
 Parse the JSON for `status`, `proposal_path`, `proposal_mode`, `changes_summary`,
 `title`, and `summary`.
 
-If no JSON block is found, fall back to line-based parsing: look for `STATUS: <value>`,
-`PROPOSAL_PATH: <value>`, `PROPOSAL_MODE: <value>`, `CHANGES_SUMMARY: <value>`,
-`TITLE: <value>`, and `SUMMARY: <value>` lines.
+### Expected Worker Fields
+
+1. `status` — primary routing. Absent: error (malformed response).
+2. `proposal_path` — re-notification, result JSON. Expected absent when `proposal_mode = "inline"`.
+3. `proposal_mode` — mode branching. Absent when `status = "revised"`: error (malformed response). Do NOT default to `"file"`.
+4. `changes_summary` — result JSON. Absent: use empty string.
+5. `title` — notification title. Absent: fall back to task_id.
+6. `summary` — notification body. Absent: use empty string.
+7. `task_id` — not consumed by orchestrator.
 
 - **status: revised** — proceed to re-notification
 - **status: no-changes** — write result JSON with `"status": "no-changes"`, stop

--- a/skills/ludics-verify-completion-worker.md
+++ b/skills/ludics-verify-completion-worker.md
@@ -73,6 +73,17 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+### Response Contract
+
+1. `status` — string, required. Always `"completed"` in non-error cases.
+2. `task_id` — string, required.
+3. `title` — string, required.
+4. `slot` — number, required.
+5. `verdict` — string, required. Values: `"complete"`, `"complete-with-followups"`, `"uncertain"`, `"incomplete"`.
+6. `followups` — object[], required. Array of `{"title", "priority"}`. `"none"` when empty.
+7. `questions` — string[], required. `"none"` when empty.
+8. `evidence` — string, required.
+
 ```json
 {
   "status": "completed",
@@ -86,13 +97,9 @@ as the last code block in your response:
 }
 ```
 
-Note: `status` is always `"completed"` for this worker in non-error cases. The
-orchestrator checks `status` first to handle errors, then uses `verdict` for
-success-path routing. Use `"none"` for `followups` and `questions` when they are empty.
-
 ## Error Handling
 
-- Task not found: Report `STATUS: error`
+- Task not found: Report `status: "error"`
 - Project path not found: Attempt verification from task file and git history only,
-  note limitation in EVIDENCE
-- No acceptance criteria: Report `VERDICT: uncertain` — cannot verify without criteria
+  note limitation in evidence
+- No acceptance criteria: Report `verdict: "uncertain"` — cannot verify without criteria

--- a/skills/ludics-verify-completion.md
+++ b/skills/ludics-verify-completion.md
@@ -44,11 +44,16 @@ Worker: `/ludics-verify-completion-worker <task_id> <project_path> <context_brie
 Extract the JSON block from the worker's response (the last fenced ` ```json ` block).
 Parse the JSON for `status`, `verdict`, `followups`, `questions`, `slot`, `title`, and `evidence`.
 
-If no JSON block is found, fall back to line-based parsing: look for `STATUS: <value>`,
-`VERDICT: <value>`, `FOLLOWUPS: <value>`, `QUESTIONS: <value>`, `SLOT: <value>`, `TITLE: <value>`,
-and `EVIDENCE: <value>` lines. On the legacy path: treat `QUESTIONS:` content as a
-pre-formatted string (send as-is in the uncertain branch); treat each numbered item in
-`FOLLOWUPS:` as `{"title": "<item text>", "priority": "B"}`.
+### Expected Worker Fields
+
+1. `status` — error check. Absent: error (malformed response).
+2. `verdict` — primary routing. Absent: error (malformed response).
+3. `followups` — follow-up task creation. Absent: treat as `"none"`, skip.
+4. `questions` — uncertain notification. Absent: send generic uncertainty message.
+5. `slot` — slot clearing. Absent: error if verdict requires clearing.
+6. `title` — notification text. Absent: fall back to task_id.
+7. `evidence` — result context. Absent: use empty string.
+8. `task_id` — not consumed by orchestrator.
 
 **Check `status` first:**
 - **status: error** — write result JSON with `"status": "error"`, stop
@@ -83,9 +88,8 @@ Then act on `verdict`:
 
 ### VERDICT: uncertain
 - Do NOT clear the slot
-- Send notification with questions. Format depends on the source:
-  - JSON array: format each element as a numbered list before sending
-  - Legacy pre-formatted string (fallback path): send as-is
+- Send notification with questions:
+  - Format each element as a numbered list before sending
   ```bash
   ludics notify outgoing "<formatted questions or generic uncertainty message>" 3 "Completion check — <task_id>"
   ```

--- a/skills/orchestrator-conventions.md
+++ b/skills/orchestrator-conventions.md
@@ -46,8 +46,9 @@ revise-proposal includes user feedback verbatim) are noted in each skill.
 - Worker runs in forked context (`context: fork`) — its file reads, git
   operations, and tool outputs do not enter Mag's conversation history
 - Only the worker's structured response returns to the orchestrator
-- Each orchestrator parses its own required response fields (STATUS plus
-  skill-specific keys); do not assume a shared field set across workers
+- Each orchestrator parses the worker's JSON response for `status` plus
+  skill-specific fields; the exact field set is documented per-skill in an
+  "Expected Worker Fields" section
 
 ## Section E — Result JSON
 
@@ -72,7 +73,9 @@ Read the request ID and write the result file:
 ## Section F — Error Handling
 
 - Task not found: result with `"status": "error"`, descriptive output
-- Worker returns `STATUS: error`: propagate to result JSON
+- Worker returns `"status": "error"` in its JSON response: propagate to result JSON
+- Each orchestrator documents per-field fallback behavior in its "Expected
+  Worker Fields" section
 - **State-mutation failure** (slot clear/start, task creation): report the
   failure in result JSON — do NOT continue as if successful. State mutations
   that fail can desync Mag from actual repo/slot state.

--- a/skills/worker-conventions.md
+++ b/skills/worker-conventions.md
@@ -49,6 +49,21 @@ Rules:
 - Keep the response concise — the orchestrator handles notifications,
   result JSON, and downstream actions
 
+## Field Annotations
+
+Each worker documents response fields in a "Response Contract" with these
+annotations:
+
+- **required**: Always present in non-error responses. List-like required fields
+  use `"none"` when empty.
+- **conditional**: Present only when a specific condition holds. Omitted entirely
+  otherwise — never `null`.
+
+The `status` field is always required. When `status` is `"error"`, only `status`
+plus a narrative field are guaranteed — other fields may be absent.
+
+Orchestrators MUST handle the absence of conditional fields gracefully.
+
 ## Error Handling
 
 Follow these conventions for all error conditions:


### PR DESCRIPTION
## Summary

- Add "Response Contract" sections to all 5 worker skills with per-field type, required/conditional annotations, and condition documentation
- Add matching "Expected Worker Fields" sections to all 5 orchestrator skills with absent-field handling rules
- Remove legacy line-based fallback parsing from all orchestrator skills
- Replace stale uppercase `STATUS:` / `VERDICT:` wording with JSON-style references across all touched files
- Add "Field Annotations" convention to `worker-conventions.md` and update `orchestrator-conventions.md` to JSON terminology

Closes #137

## Test plan
- [x] `bun run typecheck` passes
- [x] Grep confirms zero remaining "fall back to line-based" / "fallback path" / "legacy path" references
- [x] Grep confirms zero remaining `STATUS: error` / `STATUS: <value>` in touched skill files
- [x] 5 worker files each have exactly 1 "Response Contract" section
- [x] 5 orchestrator files each have exactly 1 "Expected Worker Fields" section
- [ ] Manual review: verify each worker/orchestrator pair has matching field conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)