### PR TITLE
feat: skip plan phase for medium tasks with skip_plan flag

### DIFF
--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -122,6 +122,11 @@ as the last code block in your response:
 6. `start_rationale` — string, conditional. Present only when `status = "completed"`.
 7. `title` — string, required.
 8. `summary` — string, required.
+9. `skip_plan` — boolean, optional. Present only when `status = "completed"`.
+   Set to `true` when the proposal is exhaustive and unambiguous — covers all
+   acceptance criteria, specifies exact files/functions, and leaves no design
+   choices for the coder. When true, the orchestrator writes `skip_plan: true`
+   to task frontmatter so the plan phase is skipped.
 
 ```json
 {
@@ -132,7 +137,8 @@ as the last code block in your response:
   "start_confidence": "high | low",
   "start_rationale": "<one sentence explaining confidence level>",
   "title": "<task title>",
-  "summary": "<one-line summary of what was proposed>"
+  "summary": "<one-line summary of what was proposed>",
+  "skip_plan": false
 }
 ```
 
@@ -146,6 +152,15 @@ as the last code block in your response:
 - Vague acceptance criteria alone do NOT warrant `low` — improvements can be
   refined in follow-up work
 - This is advisory only; the orchestrator makes the final decision
+
+**SKIP_PLAN guidance:**
+- `true`: proposal maps 1:1 to implementation — it IS the plan. Typically: <=5
+  files, straightforward changes with exact code pointers, no creative design
+  choices, no architecture decisions
+- `false` (default): task benefits from independent planning by coder/reviewer
+- `skip_plan` and `start_confidence` are independent signals: a proposal can
+  have high confidence but complex implementation (skip_plan=false), or trivial
+  implementation with uncertain scope (skip_plan=true, start_confidence=low)
 
 ## Error Handling
 

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -80,8 +80,10 @@ Parse the JSON for `status`, `proposal_path`, `ambiguities`, `start_confidence`,
 
 - **status: completed** — write `proposal: <proposal_path>` to the task file
   frontmatter (the orchestrator does this, not the worker, to avoid git sync
-  races from the worker's isolated context). Then proceed to auto-start
-  evaluation (next section)
+  races from the worker's isolated context). If the worker's response includes
+  `"skip_plan": true`, also write `skip_plan: true` to the task frontmatter.
+  This causes medium-effort tasks to skip the plan phase during orchestration.
+  Then proceed to auto-start evaluation (next section)
 - **status: stale** — write result JSON with `"status": "stale"`, stop
 - **status: split-needed** — queue the split skill and stop:
   ```bash
@@ -118,6 +120,13 @@ The decision respects the `start_sessions` autonomy level:
 - **Vague acceptance criteria do NOT block auto-start** — improvements can be refined
   in follow-up work.
 - Tasks with no assigned slot always defer to the user.
+
+Note: The `skip_plan` frontmatter field (if set by the worker) influences
+orchestration flags at slot start time — medium-effort tasks with
+`skip_plan: true` skip the plan phase entirely, going from setup to work.
+This field is consumed by `selectOrchestrationFlagsForTask()` in both the
+keepalive auto-assignment path (mag.ts) and the manual slot start path
+(slots/index.ts), not by auto-start-evaluate itself.
 
 ## Skill-Specific: Auto-start Slot
 

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -81,7 +81,9 @@ Parse the JSON for `status`, `proposal_path`, `ambiguities`, `start_confidence`,
 - **status: completed** — write `proposal: <proposal_path>` to the task file
   frontmatter (the orchestrator does this, not the worker, to avoid git sync
   races from the worker's isolated context). If the worker's response includes
-  `"skip_plan": true`, also write `skip_plan: true` to the task frontmatter.
+  `"skip_plan": true`, write `skip_plan: true` to the task frontmatter;
+  otherwise, remove any existing `skip_plan` field from frontmatter to prevent
+  stale values from a previous proposal run.
   This causes medium-effort tasks to skip the plan phase during orchestration.
   Then proceed to auto-start evaluation (next section)
 - **status: stale** — write result JSON with `"status": "stale"`, stop

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { canReuseSlotThread, orchestratedThreadTitle, parseT3CodeAdapterArgs, startOrchestrationProcess, stop } from "./t3code.ts";
+import { canReuseSlotThread, orchestratedThreadTitle, parseT3CodeAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -305,5 +305,50 @@ describe("t3code adapter stop — preserveState", () => {
 
     expect(result).toContain("stopped");
     expect(existsSync(join(harness, "t3code", "slot-1.json"))).toBe(false);
+  });
+});
+
+describe("selectOrchestrationFlags — skip_plan", () => {
+  test("medium effort without skipPlan includes --plan", () => {
+    const { args } = selectOrchestrationFlags("medium");
+    expect(args).toContain("--plan");
+  });
+
+  test("medium effort with skipPlan: true omits --plan", () => {
+    const { args } = selectOrchestrationFlags("medium", undefined, { skipPlan: true });
+    expect(args).not.toContain("--plan");
+  });
+
+  test("large effort with skipPlan: true still includes --plan --gather", () => {
+    const { args } = selectOrchestrationFlags("large", undefined, { skipPlan: true });
+    expect(args).toContain("--plan");
+    expect(args).toContain("--gather");
+  });
+
+  test("small effort with skipPlan: true has no phase flags", () => {
+    const { args } = selectOrchestrationFlags("small", undefined, { skipPlan: true });
+    expect(args).not.toContain("--plan");
+    expect(args).not.toContain("--gather");
+  });
+});
+
+describe("selectOrchestrationFlagsForTask — skip_plan from frontmatter", () => {
+  test("medium task with skip_plan: true omits --plan", () => {
+    const content = "---\nid: test\ntitle: test\neffort: medium\nskip_plan: true\n---\n";
+    const { args } = selectOrchestrationFlagsForTask(content, "medium");
+    expect(args).not.toContain("--plan");
+  });
+
+  test("medium task without skip_plan includes --plan", () => {
+    const content = "---\nid: test\ntitle: test\neffort: medium\n---\n";
+    const { args } = selectOrchestrationFlagsForTask(content, "medium");
+    expect(args).toContain("--plan");
+  });
+
+  test("large task with skip_plan: true still includes --plan --gather", () => {
+    const content = "---\nid: test\ntitle: test\neffort: large\nskip_plan: true\n---\n";
+    const { args } = selectOrchestrationFlagsForTask(content, "large");
+    expect(args).toContain("--plan");
+    expect(args).toContain("--gather");
   });
 });

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1,4 +1,5 @@
 import { existsSync, openSync, readFileSync } from "fs";
+import { readFrontmatterField } from "../tasks/markdown.ts";
 import { basename, join, resolve } from "path";
 import {
   getGitBranch,
@@ -662,7 +663,11 @@ const CLAUDE_OPUS_MODEL = "claude-opus-4-6";
  *
  * @returns An object with the recommended adapter name ("t3code") and args string.
  */
-export function selectOrchestrationFlags(effort: string, config?: LudicsFullConfig): { adapter: string; args: string; isDuo: boolean } {
+export function selectOrchestrationFlags(
+  effort: string,
+  config?: LudicsFullConfig,
+  options?: { skipPlan?: boolean },
+): { adapter: string; args: string; isDuo: boolean } {
   const orchCfg = loadConfigOrchestration(config);
   const mode = (orchCfg?.default_mode as string | undefined)?.trim() || "pair";
   const coder = (orchCfg?.default_coder as string | undefined)?.trim() || "claude-code";
@@ -685,7 +690,7 @@ export function selectOrchestrationFlags(effort: string, config?: LudicsFullConf
 
   if (norm === "large") {
     phaseFlags.push("--plan", "--gather");
-  } else if (norm === "medium") {
+  } else if (norm === "medium" && !options?.skipPlan) {
     phaseFlags.push("--plan");
   }
   // small / unknown: no pre-work phases
@@ -702,6 +707,20 @@ export function selectOrchestrationFlags(effort: string, config?: LudicsFullConf
   const args = [...modeArgs, ...phaseFlags].join(" ");
   // Use the global adapter setting so orchestration flags work with either backend
   return { adapter: globalAdapter(), args, isDuo };
+}
+
+/**
+ * Convenience wrapper: reads skip_plan from task file content and
+ * delegates to selectOrchestrationFlags(). Used by both slotStart()
+ * auto-fill and maybeFillEmptySlots() keepalive assignment.
+ */
+export function selectOrchestrationFlagsForTask(
+  taskContent: string,
+  effort: string,
+  config?: LudicsFullConfig,
+): { adapter: string; args: string; isDuo: boolean } {
+  const skipPlan = readFrontmatterField(taskContent, "skip_plan") === "true";
+  return selectOrchestrationFlags(effort, config, { skipPlan });
 }
 
 /** Resolve the final model for an agent, applying config and adapter arg overrides. */

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -30,7 +30,7 @@ import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
 import { readTmuxSlotState, tmuxPaneOutputHash } from "./adapters/tmux-adapter.ts";
 import { resolveSkillCommand, hasRegisteredAction } from "./skill-queue-registry.ts";
-import { selectOrchestrationFlags } from "./adapters/t3code.ts";
+import { selectOrchestrationFlagsForTask } from "./adapters/t3code.ts";
 import YAML from "yaml";
 import {
   tmuxAvailable,
@@ -2482,8 +2482,12 @@ function maybeFillEmptySlots(config?: LudicsFullConfig): void {
 
   const task = candidates[0]!;
 
-  // Auto-select orchestration flags based on task effort
-  const { adapter: autoAdapter, args: autoArgs, isDuo } = selectOrchestrationFlags(task.effort, config);
+  // Read task file content for skip_plan detection
+  const taskFile = join(harnessDir(), "tasks", `${task.id}.md`);
+  const taskContent = existsSync(taskFile) ? readFileSync(taskFile, "utf-8") : "";
+
+  // Auto-select orchestration flags based on task effort and skip_plan
+  const { adapter: autoAdapter, args: autoArgs, isDuo } = selectOrchestrationFlagsForTask(taskContent, task.effort, config);
 
   // Hierarchical duo: need 2 empty slots; assign both with swapped coder/reviewer
   if (isDuo) {

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -443,6 +443,63 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     slotAssign(1, "null", "t3code");
     await expect(slotStart(1)).rejects.toThrow("no task is assigned");
   });
+
+  test("auto-fills medium task without skip_plan — includes --plan", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-medium-plan-1", "Medium plan test");
+    slotAssign(1, "task-medium-plan-1", "t3code");
+    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
+    const args = readAdapterArgsFromSlots();
+    expect(args).toContain("--plan");
+    expect(args).toContain("--pair");
+  }, 15_000);
+
+  test("auto-fills medium task with skip_plan: true — omits --plan", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    // Write task with skip_plan: true
+    writeFileSync(join(tasksDir, "task-skip-plan-1.md"), [
+      "---",
+      "id: task-skip-plan-1",
+      'title: "Skip plan test"',
+      "project: demo",
+      "status: ready",
+      "priority: B",
+      "deadline: null",
+      "dependencies:",
+      "  blocks: []",
+      "  blocked_by: []",
+      "  relates_to: []",
+      "  subtask_of: null",
+      "effort: medium",
+      "skip_plan: true",
+      "context: demo",
+      "uses_browser: false",
+      "slot: null",
+      "adapter: null",
+      "created: 2026-03-07",
+      "started: null",
+      "completed: null",
+      "modified: null",
+      "source: local",
+      "---",
+      "",
+    ].join("\n"));
+    slotAssign(1, "task-skip-plan-1", "t3code");
+    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
+    const args = readAdapterArgsFromSlots();
+    expect(args).not.toContain("--plan");
+    expect(args).toContain("--pair");
+    expect(args).toContain("--coder");
+    expect(args).toContain("--reviewer");
+  }, 15_000);
 });
 
 describe("markSlotSetupFailed", () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -16,7 +16,7 @@ import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
 import { readSlotState, writeSlotState } from "../t3code/server.ts";
-import { selectOrchestrationFlags } from "../adapters/t3code.ts";
+import { selectOrchestrationFlagsForTask } from "../adapters/t3code.ts";
 import { readOrchestrationState, persistState, removeOrchestrationState } from "../orchestration/state.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
 import { isRemoteMachine } from "../remote.ts";
@@ -795,9 +795,9 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
 
     const effortMatch = content.match(/^effort:\s*(.+)/m);
     const effort = effortMatch ? effortMatch[1]!.trim() || "small" : "small";
-    const { args: autoArgs } = selectOrchestrationFlags(effort);
+    const { args: autoArgs } = selectOrchestrationFlagsForTask(content, effort);
     if (!autoArgs.trim()) {
-      throw new Error(`slot ${slotNum}: selectOrchestrationFlags returned empty args for effort="${effort}"`);
+      throw new Error(`slot ${slotNum}: selectOrchestrationFlagsForTask returned empty args for effort="${effort}"`);
     }
 
     // Write auto-filled flags back to the slot

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -429,5 +429,25 @@ describe("updateDependencyArray", () => {
     expect(result).toContain("dependencies: none");
     const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
     expect(fmMatch![1]).toContain("blocks: [z]");
+  });
+});
+
+describe("parseTaskFrontmatter skip_plan", () => {
+  test("parses skip_plan: true as boolean true", () => {
+    const content = "---\nid: task-1\ntitle: Test\neffort: medium\nskip_plan: true\n---\n";
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.skip_plan).toBe(true);
+  });
+
+  test("absent skip_plan defaults to false", () => {
+    const content = "---\nid: task-1\ntitle: Test\neffort: medium\n---\n";
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.skip_plan).toBe(false);
+  });
+
+  test("parses skip_plan string 'true' as boolean true", () => {
+    const content = '---\nid: task-1\ntitle: Test\nskip_plan: "true"\n---\n';
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.skip_plan).toBe(true);
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -52,6 +52,7 @@ export function parseTaskFrontmatter(content: string): Partial<TaskFrontmatter> 
       subtask_of: deps.subtask_of ? String(deps.subtask_of) : null,
     },
     effort: String(data.effort ?? "medium"),
+    skip_plan: asBoolean(data.skip_plan),
     requirements: data.requirements ? data.requirements as { os?: string; gpu?: string } : undefined,
     context: String(data.context ?? ""),
     uses_browser: asBoolean(data.uses_browser),

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -14,6 +14,7 @@ export interface TaskFrontmatter {
     subtask_of: string | null;
   };
   effort: string; // small, medium, large
+  skip_plan?: boolean;
   requirements?: { os?: string; gpu?: string };
   context: string;
   uses_browser: boolean;


### PR DESCRIPTION
## Summary

- Adds `skip_plan: true` optional frontmatter flag for medium-effort tasks with exhaustive proposals
- When set, `selectOrchestrationFlags()` omits `--plan`, so orchestration skips from setup directly to work (same path small tasks use)
- Works at the adapter-args level — no changes to phase transitions, plan-merge, plan-review, or orchestration runner
- Large tasks always get `--plan --gather` regardless of `skip_plan`

## Test plan

- [x] `parseTaskFrontmatter()` parses `skip_plan: true`, absent, and string `"true"` correctly
- [x] `selectOrchestrationFlags("medium", _, { skipPlan: true })` omits `--plan`
- [x] `selectOrchestrationFlags("large", _, { skipPlan: true })` still includes `--plan --gather`
- [x] `selectOrchestrationFlagsForTask()` integration tests cover frontmatter-to-flags chain
- [x] `slotStart` end-to-end tests verify auto-filled args with/without `skip_plan`
- [x] 887 tests pass, 1 pre-existing failure (unrelated dashboard badge color)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)