### PR TITLE
Extract orchBranchName helper and add cleanupWorktrees prefix guard

### DIFF
--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -6,8 +6,7 @@ import { join } from "path";
 import { harnessDir, cleanupDelayHours } from "../config.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
-import { removeWorktreeByPath, deleteBranches } from "./worktrees.ts";
-import { slugify } from "./util.ts";
+import { removeWorktreeByPath, deleteBranches, orchBranchName } from "./worktrees.ts";
 import { removePeerSyncLink } from "./peer-sync.ts";
 
 export interface CleanupEntry {
@@ -80,9 +79,7 @@ export function buildCleanupEntry(
   if (orchState.branches) {
     branches = [...new Set(Object.values(orchState.branches))];
   } else {
-    const featureSlug = slugify(orchState.taskId);
-    const slotSuffix = `-s${slot}`;
-    const rootBranch = `ludics/${featureSlug}${slotSuffix}/root`;
+    const rootBranch = orchBranchName(orchState.taskId, slot, "root");
     branches = [rootBranch];
     for (const agent of orchState.agents) {
       if (agent.branch && agent.branch !== rootBranch) {

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -119,6 +119,13 @@ function defaultMainBranch(projectDir: string): string {
   return local || "main";
 }
 
+/** Canonical orchestration branch name for a task/slot/suffix combination. */
+export function orchBranchName(taskId: string, slot: number | undefined, suffix: string): string {
+  const featureSlug = slugify(taskId);
+  const slotSuffix = slot ? `-s${slot}` : "";
+  return `ludics/${featureSlug}${slotSuffix}/${suffix}`;
+}
+
 export function createWorktrees(
   projectDir: string,
   taskId: string,
@@ -135,7 +142,7 @@ export function createWorktrees(
   const rootWorktree = join(parentDir, stem);
   const peerSyncDir = peerSyncPath(rootWorktree);
   const branches: Record<string, string> = {
-    root: `ludics/${featureSlug}${slotSuffix}/root`,
+    root: orchBranchName(taskId, slot, "root"),
   };
   addWorktree(projectDir, rootWorktree, branches.root, mainBranch);
 
@@ -150,7 +157,7 @@ export function createWorktrees(
     // Duo mode: each agent gets its own worktree and branch
     for (const agent of agents) {
       const path = join(parentDir, `${stem}-${slugify(agent.name)}`);
-      const branch = `ludics/${featureSlug}${slotSuffix}/${slugify(agent.name)}`;
+      const branch = orchBranchName(taskId, slot, slugify(agent.name));
       branches[agent.name] = branch;
       addWorktree(projectDir, path, branch, mainBranch);
       agentWorktrees[agent.name] = path;
@@ -218,10 +225,20 @@ export function cleanupWorktrees(
   const repoName = basename(resolve(projectDir));
   const stem = `${repoName}-${featureSlug}${slotSuffix}`;
   const rootWorktree = join(parentDir, stem);
+  const expectedPrefix = join(parentDir, `${repoName}-${featureSlug}`);
+  if (!rootWorktree.startsWith(expectedPrefix)) {
+    console.error(`ludics: refusing to remove worktree outside expected prefix: ${rootWorktree}`);
+    return;
+  }
   removeIfRegistered(projectDir, rootWorktree);
   if (mode === "duo") {
     for (const agent of agents) {
-      removeIfRegistered(projectDir, join(parentDir, `${stem}-${slugify(agent.name)}`));
+      const agentPath = join(parentDir, `${stem}-${slugify(agent.name)}`);
+      if (!agentPath.startsWith(expectedPrefix)) {
+        console.error(`ludics: refusing to remove worktree outside expected prefix: ${agentPath}`);
+        continue;
+      }
+      removeIfRegistered(projectDir, agentPath);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extract duplicated branch naming convention into a shared `orchBranchName(taskId, slot, suffix)` helper in `src/orchestration/worktrees.ts`
- Update `createWorktrees()` and `buildCleanupEntry()` to use the helper instead of inline template literals
- Add path-prefix validation in `cleanupWorktrees()` to prevent removal of directories outside the expected worktree location

## Test plan
- [x] `bun run typecheck` passes
- [x] All 739 tests pass (`bun test`)
- [ ] Verify orchestration workflow creates worktrees with unchanged branch names
- [ ] Verify cleanup skips paths that don't match expected prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)