### PR TITLE
Add _build_review* to worktree git exclude entries

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -218,6 +218,31 @@ describe("autoCommitWorktree", () => {
     expect(result.dirty).toBe(false);
     expect(result.committed).toBe(false);
   });
+
+  test("excludes _build_review* dirs while committing real changes", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-build-review");
+    initRepo(repo);
+    // Build-review artifacts that should be excluded via pathspec
+    mkdirSync(join(repo, "_build_review"), { recursive: true });
+    writeFileSync(join(repo, "_build_review", "artifact.o"), "obj\n");
+    mkdirSync(join(repo, "_build_review_round3"), { recursive: true });
+    writeFileSync(join(repo, "_build_review_round3", "artifact.o"), "obj\n");
+    // Real code change that should be committed
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "lib.ml"), "let () = ()\n");
+
+    const result = autoCommitWorktree(repo, "real changes only");
+    expect(result.dirty).toBe(true);
+    expect(result.committed).toBe(true);
+
+    const showStat = Bun.spawnSync(["git", "show", "--stat", "--format=", "HEAD"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(showStat).toContain("src/lib.ml");
+    expect(showStat).not.toContain("_build_review");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -223,11 +223,13 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-build-review");
     initRepo(repo);
-    // Build-review artifacts that should be excluded via pathspec
+    // Build-review artifacts at root and nested — both should be excluded
     mkdirSync(join(repo, "_build_review"), { recursive: true });
     writeFileSync(join(repo, "_build_review", "artifact.o"), "obj\n");
     mkdirSync(join(repo, "_build_review_round3"), { recursive: true });
     writeFileSync(join(repo, "_build_review_round3", "artifact.o"), "obj\n");
+    mkdirSync(join(repo, "sub", "_build_review_round3"), { recursive: true });
+    writeFileSync(join(repo, "sub", "_build_review_round3", "nested.o"), "obj\n");
     // Real code change that should be committed
     mkdirSync(join(repo, "src"), { recursive: true });
     writeFileSync(join(repo, "src", "lib.ml"), "let () = ()\n");

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -29,6 +29,7 @@ export const GIT_EXCLUDE_ENTRIES = [
   ".agents",
   ".agent-sessions",
   "node_modules",
+  "_build_review*",
 ];
 
 /**
@@ -282,7 +283,9 @@ export function cleanupWorktrees(
 // ---------------------------------------------------------------------------
 
 /** Pathspec exclusions derived from {@link GIT_EXCLUDE_ENTRIES} for autoCommitWorktree. */
-const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.map((e) => `:!${e}`);
+const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.map((e) =>
+  /[*?[]/.test(e) ? `:(exclude)${e}` : `:!${e}`,
+);
 
 export interface AutoCommitResult {
   /** Whether the worktree had eligible uncommitted changes. */

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -283,8 +283,10 @@ export function cleanupWorktrees(
 // ---------------------------------------------------------------------------
 
 /** Pathspec exclusions derived from {@link GIT_EXCLUDE_ENTRIES} for autoCommitWorktree. */
-const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.map((e) =>
-  /[*?[]/.test(e) ? `:(exclude)${e}` : `:!${e}`,
+const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.flatMap((e) =>
+  /[*?[]/.test(e)
+    ? [`:(exclude)${e}`, `:(exclude)**/${e}`]
+    : [`:!${e}`],
 );
 
 export interface AutoCommitResult {


### PR DESCRIPTION
## Summary
- Add `_build_review*` to `GIT_EXCLUDE_ENTRIES` in `src/orchestration/worktrees.ts` so reviewer build artifacts (`_build_review/`, `_build_review_round3/`) are never committed during orchestrated sessions.
- Fix `ORCHESTRATION_EXCLUDES` pathspec generation to use long-form `:(exclude)` for glob entries, avoiding git's short-form magic parsing failure with wildcard patterns.
- Add regression test verifying `autoCommitWorktree()` excludes `_build_review*` dirs while committing real changes.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test ./src/orchestration/worktrees.test.ts` — 33 pass, 0 fail
- [x] New test creates `_build_review/` and `_build_review_round3/` alongside real code, verifies only real changes are committed

Closes task-537987ee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)