### PR TITLE
fix: make updateFrontmatterField upsert when field is missing

### DIFF
--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, readFrontmatterField } from "./markdown.ts";
+import { addFrontmatterField, readFrontmatterField, updateFrontmatterField } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -14,6 +14,79 @@ function tmpFile(name: string, content: string): string {
 
 afterEach(() => {
   rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe("updateFrontmatterField upsert", () => {
+  test("updates existing field", () => {
+    const f = tmpFile("update.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "status", "completed");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("status: completed");
+    expect(result).not.toContain("status: ready");
+  });
+
+  test("inserts missing field before closing ---", () => {
+    const f = tmpFile("insert.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "completed", "2026-04-13");
+    const result = readFileSync(f, "utf-8");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch).not.toBeNull();
+    expect(fmMatch![1]).toContain("completed: 2026-04-13");
+  });
+
+  test("round-trip: inserted field is readable by readFrontmatterField", () => {
+    const f = tmpFile("roundtrip.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "completed", "2026-04-13T18:00Z");
+    const content = readFileSync(f, "utf-8");
+    expect(readFrontmatterField(content, "completed")).toBe("2026-04-13T18:00Z");
+    // Existing fields preserved
+    expect(readFrontmatterField(content, "id")).toBe("task-1");
+    expect(readFrontmatterField(content, "status")).toBe("ready");
+  });
+
+  test("does not insert into body when field missing from frontmatter", () => {
+    const f = tmpFile("body.md", [
+      "---",
+      "id: task-1",
+      "---",
+      "",
+      "# Title",
+      "",
+      "Some body text",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "completed", "2026-04-13");
+    const result = readFileSync(f, "utf-8");
+    // Field should be in frontmatter, not after body
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch![1]).toContain("completed: 2026-04-13");
+    // Body preserved
+    expect(result).toContain("Some body text");
+  });
 });
 
 describe("addFrontmatterField", () => {

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -68,6 +68,29 @@ describe("updateFrontmatterField upsert", () => {
     expect(readFrontmatterField(content, "status")).toBe("ready");
   });
 
+  test("inserts into frontmatter, not at body horizontal rule", () => {
+    const f = tmpFile("hrule.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+      "",
+      "---",
+      "",
+      "Some body after horizontal rule",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "completed", "2026-04-13");
+    const result = readFileSync(f, "utf-8");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch).not.toBeNull();
+    expect(fmMatch![1]).toContain("completed: 2026-04-13");
+    // Body horizontal rule and text preserved
+    expect(result).toContain("Some body after horizontal rule");
+  });
+
   test("does not insert into body when field missing from frontmatter", () => {
     const f = tmpFile("body.md", [
       "---",

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -107,6 +107,7 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
   const lines = content.split("\n");
   let inFrontmatter = false;
   let done = false;
+  let closingDelimiterIdx = -1;
   const output: string[] = [];
 
   for (const line of lines) {
@@ -117,6 +118,7 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
     }
     if (line === "---" && inFrontmatter) {
       inFrontmatter = false;
+      closingDelimiterIdx = output.length;
       output.push(line);
       continue;
     }
@@ -128,14 +130,9 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
     output.push(line);
   }
 
-  if (!done) {
-    // Upsert: insert before closing --- (last occurrence)
-    for (let i = output.length - 1; i >= 0; i--) {
-      if (output[i] === "---") {
-        output.splice(i, 0, `${field}: ${value}`);
-        break;
-      }
-    }
+  if (!done && closingDelimiterIdx >= 0) {
+    // Upsert: insert before the frontmatter closing ---
+    output.splice(closingDelimiterIdx, 0, `${field}: ${value}`);
   }
 
   writeFileSync(filePath, output.join("\n"));

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -128,36 +128,21 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
     output.push(line);
   }
 
+  if (!done) {
+    // Upsert: insert before closing --- (last occurrence)
+    for (let i = output.length - 1; i >= 0; i--) {
+      if (output[i] === "---") {
+        output.splice(i, 0, `${field}: ${value}`);
+        break;
+      }
+    }
+  }
+
   writeFileSync(filePath, output.join("\n"));
 }
 
 export function addFrontmatterField(filePath: string, field: string, value: string): void {
-  if (!existsSync(filePath)) return;
-  const content = readFileSync(filePath, "utf-8");
-
-  // Scope the existence check to the frontmatter block only.
-  // A matching line in the markdown body must not be mistaken for a frontmatter field —
-  // that would cause updateFrontmatterField (which is frontmatter-scoped) to silently no-op.
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  const fmContent = fmMatch ? fmMatch[1]! : "";
-  if (fmContent.split("\n").some((line) => line.startsWith(`${field}:`))) {
-    updateFrontmatterField(filePath, field, value);
-    return;
-  }
-
-  // Insert before closing ---
-  const lines = content.split("\n");
-  let count = 0;
-  const output: string[] = [];
-  for (const line of lines) {
-    if (line === "---") count++;
-    if (count === 2 && line === "---") {
-      output.push(`${field}: ${value}`);
-    }
-    output.push(line);
-  }
-
-  writeFileSync(filePath, output.join("\n"));
+  updateFrontmatterField(filePath, field, value);
 }
 
 export function removeFrontmatterField(filePath: string, field: string): void {


### PR DESCRIPTION
## Summary

- `updateFrontmatterField()` now inserts the field before the closing `---` when the target field doesn't exist in frontmatter, instead of silently no-oping.
- `addFrontmatterField()` simplified to a thin wrapper that delegates to `updateFrontmatterField`.
- Fixes silent data loss for 15 call sites (e.g. `tasksAbandon` writing `completed` timestamp) that assumed the field would always be written.

Closes task-3eb69fca.

## Test plan

- [x] 4 new tests for `updateFrontmatterField` upsert behavior (insert missing field, update existing field, round-trip fidelity, body preservation)
- [x] All 22 existing `markdown.test.ts` tests pass
- [x] `bun run typecheck` clean
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)