### PR TITLE
feat: requeue-on-failure and stall config validation

### DIFF
--- a/src/mag-doctor-stall.test.ts
+++ b/src/mag-doctor-stall.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+function writeConfig(homeDir: string, magSection?: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  let yaml = `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+`;
+  if (magSection) yaml += magSection;
+  writeFileSync(configPath, yaml);
+  return configPath;
+}
+
+function harnessDir(): string {
+  return join(TMP, "harness");
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-doctor-stall-"));
+  process.env.HOME = TMP;
+  process.env.LUDICS_HARNESS_DIR = harnessDir();
+  mkdirSync(join(harnessDir(), "mag"), { recursive: true });
+  // Create required directories/files for doctor to not crash
+  mkdirSync(join(TMP, ".claude"), { recursive: true });
+  mkdirSync(join(TMP, ".local", "bin"), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("magDoctor stall config validation", () => {
+  test("shows defaults when stall config not set", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP);
+    const { magDoctor } = await import("./mag.ts");
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+    // Prevent process.exit from actually exiting
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      magDoctor();
+    } catch { /* ignore */ }
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    const output = logs.join("\n");
+    expect(output).toContain("Stall detection config:");
+    expect(output).toContain("stall_threshold_seconds: not set (default 120s)");
+    expect(output).toContain("stall_nudge_cooldown_seconds: not set (default 120s)");
+  });
+
+  test("shows configured valid values", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP, `mag:
+  stall_threshold_seconds: 60
+  stall_nudge_cooldown_seconds: 90
+`);
+    const { magDoctor } = await import("./mag.ts");
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      magDoctor();
+    } catch { /* ignore */ }
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    const output = logs.join("\n");
+    expect(output).toContain("stall_threshold_seconds: 60s");
+    expect(output).toContain("stall_nudge_cooldown_seconds: 90s");
+  });
+
+  test("warns on invalid (non-positive) stall values", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP, `mag:
+  stall_threshold_seconds: -5
+  stall_nudge_cooldown_seconds: banana
+`);
+    const { magDoctor } = await import("./mag.ts");
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      magDoctor();
+    } catch { /* ignore */ }
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    const output = logs.join("\n");
+    expect(output).toContain("stall_threshold_seconds: -5 — WARNING: not a positive number");
+    expect(output).toContain("stall_nudge_cooldown_seconds:");
+    expect(output).toContain("WARNING");
+  });
+
+  test("warns on unusually low values", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP, `mag:
+  stall_threshold_seconds: 10
+`);
+    const { magDoctor } = await import("./mag.ts");
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      magDoctor();
+    } catch { /* ignore */ }
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    const output = logs.join("\n");
+    expect(output).toContain("stall_threshold_seconds: 10s — WARNING: unusually low (< 30s)");
+  });
+
+  test("warns on unusually high values", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP, `mag:
+  stall_threshold_seconds: 1000
+`);
+    const { magDoctor } = await import("./mag.ts");
+
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      magDoctor();
+    } catch { /* ignore */ }
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+
+    const output = logs.join("\n");
+    expect(output).toContain("stall_threshold_seconds: 1000s — WARNING: unusually high (> 600s)");
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -274,7 +274,11 @@ export async function maybeFeedMagQueue(): Promise<boolean> {
       }
     } catch { /* use 0 */ }
 
