### PR TITLE
feat: share validation constants between core and dashboard

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -22,6 +22,8 @@ const adapters: Record<string, Adapter> = {
   "tmux": tmuxAdapter,
 };
 
+export const ADAPTER_NAMES = Object.keys(adapters);
+
 function getAdapter(mode: string): Adapter {
   const adapter = adapters[mode];
   if (!adapter) throw new Error(`adapter not found: ${mode}`);

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -9,8 +9,9 @@ import YAML from "yaml";
 import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson } from "./slots/json.ts";
-import { slotClear, slotSetMode, slotStart, slotResume } from "./slots/index.ts";
-import { updateFrontmatterField, addFrontmatterField, TASK_ID_RE } from "./tasks/markdown.ts";
+import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES } from "./slots/index.ts";
+import { updateFrontmatterField, addFrontmatterField, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
+import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon } from "./tasks/index.ts";
 import { setQueueHold } from "./mag.ts";
 import { queueList, queueRequest } from "./queue.ts";
@@ -172,8 +173,8 @@ export function startDashboardServer(
         if (!slotParam || !/^[1-6]$/.test(slotParam)) {
           return new Response("Bad Request: slot must be 1-6", { status: 400 });
         }
-        if (!["ready", "in-progress", "done", "abandoned"].includes(status)) {
-          return new Response("Bad Request: status must be ready, in-progress, done, or abandoned", { status: 400 });
+        if (!(VALID_CLEAR_STATUSES as readonly string[]).includes(status)) {
+          return new Response(`Bad Request: status must be ${VALID_CLEAR_STATUSES.join(", ")}`, { status: 400 });
         }
         try {
           slotClear(parseInt(slotParam, 10), status);
@@ -191,8 +192,8 @@ export function startDashboardServer(
         if (!slotParam || !/^[1-6]$/.test(slotParam)) {
           return new Response("Bad Request: slot must be 1-6", { status: 400 });
         }
-        if (!mode || !["manual", "tmux", "t3code"].includes(mode)) {
-          return new Response("Bad Request: mode must be manual, tmux, or t3code", { status: 400 });
+        if (!mode || !ADAPTER_NAMES.includes(mode)) {
+          return new Response(`Bad Request: mode must be one of ${ADAPTER_NAMES.join(", ")}`, { status: 400 });
         }
         try {
           await slotSetMode(parseInt(slotParam, 10), mode);
@@ -252,7 +253,6 @@ export function startDashboardServer(
               const taskResolved = resolveTaskFile(taskId);
               if (!("error" in taskResolved)) {
                 const taskFile = taskResolved.path;
-                const PRIORITY_DECREASE: Record<string, string> = { S: "A", A: "B", B: "C" };
                 const content = readFileSync(taskFile, "utf-8");
                 const priorityMatch = content.match(/^priority:\s*(.+)$/m);
                 const currentPriority = priorityMatch ? priorityMatch[1]!.trim() : "B";
@@ -288,7 +288,6 @@ export function startDashboardServer(
           const resolved = resolveTaskFile(taskParam);
           if ("error" in resolved) return resolved.error;
           const taskFile = resolved.path;
-          const PRIORITY_INCREASE: Record<string, string> = { C: "B", B: "A", A: "S" };
           const content = readFileSync(taskFile, "utf-8");
           const priorityMatch = content.match(/^priority:\s*(.+)$/m);
           const currentPriority = priorityMatch ? priorityMatch[1]!.trim() : "B";

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -9,7 +9,7 @@ import YAML from "yaml";
 import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson } from "./slots/json.ts";
-import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES } from "./slots/index.ts";
+import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
 import { updateFrontmatterField, addFrontmatterField, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon } from "./tasks/index.ts";
@@ -169,7 +169,7 @@ export function startDashboardServer(
       // API: clear a slot as done
       if (pathname === "/api/slot-clear") {
         const slotParam = url.searchParams.get("slot");
-        const status = url.searchParams.get("status") ?? "done";
+        const status = url.searchParams.get("status") ?? CLEAR_STATUS_DONE;
         if (!slotParam || !/^[1-6]$/.test(slotParam)) {
           return new Response("Bad Request: slot must be 1-6", { status: 400 });
         }
@@ -269,7 +269,7 @@ export function startDashboardServer(
           // in the ready queue at its old priority (race with auto-assign).
           pendingPriorityWrite?.();
 
-          slotClear(slotNum, "ready");
+          slotClear(slotNum, CLEAR_STATUS_READY);
 
           lastGenerated = 0;
           return new Response("OK", { status: 200 });

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -24,6 +24,8 @@ import { heartbeatIsFresh, clusterMachine } from "../cluster.ts";
 import { safeSyncOutput } from "../spawn.ts";
 
 export const VALID_CLEAR_STATUSES = ["ready", "in-progress", "done", "abandoned"] as const;
+export const CLEAR_STATUS_READY = "ready" as const;
+export const CLEAR_STATUS_DONE = "done" as const;
 
 // Worker-side override: when set, readSlot/readAllSlots uses this data instead of
 // reading from the local harness files. Set by processSlotIntents before executing

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -23,6 +23,8 @@ import { isRemoteMachine } from "../remote.ts";
 import { heartbeatIsFresh, clusterMachine } from "../cluster.ts";
 import { safeSyncOutput } from "../spawn.ts";
 
+export const VALID_CLEAR_STATUSES = ["ready", "in-progress", "done", "abandoned"] as const;
+
 // Worker-side override: when set, readSlot/readAllSlots uses this data instead of
 // reading from the local harness files. Set by processSlotIntents before executing
 // worker intents so that slot operations use fresh controller-fetched state.
@@ -1313,8 +1315,7 @@ export async function runSlot(args: string[]): Promise<void> {
 
     case "clear": {
       const finalStatus = args[2] ?? "ready";
-      const VALID_CLEAR_STATUSES = ["ready", "in-progress", "done", "abandoned"];
-      if (!VALID_CLEAR_STATUSES.includes(finalStatus)) {
+      if (!(VALID_CLEAR_STATUSES as readonly string[]).includes(finalStatus)) {
         throw new Error(`invalid clear status: ${finalStatus} (use: ${VALID_CLEAR_STATUSES.join(", ")})`);
       }
       slotClear(slotNum, finalStatus);

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -8,6 +8,9 @@ import type { TaskFrontmatter } from "./types.ts";
 /** Regex for valid task IDs — used across all task-related endpoints. */
 export const TASK_ID_RE = /^[A-Za-z0-9._-]+$/;
 
+export const PRIORITY_INCREASE: Record<string, string> = { C: "B", B: "A", A: "S" };
+export const PRIORITY_DECREASE: Record<string, string> = { S: "A", A: "B", B: "C" };
+
 /** Numeric sort key for priority levels. S < A < B < C < anything else. */
 export function priorityValue(p: string): number {
   switch (p) {


### PR DESCRIPTION
## Summary
- Export `VALID_CLEAR_STATUSES` from `src/slots/index.ts`, `ADAPTER_NAMES` from `src/adapters/index.ts`, and `PRIORITY_INCREASE`/`PRIORITY_DECREASE` from `src/tasks/markdown.ts`
- Dashboard server imports all shared constants instead of hardcoding values
- New adapters or statuses added to core modules are now automatically accepted by the dashboard API

Closes #257

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] All 806 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)