### PR TITLE
feat: auto-create stub merged plan when planning is skipped

### DIFF
--- a/skills/orchestration/pair-reviewer-review.md
+++ b/skills/orchestration/pair-reviewer-review.md
@@ -7,7 +7,7 @@ First line must be `APPROVE` or `REQUEST_CHANGES`, then action items, then non-b
 If the implementation changes data shapes, verify that all helpers consuming the changed data have been updated. For format-compat serializers, check that round-trip fidelity tests exist (serialize → deserialize → compare). Flag missing consumer updates or missing round-trip tests as blocking action items.
 Do NOT write to a different filename — the orchestrator checks this exact path.
 
-**Pre-existing failures**: Before marking any failing test as a blocking action item, check the merged plan's `## Pre-existing test failures (baseline)` section. Failures listed there are pre-existing and must not block acceptance unless the task's acceptance criteria explicitly require fixing them. Flag any *new* failures (not in the baseline) as blocking. If the merged plan has no baseline section (older plan format), treat all failures as potentially blocking.
+**Pre-existing failures**: Before marking any failing test as a blocking action item, check the merged plan's `## Pre-existing test failures (baseline)` section. Failures listed there are pre-existing and must not block acceptance unless the task's acceptance criteria explicitly require fixing them. Flag any *new* failures (not in the baseline) as blocking. If the merged plan has no baseline section (older plan format), treat all failures as potentially blocking. If the baseline section says planning was skipped, do not block on test failures unless they are clearly caused by the task's changes.
 
 ```sh
 printf '%s|%s|reviewer work review complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, readFileSync, readdirSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { emitEvent } from "../events.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
@@ -1194,6 +1194,25 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
       } catch {
         // plans dir missing — plan-review will handle gracefully
       }
+    }
+  }
+  // When planning is skipped entirely (pre-work → work), create a stub merged plan
+  // so the reviewer template finds a baseline section and doesn't block on pre-existing failures.
+  // Only from pre-plan phases (setup/gather/clarify/pushback) — not from plan/plan-merge/plan-review,
+  // which indicate planning was attempted but failed, a different situation.
+  const PRE_PLAN_PHASES: readonly Phase[] = ["setup", "gather", "clarify", "pushback"];
+  if (next === "work" && PRE_PLAN_PHASES.includes(state.phase)) {
+    const mergedPath = mergedPlanFilePath(state.peerSyncDir, state.round, 0);
+    if (!existsSync(mergedPath)) {
+      mkdirSync(join(state.peerSyncDir, "plans"), { recursive: true });
+      writeFileSync(mergedPath, [
+        "# Stub Plan (planning phase skipped)",
+        "",
+        "## Pre-existing test failures (baseline)",
+        "",
+        "(not recorded -- planning was skipped)",
+        "",
+      ].join("\n"));
     }
   }
   // Track plan-merge iterations: increment planMergeRound each time we loop back.


### PR DESCRIPTION
## Summary

- When orchestration skips planning (`enablePlan: false`), auto-creates a stub merged plan file at `plans/round-{N}-merged-0.md` with a `## Pre-existing test failures (baseline)` section
- Guard restricted to pre-plan phases (setup/gather/clarify/pushback) to avoid masking planning-path failures
- Updates reviewer template to not block on test failures when baseline indicates planning was skipped

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` — all 739 tests pass
- [x] Verified guard excludes plan/plan-merge/plan-review phases
- [x] Verified existsSync guard prevents overwriting real merged plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)