### PR TITLE
Extract AGENT_NAME_RE and canonical-round validation into filename-utils.ts

### DIFF
--- a/src/orchestration/filename-utils.test.ts
+++ b/src/orchestration/filename-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_NAME_RE, validateAgentName, parseCanonicalInt } from "./filename-utils";
+
+describe("AGENT_NAME_RE", () => {
+  test("matches valid agent names", () => {
+    expect(AGENT_NAME_RE.test("coder-1")).toBe(true);
+    expect(AGENT_NAME_RE.test("agent_a")).toBe(true);
+    expect(AGENT_NAME_RE.test("abc")).toBe(true);
+  });
+  test("rejects invalid agent names", () => {
+    expect(AGENT_NAME_RE.test("")).toBe(false);
+    expect(AGENT_NAME_RE.test("a b")).toBe(false);
+    expect(AGENT_NAME_RE.test("a/b")).toBe(false);
+  });
+});
+
+describe("validateAgentName", () => {
+  test("accepts valid names", () => {
+    expect(() => validateAgentName("coder-1", "test")).not.toThrow();
+    expect(() => validateAgentName("agent_a", "test")).not.toThrow();
+  });
+  test("throws on invalid names with context", () => {
+    expect(() => validateAgentName("", "plan filename")).toThrow("plan filename");
+    expect(() => validateAgentName("a b", "review filename")).toThrow("review filename");
+    expect(() => validateAgentName("a/b", "merge vote filename")).toThrow("merge vote filename");
+  });
+});
+
+describe("parseCanonicalInt", () => {
+  test("returns the number for canonical strings", () => {
+    expect(parseCanonicalInt("0")).toBe(0);
+    expect(parseCanonicalInt("1")).toBe(1);
+    expect(parseCanonicalInt("42")).toBe(42);
+  });
+  test("returns null for non-canonical representations", () => {
+    expect(parseCanonicalInt("01")).toBeNull();
+    expect(parseCanonicalInt("abc")).toBeNull();
+    expect(parseCanonicalInt("")).toBeNull();
+  });
+});

--- a/src/orchestration/filename-utils.ts
+++ b/src/orchestration/filename-utils.ts
@@ -1,0 +1,22 @@
+/** Shared filename validation helpers for orchestration file-naming modules. */
+
+/** Matches valid agent names: word characters and hyphens. */
+export const AGENT_NAME_RE = /^[\w-]+$/;
+
+/** Throws if `name` does not match AGENT_NAME_RE. */
+export function validateAgentName(name: string, context: string): void {
+  if (!AGENT_NAME_RE.test(name)) {
+    throw new Error(`invalid agent name for ${context}: "${name}" (must match [\\w-]+)`);
+  }
+}
+
+/**
+ * Parse an integer from `token` and return it only if its string
+ * representation round-trips (rejects zero-padded or non-canonical forms).
+ * Returns `null` for non-canonical or non-numeric input.
+ */
+export function parseCanonicalInt(token: string): number | null {
+  const n = parseInt(token, 10);
+  if (isNaN(n) || String(n) !== token) return null;
+  return n;
+}

--- a/src/orchestration/merge-vote-files.ts
+++ b/src/orchestration/merge-vote-files.ts
@@ -1,13 +1,11 @@
 import { join } from "path";
+import { validateAgentName, parseCanonicalInt } from "./filename-utils";
 
-const AGENT_NAME_RE = /^[\w-]+$/;
 const MERGE_VOTE_RE = /^round-(\d+)-([\w-]+)\.txt$/;
 
 /** Build a merge vote filename. */
 export function mergeVoteFilename(round: number, agentName: string): string {
-  if (!AGENT_NAME_RE.test(agentName)) {
-    throw new Error(`invalid agent name for merge vote filename: "${agentName}" (must match [\\w-]+)`);
-  }
+  validateAgentName(agentName, "merge vote filename");
   return `round-${round}-${agentName}.txt`;
 }
 
