### PR TITLE
refactor: extract frontmatterBounds helper and consolidate mutation functions

### DIFF
--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, readFrontmatterField, updateFrontmatterField, transitionStatus } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -341,5 +341,93 @@ describe("transitionStatus", () => {
     const content = readFileSync(f, "utf-8");
     expect(content).toContain("status: abandoned");
     expect(content).not.toContain("status: done");
+  });
+});
+
+describe("frontmatterBounds", () => {
+  test("returns bounds for valid frontmatter", () => {
+    const lines = ["---", "id: task-1", "status: ready", "---", "", "# Title"];
+    expect(frontmatterBounds(lines)).toEqual({ openLine: 0, closeLine: 3 });
+  });
+
+  test("returns null when first line is not ---", () => {
+    const lines = ["# Title", "---", "id: task-1", "---"];
+    expect(frontmatterBounds(lines)).toBeNull();
+  });
+
+  test("returns null for empty array", () => {
+    expect(frontmatterBounds([])).toBeNull();
+  });
+
+  test("returns null when no closing delimiter", () => {
+    const lines = ["---", "id: task-1", "status: ready"];
+    expect(frontmatterBounds(lines)).toBeNull();
+  });
+
+  test("ignores body --- lines", () => {
+    const lines = ["---", "id: task-1", "---", "", "---", "body"];
+    const bounds = frontmatterBounds(lines);
+    expect(bounds).toEqual({ openLine: 0, closeLine: 2 });
+  });
+});
+
+describe("removeFrontmatterField", () => {
+  test("removes a simple field", () => {
+    const f = tmpFile("remove-simple.md", "---\nid: task-1\nslot: 3\nstatus: ready\n---\n\n# Title\n");
+    removeFrontmatterField(f, "slot");
+    const result = readFileSync(f, "utf-8");
+    expect(result).not.toContain("slot:");
+    expect(result).toContain("id: task-1");
+    expect(result).toContain("status: ready");
+  });
+
+  test("removes field with indented continuation lines", () => {
+    const f = tmpFile("remove-block.md", "---\nid: task-1\ndependencies:\n  blocks: []\n  blocked_by: []\nstatus: ready\n---\n\n# Title\n");
+    removeFrontmatterField(f, "dependencies");
+    const result = readFileSync(f, "utf-8");
+    expect(result).not.toContain("dependencies:");
+    expect(result).not.toContain("blocks:");
+    expect(result).toContain("status: ready");
+  });
+
+  test("no-op on file without frontmatter", () => {
+    const f = tmpFile("remove-nofm.md", "# Just a title\n\nSome body.\n");
+    removeFrontmatterField(f, "id");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toBe("# Just a title\n\nSome body.\n");
+  });
+
+  test("does not remove body lines matching field name", () => {
+    const f = tmpFile("remove-body.md", "---\nid: task-1\n---\n\nslot: 5\n");
+    removeFrontmatterField(f, "slot");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("slot: 5");
+  });
+});
+
+describe("updateDependencyArray", () => {
+  test("updates existing subfield", () => {
+    const f = tmpFile("dep-update.md", "---\nid: task-1\ndependencies:\n  blocks: []\n  blocked_by: [a]\n---\n\n# Title\n");
+    updateDependencyArray(f, "blocked_by", ["a", "b"]);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("blocked_by: [a, b]");
+  });
+
+  test("inserts missing subfield", () => {
+    const f = tmpFile("dep-insert.md", "---\nid: task-1\ndependencies:\n  blocks: []\n---\n\n# Title\n");
+    updateDependencyArray(f, "relates_to", ["x"]);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("relates_to: [x]");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch![1]).toContain("relates_to: [x]");
+  });
+
+  test("does not touch body content", () => {
+    const f = tmpFile("dep-body.md", "---\nid: task-1\ndependencies:\n  blocks: []\n---\n\ndependencies: none\n");
+    updateDependencyArray(f, "blocks", ["z"]);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("dependencies: none");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch![1]).toContain("blocks: [z]");
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -104,38 +104,38 @@ export function readFrontmatterField(content: string, field: string): string | n
   return str;
 }
 
+/** Return line indices of the opening and closing `---` delimiters.
+ *  Returns null if no valid frontmatter block is found. */
+export function frontmatterBounds(lines: string[]): { openLine: number; closeLine: number } | null {
+  if (lines.length < 2 || lines[0] !== "---") return null;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") return { openLine: 0, closeLine: i };
+  }
+  return null;
+}
+
 export function updateFrontmatterField(filePath: string, field: string, value: string): void {
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
-  let inFrontmatter = false;
+  const bounds = frontmatterBounds(lines);
+  if (!bounds) return;
+
   let done = false;
-  let closingDelimiterIdx = -1;
   const output: string[] = [];
 
-  for (const line of lines) {
-    if (line === "---" && !inFrontmatter) {
-      inFrontmatter = true;
-      output.push(line);
-      continue;
-    }
-    if (line === "---" && inFrontmatter) {
-      inFrontmatter = false;
-      closingDelimiterIdx = output.length;
-      output.push(line);
-      continue;
-    }
-    if (inFrontmatter && !done && line.startsWith(`${field}:`)) {
+  for (let i = 0; i < lines.length; i++) {
+    if (i > bounds.openLine && i < bounds.closeLine && !done && lines[i]!.startsWith(`${field}:`)) {
       output.push(`${field}: ${value}`);
       done = true;
       continue;
     }
-    output.push(line);
+    output.push(lines[i]!);
   }
 
-  if (!done && closingDelimiterIdx >= 0) {
+  if (!done) {
     // Upsert: insert before the frontmatter closing ---
-    output.splice(closingDelimiterIdx, 0, `${field}: ${value}`);
+    output.splice(bounds.closeLine, 0, `${field}: ${value}`);
   }
 
   writeFileSync(filePath, output.join("\n"));
@@ -206,29 +206,20 @@ export function removeFrontmatterField(filePath: string, field: string): void {
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
-  let inFrontmatter = false;
+  const bounds = frontmatterBounds(lines);
+  if (!bounds) { writeFileSync(filePath, content); return; }
+
   const output: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (line === "---" && !inFrontmatter) {
-      inFrontmatter = true;
-      output.push(line);
-      continue;
-    }
-    if (line === "---" && inFrontmatter) {
-      inFrontmatter = false;
-      output.push(line);
-      continue;
-    }
-    if (inFrontmatter && line.startsWith(`${field}:`)) {
+    if (i > bounds.openLine && i < bounds.closeLine && lines[i]!.startsWith(`${field}:`)) {
       // Skip this line and any indented continuation lines (block YAML values)
-      while (i + 1 < lines.length && lines[i + 1] !== "---" && /^\s+/.test(lines[i + 1]!)) {
+      while (i + 1 < bounds.closeLine && /^\s+/.test(lines[i + 1]!)) {
         i++;
       }
       continue;
     }
-    output.push(line);
+    output.push(lines[i]!);
   }
 
   writeFileSync(filePath, output.join("\n"));
@@ -242,7 +233,9 @@ export function updateDependencyArray(filePath: string, subfield: string, values
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
-  let inFrontmatter = false;
+  const bounds = frontmatterBounds(lines);
+  if (!bounds) return;
+
   let inDeps = false;
   let found = false;
   let lastDepsLineIdx = -1;
@@ -251,21 +244,15 @@ export function updateDependencyArray(filePath: string, subfield: string, values
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (line === "---" && !inFrontmatter) {
-      inFrontmatter = true;
-      output.push(line);
-      continue;
-    }
-    if (line === "---" && inFrontmatter) {
+    if (i === bounds.closeLine) {
       // If we never found the subfield, insert it before closing ---
       if (!found && lastDepsLineIdx >= 0) {
         output.splice(lastDepsLineIdx + 1, 0, formatted);
       }
-      inFrontmatter = false;
       output.push(line);
       continue;
     }
-    if (inFrontmatter) {
+    if (i > bounds.openLine && i < bounds.closeLine) {
       if (line.startsWith("dependencies:")) {
         inDeps = true;
         lastDepsLineIdx = output.length;


### PR DESCRIPTION
## Summary

- Extract shared `frontmatterBounds(lines)` helper in `src/tasks/markdown.ts` returning `{ openLine, closeLine } | null`
- Refactor `updateFrontmatterField`, `removeFrontmatterField`, and `updateDependencyArray` to use the helper instead of inline `inFrontmatter` tracking
- Add 12 regression tests for the new helper and refactored functions

## Test plan

- [x] All 33 existing tests pass without modification
- [x] 12 new tests added for `frontmatterBounds`, `removeFrontmatterField`, `updateDependencyArray`
- [x] Typecheck passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)