-    const maxRetries = DEFAULT_MAX_REQUEUE_RETRIES;
+    const config = loadConfigSync();
+    const magCfg = config.mag as Record<string, unknown> | undefined;
+    const configuredRetries = Number(magCfg?.max_requeue_retries);
+    const maxRetries = (Number.isFinite(configuredRetries) && configuredRetries > 0)
+      ? configuredRetries : DEFAULT_MAX_REQUEUE_RETRIES;
     if (retryCount >= maxRetries) {
       console.error(`ludics: queue item dropped after ${maxRetries} failed retries`);
       emitEvent({ event_type: "mag_queue_dropped", source: "keepalive", scope: "mag", status: "dropped", message: `dropped after ${maxRetries} retries: ${popped.command}` });
@@ -3610,9 +3614,9 @@ export async function runMag(args: string[]): Promise<void> {
       clearStartupWatchdogEpoch();
       if (existsSync(join(harnessDir(), "mag", "paused"))) break;
       if (!clusterIsController()) break;
-      const skillCommand = await queuePopSkill();
-      if (skillCommand) {
-        console.log(JSON.stringify({ decision: "block", reason: skillCommand }));
+      const popped = await queuePopSkill();
+      if (popped) {
+        console.log(JSON.stringify({ decision: "block", reason: popped.command }));
       }
       break;
     }

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -6,7 +6,7 @@ import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, stateRep
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, recentResults } from "./queue.ts";
+import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, recentResults } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName, clusterMachine } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -107,6 +107,7 @@ function triggerSkill(session: string, cmd: string): boolean {
 
 const DEFAULT_STALL_THRESHOLD_MS = 120_000; // 2 minutes
 const DEFAULT_STALL_NUDGE_COOLDOWN_MS = 120_000; // 2 minutes between stall nudges
+const DEFAULT_MAX_REQUEUE_RETRIES = 3;
 const DEFAULT_STARTUP_WATCHDOG_SECONDS = 60;
 const DEFAULT_STARTUP_HELPER_STUCK_SECONDS = 45;
 const STARTUP_ALERT_TITLE = "Mag alert";
@@ -257,17 +258,39 @@ export async function maybeFeedMagQueue(): Promise<boolean> {
   // Remove the claim marker now that we own the transition
   try { unlinkSync(claimPath); } catch {}
 
-  const command = await queuePopSkill();
-  if (!command) return false;
+  const popped = await queuePopSkill();
+  if (!popped) return false;
 
-  const sent = triggerSkill(MAG_SESSION_NAME, command);
+  const sent = triggerSkill(MAG_SESSION_NAME, popped.command);
   if (sent) {
-    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${command}` });
+    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${popped.command}` });
   } else {
-    console.error("ludics: failed to deliver queued request to Mag session");
-    emitEvent({ event_type: "mag_queue_feed_failed", source: "keepalive", scope: "mag", status: "failed", message: "tmux send-keys failed" });
-    // At-most-once delivery: popped item is lost if triggerSkill fails.
-    // Matches current queue-pop behavior. Requeue mechanism out of scope.
+    // Requeue the failed item for retry on next keepalive cycle.
+    let retryCount = 0;
+    try {
+      const parsed: unknown = JSON.parse(popped.line);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        retryCount = Number((parsed as Record<string, unknown>)._retry_count) || 0;
+      }
+    } catch { /* use 0 */ }
+
+    const maxRetries = DEFAULT_MAX_REQUEUE_RETRIES;
+    if (retryCount >= maxRetries) {
+      console.error(`ludics: queue item dropped after ${maxRetries} failed retries`);
+      emitEvent({ event_type: "mag_queue_dropped", source: "keepalive", scope: "mag", status: "dropped", message: `dropped after ${maxRetries} retries: ${popped.command}` });
+    } else {
+      // Increment retry count and reinsert at front of queue
+      let updated: Record<string, unknown>;
+      try {
+        updated = JSON.parse(popped.line) as Record<string, unknown>;
+      } catch {
+        updated = { raw: popped.line };
+      }
+      updated._retry_count = retryCount + 1;
+      queueReinsertHead(JSON.stringify(updated));
+      console.error(`ludics: requeued failed delivery (retry ${retryCount + 1}/${maxRetries})`);
+      emitEvent({ event_type: "mag_queue_requeued", source: "keepalive", scope: "mag", message: `retry ${retryCount + 1}/${maxRetries}: ${popped.command}` });
+    }
   }
   return sent;
 }
@@ -1197,7 +1220,7 @@ function dequeueQueueHead(expectedLine?: string): QueueDequeueResult {
   }
 }
 
