### PR TITLE
fix: make taskSpecText resilient to bad proposal paths

### DIFF
--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -343,6 +343,7 @@ describe("skills", () => {
     const { join: j } = await import("path");
     const tmpDir = mkdtempSync("/tmp/ludics-skills-badpath-test-");
     const origHarness = process.env.LUDICS_HARNESS_DIR;
+    const spy = spyOn(console, "error");
     try {
       const harnessTasks = j(tmpDir, "harness", "tasks");
       mkdir2(harnessTasks, { recursive: true });
@@ -351,15 +352,14 @@ describe("skills", () => {
         "", "## Acceptance Criteria", "", "- [ ] Legacy content here",
       ].join("\n"));
       process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
-      const spy = spyOn(console, "error");
       const { buildSkillContext } = await import("./skills.ts");
       const state = { ...makeState(), taskId: "task-bad", projectDir: j(tmpDir, "project"), round: 1 };
       const ctx = buildSkillContext(state, state.agents[0]!);
       expect(ctx["TASK_SPEC"]).toContain("Legacy content here");
       expect(ctx["TASK_SPEC"]).not.toContain("Read the full proposal");
       expect(spy).toHaveBeenCalledWith(expect.stringContaining("ignoring bad proposal path"));
-      spy.mockRestore();
     } finally {
+      spy.mockRestore();
       if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
       else delete process.env.LUDICS_HARNESS_DIR;
       rmSync(tmpDir, { recursive: true, force: true });

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -118,8 +118,15 @@ function taskSpecText(state: OrchestrationState): string {
   const proposalValue = readFrontmatterField(content, "proposal");
   if (proposalValue) {
     if (proposalValue !== "inline") {
+      let proposalFile: string;
       try {
-        const proposalFile = resolveProposalAbsPath(state.projectDir, proposalValue);
+        proposalFile = resolveProposalAbsPath(state.projectDir, proposalValue);
+      } catch (err) {
+        console.error(`ludics: taskSpecText: ignoring bad proposal path: ${(err as Error).message}`);
+        // Fall through to legacy/inline path below.
+        proposalFile = "";
+      }
+      if (proposalFile) {
         // Only read proposal file contents if it is inside the project tree, to avoid
         // exposing arbitrary local file content through the Proposal summary line.
         const projectRoot = state.projectDir.endsWith("/") ? state.projectDir : `${state.projectDir}/`;
@@ -139,8 +146,6 @@ function taskSpecText(state: OrchestrationState): string {
           }
         }
         return contentWithPointer;
-      } catch (err) {
-        console.error(`ludics: taskSpecText: ignoring bad proposal path: ${(err as Error).message}`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Wraps the proposal-file resolution block in `taskSpecText()` with a try-catch so bad `proposal:` paths (absolute, home-relative, tree-escaping) log a warning via `console.error` and fall through to the legacy/inline code path instead of throwing
- Adds test case verifying a task with `proposal: /etc/passwd` returns legacy content, excludes proposal pointer, and logs the expected warning

## Test plan

- [x] `bun run typecheck` passes
- [x] All 37 tests in `skills.test.ts` pass (including new bad-path test)
- [x] Existing file-based and inline proposal tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)