### PR TITLE
Make queueRequest type-safe for action-specific fields

### DIFF
--- a/src/mag.ts
+++ b/src/mag.ts
@@ -474,7 +474,7 @@ function tryQueueFeedbackDigest(repo: string): { queued: boolean; reason?: strin
   if (remaining > 0) {
     return { queued: false, reason: `cooldown active (${remaining}s remaining)` };
   }
-  queueRequest("feedback-digest", `"repo":"${repo}"`);
+  queueRequest({ action: "feedback-digest", repo });
   markFeedbackDigestQueued(repo);
   return { queued: true };
 }
@@ -2033,7 +2033,7 @@ function maybeUnstickAssignedSlots(): void {
     // Not elaborated — needs elaboration first
     if (!isElaborated(content)) {
       if (!autoProposalDebounced(taskId)) {
-        queueRequest("elaborate", `"task":"${taskId}"`);
+        queueRequest({ action: "elaborate", task: taskId });
         markAutoProposalQueued(taskId);
         emitEvent({ event_type: "slot_unstick", source: "keepalive", scope: "slot", slot: slotNum, task: taskId, message: `queued elaboration for stuck slot ${slotNum}` });
         console.error(`ludics: slot ${slotNum} stuck — queued elaboration for ${taskId}`);
@@ -2043,7 +2043,7 @@ function maybeUnstickAssignedSlots(): void {
 
     // Elaborated, no questions, no proposal — re-queue draft-proposal
     if (!autoProposalDebounced(taskId)) {
-      queueRequest("draft-proposal", `"task":"${taskId}"`);
+      queueRequest({ action: "draft-proposal", task: taskId });
       markAutoProposalQueued(taskId);
       emitEvent({ event_type: "slot_unstick", source: "keepalive", scope: "slot", slot: slotNum, task: taskId, message: `re-queued draft-proposal for stuck slot ${slotNum}` });
       console.error(`ludics: slot ${slotNum} stuck — re-queued draft-proposal for ${taskId}`);
@@ -2084,7 +2084,7 @@ function maybeQueueProposals(): void {
     if (content.includes("\nproposal:")) continue;
     if (autoProposalDebounced(task.id)) continue;
 
-    queueRequest("draft-proposal", `"task":"${task.id}"`);
+    queueRequest({ action: "draft-proposal", task: task.id });
     markAutoProposalQueued(task.id);
     console.error(`ludics: auto-queued draft-proposal for ${task.id} (ready queue position)`);
     return; // one per cycle
@@ -2313,7 +2313,7 @@ function maybeFillEmptySlots(): void {
   const topCandidate = candidates[0]!;
   if (!topCandidate.elaborated) {
     if (!autoProposalDebounced(topCandidate.id)) {
-      queueRequest("elaborate", `"task":"${topCandidate.id}"`);
+      queueRequest({ action: "elaborate", task: topCandidate.id });
       markAutoProposalQueued(topCandidate.id); // reuse debounce to avoid re-queuing
       emitEvent({ event_type: "task_elaborate_queued", source: "keepalive", scope: "task", task: topCandidate.id, message: `top candidate needs elaboration` });
       console.error(`ludics: top candidate ${topCandidate.id} needs elaboration — queued`);
@@ -2402,7 +2402,7 @@ function maybeFillEmptySlots(): void {
   const taskFile = join(harnessDir(), "tasks", `${task.id}.md`);
   const taskContent = existsSync(taskFile) ? readFileSync(taskFile, "utf-8") : "";
   if (!taskContent.includes("\nproposal:")) {
-    queueRequest("draft-proposal", `"task":"${task.id}"`);
+    queueRequest({ action: "draft-proposal", task: task.id });
     markAutoProposalQueued(task.id);
     emitEvent({ event_type: "mag_auto_proposal", source: "keepalive", scope: "mag", task: task.id, message: `auto-queued draft-proposal for ${task.id}` });
     console.error(`ludics: auto-queued draft-proposal for ${task.id}`);
@@ -3068,7 +3068,7 @@ export function magBriefing(wait: boolean = true, timeout: number = 300): void {
     console.error("ludics: mag briefing skipped — not the federation controller");
     return;
   }
-  const requestId = queueRequest("briefing");
+  const requestId = queueRequest({ action: "briefing" });
   console.log(`Queued briefing request: ${requestId}`);
 
   // Auto-queue feedback-digest once daily alongside the briefing trigger.
@@ -3115,7 +3115,7 @@ export function magBriefing(wait: boolean = true, timeout: number = 300): void {
 }
 
 function magMessage(text: string): void {
-  queueRequest("message", `"content":${JSON.stringify(text)}`);
+  queueRequest({ action: "message", content: text });
   console.log("Message queued for Mag");
 }
 
@@ -3212,13 +3212,13 @@ export async function runMag(args: string[]): Promise<void> {
       magBriefing();
       break;
     case "suggest":
-      queueRequest("suggest");
+      queueRequest({ action: "suggest" });
       console.log("Queued suggest request");
       break;
     case "elaborate": {
       const taskId = args[1];
       if (!taskId) throw new Error("task id required");
-      queueRequest("elaborate", `"task":"${taskId}"`);
+      queueRequest({ action: "elaborate", task: taskId });
       console.log(`Queued elaborate request for ${taskId}`);
       break;
     }
@@ -3227,7 +3227,7 @@ export async function runMag(args: string[]): Promise<void> {
         console.error("ludics: mag health-check skipped — not the federation controller");
         break;
       }
-      queueRequest("health-check");
+      queueRequest({ action: "health-check" });
       console.log("Queued health-check request");
       break;
     case "message": {
@@ -3302,7 +3302,7 @@ export async function runMag(args: string[]): Promise<void> {
     case "draft-proposal": {
       const taskId = args[1];
       if (!taskId) throw new Error("task id required");
-      queueRequest("draft-proposal", `"task":"${taskId}"`);
+      queueRequest({ action: "draft-proposal", task: taskId });
       console.log(`Queued draft-proposal request for ${taskId}`);
       break;
     }
@@ -3316,10 +3316,9 @@ export async function runMag(args: string[]): Promise<void> {
         const reviseTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
         if (existsSync(reviseTaskFile)) removeFrontmatterField(reviseTaskFile, "approved");
         if (feedback) {
-          const escaped = JSON.stringify(feedback);
-          queueRequest("revise-proposal", `"task":"${taskId}","feedback":${escaped}`);
+          queueRequest({ action: "revise-proposal", task: taskId, feedback });
         } else {
-          queueRequest("revise-proposal", `"task":"${taskId}"`);
+          queueRequest({ action: "revise-proposal", task: taskId });
         }
       }
       console.log(`Queued revise-proposal request for ${taskIds.join(", ")}`);
@@ -3328,14 +3327,14 @@ export async function runMag(args: string[]): Promise<void> {
     case "split-task": {
       const taskId = args[1];
       if (!taskId) throw new Error("task id required");
-      queueRequest("split-task", `"task":"${taskId}"`);
+      queueRequest({ action: "split-task", task: taskId });
       console.log(`Queued split-task request for ${taskId}`);
       break;
     }
     case "verify-completion": {
       const taskId = args[1];
       if (!taskId) throw new Error("task id required");
-      queueRequest("verify-completion", `"task":"${taskId}"`);
+      queueRequest({ action: "verify-completion", task: taskId });
       console.log(`Queued verify-completion request for ${taskId}`);
       break;
     }
@@ -3387,14 +3386,14 @@ export async function runMag(args: string[]): Promise<void> {
         break;
       }
 
-      queueRequest("adopt-sessions");
+      queueRequest({ action: "adopt-sessions" });
       console.log(`Queued adopt-sessions request (${fingerprint.unclassifiedCount} unclassified session(s))`);
       break;
     }
     case "process-suggestions": {
       const taskId = args[1];
       if (!taskId) throw new Error("task id required");
-      queueRequest("process-suggestions", `"task":"${taskId}"`);
+      queueRequest({ action: "process-suggestions", task: taskId });
       console.log(`Queued process-suggestions request for ${taskId}`);
       break;
     }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -740,7 +740,7 @@ export function expirePendingRevises(timeoutSec: number = 900): void {
       const ts = parseInt(readFileSync(join(magDir, f), "utf-8").trim(), 10);
       if (now - ts > timeoutSec) {
         unlinkSync(join(magDir, f));
-        queueRequest("revise-proposal", `"task":"${taskId}"`);
+        queueRequest({ action: "revise-proposal", task: taskId });
         console.log(`ludics: pending revise for ${taskId} timed out, queued without feedback`);
       }
     } catch {
@@ -769,7 +769,7 @@ export function expirePendingFollowupRevises(timeoutSec: number = 900): void {
       }
       if (now - created > timeoutSec) {
         unlinkSync(filePath);
-        queueRequest("adapter-followup", `"task":"${taskId}","adapter":"${adapter}"`);
+        queueRequest({ action: "adapter-followup", task: taskId, adapter });
         console.log(`ludics: pending followup revise for ${taskId} (${adapter}) timed out, queued without feedback`);
       }
     } catch {
@@ -858,41 +858,34 @@ export async function subscribeIncoming(): Promise<void> {
                 setPendingFollowupRevise(taskId, adapter);
               } else if (followupNewMatch) {
                 // New format — route as t3code followup
-                queueRequest("adapter-followup", `"task":"${followupNewMatch[1]!}","adapter":"t3code","followup_msg":""`);
+                queueRequest({ action: "adapter-followup", task: followupNewMatch[1]!, adapter: "t3code", followup_msg: "" });
               } else if (followupLegacyMatch) {
                 // Legacy format
                 const adapter = followupLegacyMatch[1]!;
                 const taskId = followupLegacyMatch[2]!;
-                queueRequest("adapter-followup", `"task":"${taskId}","adapter":"${adapter}","followup_msg":""`);
+                queueRequest({ action: "adapter-followup", task: taskId, adapter, followup_msg: "" });
               } else if (doneMatch) {
-                queueRequest("complete-task", `"task":"${doneMatch[1]!}"`);
+                queueRequest({ action: "complete-task", task: doneMatch[1]! });
               } else if (launchNewMatch || launchLegacyMatch) {
                 // Both new and legacy launch — route to mag queue as message
-                const escaped = JSON.stringify(msg);
-                queueRequest("message", `"content":${escaped}`);
+                queueRequest({ action: "message", content: msg });
               } else if (abandonMatch) {
                 // Route Abandon messages directly — bypass pending-revise consumption
-                const escaped = JSON.stringify(msg);
-                queueRequest("message", `"content":${escaped}`);
+                queueRequest({ action: "message", content: msg });
               } else {
                 const pendingTaskIds = consumeAllPendingRevises();
                 const pendingFollowups = consumeAllPendingFollowupRevises();
 
                 if (pendingTaskIds.length > 0 || pendingFollowups.length > 0) {
-                  const escaped = JSON.stringify(msg);
                   for (const taskId of pendingTaskIds) {
-                    queueRequest("revise-proposal", `"task":"${taskId}","feedback":${escaped}`);
+                    queueRequest({ action: "revise-proposal", task: taskId, feedback: msg });
                   }
                   for (const pending of pendingFollowups) {
-                    queueRequest(
-                      "adapter-followup",
-                      `"task":"${pending.taskId}","adapter":"${pending.adapter}","followup_msg":${escaped}`,
-                    );
+                    queueRequest({ action: "adapter-followup", task: pending.taskId, adapter: pending.adapter, followup_msg: msg });
                   }
                 } else {
                   // Normal message — direct queue injection
-                  const escaped = JSON.stringify(msg);
-                  queueRequest("message", `"content":${escaped}`);
+                  queueRequest({ action: "message", content: msg });
                 }
               }
 

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -29,21 +29,14 @@ describe("queueHasPendingFeedbackDigest", () => {
 
   test("matches feedback-digest with repo field", async () => {
     const { queueRequest, queueHasPendingFeedbackDigest } = await loadQueue();
-    queueRequest("feedback-digest", `"repo":"ludics"`);
+    queueRequest({ action: "feedback-digest", repo: "ludics" });
     expect(queueHasPendingFeedbackDigest("ludics")).toBe(true);
     expect(queueHasPendingFeedbackDigest("other-repo")).toBe(false);
   });
 
-  test("does not match feedback-digest without repo field", async () => {
-    const { queueRequest, queueHasPendingFeedbackDigest } = await loadQueue();
-    queueRequest("feedback-digest");
-    // Without repo field, repo check should not match
-    expect(queueHasPendingFeedbackDigest("ludics")).toBe(false);
-  });
-
   test("does not match other actions", async () => {
     const { queueRequest, queueHasPendingFeedbackDigest } = await loadQueue();
-    queueRequest("briefing");
+    queueRequest({ action: "briefing" });
     expect(queueHasPendingFeedbackDigest("ludics")).toBe(false);
   });
 });
@@ -132,7 +125,7 @@ describe("queuePopAll", () => {
 describe("queueRequest includes extra fields", () => {
   test("feedback-digest with repo field is parseable", async () => {
     const { queueRequest } = await loadQueue();
-    queueRequest("feedback-digest", `"repo":"ludics"`);
+    queueRequest({ action: "feedback-digest", repo: "ludics" });
     const content = readFileSync(join(tmpDir, "mag", "queue.jsonl"), "utf-8").trim();
     const parsed = JSON.parse(content);
     expect(parsed.action).toBe("feedback-digest");

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -34,22 +34,25 @@ function nextRequestId(): string {
   return `req-${epoch}-${suffix}`;
 }
 
-export function queueRequest(action: string, extra?: string): string {
+export type QueueAction =
+  | { action: "briefing" | "suggest" | "health-check" | "adopt-sessions" }
+  | { action: "elaborate" | "draft-proposal" | "split-task" | "verify-completion" | "complete-task" | "process-suggestions"; task: string }
+  | { action: "revise-proposal"; task: string; feedback?: string }
+  | { action: "preempt"; task: string; autonomy: string }
+  | { action: "feedback-digest"; repo: string }
+  | { action: "message"; content: string }
+  | { action: "adapter-followup"; task: string; adapter: string; followup_msg?: string };
+
+export function queueRequest(req: QueueAction): string {
   const file = queueFile();
   mkdirSync(dirname(file), { recursive: true });
 
   const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const requestId = nextRequestId();
 
-  let request: string;
-  if (extra) {
-    request = `{"id":"${requestId}","action":"${action}","timestamp":"${timestamp}",${extra}}`;
-  } else {
-    request = `{"id":"${requestId}","action":"${action}","timestamp":"${timestamp}"}`;
-  }
-
-  appendFileSync(file, request + "\n");
-  emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action, message: requestId });
+  const record = { id: requestId, ...req, timestamp };
+  appendFileSync(file, JSON.stringify(record) + "\n");
+  emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action: req.action, message: requestId });
   return requestId;
 }
 

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -451,7 +451,7 @@ function writeRetrospective(data: RetrospectiveData): void {
   const hasRequestChanges = data.reviews?.some(r => r.verdict === "request_changes") ?? false;
   if (data.suggestRefactorSummary || Object.keys(data.workflowFeedback).length > 0 || hasRequestChanges) {
     try {
-      queueRequest("process-suggestions", `"task":"${data.taskId}"`);
+      queueRequest({ action: "process-suggestions", task: data.taskId });
     } catch {
       // Non-critical: don't fail retrospective write if queue append fails
     }

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -818,7 +818,7 @@ function tasksQueueElaborations(): void {
 
     if (alreadyQueued.includes(`"task":"${taskId}"`)) continue;
 
-    queueRequest("elaborate", `"task":"${taskId}"`);
+    queueRequest({ action: "elaborate", task: taskId });
     emitEvent({ event_type: "task_elaborate_queued", source: "sync", scope: "task", task: taskId });
     count++;
   }
@@ -906,7 +906,7 @@ function tasksQueuePreemptions(): void {
     if (alreadyQueuedForTask) continue;
 
     const autonomy = preemptAutonomy();
-    queueRequest("preempt", `"task":"${id}","autonomy":"${autonomy}"`);
+    queueRequest({ action: "preempt", task: id, autonomy });
     emitEvent({ event_type: "task_preempt_queued", source: "sync", scope: "task", task: id, message: `priority project: ${project}` });
     // Mark task immediately so subsequent syncs won't re-queue it
     // (closes the race window between queue-pop and actual slot assignment)


### PR DESCRIPTION
## Summary
- Replace raw JSON fragment `extra` parameter in `queueRequest` with a `QueueAction` discriminated union type
- All ~30 call sites across `mag.ts`, `notify.ts`, `tasks/sync.ts`, `retrospective.ts` migrated to the new typed signature
- Uses `JSON.stringify` on the whole record instead of manual template string splicing, eliminating double-encoding risks

## Test plan
- [x] `bun run typecheck` passes (no type errors)
- [x] `bun run build` compiles successfully
- [x] `bun test src/queue.test.ts` — all 15 tests pass
- [x] Serialized JSONL output format unchanged (verified by existing tests)
- [x] Removed test for `feedback-digest` without `repo` — now a compile-time error

Closes task-3e1268ce

🤖 Generated with [Claude Code](https://claude.com/claude-code)