### PR TITLE
feat: add atomic queue pop commands (mag queue pop one/all)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,8 @@ Commands:
   mag process-suggestions <id> Queue suggestion processing for completed task
   mag message "text"           Send async message to Mag
   mag queue                    Show pending queue requests
+  mag queue pop one            Pop and print first queue item (JSONL)
+  mag queue pop all            Pop and print all queue items (JSONL)
   mag context                  Pre-compute briefing context file
 
   notify outgoing <msg>        Send notification to user

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3154,9 +3154,36 @@ export async function runMag(args: string[]): Promise<void> {
       break;
     }
     case "queue": {
-      // Reuse the existing queueShow
-      const { queueShow } = await import("./queue.ts");
-      queueShow();
+      const sub2 = args[1];
+      if (sub2 === "pop") {
+        const mode = args[2];
+        if (args.length > 3) {
+          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue pop one|all)`);
+        }
+        const { queuePopOne, queuePopAll } = await import("./queue.ts");
+        if (mode === "one") {
+          const line = queuePopOne();
+          if (line === null) {
+            process.exitCode = 1;
+          } else {
+            console.log(line);
+          }
+        } else if (mode === "all") {
+          const lines = queuePopAll();
+          if (lines.length === 0) {
+            process.exitCode = 1;
+          } else {
+            for (const l of lines) console.log(l);
+          }
+        } else {
+          throw new Error(`unknown queue pop mode: ${mode ?? "(missing)"} (use: one, all)`);
+        }
+      } else if (!sub2) {
+        const { queueShow } = await import("./queue.ts");
+        queueShow();
+      } else {
+        throw new Error(`unknown queue subcommand: ${sub2} (use: pop one, pop all)`);
+      }
       break;
     }
     case "context":
@@ -3314,6 +3341,6 @@ export async function runMag(args: string[]): Promise<void> {
       break;
     }
     default:
-      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue-pop, context, feedback-digest)`);
+      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue pop one, queue pop all, queue-pop, context, feedback-digest)`);
   }
 }

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, readFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -45,6 +45,87 @@ describe("queueHasPendingFeedbackDigest", () => {
     const { queueRequest, queueHasPendingFeedbackDigest } = await loadQueue();
     queueRequest("briefing");
     expect(queueHasPendingFeedbackDigest("ludics")).toBe(false);
+  });
+});
+
+describe("queuePopOne", () => {
+  test("returns null for missing queue file", async () => {
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBeNull();
+  });
+
+  test("returns null for empty queue file", async () => {
+    writeFileSync(join(tmpDir, "mag", "queue.jsonl"), "");
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBeNull();
+  });
+
+  test("returns first line and leaves tail with newline termination", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n{"id":"b"}\n{"id":"c"}\n');
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBe('{"id":"a"}');
+    expect(readFileSync(qf, "utf-8")).toBe('{"id":"b"}\n{"id":"c"}\n');
+  });
+
+  test("single-item queue leaves empty file content", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n');
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBe('{"id":"a"}');
+    expect(readFileSync(qf, "utf-8")).toBe("");
+  });
+
+  test("returns raw line even if malformed JSON", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, "not-json-but-not-blank\n");
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBe("not-json-but-not-blank");
+  });
+
+  test("skips blank lines from corruption", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n\n{"id":"b"}\n');
+    const { queuePopOne } = await loadQueue();
+    expect(queuePopOne()).toBe('{"id":"a"}');
+    expect(readFileSync(qf, "utf-8")).toBe('{"id":"b"}\n');
+  });
+});
+
+describe("queuePopAll", () => {
+  test("returns [] for missing queue file", async () => {
+    const { queuePopAll } = await loadQueue();
+    expect(queuePopAll()).toEqual([]);
+  });
+
+  test("returns [] for empty queue file", async () => {
+    writeFileSync(join(tmpDir, "mag", "queue.jsonl"), "");
+    const { queuePopAll } = await loadQueue();
+    expect(queuePopAll()).toEqual([]);
+  });
+
+  test("returns all lines in FIFO order and empties the file", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n{"id":"b"}\n');
+    const { queuePopAll } = await loadQueue();
+    expect(queuePopAll()).toEqual(['{"id":"a"}', '{"id":"b"}']);
+    expect(readFileSync(qf, "utf-8")).toBe("");
+  });
+
+  test("single-item queue returns [item] and empties file", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n');
+    const { queuePopAll } = await loadQueue();
+    expect(queuePopAll()).toEqual(['{"id":"a"}']);
+    expect(readFileSync(qf, "utf-8")).toBe("");
+  });
+
+  test("skips blank lines from corruption", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n\n{"id":"b"}\n');
+    const { queuePopAll } = await loadQueue();
+    expect(queuePopAll()).toEqual(['{"id":"a"}', '{"id":"b"}']);
+    expect(readFileSync(qf, "utf-8")).toBe("");
   });
 });
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,6 +1,6 @@
 // Mag queue functions — queue-based communication with Claude Code Mag session
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, renameSync } from "fs";
 import { join, dirname } from "path";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
@@ -65,6 +65,41 @@ export function queuePop(): string | null {
   writeFileSync(file, lines.slice(1).join("\n") + (lines.length > 1 ? "\n" : ""));
   emitEvent({ event_type: "queue_pop", source: "keepalive", scope: "queue", message: first.slice(0, 200) });
   return first;
+}
+
+function readQueueLines(): string[] {
+  const file = queueFile();
+  if (!existsSync(file)) return [];
+  const content = readFileSync(file, "utf-8");
+  if (!content || content === "\n") return [];
+  const lines = content.endsWith("\n") ? content.slice(0, -1).split("\n") : content.split("\n");
+  // Blank lines are not valid JSONL entries — drop them as corruption.
+  // Non-blank malformed JSON is preserved as-is.
+  return lines.filter(l => l.length > 0);
+}
+
+function writeQueueLines(lines: string[]): void {
+  const file = queueFile();
+  const tmp = file + ".tmp";
+  writeFileSync(tmp, lines.length > 0 ? lines.join("\n") + "\n" : "");
+  renameSync(tmp, file);
+}
+
+export function queuePopOne(): string | null {
+  const lines = readQueueLines();
+  if (lines.length === 0) return null;
+  const first = lines[0]!;
+  writeQueueLines(lines.slice(1));
+  emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: first.slice(0, 200) });
+  return first;
+}
+
+export function queuePopAll(): string[] {
+  const lines = readQueueLines();
+  if (lines.length === 0) return [];
+  writeQueueLines([]);
+  emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: `popped ${lines.length} items` });
+  return lines;
 }
 
 export function queuePending(): boolean {


### PR DESCRIPTION
## Summary
- Add `ludics mag queue pop one` and `ludics mag queue pop all` CLI commands for safe manual queue draining
- New `queuePopOne()` and `queuePopAll()` in `src/queue.ts` using write-tmp + renameSync atomic pattern
- Strict arg validation: rejects trailing args, unknown subcommands, missing mode

## Test plan
- [x] `bun run typecheck` passes
- [x] 16 tests pass in `src/queue.test.ts` (11 new: pop one/all for missing, empty, multi-item, single-item, malformed JSON, blank-line corruption)
- [ ] Manual smoke: `mag queue pop one` prints first JSONL line, exit 0; empty queue exits 1
- [ ] Manual smoke: `mag queue pop all` prints all JSONL lines, exit 0; empty queue exits 1
- [ ] `mag queue` (no args) still shows human-readable summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)