### PR TITLE
Extract orchWorktreeStem, test orchBranchName, guard removeWorktreeByPath

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { autoCommitWorktree, cleanupWorktrees, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, cleanupWorktrees, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, orchBranchName, orchWorktreeStem, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -374,6 +374,109 @@ describe("cleanupWorktrees resilience", () => {
     expect(() =>
       cleanupWorktrees("/nonexistent/path/xxxxx", "task-1", [{ name: "a1" }, { name: "a2" }], 1),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchBranchName
+// ---------------------------------------------------------------------------
+
+describe("orchBranchName", () => {
+  test("standard case with slot", () => {
+    expect(orchBranchName("task-abc", 2, "root")).toBe("ludics/task-abc-s2/root");
+  });
+
+  test("no slot", () => {
+    expect(orchBranchName("task-abc", undefined, "coder")).toBe("ludics/task-abc/coder");
+  });
+
+  test("GitHub issue ID", () => {
+    expect(orchBranchName("gh-ludics-42", 1, "reviewer")).toBe("ludics/gh-ludics-42-s1/reviewer");
+  });
+
+  test("special characters in taskId are slugified", () => {
+    expect(orchBranchName("My Task!@#$", undefined, "root")).toBe("ludics/my-task/root");
+  });
+
+  test("long task ID preserves content", () => {
+    const longId = "task-" + "a".repeat(100);
+    const result = orchBranchName(longId, 3, "coder");
+    expect(result).toStartWith("ludics/task-");
+    expect(result).toEndWith("-s3/coder");
+  });
+
+  test("suffix is used verbatim", () => {
+    expect(orchBranchName("t1", 1, "my-agent")).toBe("ludics/t1-s1/my-agent");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orchWorktreeStem
+// ---------------------------------------------------------------------------
+
+describe("orchWorktreeStem", () => {
+  test("standard case with slot", () => {
+    expect(orchWorktreeStem("myrepo", "task-abc", 2)).toBe("myrepo-task-abc-s2");
+  });
+
+  test("without slot", () => {
+    expect(orchWorktreeStem("myrepo", "task-abc")).toBe("myrepo-task-abc");
+  });
+
+  test("slot explicitly undefined", () => {
+    expect(orchWorktreeStem("myrepo", "task-abc", undefined)).toBe("myrepo-task-abc");
+  });
+
+  test("special characters in taskId", () => {
+    expect(orchWorktreeStem("repo", "My Task!@#$", 1)).toBe("repo-my-task-s1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeWorktreeByPath prefix guard
+// ---------------------------------------------------------------------------
+
+describe("removeWorktreeByPath prefix guard", () => {
+  test("refuses to remove path that does not match repo naming", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "remove-guard");
+    initRepo(repo);
+
+    const warnings: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      removeWorktreeByPath(repo, "/some/random/path");
+    } finally {
+      console.error = origErr;
+    }
+
+    expect(warnings.some((w) => w.includes("refusing") && w.includes("random"))).toBe(true);
+  });
+
+  test("allows removal of path matching repo naming", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "remove-guard-ok");
+    initRepo(repo);
+
+    // Create a worktree with proper naming
+    const setup = createWorktrees(repo, "feat", [{ name: "a1" }], "main", 1);
+
+    // Should not warn — path matches naming
+    const warnings: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      removeWorktreeByPath(repo, setup.rootWorktree);
+    } finally {
+      console.error = origErr;
+    }
+
+    expect(warnings.filter((w) => w.includes("refusing"))).toHaveLength(0);
+
+    // Clean up remaining worktrees
+    cleanupWorktrees(repo, "feat", [{ name: "a1" }], 1);
   });
 });
 

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -499,6 +499,29 @@ describe("removeWorktreeByPath prefix guard", () => {
     // Clean up remaining worktrees
     cleanupWorktrees(repo, "task-abc123", [{ name: "a1" }], 1);
   });
+
+  test("allows single-token slug with slot suffix (e.g. feat-s1)", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "remove-guard-single-slug");
+    initRepo(repo);
+
+    // Create a worktree with single-token taskId + slot
+    const setup = createWorktrees(repo, "feat", [{ name: "a1" }], "main", 1);
+
+    const warnings: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      removeWorktreeByPath(repo, setup.rootWorktree);
+    } finally {
+      console.error = origErr;
+    }
+
+    expect(warnings.filter((w) => w.includes("refusing"))).toHaveLength(0);
+
+    cleanupWorktrees(repo, "feat", [{ name: "a1" }], 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { autoCommitWorktree, cleanupWorktrees, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, orchBranchName, orchWorktreeStem, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -454,16 +454,37 @@ describe("removeWorktreeByPath prefix guard", () => {
     expect(warnings.some((w) => w.includes("refusing") && w.includes("random"))).toBe(true);
   });
 
-  test("allows removal of path matching repo naming", () => {
+  test("refuses repo-prefixed non-task paths like backup or scratch", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "remove-guard-generic");
+    initRepo(repo);
+
+    const warnings: string[] = [];
+    const origErr = console.error;
+    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+    try {
+      // These share the repo prefix but are not orchestration worktrees
+      removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-backup"));
+      removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-scratch"));
+      removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-OLD"));
+    } finally {
+      console.error = origErr;
+    }
+
+    expect(warnings).toHaveLength(3);
+    expect(warnings.every((w) => w.includes("refusing"))).toBe(true);
+  });
+
+  test("allows removal of path matching orchestration naming", () => {
     if (!Bun.which("git")) return;
     mkdirSync(TMP, { recursive: true });
     const repo = join(TMP, "remove-guard-ok");
     initRepo(repo);
 
-    // Create a worktree with proper naming
-    const setup = createWorktrees(repo, "feat", [{ name: "a1" }], "main", 1);
+    // Create a worktree with proper task-style naming
+    const setup = createWorktrees(repo, "task-abc123", [{ name: "a1" }], "main", 1);
 
-    // Should not warn — path matches naming
+    // Should not warn — path matches orchestration naming
     const warnings: string[] = [];
     const origErr = console.error;
     console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
@@ -476,7 +497,7 @@ describe("removeWorktreeByPath prefix guard", () => {
     expect(warnings.filter((w) => w.includes("refusing"))).toHaveLength(0);
 
     // Clean up remaining worktrees
-    cleanupWorktrees(repo, "feat", [{ name: "a1" }], 1);
+    cleanupWorktrees(repo, "task-abc123", [{ name: "a1" }], 1);
   });
 });
 

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -73,8 +73,15 @@ function removeIfRegistered(projectDir: string, path: string): void {
   }
 }
 
-/** Remove a single worktree by its concrete path. Idempotent — no-op if not registered. */
+/** Remove a single worktree by its concrete path. Idempotent — no-op if not registered.
+ *  Safety: validates that the path basename matches expected worktree naming (`{repoName}-`)
+ *  to prevent accidental removal of unrelated directories. */
 export function removeWorktreeByPath(projectDir: string, path: string): void {
+  const repoName = basename(resolve(projectDir));
+  if (!basename(path).startsWith(repoName + "-")) {
+    console.error(`ludics: refusing to remove worktree "${path}" — does not match expected naming`);
+    return;
+  }
   removeIfRegistered(projectDir, path);
 }
 
@@ -126,6 +133,13 @@ export function orchBranchName(taskId: string, slot: number | undefined, suffix:
   return `ludics/${featureSlug}${slotSuffix}/${suffix}`;
 }
 
+/** Canonical worktree directory stem: `{repoName}-{slug}{slotSuffix}`. */
+export function orchWorktreeStem(repoName: string, taskId: string, slot?: number): string {
+  const featureSlug = slugify(taskId);
+  const slotSuffix = slot ? `-s${slot}` : "";
+  return `${repoName}-${featureSlug}${slotSuffix}`;
+}
+
 export function createWorktrees(
   projectDir: string,
   taskId: string,
@@ -134,11 +148,9 @@ export function createWorktrees(
   slot?: number,
   mode: "duo" | "pair" = "duo",
 ): WorktreeSetup {
-  const featureSlug = slugify(taskId);
-  const slotSuffix = slot ? `-s${slot}` : "";
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));
-  const stem = `${repoName}-${featureSlug}${slotSuffix}`;
+  const stem = orchWorktreeStem(repoName, taskId, slot);
   const rootWorktree = join(parentDir, stem);
   const peerSyncDir = peerSyncPath(rootWorktree);
   const branches: Record<string, string> = {
@@ -220,10 +232,9 @@ export function cleanupWorktrees(
   mode: "duo" | "pair" = "duo",
 ): void {
   const featureSlug = slugify(taskId);
-  const slotSuffix = slot ? `-s${slot}` : "";
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));
-  const stem = `${repoName}-${featureSlug}${slotSuffix}`;
+  const stem = orchWorktreeStem(repoName, taskId, slot);
   const rootWorktree = join(parentDir, stem);
   const expectedPrefix = join(parentDir, `${repoName}-${featureSlug}`);
   if (!rootWorktree.startsWith(expectedPrefix)) {

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -73,13 +73,24 @@ function removeIfRegistered(projectDir: string, path: string): void {
   }
 }
 
+/**
+ * Matches the suffix after `{repoName}-` in orchestration worktree basenames.
+ * Shape: `{taskSlug}(-s{N})?(-{agentSlug})?`
+ * Task slugs always contain at least one hyphen (`task-xxxx`, `gh-repo-42`),
+ * which distinguishes them from generic names like `backup` or `scratch`.
+ */
+const ORCH_WORKTREE_SUFFIX_RE = /^[a-z0-9]+-[a-z0-9]+(-[a-z0-9]+)*(-s\d+)?(-[a-z0-9]+(-[a-z0-9]+)*)?$/;
+
 /** Remove a single worktree by its concrete path. Idempotent — no-op if not registered.
- *  Safety: validates that the path basename matches expected worktree naming (`{repoName}-`)
- *  to prevent accidental removal of unrelated directories. */
+ *  Safety: validates that the path basename matches the orchestration worktree naming
+ *  pattern (`{repoName}-{taskSlug}(-s{N})?(-{agentSlug})?`) to prevent accidental
+ *  removal of unrelated directories. */
 export function removeWorktreeByPath(projectDir: string, path: string): void {
   const repoName = basename(resolve(projectDir));
-  if (!basename(path).startsWith(repoName + "-")) {
-    console.error(`ludics: refusing to remove worktree "${path}" — does not match expected naming`);
+  const base = basename(path);
+  const prefix = repoName + "-";
+  if (!base.startsWith(prefix) || !ORCH_WORKTREE_SUFFIX_RE.test(base.slice(prefix.length))) {
+    console.error(`ludics: refusing to remove worktree "${path}" — does not match orchestration naming`);
     return;
   }
   removeIfRegistered(projectDir, path);

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -73,13 +73,25 @@ function removeIfRegistered(projectDir: string, path: string): void {
   }
 }
 
+/** Overall slug shape: lowercase alphanumeric segments separated by hyphens. */
+const SLUG_SHAPE_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+/** Multi-segment slug — at least two hyphen-separated segments (e.g. `task-abc`). */
+const MULTI_SEGMENT_SLUG_RE = /^[a-z0-9]+-[a-z0-9]+/;
+/** Slot marker anywhere in the suffix (e.g. `-s3`). */
+const SLOT_MARKER_RE = /-s\d+(?:-|$)/;
+
 /**
- * Matches the suffix after `{repoName}-` in orchestration worktree basenames.
- * Shape: `{taskSlug}(-s{N})?(-{agentSlug})?`
- * Task slugs always contain at least one hyphen (`task-xxxx`, `gh-repo-42`),
- * which distinguishes them from generic names like `backup` or `scratch`.
+ * Validate that `suffix` (the part after `{repoName}-`) matches the
+ * orchestration worktree naming shape: `{taskSlug}(-s{N})?(-{agentSlug})?`.
+ *
+ * Accepts multi-segment task slugs (`task-abc`, `task-abc-s2-agent`) and
+ * single-segment slugs only when a slot marker is present (`feat-s1`).
+ * Rejects generic names like `backup` or `scratch` that lack both traits.
  */
-const ORCH_WORKTREE_SUFFIX_RE = /^[a-z0-9]+-[a-z0-9]+(-[a-z0-9]+)*(-s\d+)?(-[a-z0-9]+(-[a-z0-9]+)*)?$/;
+function isOrchWorktreeSuffix(suffix: string): boolean {
+  if (!SLUG_SHAPE_RE.test(suffix)) return false;
+  return MULTI_SEGMENT_SLUG_RE.test(suffix) || SLOT_MARKER_RE.test(suffix);
+}
 
 /** Remove a single worktree by its concrete path. Idempotent — no-op if not registered.
  *  Safety: validates that the path basename matches the orchestration worktree naming
@@ -89,7 +101,7 @@ export function removeWorktreeByPath(projectDir: string, path: string): void {
   const repoName = basename(resolve(projectDir));
   const base = basename(path);
   const prefix = repoName + "-";
-  if (!base.startsWith(prefix) || !ORCH_WORKTREE_SUFFIX_RE.test(base.slice(prefix.length))) {
+  if (!base.startsWith(prefix) || !isOrchWorktreeSuffix(base.slice(prefix.length))) {
     console.error(`ludics: refusing to remove worktree "${path}" — does not match orchestration naming`);
     return;
   }


### PR DESCRIPTION
## Summary

- Extract `orchWorktreeStem(repoName, taskId, slot)` helper to deduplicate the worktree stem pattern between `createWorktrees()` and `cleanupWorktrees()`
- Add unit tests for `orchBranchName()` covering slug edge cases (special chars, long names, slot/no-slot, GitHub issue IDs)
- Add safety guard to `removeWorktreeByPath()` validating the path matches the orchestration naming shape (`{repoName}-{taskSlug}(-s{N})?(-{agentSlug})?`), rejecting generic names like `repo-backup`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` compiles successfully
- [x] `bun test src/orchestration/worktrees.test.ts` — 31 tests pass (12 new)
- [x] Regression test proves repo-prefixed non-task paths (`repo-backup`, `repo-scratch`) are refused

🤖 Generated with [Claude Code](https://claude.com/claude-code)