### PR TITLE
Enforce exhaustive symbol search in orchestration templates

### DIFF
--- a/skills/orchestration/pair-coder-plan.md
+++ b/skills/orchestration/pair-coder-plan.md
@@ -16,6 +16,7 @@ Write an implementation plan for `{{TASK_ID}}` to `{{PLAN_FILE}}` from `{{WORKTR
 **Formatting**: Use numbered lists for structured data in your plan. Do not use wide markdown tables — they get truncated when passed between agents.
 Be concrete: files to change, expected behavior, edge cases, validation steps.
 When the task changes data shapes (field extraction, JSON migration, section restructuring), explicitly list every downstream consumer of the affected data in the plan. For each consumer, note whether it needs updating and why. Grep for field names, section headers, and type references to ensure no consumer is missed.
+**Exhaustive occurrence search**: For every symbol, pattern, or function you plan to modify or replace, run a project-wide grep/ripgrep search and list all occurrences in the plan with a disposition (modify / skip with reason / N/A). Search not just for canonical function names but also for inline reimplementations — regex patterns, copy-pasted logic, and string literals that duplicate the same behavior.
 Do not implement yet -- the reviewer is planning in parallel; plans will be merged next.
 
 ```sh

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -11,6 +11,7 @@ Reviewer guidance from prior round:
 {{PEER_REVIEW}}
 
 Commit in small batches (4-6 files). **For each behavior change, include a regression test in the same batch.** Build, lint, and run targeted tests before signaling done.
+**Before modifying any symbol**: Re-run a project-wide grep for that symbol (and its inline reimplementations — regex patterns, copy-pasted logic) to catch occurrences the plan may have missed. Handle any newly discovered occurrences immediately rather than deferring to a future round.
 When changing data shapes or writing format-compat serializers, write a round-trip fidelity test (serialize → deserialize → compare key fields) for each affected serializer. This catches silent field omissions and header-line assumption mismatches early.
 Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
 

--- a/skills/orchestration/pair-reviewer-plan-review.md
+++ b/skills/orchestration/pair-reviewer-plan-review.md
@@ -17,6 +17,7 @@ If alignment gaps are found, use REQUEST_CHANGES with explicit remediation — f
 
 Review the merged plan for `{{TASK_ID}}`:
 If the plan involves data shape changes (field extraction, JSON migration, section restructuring), check that all downstream consumers of the changed data are identified and their required updates are noted. Request changes if consumers appear to be missing — grep for field names and section-header patterns to verify completeness.
+**Occurrence completeness**: Verify that the plan lists all project-wide occurrences of every symbol or pattern being modified — including inline reimplementations (regex patterns, copy-pasted logic), not just canonical function references. If occurrences are missing, `REQUEST_CHANGES` with the specific grep commands you ran and their results showing the missed occurrences.
 
 When reviewing the plan, verify regression test coverage:
 - Does each behavior change (serialization, rendering, validation, CLI output) have a corresponding regression test identified?


### PR DESCRIPTION
## Summary
- Adds exhaustive occurrence search instructions to `pair-coder-plan.md`, `pair-coder-work.md`, and `pair-reviewer-plan-review.md`
- Coders must grep project-wide for every symbol they plan to modify (including inline reimplementations) and list occurrences with dispositions
- Reviewers must verify occurrence completeness and REQUEST_CHANGES with specific grep results if gaps are found

Closes #241

## Test plan
- [ ] Verify template text renders correctly when passed through orchestration variable expansion
- [ ] Confirm no existing template variables or formatting are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)