### PR TITLE
fix: catch spawn exceptions in maybeGit

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -364,3 +364,15 @@ describe("ensureGitExcludes", () => {
     cleanupWorktrees(repo, "ga", [{ name: "c1" }], 8);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cleanupWorktrees resilience
+// ---------------------------------------------------------------------------
+
+describe("cleanupWorktrees resilience", () => {
+  test("does not throw when projectDir does not exist", () => {
+    expect(() =>
+      cleanupWorktrees("/nonexistent/path/xxxxx", "task-1", [{ name: "a1" }, { name: "a2" }], 1),
+    ).not.toThrow();
+  });
+});

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -24,14 +24,18 @@ export function runGit(projectDir: string, args: string[]): string {
 }
 
 function maybeGit(projectDir: string, args: string[]): string {
-  const result = Bun.spawnSync(["git", ...args], {
-    cwd: projectDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env: process.env as Record<string, string>,
-  });
-  if (result.exitCode !== 0) return "";
-  return result.stdout.toString().trim();
+  try {
+    const result = Bun.spawnSync(["git", ...args], {
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env as Record<string, string>,
+    });
+    if (result.exitCode !== 0) return "";
+    return result.stdout.toString().trim();
+  } catch {
+    return "";
+  }
 }
 
 /** Paths that the orchestrator manages inside worktrees and must never be committed. */


### PR DESCRIPTION
## Summary
- Wraps `Bun.spawnSync` in `maybeGit` (`src/orchestration/worktrees.ts`) with try/catch, returning `""` on exception — matching its existing best-effort contract
- Prevents `cleanupWorktrees` from crashing when `projectDir` no longer exists on disk (e.g., partially-deleted state)
- Adds test verifying `cleanupWorktrees` with a nonexistent path doesn't throw

## Test plan
- [x] `bun run typecheck` passes
- [x] All 17 worktrees tests pass (including new resilience test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)