### PR TITLE
refactor: migrate project: regex reads to readFrontmatterField

### DIFF
--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1843,8 +1843,8 @@ function computeSessionProjectMatches(): string {
         const taskFile = join(harness, "tasks", `${taskId}.md`);
         if (existsSync(taskFile)) {
           const content = readFileSync(taskFile, "utf-8");
-          const pm = content.match(/^project:\s*(.+)$/m);
-          if (pm) projectsInSlots.set(pm[1]!.trim(), i);
+          const pm = readFrontmatterField(content, "project");
+          if (pm) projectsInSlots.set(pm, i);
         }
       }
       // Also check path for project match
@@ -1892,15 +1892,12 @@ function computeSessionProjectMatches(): string {
         } catch { /* skip parse errors */ }
       }
 
-      const projectMatch = content.match(/^project:\s*(.+)$/m);
-      const project = projectMatch ? projectMatch[1]!.trim() : "";
+      const project = readFrontmatterField(content, "project") ?? "";
       if (!project) continue;
 
-      const titleMatch = content.match(/^title:\s*"?(.+?)"?\s*$/m);
-      const title = titleMatch ? titleMatch[1]! : id;
+      const title = readFrontmatterField(content, "title") ?? id;
 
-      const priorityMatch = content.match(/^priority:\s*(.+)$/m);
-      const priority = priorityMatch ? priorityMatch[1]!.trim() : "B";
+      const priority = readFrontmatterField(content, "priority") ?? "B";
 
       const elaborated = isElaborated(content);
 
@@ -2110,8 +2107,8 @@ async function maybeAutoStartSlots(): Promise<void> {
     if (isTaskDeferred(taskId)) continue;
 
     // Skip tasks from postponed projects
-    const projectMatch = content.match(/^project:\s*(.+)$/m);
-    if (projectMatch && postponedProjectSet().has(projectMatch[1]!.trim().toLowerCase())) continue;
+    const projectName = readFrontmatterField(content, "project");
+    if (projectName && postponedProjectSet().has(projectName.toLowerCase())) continue;
 
     // Task has a proposal but no session — auto-start
     try {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -11,7 +11,7 @@ import { journalAppend } from "../journal.ts";
 import { emitEvent } from "../events.ts";
 import { runAdapterAction, readAdapterState, readAdapterLastActivity } from "../adapters/index.ts";
 import type { AdapterContext } from "../adapters/index.ts";
-import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus } from "../tasks/markdown.ts";
+import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus, readFrontmatterField } from "../tasks/markdown.ts";
 import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
@@ -692,9 +692,9 @@ function makeAdapterContext(slotNum: number, data: SlotData): AdapterContext {
     const taskFile = join(harnessDir(), "tasks", `${data.task}.md`);
     if (existsSync(taskFile)) {
       const content = readFileSync(taskFile, "utf-8");
-      const projectMatch = content.match(/^project:\s*(.+)$/m);
-      if (projectMatch) {
-        resolvedPath = resolveProjectPath(projectMatch[1]!.trim());
+      const project = readFrontmatterField(content, "project");
+      if (project) {
+        resolvedPath = resolveProjectPath(project);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replace 4 raw `/^project:\s*(.+)$/m` regex patterns in `src/slots/index.ts` (1 site) and `src/mag.ts` (3 sites) with `readFrontmatterField` helper that correctly scopes reads to YAML frontmatter
- Also migrate adjacent `title:` and `priority:` regex reads in the same `mag.ts` code block
- Prevents false matches from markdown body content (same class of bug fixed in gh-ludics-170)

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] `bun test src/tasks/markdown.test.ts` — all 33 tests pass (includes body-scope regression test)
- [x] Verified zero remaining `project:` regex reads in both target files

🤖 Generated with [Claude Code](https://claude.com/claude-code)