### PR TITLE
Add code-proposal alignment checklists to plan merge templates

### DIFF
--- a/skills/orchestration/pair-coder-plan-merge.md
+++ b/skills/orchestration/pair-coder-plan-merge.md
@@ -2,6 +2,23 @@
 
 {{PROPOSAL_INSTRUCTION}}
 
+## Code-Proposal Alignment Checklist
+
+Before merging the plans, verify that the proposal's code assumptions match the actual codebase in this worktree. Use grep, search, or type-check to confirm each item:
+
+- [ ] APIs/functions mentioned in the proposal exist in the codebase
+- [ ] Function/module signatures match proposal expectations
+- [ ] Data structures (types, interfaces) exist as assumed
+- [ ] File paths referenced in the proposal point to actual files
+- [ ] Dependencies mentioned in the proposal are available
+- [ ] If the proposal assumes code added by prior phases, confirm it is present
+
+If any assumption is violated, document the gap in the merged plan:
+"⚠️ ASSUMPTION GAP: proposal assumes X but codebase has Y. Recommend [specific remediation]."
+
+Minor gaps (e.g., a renamed method with identical behavior): document clearly but proceed with the merge.
+Substantial gaps (e.g., an entire API or module is missing, would cause implementation rework): reassign to reviewer with REQUEST_CHANGES.
+
 Merge the two independent plans for `{{TASK_ID}}` into one at `{{MERGED_PLAN_FILE}}`.
 
 **Your plan**: `{{PLAN_FILE}}`

--- a/skills/orchestration/pair-reviewer-plan-review.md
+++ b/skills/orchestration/pair-reviewer-plan-review.md
@@ -2,6 +2,19 @@
 
 {{PROPOSAL_INSTRUCTION}}
 
+## Verify Code-Proposal Alignment
+
+Check the merged plan against the proposal and actual codebase:
+
+- [ ] Does the plan's technical approach match proposal assumptions?
+- [ ] Are all proposed code changes feasible in the current codebase?
+- [ ] If the plan-merge phase found gaps, are they documented with ASSUMPTION GAP markers?
+
+If alignment gaps are found, use REQUEST_CHANGES with explicit remediation — for example:
+- "Proposal needs revision to account for X"
+- "Plan should add an intermediate refactoring step before Y"
+- "Accept gap as known risk with rationale: Z"
+
 Review the merged plan for `{{TASK_ID}}`:
 
 {{PEER_PLAN}}


### PR DESCRIPTION
## Summary

- Adds a **Code-Proposal Alignment Checklist** to `pair-coder-plan-merge.md` instructing coders to verify proposal assumptions (APIs, signatures, data structures, file paths, dependencies, prior-phase additions) against the actual codebase before merging plans
- Adds a **Verify Code-Proposal Alignment** section to `pair-reviewer-plan-review.md` instructing reviewers to check the merged plan against proposal assumptions and request changes with explicit remediation when gaps are found
- Both sections use `ASSUMPTION GAP` markers and `REQUEST_CHANGES` guidance to surface mismatches early

Closes #220

## Test plan

- [x] `bun test` passes (739 tests, 0 failures)
- [x] No new template variables introduced
- [x] Both sections positioned after `{{PROPOSAL_INSTRUCTION}}` and before main instructions
- [x] All 6 acceptance criteria verified against proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)