### PR TITLE
refactor: tasksCreate returns result object instead of printing

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -122,15 +122,7 @@ export function checkProjectTestHealth(
   saveTestHealthState(state);
 
   if (!passed) {
-    // Redirect stdout to stderr during task creation to avoid corrupting
-    // stop-hook stdout (used by orchestration on-stop and legacy mag queue-pop).
-    const origWrite = process.stdout.write;
-    process.stdout.write = process.stderr.write.bind(process.stderr);
-    try {
-      tasksCreate(`Fix broken test suite: ${project.name}`, project.name, "A");
-    } finally {
-      process.stdout.write = origWrite;
-    }
+    tasksCreate(`Fix broken test suite: ${project.name}`, project.name, "A");
   }
 
   return { skipped: false, passed, duration, failures };

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -75,7 +75,7 @@ export function tasksCreate(
   project: string = "personal",
   priority: string = "B",
   usesBrowser: boolean = false,
-): void {
+): { created: boolean; id: string; path: string } {
   const dir = tasksDir();
   mkdirSync(dir, { recursive: true });
 
@@ -84,9 +84,7 @@ export function tasksCreate(
   const file = join(dir, `${id}.md`);
 
   if (existsSync(file)) {
-    console.log(`Task already exists: ${file}`);
-    console.log(`ID: ${id}`);
-    return;
+    return { created: false, id, path: file };
   }
 
   const content = `---
@@ -128,8 +126,7 @@ Created manually via ludics.
 
   writeFileSync(file, content, { flag: "wx" });
   emitEvent({ event_type: "task_created", source: "cli", scope: "task", task: id, message: title });
-  console.log(`Created task: ${file}`);
-  console.log(`ID: ${id}`);
+  return { created: true, id, path: file };
 }
 
 function tasksFilesList(): void {
@@ -697,7 +694,13 @@ export async function runTasks(args: string[]): Promise<void> {
           priority = a;
         }
       }
-      tasksCreate(title, project, priority, usesBrowser);
+      const result = tasksCreate(title, project, priority, usesBrowser);
+      if (result.created) {
+        console.log(`Created task: ${result.path}`);
+      } else {
+        console.log(`Task already exists: ${result.path}`);
+      }
+      console.log(`ID: ${result.id}`);
       break;
     }
     case "files":


### PR DESCRIPTION
## Summary
- `tasksCreate()` now returns `{ created: boolean; id: string; path: string }` instead of `void`
- Removed all `console.log` calls from `tasksCreate()` — CLI caller in `runTasks` handles output
- Removed the brittle `process.stdout.write` redirect hack in `src/health.ts`

## Test plan
- [x] `bun run typecheck` passes
- [ ] Run `ludics tasks create "test" personal B` — verify same stdout output as before
- [ ] Trigger health check on a failing project — verify no stdout contamination

🤖 Generated with [Claude Code](https://claude.com/claude-code)