@@ -20,7 +18,7 @@ export function mergeVoteFilePath(peerSyncDir: string, round: number, agentName:
 export function parseMergeVoteFilename(filename: string): { round: number; agentName: string } | null {
   const m = filename.match(MERGE_VOTE_RE);
   if (!m) return null;
-  const round = parseInt(m[1]!, 10);
-  if (String(round) !== m[1]) return null; // reject non-canonical (e.g. zero-padded) rounds
+  const round = parseCanonicalInt(m[1]!);
+  if (round === null) return null;
   return { round, agentName: m[2]! };
 }

--- a/src/orchestration/plan-files.ts
+++ b/src/orchestration/plan-files.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { validateAgentName, parseCanonicalInt } from "./filename-utils";
 
 export type PlanFileType = "plan" | "merged";
 
@@ -9,15 +10,12 @@ export interface ParsedPlanFilename {
   planMergeRound?: number;
 }
 
-const AGENT_NAME_RE = /^[\w-]+$/;
 const PLAN_RE = /^round-(\d+)-([\w-]+)\.md$/;
 const MERGED_RE = /^round-(\d+)-merged-(\d+)\.md$/;
 
 /** Build an individual plan filename. */
 export function planFilename(round: number, agentName: string): string {
-  if (!AGENT_NAME_RE.test(agentName)) {
-    throw new Error(`invalid agent name for plan filename: "${agentName}" (must match [\\w-]+)`);
-  }
+  validateAgentName(agentName, "plan filename");
   return `round-${round}-${agentName}.md`;
 }
 
@@ -42,15 +40,15 @@ export function parsePlanFilename(filename: string): ParsedPlanFilename | null {
   // so we need to check the more specific pattern first.
   let m = filename.match(MERGED_RE);
   if (m) {
-    const round = parseInt(m[1]!, 10);
-    const planMergeRound = parseInt(m[2]!, 10);
-    if (String(round) !== m[1] || String(planMergeRound) !== m[2]) return null;
+    const round = parseCanonicalInt(m[1]!);
+    const planMergeRound = parseCanonicalInt(m[2]!);
+    if (round === null || planMergeRound === null) return null;
     return { type: "merged", round, planMergeRound };
   }
   m = filename.match(PLAN_RE);
   if (m) {
-    const round = parseInt(m[1]!, 10);
-    if (String(round) !== m[1]) return null;
+    const round = parseCanonicalInt(m[1]!);
+    if (round === null) return null;
     return { type: "plan", round, agentName: m[2]! };
   }
   return null;

--- a/src/orchestration/review-files.ts
+++ b/src/orchestration/review-files.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import { validateAgentName, parseCanonicalInt } from "./filename-utils";
 
 export type ReviewFileType = "review" | "plan-review";
 
@@ -8,15 +9,12 @@ export interface ParsedReviewFilename {
   agentName: string;
 }
 
-const AGENT_NAME_RE = /^[\w-]+$/;
 const REVIEW_RE = /^round-(\d+)-([\w-]+)\.md$/;
 const PLAN_REVIEW_RE = /^plan-merge-(\d+)-([\w-]+)\.md$/;
 
 /** Build a review filename from components. */
 export function reviewFilename(type: ReviewFileType, round: number, agentName: string): string {
-  if (!AGENT_NAME_RE.test(agentName)) {
-    throw new Error(`invalid agent name for review filename: "${agentName}" (must match [\\w-]+)`);
-  }
+  validateAgentName(agentName, "review filename");
   return type === "plan-review"
     ? `plan-merge-${round}-${agentName}.md`
     : `round-${round}-${agentName}.md`;
@@ -33,14 +31,14 @@ export function reviewFilePath(
 export function parseReviewFilename(filename: string): ParsedReviewFilename | null {
   let m = filename.match(REVIEW_RE);
   if (m) {
-    const round = parseInt(m[1]!, 10);
-    if (String(round) !== m[1]) return null;
+    const round = parseCanonicalInt(m[1]!);
+    if (round === null) return null;
     return { type: "review", round, agentName: m[2]! };
   }
   m = filename.match(PLAN_REVIEW_RE);
   if (m) {
-    const round = parseInt(m[1]!, 10);
-    if (String(round) !== m[1]) return null;
+    const round = parseCanonicalInt(m[1]!);
+    if (round === null) return null;
     return { type: "plan-review", round, agentName: m[2]! };
   }
   return null;


### PR DESCRIPTION
## Summary
- Extract duplicated `AGENT_NAME_RE` regex and canonical-round integer guard from `review-files.ts`, `plan-files.ts`, and `merge-vote-files.ts` into new shared `src/orchestration/filename-utils.ts`
- New module exports `AGENT_NAME_RE`, `validateAgentName()`, and `parseCanonicalInt()`
- Add `filename-utils.test.ts` with unit tests for the new helpers

## Test plan
- [x] All existing tests pass unchanged (43 tests, 0 failures)
- [x] New `filename-utils.test.ts` covers valid/invalid agent names and canonical/non-canonical integers
- [x] `bun run typecheck` clean
- [x] `bun run build` succeeds

Closes task-7ef02569

🤖 Generated with [Claude Code](https://claude.com/claude-code)