### PR TITLE
Extract ensureRemoteMachineReachable helper, add clusterMachine check to slotStop

### DIFF
--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -16,15 +16,29 @@ const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
 let TMP = "";
 
-function writeConfig(homeDir: string): string {
+function writeConfig(homeDir: string, { cluster }: { cluster?: boolean } = {}): string {
   const configDir = join(homeDir, ".config", "ludics");
   mkdirSync(configDir, { recursive: true });
   const configPath = join(configDir, "config.yaml");
-  writeFileSync(configPath, `state_repo: owner/ludics-state
+  let yaml = `state_repo: owner/ludics-state
 state_path: harness
 slots:
   count: 2
-`);
+`;
+  if (cluster) {
+    yaml += `cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: worker-a
+      host: worker-a.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`;
+  }
+  writeFileSync(configPath, yaml);
   return configPath;
 }
 
@@ -806,6 +820,9 @@ describe("remote slot dispatch via HTTP", () => {
   });
 
   test("remote slotStop (non-force) writes a stop intent and returns early", async () => {
+    // Need cluster config so clusterMachine("worker-a") resolves
+    process.env.LUDICS_CONFIG = writeConfig(TMP, { cluster: true });
+
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");
     mkdirSync(tasksDir, { recursive: true });
@@ -873,6 +890,25 @@ describe("remote slot dispatch via HTTP", () => {
 
     // No heartbeat → machine offline
     await expect(slotStop(1, false, false)).rejects.toThrow("offline — cannot stop");
+  });
+
+  test("remote slotStop (non-force) fails fast when no cluster config for machine", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-remote-stop-noconfig", "Remote stop no cluster config test");
+
+    // Create a fresh heartbeat so heartbeatIsFresh("worker-a") returns true
+    const hbDir = getHeartbeatsDir();
+    mkdirSync(hbDir, { recursive: true });
+    writeFileSync(join(hbDir, "worker-a.json"), JSON.stringify({ epoch: Math.floor(Date.now() / 1000) }));
+
+    slotAssign(1, "task-remote-stop-noconfig", "tmux", "", "", "", "worker-a");
+
+    // Heartbeat is fresh but no cluster config → should throw
+    await expect(slotStop(1, false, false)).rejects.toThrow("no cluster config for machine worker-a");
   });
 
   test("remote slotResume fails fast when machine is offline", async () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -690,6 +690,32 @@ function makeAdapterContext(slotNum: number, data: SlotData): AdapterContext {
  *
  * @throws {Error} If the assigned remote machine is offline or has no cluster config.
  */
+
+/** Shared remote-dispatch logic for slotStart, slotStop (non-force), and slotResume.
+ *  Validates heartbeat + cluster config, records an intent, logs, and emits an event.
+ *  Callers should `return` after awaiting this function. */
+async function ensureRemoteMachineReachable(
+  slotNum: number,
+  machine: string,
+  action: "start" | "stop" | "resume",
+  adapter: string,
+  intentPayload: Record<string, unknown>,
+): Promise<void> {
+  if (!heartbeatIsFresh(machine)) {
+    throw new Error(`slot ${slotNum}: assigned machine ${machine} is offline — cannot ${action}`);
+  }
+  const targetMachine = clusterMachine(machine);
+  if (!targetMachine) {
+    throw new Error(`slot ${slotNum}: no cluster config for machine ${machine}`);
+  }
+  const { recordIntent } = await import("../cluster-http.ts");
+  const epoch = Math.floor(Date.now() / 1000);
+  recordIntent(slotNum, { action, epoch, machine, ...intentPayload });
+  console.error(`ludics: slot ${slotNum}: ${action} intent recorded for ${machine}`);
+  journalAppend("slot", `Slot ${slotNum} ${action} intent recorded for ${machine}`);
+  emitEvent({ event_type: `slot_${action}_queued`, source: "cli", scope: "slot", slot: slotNum, adapter, machine, message: `${action} intent recorded for ${machine}` });
+}
+
 export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = true }: { startTtyd?: boolean } = {}): Promise<void> {
   ensureSlotsDir();
   const count = slotsCount();
@@ -703,19 +729,7 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
 
   // Remote dispatch: record intent in controller memory (pure pull model)
   if (ctx.machine && isRemoteMachine(ctx.machine)) {
-    if (!heartbeatIsFresh(ctx.machine)) {
-      throw new Error(`slot ${slotNum}: assigned machine ${ctx.machine} is offline — cannot start`);
-    }
-    const targetMachine = clusterMachine(ctx.machine);
-    if (!targetMachine) {
-      throw new Error(`slot ${slotNum}: no cluster config for machine ${ctx.machine}`);
-    }
-    const { recordIntent } = await import("../cluster-http.ts");
-    const epoch = Math.floor(Date.now() / 1000);
-    recordIntent(slotNum, { action: "start", epoch, machine: ctx.machine, taskId: ctx.taskId });
-    console.error(`ludics: slot ${slotNum}: start intent recorded for ${ctx.machine}`);
-    journalAppend("slot", `Slot ${slotNum} start intent recorded for ${ctx.machine}`);
-    emitEvent({ event_type: "slot_start_queued", source: "cli", scope: "slot", slot: slotNum, adapter: ctx.mode, machine: ctx.machine, message: `start intent recorded for ${ctx.machine}` });
+    await ensureRemoteMachineReachable(slotNum, ctx.machine, "start", ctx.mode, { taskId: ctx.taskId });
     return;
   }
 
@@ -808,15 +822,7 @@ export async function slotStop(slotNum: number, force: boolean = false, preserve
     if (force) {
       console.error(`ludics: slot ${slotNum}: force-clearing local state (skipping remote stop on ${ctx.machine})`);
     } else {
-      if (!heartbeatIsFresh(ctx.machine)) {
-        throw new Error(`slot ${slotNum}: assigned machine ${ctx.machine} is offline — cannot stop`);
-      }
-      const { recordIntent } = await import("../cluster-http.ts");
-      const epoch = Math.floor(Date.now() / 1000);
-      recordIntent(slotNum, { action: "stop", epoch, machine: ctx.machine, taskId: ctx.taskId, preserveState });
-      console.error(`ludics: slot ${slotNum}: stop intent recorded for ${ctx.machine}`);
-      journalAppend("slot", `Slot ${slotNum} stop intent recorded for ${ctx.machine}`);
-      emitEvent({ event_type: "slot_stop_queued", source: "cli", scope: "slot", slot: slotNum, adapter: ctx.mode, machine: ctx.machine, message: `stop intent recorded for ${ctx.machine}` });
+      await ensureRemoteMachineReachable(slotNum, ctx.machine, "stop", ctx.mode, { taskId: ctx.taskId, preserveState });
       return;
     }
   } else {
@@ -850,19 +856,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
 
   // Remote dispatch: if slot is owned by another machine, send via HTTP
   if (ctx.machine && isRemoteMachine(ctx.machine)) {
-    if (!heartbeatIsFresh(ctx.machine)) {
-      throw new Error(`slot ${slotNum}: assigned machine ${ctx.machine} is offline — cannot resume`);
-    }
-    const targetMachine = clusterMachine(ctx.machine);
-    if (!targetMachine) {
-      throw new Error(`slot ${slotNum}: no cluster config for machine ${ctx.machine}`);
-    }
-    const { recordIntent } = await import("../cluster-http.ts");
-    const epoch = Math.floor(Date.now() / 1000);
-    recordIntent(slotNum, { action: "resume", epoch, machine: ctx.machine, taskId: ctx.taskId });
-    console.error(`ludics: slot ${slotNum}: resume intent recorded for ${ctx.machine}`);
-    journalAppend("slot", `Slot ${slotNum} resume intent recorded for ${ctx.machine}`);
-    emitEvent({ event_type: "slot_resume_queued", source: "cli", scope: "slot", slot: slotNum, adapter: ctx.mode, machine: ctx.machine, message: `resume intent recorded for ${ctx.machine}` });
+    await ensureRemoteMachineReachable(slotNum, ctx.machine, "resume", ctx.mode, { taskId: ctx.taskId });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Extract shared `ensureRemoteMachineReachable` helper in `src/slots/index.ts` to deduplicate remote-dispatch logic across `slotStart`, `slotStop`, and `slotResume`
- Fix missing `clusterMachine()` null-check in `slotStop` non-force path, matching `slotStart` and `slotResume` behavior
- Add regression test for `slotStop` with missing cluster config

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/slots/index.test.ts` — all 43 tests pass (42 existing + 1 new)
- [x] Reviewer APPROVE with no action items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes task-2f3761af