### PR TITLE
test: regression tests for addFrontmatterField body-scope bug

### DIFF
--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, updateFrontmatterField } from "./markdown.ts";
+import { addFrontmatterField } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 


### PR DESCRIPTION
## Summary
- Adds `src/tasks/markdown.test.ts` with 4 test cases for `addFrontmatterField`
- Covers the regression from commit e018874: field insertion when body contains a matching `field: value` line
- Also tests normal paths: basic insertion, delegation to `updateFrontmatterField`, and combined frontmatter+body scenarios

## Test plan
- [x] `bun test src/tasks/markdown.test.ts` — 4 pass, 0 fail
- [x] `bun run typecheck` — clean

Closes task-dae0b00f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)