### PR TITLE
Split PHASE_CATEGORIES: pre-plan vs planning

### DIFF
--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -3,8 +3,10 @@ import * as peerSyncMod from "./peer-sync.ts";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, phaseTimeoutExpired } from "./phases.ts";
+import { evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, PHASE_CATEGORIES, phaseTimeoutExpired } from "./phases.ts";
 import { statusFileFingerprint } from "./peer-sync.ts";
+import { mergedPlanFilePath } from "./plan-files.ts";
+import { applyPhaseSideEffects } from "./runner.ts";
 import { defaultOrchestrationConfig, initAgentRuntimeState, type OrchestrationState } from "./state.ts";
 
 const ORIGINAL_HOME = process.env.HOME;
@@ -822,5 +824,61 @@ describe("evaluateTransition — bail-out", () => {
     // Reviewer has bail-out-confirmed but coder is NOT bail-out — pair contract not met.
     // Without a review file, artifact validation should block.
     expect(isAgentDone(state, state.agents[1])).toBe(false);
+  });
+});
+
+describe("PHASE_CATEGORIES split — pre-plan vs planning", () => {
+  test("pre-plan phases map to 'pre-plan'", () => {
+    for (const phase of ["setup", "gather", "clarify", "pushback"] as const) {
+      expect(PHASE_CATEGORIES[phase]).toBe("pre-plan");
+    }
+  });
+
+  test("planning phases map to 'planning'", () => {
+    for (const phase of ["plan", "plan-merge", "plan-review"] as const) {
+      expect(PHASE_CATEGORIES[phase]).toBe("planning");
+    }
+  });
+});
+
+describe("applyPhaseSideEffects — stub plan creation (gh-ludics-254)", () => {
+  test("creates stub merged plan when pre-plan phase → work (planning skipped)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gh254-stub-"));
+    const state = makeState({
+      phase: "setup",
+      round: 1,
+      peerSyncDir: tmpDir,
+    });
+    applyPhaseSideEffects(state, "work");
+    const stubPath = mergedPlanFilePath(tmpDir, 1, 0);
+    expect(existsSync(stubPath)).toBe(true);
+    expect(readFileSync(stubPath, "utf-8")).toContain("planning phase skipped");
+  });
+
+  test("does NOT overwrite existing merged plan when pre-plan → work", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gh254-nooverwrite-"));
+    mkdirSync(join(tmpDir, "plans"), { recursive: true });
+    const stubPath = mergedPlanFilePath(tmpDir, 1, 0);
+    const existingContent = "# Real Merged Plan\nKeep this content.\n";
+    writeFileSync(stubPath, existingContent);
+    const state = makeState({
+      phase: "clarify",
+      round: 1,
+      peerSyncDir: tmpDir,
+    });
+    applyPhaseSideEffects(state, "work");
+    expect(readFileSync(stubPath, "utf-8")).toBe(existingContent);
+  });
+
+  test("does NOT create stub when planning phase → work (planning attempted)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gh254-noplanning-"));
+    const state = makeState({
+      phase: "plan-review",
+      round: 1,
+      peerSyncDir: tmpDir,
+    });
+    applyPhaseSideEffects(state, "work");
+    const stubPath = mergedPlanFilePath(tmpDir, 1, 0);
+    expect(existsSync(stubPath)).toBe(false);
   });
 });

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -32,7 +32,7 @@ export type Phase =
   | "final-merge"
   | "done";
 
-export type PhaseCategory = "pre-work" | "main-loop" | "pr" | "merge" | "post-merge" | "terminal";
+export type PhaseCategory = "pre-plan" | "planning" | "main-loop" | "pr" | "merge" | "post-merge" | "terminal";
 
 export interface TransitionRule {
   from: Phase;
@@ -41,13 +41,13 @@ export interface TransitionRule {
 }
 
 export const PHASE_CATEGORIES: Record<Phase, PhaseCategory> = {
-  setup: "pre-work",
-  gather: "pre-work",
-  clarify: "pre-work",
-  pushback: "pre-work",
-  plan: "pre-work",
-  "plan-merge": "pre-work",
-  "plan-review": "pre-work",
+  setup: "pre-plan",
+  gather: "pre-plan",
+  clarify: "pre-plan",
+  pushback: "pre-plan",
+  plan: "planning",
+  "plan-merge": "planning",
+  "plan-review": "planning",
   work: "main-loop",
   review: "main-loop",
   "update-docs": "main-loop",

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1063,7 +1063,7 @@ export async function interruptAgent(
 
 async function handleTimeout(state: OrchestrationState, transport: OrchestrationTransport): Promise<void> {
   const category = PHASE_CATEGORIES[state.phase];
-  if (category === "pre-work" || category === "terminal") return;
+  if (category === "pre-plan" || category === "planning" || category === "terminal") return;
 
   // Note: for forwarded pr-comments (upstream monitoring), timeout interrupts are NOT
   // suppressed. If redispatchForPrComments dispatched a turn that hangs, it should be
@@ -1322,12 +1322,11 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
       }
     }
   }
-  // When planning is skipped entirely (pre-work → work), create a stub merged plan
+  // When planning is skipped entirely (pre-plan → work), create a stub merged plan
   // so the reviewer template finds a baseline section and doesn't block on pre-existing failures.
   // Only from pre-plan phases (setup/gather/clarify/pushback) — not from plan/plan-merge/plan-review,
   // which indicate planning was attempted but failed, a different situation.
-  const PRE_PLAN_PHASES: readonly Phase[] = ["setup", "gather", "clarify", "pushback"];
-  if (next === "work" && PRE_PLAN_PHASES.includes(state.phase)) {
+  if (next === "work" && PHASE_CATEGORIES[state.phase] === "pre-plan") {
     const mergedPath = mergedPlanFilePath(state.peerSyncDir, state.round, 0);
     if (!existsSync(mergedPath)) {
       mkdirSync(join(state.peerSyncDir, "plans"), { recursive: true });


### PR DESCRIPTION
## Summary
- Split `"pre-work"` phase category into `"pre-plan"` (setup/gather/clarify/pushback) and `"planning"` (plan/plan-merge/plan-review)
- Updated `handleTimeout()` to skip both `"pre-plan"` and `"planning"` categories
- Replaced inline `PRE_PLAN_PHASES` array in `applyPhaseSideEffects()` with `PHASE_CATEGORIES[state.phase] === "pre-plan"` check
- Added 5 regression tests: category mapping verification + stub-plan creation behavior

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] All 59 tests in phases.test.ts pass (including 5 new ones)

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)