-async function queuePopSkill(): Promise<string | null> {
+async function queuePopSkill(): Promise<{ command: string; line: string } | null> {
   const queueFile = join(harnessDir(), "mag", "queue.jsonl");
   if (!existsSync(queueFile)) return null;
 
@@ -1217,7 +1240,9 @@ async function queuePopSkill(): Promise<string | null> {
     writeFileSync(requestIdFile, requestId);
   }
 
-  return await resolveQueueRequestCommand(request, true);
+  const command = await resolveQueueRequestCommand(request, true);
+  if (!command) return null;
+  return { command, line: popped.line };
 }
 
 /** Resolve a queue request to a skill command or execute it programmatically.
@@ -3153,6 +3178,33 @@ export function magDoctor(): void {
     console.log(`  Settings: ~/.claude/settings.json hooks — NOT CONFIGURED`);
     console.log("  Install with: ludics init --hooks");
     allOk = false;
+  }
+
+  // --- Stall config validation ---
+  console.log("Stall detection config:");
+  const config = loadConfigSync();
+  const mag = config.mag as Record<string, unknown> | undefined;
+
+  for (const [key, defaultSec] of [
+    ["stall_threshold_seconds", DEFAULT_STALL_THRESHOLD_MS / 1000],
+    ["stall_nudge_cooldown_seconds", DEFAULT_STALL_NUDGE_COOLDOWN_MS / 1000],
+  ] as const) {
+    const raw = mag?.[key];
+    if (raw !== undefined) {
+      const num = Number(raw);
+      if (!Number.isFinite(num) || num <= 0) {
+        console.log(`  ${key}: ${JSON.stringify(raw)} — WARNING: not a positive number, using default ${defaultSec}s`);
+        allOk = false;
+      } else if (num < 30) {
+        console.log(`  ${key}: ${num}s — WARNING: unusually low (< 30s)`);
+      } else if (num > 600) {
+        console.log(`  ${key}: ${num}s — WARNING: unusually high (> 600s)`);
+      } else {
+        console.log(`  ${key}: ${num}s`);
+      }
+    } else {
+      console.log(`  ${key}: not set (default ${defaultSec}s)`);
+    }
   }
 
   console.log("");

--- a/src/queue-reinsert.test.ts
+++ b/src/queue-reinsert.test.ts
@@ -46,6 +46,18 @@ afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
 });
 
+function writeConfigWithMag(homeDir: string, magSection: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+${magSection}`);
+  return configPath;
+}
+
 describe("queueReinsertHead", () => {
   test("prepends line to empty queue", async () => {
     const { queueReinsertHead } = await import("./queue.ts");
@@ -83,5 +95,78 @@ describe("queueReinsertHead", () => {
     expect(parsed.task).toBe(original.task);
     expect(parsed.timestamp).toBe(original.timestamp);
     expect(parsed._retry_count).toBe(original._retry_count);
+  });
+});
+
+describe("requeue retry-count simulation", () => {
+  test("retry count increments on each reinsert and item is droppable after max", async () => {
+    const { queueReinsertHead } = await import("./queue.ts");
+    const DEFAULT_MAX = 3;
+
+    // Simulate the requeue logic from maybeFeedMagQueue
+    const original = { id: "req-99", action: "briefing", timestamp: "2026-04-15T00:00:00Z" };
+    let line = JSON.stringify(original);
+
+    for (let attempt = 0; attempt < DEFAULT_MAX; attempt++) {
+      // Parse, increment retry count, reinsert
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      const retryCount = Number(parsed._retry_count) || 0;
+      expect(retryCount).toBe(attempt);
+
+      parsed._retry_count = retryCount + 1;
+      const updatedLine = JSON.stringify(parsed);
+
+      // Clear queue and reinsert
+      writeFileSync(queueFile(), "");
+      queueReinsertHead(updatedLine);
+
+      // Read it back
+      const content = readFileSync(queueFile(), "utf-8").trim();
+      const readBack = JSON.parse(content);
+      expect(readBack._retry_count).toBe(attempt + 1);
+      expect(readBack.id).toBe("req-99");
+      line = content;
+    }
+
+    // After max retries, should be dropped (retry count >= max)
+    const final = JSON.parse(line) as Record<string, unknown>;
+    expect(Number(final._retry_count)).toBe(DEFAULT_MAX);
+    expect(Number(final._retry_count) >= DEFAULT_MAX).toBe(true);
+  });
+});
+
+describe("configurable max_requeue_retries", () => {
+  test("config value is read when set to a positive number", async () => {
+    process.env.LUDICS_CONFIG = writeConfigWithMag(TMP, `mag:
+  max_requeue_retries: 5
+`);
+    const { loadConfigSync } = await import("./config.ts");
+    const config = loadConfigSync();
+    const mag = config.mag as Record<string, unknown> | undefined;
+    const configured = Number(mag?.max_requeue_retries);
+    expect(configured).toBe(5);
+    expect(Number.isFinite(configured) && configured > 0).toBe(true);
+  });
+
+  test("falls back to default when not configured", async () => {
+    // Default config has no mag section
+    const { loadConfigSync } = await import("./config.ts");
+    const config = loadConfigSync();
+    const mag = config.mag as Record<string, unknown> | undefined;
+    const configured = Number(mag?.max_requeue_retries);
+    const maxRetries = (Number.isFinite(configured) && configured > 0) ? configured : 3;
+    expect(maxRetries).toBe(3);
+  });
+
+  test("falls back to default when value is invalid", async () => {
+    process.env.LUDICS_CONFIG = writeConfigWithMag(TMP, `mag:
+  max_requeue_retries: -1
+`);
+    const { loadConfigSync } = await import("./config.ts");
+    const config = loadConfigSync();
+    const mag = config.mag as Record<string, unknown> | undefined;
+    const configured = Number(mag?.max_requeue_retries);
+    const maxRetries = (Number.isFinite(configured) && configured > 0) ? configured : 3;
+    expect(maxRetries).toBe(3);
   });
 });

--- a/src/queue-reinsert.test.ts
+++ b/src/queue-reinsert.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+`);
+  return configPath;
+}
+
+function harnessDir(): string {
+  return join(TMP, "harness");
+}
+
+function queueFile(): string {
+  return join(harnessDir(), "mag", "queue.jsonl");
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-queue-reinsert-"));
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = harnessDir();
+  mkdirSync(join(harnessDir(), "mag"), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("queueReinsertHead", () => {
+  test("prepends line to empty queue", async () => {
+    const { queueReinsertHead } = await import("./queue.ts");
+    const line = JSON.stringify({ id: "req-1", action: "briefing", _retry_count: 1 });
+    queueReinsertHead(line);
+
+    const content = readFileSync(queueFile(), "utf-8").trim();
+    expect(content).toBe(line);
+  });
+
+  test("prepends line to front of existing queue", async () => {
+    const { queueReinsertHead } = await import("./queue.ts");
+    const existing = JSON.stringify({ id: "req-2", action: "suggest" });
+    writeFileSync(queueFile(), existing + "\n");
+
+    const newLine = JSON.stringify({ id: "req-1", action: "briefing", _retry_count: 1 });
+    queueReinsertHead(newLine);
+
+    const lines = readFileSync(queueFile(), "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).id).toBe("req-1");
+    expect(JSON.parse(lines[1]!).id).toBe("req-2");
+  });
+
+  test("round-trip: reinserted line preserves all fields", async () => {
+    const { queueReinsertHead } = await import("./queue.ts");
+    const original = { id: "req-42", action: "elaborate", task: "task-abc", timestamp: "2026-04-15T00:00:00Z", _retry_count: 2 };
+    const line = JSON.stringify(original);
+    queueReinsertHead(line);
+
+    const content = readFileSync(queueFile(), "utf-8").trim();
+    const parsed = JSON.parse(content);
+    expect(parsed.id).toBe(original.id);
+    expect(parsed.action).toBe(original.action);
+    expect(parsed.task).toBe(original.task);
+    expect(parsed.timestamp).toBe(original.timestamp);
+    expect(parsed._retry_count).toBe(original._retry_count);
+  });
+});

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -98,6 +98,11 @@ function writeQueueLines(lines: string[]): void {
   renameSync(tmp, file);
 }
 
+export function queueReinsertHead(line: string): void {
+  const lines = readQueueLines();
+  writeQueueLines([line, ...lines]);
+}
+
 export function queuePopOne(): string | null {
   const lines = readQueueLines();
   if (lines.length === 0) return null;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -98,6 +98,10 @@ function writeQueueLines(lines: string[]): void {
   renameSync(tmp, file);
 }
 
+// Note: same read-modify-write pattern as queuePopOne/queuePopAll.
+// Concurrent appendFileSync (from queueRequest) between read and rename
+// could theoretically be lost, but the window is tiny and a proper fix
+// requires a queue-wide lock (out of scope for this change).
 export function queueReinsertHead(line: string): void {
   const lines = readQueueLines();
   writeQueueLines([line, ...lines]);

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -87,6 +87,9 @@ mag:
   ensure_t3code: true         # Auto-start shared t3code server on keepalive (default: true)
   nudge_throttle_seconds: 60  # Minimum seconds between automatic "Continue." nudges (default: 60)
   nudge_backoff_seconds: 600  # If no stop hook fired since last nudge, suppress repeat nudges for this long (default: 600)
+  stall_threshold_seconds: 120    # How long pane output must be unchanged before a stall nudge (default: 120)
+  stall_nudge_cooldown_seconds: 120  # Minimum gap between stall nudges (default: 120)
+  max_requeue_retries: 3          # Max times a failed queue delivery is retried before dropping (default: 3)
   test_health_night_hours: [0, 6]  # Local-time hour window [start, end) during which test suites
                                    # are eligible to run. Uses local time to match launchd semantics.
                                    # Tests also run if last run was 24+ hours ago (stale fallback).


### PR DESCRIPTION
## Summary
- When `triggerSkill()` fails in `maybeFeedMagQueue()`, the popped queue item is reinserted at the front of `queue.jsonl` with a `_retry_count` field, retried on next keepalive cycle (max 3 retries before drop)
- Emits `mag_queue_requeued` on retry and `mag_queue_dropped` when max retries exceeded
- `magDoctor()` now validates `stall_threshold_seconds` and `stall_nudge_cooldown_seconds`: warns if invalid, shows effective values, flags unusually low (<30s) or high (>600s) thresholds

## Test plan
- [x] `queueReinsertHead` unit tests (empty queue, front insertion, round-trip field preservation)
- [x] `magDoctor` stall config validation tests (defaults, valid values, invalid values, low/high warnings)
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)