### PR TITLE
refactor: remove redundant network config key

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -76,7 +76,6 @@ export interface LudicsFullConfig {
     token?: string;
   };
   dashboard?: { port?: number; ttl?: number };
-  network?: { hostname?: string };
   cluster?: {
     transport?: string;
     domain?: string;
@@ -238,7 +237,6 @@ export function loadConfigSync(): LudicsFullConfig {
     triggers: data.triggers as LudicsFullConfig["triggers"],
     notifications: data.notifications as LudicsFullConfig["notifications"],
     dashboard: data.dashboard as LudicsFullConfig["dashboard"],
-    network: data.network as LudicsFullConfig["network"],
     cluster: (data.cluster ?? data["feder" + "ation"]) as LudicsFullConfig["cluster"],
   };
 }

--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -1,0 +1,55 @@
+// Network tests — verify hostname fallback chain and networkStatus output
+
+import { describe, it, expect, spyOn } from "bun:test";
+import * as network from "./network.ts";
+
+describe("networkHostname", () => {
+  it("returns localhost when mode is localhost", () => {
+    const spy = spyOn(network, "networkMode").mockReturnValue("localhost");
+    try {
+      expect(network.networkHostname()).toBe("localhost");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not use hostnameFromConfig in the fallback chain", () => {
+    // After removing hostnameFromConfig, the fallback chain in tailscale mode is:
+    // tailscale CLI → cluster machine host → localhost
+    // Verify no config.network.hostname lookup exists
+    const src = require("fs").readFileSync(require.resolve("./network.ts"), "utf8");
+    expect(src).not.toContain("hostnameFromConfig");
+    expect(src).not.toContain("config.network");
+  });
+
+  it("uses tailscale hostname when available", () => {
+    const modeSpy = spyOn(network, "networkMode").mockReturnValue("tailscale");
+    const tsSpy = spyOn(network, "hostnameTailscale").mockReturnValue("myhost.tailnet.ts.net");
+    try {
+      expect(network.networkHostname()).toBe("myhost.tailnet.ts.net");
+    } finally {
+      modeSpy.mockRestore();
+      tsSpy.mockRestore();
+    }
+  });
+});
+
+describe("networkStatus", () => {
+  it("does not print a Config hostname line", () => {
+    const modeSpy = spyOn(network, "networkMode").mockReturnValue("tailscale");
+    const tsSpy = spyOn(network, "hostnameTailscale").mockReturnValue("host.ts.net");
+    const lines: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    });
+    try {
+      network.networkStatus();
+      const configLine = lines.find((l) => l.includes("Config hostname"));
+      expect(configLine).toBeUndefined();
+    } finally {
+      modeSpy.mockRestore();
+      tsSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/network.ts
+++ b/src/network.ts
@@ -8,11 +8,6 @@ export function networkMode(): string {
   return config.cluster?.transport ?? "localhost";
 }
 
-function hostnameFromConfig(): string {
-  const config = loadConfigSync();
-  return config.network?.hostname ?? "";
-}
-
 function findTailscaleCli(): string | null {
   const which = safeSyncOutput(["which", "tailscale"]);
   if (which.ok) return which.stdout;
@@ -54,9 +49,6 @@ export function networkHostname(): string {
     const tsHost = hostnameTailscale();
     if (tsHost) return tsHost;
 
-    const configHost = hostnameFromConfig();
-    if (configHost) return configHost;
-
     // Fallback: use cluster machine host field (works from launchd where Tailscale CLI is unavailable)
     try {
       const { clusterCurrentMachine } = require("./cluster.ts");
@@ -94,11 +86,6 @@ export function networkStatus(): void {
       }
     } else {
       console.log("Tailscale CLI: not installed");
-    }
-
-    const configHost = hostnameFromConfig();
-    if (configHost) {
-      console.log(`Config hostname: ${configHost}`);
     }
   }
 

--- a/templates/harness/config.yaml
+++ b/templates/harness/config.yaml
@@ -122,9 +122,3 @@ triggers:
     interval: 300
     action: cluster tick
 
-# Network settings for hostname override
-network:
-  # Explicit hostname override (optional)
-  # If not set and cluster.transport is tailscale, auto-detects from `tailscale status`
-  hostname: ""
-


### PR DESCRIPTION
## Summary
- Remove the `network` config key (`{ hostname?: string }`) from `LudicsConfig` type — made redundant after gh-ludics-258 removed `network.mode`
- Remove `hostnameFromConfig()` helper and its call sites in `networkHostname()` and `networkStatus()`
- Remove the `network:` template section from `templates/harness/config.yaml`
- The hostname fallback chain now goes: tailscale CLI → cluster machine `host` lookup → localhost

## Test plan
- [x] Added `src/network.test.ts` verifying:
  - `hostnameFromConfig` is no longer in the source
  - `networkHostname()` returns localhost in localhost mode
  - `networkHostname()` uses tailscale hostname when available
  - `networkStatus()` no longer prints "Config hostname" line
- [x] `bun run typecheck` passes
- [x] `bun run build` compiles cleanly

Closes task-2086a0ad / relates to gh-ludics-258

🤖 Generated with [Claude Code](https://claude.com/claude-code)