### PR TITLE
feat: allow agent-duo to bail out of obsolete tasks

### DIFF
--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -20,6 +20,15 @@ For each criterion, state explicitly (in your thinking) how the implementation s
 Only after confirming every criterion is met should you write the status file below.
 {{/IF}}
 
+If the task is already resolved on the base branch (fix already merged, 0 meaningful changes needed),
+do NOT make empty commits. Instead, signal bail-out:
+
+```sh
+printf 'bail-out|%s|<describe why task is obsolete>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+Only use bail-out when genuinely nothing needs to be done. If the task is partially done, complete it normally.
+
 ```sh
 printf '%s|%s|coder work complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/skills/orchestration/pair-reviewer-review.md
+++ b/skills/orchestration/pair-reviewer-review.md
@@ -9,6 +9,15 @@ Do NOT write to a different filename — the orchestrator checks this exact path
 
 **Pre-existing failures**: Before marking any failing test as a blocking action item, check the merged plan's `## Pre-existing test failures (baseline)` section. Failures listed there are pre-existing and must not block acceptance unless the task's acceptance criteria explicitly require fixing them. Flag any *new* failures (not in the baseline) as blocking. If the merged plan has no baseline section (older plan format), treat all failures as potentially blocking. If the baseline section says planning was skipped, do not block on test failures unless they are clearly caused by the task's changes.
 
+If the coder wrote a `bail-out` status and you agree the task is already resolved or obsolete
+(verify by checking the base branch), confirm the bail-out:
+
+```sh
+printf 'bail-out-confirmed|%s|<describe why you agree task is obsolete>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+If you disagree with the bail-out, write `REQUEST_CHANGES` in your review file explaining what still needs to be done.
+
 ```sh
 printf '%s|%s|reviewer work review complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -253,6 +253,10 @@ export async function clusterPostTaskUpdate(taskId: string, field: string, value
   return resolveAndPost("/api/cluster/task-update", { taskId, field, value });
 }
 
