### PR TITLE
feat: isolate test harness directory via global preload

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/test-setup.ts"]

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,9 @@
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Safety net: all tests get an isolated harness directory by default.
+// Individual test files can override this in their own beforeAll/beforeEach.
+if (!process.env.LUDICS_HARNESS_DIR) {
+  process.env.LUDICS_HARNESS_DIR = mkdtempSync(join(tmpdir(), "ludics-test-"));
+}


### PR DESCRIPTION
## Summary
- Add `bunfig.toml` with `[test] preload` pointing to `src/test-setup.ts`
- Preload sets `LUDICS_HARNESS_DIR` to a temp directory (`mkdtempSync`) before any test imports
- Prevents EPERM flakes when `bun test` runs in reviewer worktrees with different filesystem permissions

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (806 tests, 0 failures)
- [x] Tests that already set their own `LUDICS_HARNESS_DIR` continue to override the preload default

Closes task-5199318d

🤖 Generated with [Claude Code](https://claude.com/claude-code)