### PR TITLE
fix: add heartbeatIsFresh check to slotStop remote path

### DIFF
--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -811,6 +811,11 @@ describe("remote slot dispatch via HTTP", () => {
     writeSlotJson(2, emptySlotData(2), harness);
     writeTask(tasksDir, "task-remote-2", "Remote stop test");
 
+    // Create a fresh heartbeat so heartbeatIsFresh("worker-a") returns true
+    const hbDir = getHeartbeatsDir();
+    mkdirSync(hbDir, { recursive: true });
+    writeFileSync(join(hbDir, "worker-a.json"), JSON.stringify({ epoch: Math.floor(Date.now() / 1000) }));
+
     slotAssign(1, "task-remote-2", "tmux", "", "", "", "worker-a");
 
     // Stamp Session Started to simulate an active session
@@ -852,6 +857,20 @@ describe("remote slot dispatch via HTTP", () => {
     // Session Started should be cleared (force path runs cleanup)
     const data = readSlotJson(1, harness);
     expect(data.sessionStarted).toBeNull();
+  });
+
+  test("remote slotStop (non-force) fails fast when machine is offline", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-remote-stop-offline", "Remote stop offline test");
+
+    slotAssign(1, "task-remote-stop-offline", "tmux", "", "", "", "worker-a");
+
+    // No heartbeat → machine offline
+    await expect(slotStop(1, false, false)).rejects.toThrow("offline — cannot stop");
   });
 
   test("remote slotResume fails fast when machine is offline", async () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -799,6 +799,9 @@ export async function slotStop(slotNum: number, force: boolean = false, preserve
     if (force) {
       console.error(`ludics: slot ${slotNum}: force-clearing local state (skipping remote stop on ${ctx.machine})`);
     } else {
+      if (!heartbeatIsFresh(ctx.machine)) {
+        throw new Error(`slot ${slotNum}: assigned machine ${ctx.machine} is offline — cannot stop`);
+      }
       const { recordIntent } = await import("../cluster-http.ts");
       const epoch = Math.floor(Date.now() / 1000);
       recordIntent(slotNum, { action: "stop", epoch, machine: ctx.machine, taskId: ctx.taskId, preserveState });


### PR DESCRIPTION
## Summary
- Adds `heartbeatIsFresh()` guard to `slotStop`'s non-force remote dispatch path, matching `slotStart` and `slotResume` behavior
- Prevents silently queuing a stop intent for an offline machine that will never execute it
- Adds test for the offline case; updates existing happy-path test to stamp a heartbeat

## Test plan
- [x] New test `"remote slotStop (non-force) fails fast when machine is offline"` passes
- [x] Existing happy-path test updated with heartbeat stamp, still passes
- [x] All 42 slot tests pass
- [x] Typecheck clean

Closes task-8d4a972a

🤖 Generated with [Claude Code](https://claude.com/claude-code)