+export async function clusterPostTaskSectionAppend(taskId: string, section: string, line: string): Promise<{ ok: boolean }> {
+  return resolveAndPost("/api/cluster/task-section-append", { taskId, section, line });
+}
+
 export async function clusterGetTask(taskId: string): Promise<{ ok: boolean; data?: string }> {
   const result = await resolveAndGet(`/api/cluster/task/${taskId}`);
   return { ok: result.ok, data: typeof result.data === "string" ? result.data : undefined };
@@ -382,6 +386,7 @@ const taskMatch = pathname.match(/^\/api\/cluster\/task\/(.+)$/);
     case "/api/cluster/event": return handlePostEvent(body);
     case "/api/cluster/orchestration-state": return handlePostOrchestrationState(body);
     case "/api/cluster/task-update": return handlePostTaskUpdate(body);
+    case "/api/cluster/task-section-append": return handlePostTaskSectionAppend(body);
     case "/api/cluster/slot-update": return handlePostSlotUpdate(body);
     default:
       return jsonResponse(404, { error: "not found" });
@@ -618,6 +623,24 @@ function handlePostTaskUpdate(body: Record<string, unknown>): Response {
   try {
     const { updateFrontmatterField } = require("./tasks/markdown.ts");
     updateFrontmatterField(file, field, value);
+  } catch (err) {
+    return jsonResponse(500, { error: String(err) });
+  }
+  return jsonResponse(200, { ok: true });
+}
+
+function handlePostTaskSectionAppend(body: Record<string, unknown>): Response {
+  const taskId = String(body.taskId ?? "");
+  const section = String(body.section ?? "");
+  const line = String(body.line ?? "");
+  if (!taskId || !section || !line) return jsonResponse(400, { error: "taskId, section, and line required" });
+  const TASK_ID_RE = /^[a-z0-9_-]+$/i;
+  if (!TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
+  const file = join(harnessDir(), "tasks", `${taskId}.md`);
+  if (!existsSync(file)) return jsonResponse(404, { error: "task not found" });
+  try {
+    const { appendToSection } = require("./tasks/markdown.ts");
+    appendToSection(file, section, line);
   } catch (err) {
     return jsonResponse(500, { error: String(err) });
   }

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -814,4 +814,13 @@ describe("evaluateTransition — bail-out", () => {
     // Reviewer has bail-out-confirmed but no review file exists — should still be done
     expect(isAgentDone(state, state.agents[1])).toBe(true);
   });
+
+  test("lone bail-out-confirmed without coder bail-out does NOT bypass artifact validation", () => {
+    const state = makeState({ phase: "review" });
+    state.agentStates.coder.status = "done";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    // Reviewer has bail-out-confirmed but coder is NOT bail-out — pair contract not met.
+    // Without a review file, artifact validation should block.
+    expect(isAgentDone(state, state.agents[1])).toBe(false);
+  });
 });

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -3,7 +3,7 @@ import * as peerSyncMod from "./peer-sync.ts";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { evaluateTransition, findPlanFiles, isAgentDone, phaseTimeoutExpired } from "./phases.ts";
+import { evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, phaseTimeoutExpired } from "./phases.ts";
 import { statusFileFingerprint } from "./peer-sync.ts";
 import { defaultOrchestrationConfig, initAgentRuntimeState, type OrchestrationState } from "./state.ts";
 
@@ -742,5 +742,76 @@ describe("isAgentDone — stale status detection (gh-ludics-122)", () => {
 
     expect(isAgentDone(state, state.agents[1])).toBe(false);
     expect(evaluateTransition(state)).toBeNull();
+  });
+});
+
+describe("isPairBailedOut", () => {
+  test("returns true when coder=bail-out and reviewer=bail-out-confirmed", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(isPairBailedOut(state)).toBe(true);
+  });
+
+  test("returns false when only coder has bail-out", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "review-done";
+    expect(isPairBailedOut(state)).toBe(false);
+  });
+
+  test("returns false when only reviewer has bail-out-confirmed", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "done";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(isPairBailedOut(state)).toBe(false);
+  });
+
+  test("returns false when no coder or reviewer role", () => {
+    const state = makeState({
+      agents: [
+        { name: "a1", provider: "claude-code", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
+        { name: "a2", provider: "claude-code", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    });
+    expect(isPairBailedOut(state)).toBe(false);
+  });
+});
+
+describe("evaluateTransition — bail-out", () => {
+  test("work phase transitions to done when both agents bail out", () => {
+    const state = makeState({ phase: "work" });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("review phase transitions to done when both agents bail out", () => {
+    const state = makeState({ phase: "review" });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("update-docs phase transitions to done when both agents bail out", () => {
+    const state = makeState({ phase: "update-docs" });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("work phase transitions to review when bail-out is one-sided", () => {
+    const state = makeState({ phase: "work" });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "done";
+    expect(evaluateTransition(state)).toBe("review");
+  });
+
+  test("bail-out statuses bypass artifact validation (reviewer without review file)", () => {
+    const state = makeState({ phase: "review" });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    // Reviewer has bail-out-confirmed but no review file exists — should still be done
+    expect(isAgentDone(state, state.agents[1])).toBe(true);
   });
 });

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -193,8 +193,10 @@ export function agentParticipatesInPhase(
 /** Check done-status + required artifact. Shared by both lifecycle branches of isAgentDone. */
 function validateDoneStatus(state: OrchestrationState, agent: AgentConfig, runtime: AgentRuntimeState): boolean {
   if (!DONE_STATUSES.has(runtime.status)) return false;
-  // Bail-out statuses bypass artifact validation — no review file or PR file expected.
-  if (runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") return true;
+  // Bail-out statuses bypass artifact validation only when the full pair bail-out
+  // contract is satisfied (coder=bail-out + reviewer=bail-out-confirmed). A lone
+  // bail-out-confirmed without the coder side must not skip artifact checks.
+  if ((runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") && isPairBailedOut(state)) return true;
   if (!hasRequiredArtifact(state, agent)) {
     emitEvent({
       event_type: "orchestration_warning",

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -143,6 +143,8 @@ export const DONE_STATUSES = new Set([
   "final-merge-done",
   "turn-complete",
   "completed",
+  "bail-out",
+  "bail-out-confirmed",
 ]);
 
 export function phaseTimeoutExpired(state: OrchestrationState): boolean {
@@ -191,6 +193,8 @@ export function agentParticipatesInPhase(
 /** Check done-status + required artifact. Shared by both lifecycle branches of isAgentDone. */
 function validateDoneStatus(state: OrchestrationState, agent: AgentConfig, runtime: AgentRuntimeState): boolean {
   if (!DONE_STATUSES.has(runtime.status)) return false;
+  // Bail-out statuses bypass artifact validation — no review file or PR file expected.
+  if (runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") return true;
   if (!hasRequiredArtifact(state, agent)) {
     emitEvent({
       event_type: "orchestration_warning",
@@ -327,6 +331,16 @@ export function allAgentsDone(state: OrchestrationState): boolean {
   const participants = state.agents.filter((agent) => agentParticipatesInPhase(state, agent));
   if (participants.length === 0) return true;
   return participants.every((agent) => isAgentDone(state, agent));
+}
+
+/** True when both agents have signaled bail-out: coder wrote "bail-out", reviewer confirmed with "bail-out-confirmed". */
+export function isPairBailedOut(state: OrchestrationState): boolean {
+  const coder = state.agents.find(a => a.role === "coder");
+  const reviewer = state.agents.find(a => a.role === "reviewer");
+  if (!coder || !reviewer) return false;
+  const cs = state.agentStates[coder.name]?.status ?? "";
+  const rs = state.agentStates[reviewer.name]?.status ?? "";
+  return cs === "bail-out" && rs === "bail-out-confirmed";
 }
 
 function hasAnyPr(state: OrchestrationState): boolean {
@@ -480,11 +494,15 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
     }
 
     case "work":
-      if (allAgentsDone(state) || phaseTimeoutExpired(state)) return "review";
+      if (allAgentsDone(state) || phaseTimeoutExpired(state)) {
+        if (isPairBailedOut(state)) return "done";
+        return "review";
+      }
       return null;
 
     case "review":
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (isPairBailedOut(state)) return "done";
       {
         const reviewVerdict = pairReviewVerdict(state);
         if (reviewVerdict === "request_changes") return "work";
@@ -493,6 +511,7 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
 
     case "update-docs":
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (isPairBailedOut(state)) return "done";
       if (hasAnyPr(state)) return "pr-comments";
       return "pr-create";
 

--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -4,11 +4,13 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { isAgentDone, pairReviewVerdict } from "./phases.ts";
 import { updateTurnLifecycle, T3CodeTransport } from "./transport-t3code.ts";
-import { refreshAgentStatuses, maybePostCodexReviewRequests, checkAndRedispatchPrComments, autoCommitAgent, autoCommitAllAgents, detectAndNudgeHungAgents, interruptAgent, applyPhaseSideEffects, verifyPhaseOutcome, PR_CREATE_GATE, FINAL_MERGE_GATE, handleVerifyFailure, getFirstPrUrl, preparePhaseRedispatch, skipToPhase, MAX_VERIFY_ATTEMPTS } from "./runner.ts";
+import { refreshAgentStatuses, maybePostCodexReviewRequests, checkAndRedispatchPrComments, autoCommitAgent, autoCommitAllAgents, detectAndNudgeHungAgents, interruptAgent, applyPhaseSideEffects, verifyPhaseOutcome, PR_CREATE_GATE, FINAL_MERGE_GATE, handleVerifyFailure, getFirstPrUrl, preparePhaseRedispatch, skipToPhase, MAX_VERIFY_ATTEMPTS, checkZeroCommitsAutoBailOut } from "./runner.ts";
 import * as notify from "../notify.ts";
 import * as peerSync from "./peer-sync.ts";
 import * as events from "../events.ts";
 import * as github from "./github.ts";
+import * as config from "../config.ts";
+import * as stateMod from "./state.ts";
 import { orchOnStop } from "./index.ts";
 import { readStopHookRecord, writeStopHookRecord, writeAgentMarkerFiles, readAgentMarkerFile } from "./peer-sync.ts";
 import { defaultOrchestrationConfig, initAgentRuntimeState, persistState, type AgentTurnLifecycle, type OrchestrationState } from "./state.ts";
@@ -2634,6 +2636,158 @@ describe("handleVerifyFailure", () => {
     expect(result).toBe("hold");
     expect(eventSpy).not.toHaveBeenCalled();
     expect(notifySpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleVerifyFailure — has_questions surfacing
+// ---------------------------------------------------------------------------
+
+describe("handleVerifyFailure — has_questions", () => {
+  let eventSpy: ReturnType<typeof spyOn>;
+  let notifySpy: ReturnType<typeof spyOn>;
+  let harnessSpy: ReturnType<typeof spyOn>;
+  let tmpHarness: string;
+
+  beforeEach(() => {
+    eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    notifySpy = spyOn(notify, "notifyAgents").mockImplementation(() => {});
+    tmpHarness = makeTmpDir();
+    mkdirSync(join(tmpHarness, "tasks"), { recursive: true });
+    harnessSpy = spyOn(config, "harnessDir").mockReturnValue(tmpHarness);
+  });
+
+  afterEach(() => {
+    eventSpy.mockRestore();
+    notifySpy.mockRestore();
+    harnessSpy.mockRestore();
+  });
+
+  test("sets has_questions and appends to Questions section on max attempts", () => {
+    const taskFile = join(tmpHarness, "tasks", "feat.md");
+    writeFileSync(taskFile, "---\ntitle: test\nstatus: in-progress\n---\n\n## Questions\n\nNone.\n");
+
+    const state = makeState({
+      phase: "pr-create",
+      prCreateVerifyAttempts: MAX_VERIFY_ATTEMPTS - 1,
+    });
+    handleVerifyFailure(state, "prCreate", "still missing");
+
+    const content = readFileSync(taskFile, "utf-8");
+    expect(content).toContain("has_questions: true");
+    expect(content).toContain("Manual intervention required (slot 1)");
+    expect(content).not.toContain("None.");
+  });
+
+  test("does not duplicate question on repeated calls", () => {
+    const taskFile = join(tmpHarness, "tasks", "feat.md");
+    writeFileSync(taskFile, "---\ntitle: test\nstatus: in-progress\n---\n\n## Questions\n\nNone.\n");
+
+    const state = makeState({
+      phase: "pr-create",
+      prCreateVerifyAttempts: MAX_VERIFY_ATTEMPTS - 1,
+    });
+    handleVerifyFailure(state, "prCreate", "still missing");
+
+    // Second call (already at max — returns hold silently, but test idempotency of appendToSection)
+    const { appendToSection } = require("../tasks/markdown.ts");
+    appendToSection(taskFile, "Questions",
+      `- **Manual intervention required (slot 1)**: pr-create failed after ${MAX_VERIFY_ATTEMPTS} attempts`);
+
+    const content = readFileSync(taskFile, "utf-8");
+    const count = content.split("Manual intervention required").length - 1;
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkZeroCommitsAutoBailOut
+// ---------------------------------------------------------------------------
+
+describe("checkZeroCommitsAutoBailOut", () => {
+  let eventSpy: ReturnType<typeof spyOn>;
+  let persistSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    persistSpy = spyOn(stateMod, "persistState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    eventSpy.mockRestore();
+    persistSpy.mockRestore();
+  });
+
+  test("returns false when phase is not pr-create", () => {
+    const state = makeState({ phase: "work" });
+    expect(checkZeroCommitsAutoBailOut(state)).toBe(false);
+    expect(state.phase).toBe("work");
+  });
+
+  test("auto-bails when coder worktree has 0 commits ahead", () => {
+    // Create a real git repo where HEAD is on origin/HEAD (0 commits ahead)
+    const tmpDir = makeTmpDir();
+    const repoDir = join(tmpDir, "repo");
+    mkdirSync(repoDir, { recursive: true });
+    Bun.spawnSync(["git", "init", "--initial-branch", "main"], { cwd: repoDir });
+    Bun.spawnSync(["git", "config", "user.email", "test@test.com"], { cwd: repoDir });
+    Bun.spawnSync(["git", "config", "user.name", "Test"], { cwd: repoDir });
+    writeFileSync(join(repoDir, "file.txt"), "hello");
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repoDir });
+    // Create a fake origin/HEAD ref pointing to current HEAD
+    Bun.spawnSync(["git", "update-ref", "refs/remotes/origin/HEAD", "HEAD"], { cwd: repoDir });
+
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "pr-create",
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    const result = checkZeroCommitsAutoBailOut(state);
+    expect(result).toBe(true);
+    expect(state.phase).toBe("done");
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+    expect(eventSpy.mock.calls[0][0].event_type).toBe("bail_out");
+  });
+
+  test("does not bail when coder worktree has commits ahead", () => {
+    const tmpDir = makeTmpDir();
+    const repoDir = join(tmpDir, "repo");
+    mkdirSync(repoDir, { recursive: true });
+    Bun.spawnSync(["git", "init", "--initial-branch", "main"], { cwd: repoDir });
+    Bun.spawnSync(["git", "config", "user.email", "test@test.com"], { cwd: repoDir });
+    Bun.spawnSync(["git", "config", "user.name", "Test"], { cwd: repoDir });
+    writeFileSync(join(repoDir, "file.txt"), "hello");
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repoDir });
+    // Set origin/HEAD to current commit
+    Bun.spawnSync(["git", "update-ref", "refs/remotes/origin/HEAD", "HEAD"], { cwd: repoDir });
+    // Add another commit (1 ahead)
+    writeFileSync(join(repoDir, "file2.txt"), "world");
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+    Bun.spawnSync(["git", "commit", "-m", "extra"], { cwd: repoDir });
+
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "pr-create",
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    const result = checkZeroCommitsAutoBailOut(state);
+    expect(result).toBe(false);
+    expect(state.phase).toBe("pr-create");
+    expect(eventSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -171,7 +171,13 @@ export function handleVerifyFailure(
 
 /** Set has_questions on the task and append the reason to ## Questions, cluster-safe. */
 export function surfaceManualIntervention(taskId: string, questionLine: string): void {
-  let taskUpdated = false;
+  // Always write locally first so the data is persisted even if cluster forwarding fails.
+  const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+  if (existsSync(taskFile)) {
+    addFrontmatterField(taskFile, "has_questions", "true");
+    appendToSection(taskFile, "Questions", questionLine);
+  }
+  // On worker machines, also forward to the controller so the dashboard sees it.
   try {
     const { clusterIsController, clusterCurrentMachineName } = require("../cluster.ts");
     if (clusterCurrentMachineName() && !clusterIsController()) {
@@ -180,16 +186,8 @@ export function surfaceManualIntervention(taskId: string, questionLine: string):
         clusterPostTaskUpdate(taskId, "has_questions", "true").catch(() => {});
         clusterPostTaskSectionAppend(taskId, "Questions", questionLine).catch(() => {});
       }).catch(() => {});
-      taskUpdated = true;
     }
   } catch { /* standalone mode */ }
-  if (!taskUpdated) {
-    const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
-    if (existsSync(taskFile)) {
-      addFrontmatterField(taskFile, "has_questions", "true");
-      appendToSection(taskFile, "Questions", questionLine);
-    }
-  }
 }
 
 /** Get the first available PR URL from agent runtime state, falling back to peer-sync artifact. */

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -16,7 +16,7 @@ import {
 } from "./state.ts";
 import { isoNow, makeId, nowEpoch, sleep } from "./util.ts";
 import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, validateAndFixPrFile, type PrVerification } from "./github.ts";
-import { updateFrontmatterField } from "../tasks/markdown.ts";
+import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
 import { findProjectConfig, globalAdapter, harnessDir, ludicsRoot } from "../config.ts";
 import { notifyAgents } from "../notify.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
@@ -156,6 +156,10 @@ export function handleVerifyFailure(
       3,
       `Slot ${state.slot}: manual intervention`,
     );
+    // Surface in dashboard via has_questions tile.
+    // Use cluster forwarding when running as a worker so the controller's task file is updated.
+    const questionLine = `- **Manual intervention required (slot ${state.slot})**: ${phaseLabel} failed after ${MAX_VERIFY_ATTEMPTS} attempts`;
+    surfaceManualIntervention(state.taskId, questionLine);
     return "hold";
   }
 
@@ -163,6 +167,29 @@ export function handleVerifyFailure(
   state.phaseRetryContext = reason;
   preparePhaseRedispatch(state);
   return "redispatch";
+}
+
+/** Set has_questions on the task and append the reason to ## Questions, cluster-safe. */
+export function surfaceManualIntervention(taskId: string, questionLine: string): void {
+  let taskUpdated = false;
+  try {
+    const { clusterIsController, clusterCurrentMachineName } = require("../cluster.ts");
+    if (clusterCurrentMachineName() && !clusterIsController()) {
+      // Fire-and-forget: handleVerifyFailure is synchronous, so we cannot await.
+      import("../cluster-http.ts").then(({ clusterPostTaskUpdate, clusterPostTaskSectionAppend }) => {
+        clusterPostTaskUpdate(taskId, "has_questions", "true").catch(() => {});
+        clusterPostTaskSectionAppend(taskId, "Questions", questionLine).catch(() => {});
+      }).catch(() => {});
+      taskUpdated = true;
+    }
+  } catch { /* standalone mode */ }
+  if (!taskUpdated) {
+    const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+    if (existsSync(taskFile)) {
+      addFrontmatterField(taskFile, "has_questions", "true");
+      appendToSection(taskFile, "Questions", questionLine);
+    }
+  }
 }
 
 /** Get the first available PR URL from agent runtime state, falling back to peer-sync artifact. */
@@ -1306,6 +1333,33 @@ function readFileIfExists(path: string): string | null {
   return value || null;
 }
 
+/**
+ * 0-commits-ahead auto-bail-out: if pr-create phase and the coder worktree has no commits
+ * ahead of the base branch, skip PR creation and transition directly to done.
+ * Returns true if bail-out was triggered (caller should break the loop).
+ */
+export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean {
+  if (state.phase !== "pr-create") return false;
+  const coder = state.agents.find(a => a.role === "coder");
+  if (!coder) return false;
+  const revList = Bun.spawnSync(
+    ["git", "rev-list", "--count", "origin/HEAD..HEAD"],
+    { cwd: coder.worktreePath },
+  );
+  const count = parseInt(String(revList.stdout).trim(), 10);
+  if (revList.exitCode !== 0 || count !== 0) return false;
+  emitEvent({
+    event_type: "bail_out",
+    source: "orchestration", scope: "slot",
+    slot: state.slot, task: state.taskId,
+    action: "pr-create auto-bail-out", status: "skipped",
+    message: "0 commits ahead of base branch — no PR possible, task obsolete",
+  });
+  state.phase = "done";
+  persistState(state);
+  return true;
+}
+
 export async function runOrchestration(
   state: OrchestrationState,
   transport?: OrchestrationTransport,
@@ -1331,6 +1385,8 @@ export async function runOrchestration(
       const { captureTmuxAgentOutputs } = await import("./tmux-capture.ts");
       captureTmuxAgentOutputs(state);
     }
+
+    if (checkZeroCommitsAutoBailOut(state)) break;
 
     // --- Verification gates: confirm actual outcome before allowing transition ---
     const prCreateDecision = verifyPhaseOutcome(state, PR_CREATE_GATE);

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, readFrontmatterField, updateFrontmatterField } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, readFrontmatterField, updateFrontmatterField } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -261,5 +261,44 @@ describe("readFrontmatterField", () => {
     const content = "---\n: : :\n  bad:\n    - [\n---\n";
     expect(() => readFrontmatterField(content, "project")).not.toThrow();
     expect(readFrontmatterField(content, "project")).toBeNull();
+  });
+});
+
+describe("appendToSection", () => {
+  test("appends to existing section with content", () => {
+    const f = tmpFile("append-existing.md", "---\ntitle: test\n---\n\n## Questions\n\n- Existing item\n");
+    appendToSection(f, "Questions", "- New item");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("- Existing item\n- New item\n");
+  });
+
+  test("replaces None. placeholder", () => {
+    const f = tmpFile("append-none.md", "---\ntitle: test\n---\n\n## Questions\n\nNone.\n");
+    appendToSection(f, "Questions", "- Intervention required");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("- Intervention required");
+    expect(result).not.toContain("None.");
+  });
+
+  test("creates missing section at end of file", () => {
+    const f = tmpFile("append-missing.md", "---\ntitle: test\n---\n\n## Notes\n\nSome notes.\n");
+    appendToSection(f, "Questions", "- New question");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("## Questions\n\n- New question\n");
+  });
+
+  test("does not duplicate identical line", () => {
+    const f = tmpFile("append-dedup.md", "---\ntitle: test\n---\n\n## Questions\n\n- Already here\n");
+    appendToSection(f, "Questions", "- Already here");
+    const result = readFileSync(f, "utf-8");
+    const count = result.split("- Already here").length - 1;
+    expect(count).toBe(1);
+  });
+
+  test("works with different section names", () => {
+    const f = tmpFile("append-other.md", "---\ntitle: test\n---\n\n## Notes\n\nExisting.\n");
+    appendToSection(f, "Notes", "- Appended note");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("Existing.\n- Appended note\n");
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -142,6 +142,40 @@ export function addFrontmatterField(filePath: string, field: string, value: stri
   updateFrontmatterField(filePath, field, value);
 }
 
+/** Append a line to a markdown section (## heading). Handles "None." replacement, dedup, and missing sections. */
+export function appendToSection(filePath: string, section: string, line: string): void {
+  if (!existsSync(filePath)) return;
+  let content = readFileSync(filePath, "utf-8");
+  const header = `## ${section}`;
+
+  // Dedupe: don't append if exact line already present
+  if (content.includes(line)) return;
+
+  if (content.includes(header)) {
+    // Replace "None." placeholder if present
+    const nonePattern = new RegExp(`(${header}\\s*\\n\\s*)None\\.`);
+    if (nonePattern.test(content)) {
+      content = content.replace(nonePattern, `$1${line}`);
+    } else {
+      // Append after existing section content, before next ## header or EOF
+      const headerIdx = content.indexOf(header);
+      const afterHeader = headerIdx + header.length;
+      const nextHeaderMatch = content.slice(afterHeader).match(/\n## /);
+      const insertIdx = nextHeaderMatch
+        ? afterHeader + nextHeaderMatch.index!
+        : content.length;
+      const before = content.slice(0, insertIdx).trimEnd();
+      const after = content.slice(insertIdx);
+      content = before + "\n" + line + "\n" + after;
+    }
+  } else {
+    // Create section at end of document
+    content = content.trimEnd() + `\n\n${header}\n\n${line}\n`;
+  }
+
+  writeFileSync(filePath, content);
+}
+
 export function removeFrontmatterField(filePath: string, field: string): void {
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");


### PR DESCRIPTION
## Summary

- Add bail-out status recognition (`bail-out` / `bail-out-confirmed`) so agent pairs can skip PR/merge phases when a task is already resolved on main
- Auto-detect 0 commits ahead in `pr-create` phase and transition directly to done, preventing the 3-attempt `validateAndFixPrFile` retry loop
- Surface `manual_intervention_required` in the dashboard by setting `has_questions` on the task file (cluster-safe via new `clusterPostTaskSectionAppend` API)
- Add `appendToSection` markdown helper with dedup, `None.` replacement, and missing-section creation
- Update pair-coder-work and pair-reviewer-review templates with bail-out instructions

## Test plan

- [x] `isPairBailedOut` returns true/false for correct/mismatched status combinations
- [x] `evaluateTransition` returns `"done"` in work/review/update-docs when both agents bail out
- [x] Bail-out statuses bypass artifact validation (reviewer without review file)
- [x] `checkZeroCommitsAutoBailOut` auto-bails with 0 commits ahead, does not bail with >0
- [x] `handleVerifyFailure` sets `has_questions` and appends to Questions section
- [x] `appendToSection` handles existing content, `None.` replacement, missing section, dedup
- [x] `bun run typecheck` passes
- [x] `bun run build` compiles
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)