### PR TITLE
Fix PR targeting for upstream_repo projects

### DIFF
--- a/skills/orchestration/forward-pr.md
+++ b/skills/orchestration/forward-pr.md
@@ -23,6 +23,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 2. Set up upstream remote and detect default branch:
 ```sh
 git remote add upstream https://github.com/{{UPSTREAM_REPO}}.git 2>/dev/null || true
+git config --unset remote.upstream.gh-resolved 2>/dev/null || true
 git fetch upstream
 UPSTREAM_DEFAULT=$(git remote show upstream | sed -n 's/.*HEAD branch: //p')
 ```

--- a/skills/orchestration/pair-coder-pr-create.md
+++ b/skills/orchestration/pair-coder-pr-create.md
@@ -4,7 +4,7 @@ Push and create a PR from `{{WORKTREE_PATH}}`. Write **only the bare PR URL** to
 
 ```sh
 git push -u origin HEAD
-gh pr create --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
+gh pr create --repo "{{PROJECT_REPO}}" --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
 ```
 
 ```sh

--- a/skills/orchestration/pair-coder-pr-create.md
+++ b/skills/orchestration/pair-coder-pr-create.md
@@ -4,7 +4,7 @@ Push and create a PR from `{{WORKTREE_PATH}}`. Write **only the bare PR URL** to
 
 ```sh
 git push -u origin HEAD
-gh pr create --repo "{{PROJECT_REPO}}" --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
+gh pr create {{PR_CREATE_REPO_FLAG}} --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
 ```
 
 ```sh

--- a/skills/orchestration/pr-create.md
+++ b/skills/orchestration/pr-create.md
@@ -4,7 +4,7 @@ Push and create a PR from `{{WORKTREE_PATH}}`. Write **only the bare PR URL** to
 
 ```sh
 git push -u origin HEAD
-gh pr create --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
+gh pr create --repo "{{PROJECT_REPO}}" --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
 ```
 
 ```sh

--- a/skills/orchestration/pr-create.md
+++ b/skills/orchestration/pr-create.md
@@ -4,7 +4,7 @@ Push and create a PR from `{{WORKTREE_PATH}}`. Write **only the bare PR URL** to
 
 ```sh
 git push -u origin HEAD
-gh pr create --repo "{{PROJECT_REPO}}" --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
+gh pr create {{PR_CREATE_REPO_FLAG}} --title "<concise title>" --body "<description>" | tee "{{PR_FILE}}"
 ```
 
 ```sh

--- a/skills/orchestration/upstream-final-merge.md
+++ b/skills/orchestration/upstream-final-merge.md
@@ -12,6 +12,7 @@ UPSTREAM_PR_URL=$(cat "{{PR_FILE}}" 2>/dev/null)
 2. Set up upstream remote and detect default branch:
 ```sh
 git remote add upstream https://github.com/{{UPSTREAM_REPO}}.git 2>/dev/null || true
+git config --unset remote.upstream.gh-resolved 2>/dev/null || true
 git fetch upstream
 UPSTREAM_DEFAULT=$(git remote show upstream | sed -n 's/.*HEAD branch: //p')
 ```

--- a/src/orchestration/github.ts
+++ b/src/orchestration/github.ts
@@ -104,6 +104,7 @@ export function validateAndFixPrFile(
   prFile: string,
   worktreePath: string,
   branch: string,
+  repo?: string,
 ): string | null {
   if (!existsSync(prFile)) return null;
   const content = readFileSync(prFile, "utf-8").trim();
@@ -119,10 +120,9 @@ export function validateAndFixPrFile(
   const titleMatch = content.match(/^#\s+(.+)$/m);
   const title = titleMatch ? titleMatch[1]!.trim() : `feat: ${branch}`;
 
-  const result = safeSyncOutput(
-    ["gh", "pr", "create", "--title", title, "--body", content, "--head", branch],
-    { cwd: worktreePath },
-  );
+  const args = ["gh", "pr", "create", "--title", title, "--body", content, "--head", branch];
+  if (repo) args.splice(2, 0, "--repo", repo);
+  const result = safeSyncOutput(args, { cwd: worktreePath });
   if (!result.ok) return null;
   const url = result.stdout;
   if (!isPrUrl(url)) return null;

--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -10,6 +10,7 @@ import * as peerSync from "./peer-sync.ts";
 import * as events from "../events.ts";
 import * as github from "./github.ts";
 import * as config from "../config.ts";
+import * as spawn from "../spawn.ts";
 import * as stateMod from "./state.ts";
 import { orchOnStop } from "./index.ts";
 import { readStopHookRecord, writeStopHookRecord, writeAgentMarkerFiles, readAgentMarkerFile } from "./peer-sync.ts";
@@ -3176,15 +3177,18 @@ describe("validatePreviousPhaseArtifacts", () => {
 describe("validateAgentPrFiles (eager repair)", () => {
   let fixSpy: ReturnType<typeof spyOn>;
   let notifySpy: ReturnType<typeof spyOn>;
+  let configSpy: ReturnType<typeof spyOn>;
   let dir: string;
 
   beforeEach(() => {
     dir = makeTmpDir();
     notifySpy = spyOn(notify, "notifyAgents").mockImplementation(() => {});
+    configSpy = spyOn(config, "findProjectConfig").mockReturnValue({ repo: "org/test-repo", name: "test" } as any);
   });
   afterEach(() => {
     fixSpy?.mockRestore();
     notifySpy.mockRestore();
+    configSpy.mockRestore();
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -3197,6 +3201,9 @@ describe("validateAgentPrFiles (eager repair)", () => {
     writeFileSync(join(dir, "coder.pr"), "# My PR\nSome markdown body\n");
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
+    expect(fixSpy).toHaveBeenCalledWith(
+      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+    );
     expect(state.agentStates.coder.prUrl).toBe("https://github.com/org/repo/pull/1");
   });
 
@@ -3228,6 +3235,9 @@ describe("validateAgentPrFiles (eager repair)", () => {
     state.agentStates.coder.status = "pr-create-done";
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
+    expect(fixSpy).toHaveBeenCalledWith(
+      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+    );
   });
 
   test("skips empty .pr file", () => {
@@ -3249,8 +3259,56 @@ describe("validateAgentPrFiles (eager repair)", () => {
     writeFileSync(join(dir, "coder.pr"), "# Bad PR body\n");
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
+    expect(fixSpy).toHaveBeenCalledWith(
+      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+    );
     expect(state.agentStates.coder.prUrl).toBeFalsy();
     expect(notifySpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("validateAndFixPrFile --repo argument", () => {
+  let spawnSpy: ReturnType<typeof spyOn>;
+  let dir: string;
+
+  beforeEach(() => { dir = makeTmpDir(); });
+  afterEach(() => {
+    spawnSpy?.mockRestore();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("passes --repo when repo argument provided", () => {
+    spawnSpy = spyOn(spawn, "safeSyncOutput").mockReturnValue({
+      ok: true, stdout: "https://github.com/org/repo/pull/42", stderr: "",
+    } as any);
+    const prFile = join(dir, "test.pr");
+    writeFileSync(prFile, "# My PR\nSome description\n");
+
+    const result = github.validateAndFixPrFile(prFile, "/tmp/wt", "my-branch", "org/repo");
+
+    const ghCall = spawnSpy.mock.calls.find(
+      (call: any) => Array.isArray(call[0]) && call[0][0] === "gh"
+    );
+    expect(ghCall).toBeDefined();
+    expect(ghCall![0]).toContain("--repo");
+    expect(ghCall![0]).toContain("org/repo");
+    expect(result).toBe("https://github.com/org/repo/pull/42");
+  });
+
+  test("omits --repo when repo argument not provided", () => {
+    spawnSpy = spyOn(spawn, "safeSyncOutput").mockReturnValue({
+      ok: true, stdout: "https://github.com/org/repo/pull/42", stderr: "",
+    } as any);
+    const prFile = join(dir, "test.pr");
+    writeFileSync(prFile, "# My PR\nSome description\n");
+
+    github.validateAndFixPrFile(prFile, "/tmp/wt", "my-branch");
+
+    const ghCall = spawnSpy.mock.calls.find(
+      (call: any) => Array.isArray(call[0]) && call[0][0] === "gh"
+    );
+    expect(ghCall).toBeDefined();
+    expect(ghCall![0]).not.toContain("--repo");
   });
 });
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1013,6 +1013,7 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
  * Settled-mode repair: existing behavior for when .pr doesn't exist yet.
  */
 export function validateAgentPrFiles(state: OrchestrationState): void {
+  const projectRepo = findProjectConfig(state.projectDir)?.repo;
   for (const agent of state.agents) {
     if (!agentParticipatesInPhase(state, agent)) continue;
     const runtime = state.agentStates[agent.name];
@@ -1025,7 +1026,7 @@ export function validateAgentPrFiles(state: OrchestrationState): void {
       try {
         const content = readFileSync(prFile, "utf-8").trim();
         if (content && !isPrUrl(content)) {
-          const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch);
+          const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch, projectRepo);
           if (fixedUrl && !runtime.prUrl) {
             runtime.prUrl = fixedUrl;
             notifyAgents(
@@ -1046,7 +1047,7 @@ export function validateAgentPrFiles(state: OrchestrationState): void {
     const turnSettled = lc && (lc.state === "settled" || lc.state === "error");
     const statusDone = DONE_STATUSES.has(runtime.status);
     if (!turnSettled && !statusDone && !runtime.interrupted) continue;
-    const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch);
+    const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch, projectRepo);
     if (fixedUrl && !runtime.prUrl) {
       runtime.prUrl = fixedUrl;
       notifyAgents(

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -213,8 +213,20 @@ describe("skills", () => {
     const rendered = substituteTemplate(template, {
       ...baseCtx(),
       PROJECT_REPO: "owner/my-staging",
+      PR_CREATE_REPO_FLAG: '--repo "owner/my-staging"',
     });
     expect(rendered).toContain('gh pr create --repo "owner/my-staging"');
+  });
+
+  test("pr-create template omits --repo when PROJECT_REPO unavailable", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pr-create.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PR_CREATE_REPO_FLAG: "",
+    });
+    expect(rendered).toContain("gh pr create  --title");
+    expect(rendered).not.toContain("--repo");
   });
 
   test("pair-coder-pr-create template includes --repo with PROJECT_REPO", () => {
@@ -223,6 +235,7 @@ describe("skills", () => {
     const rendered = substituteTemplate(template, {
       ...baseCtx(),
       PROJECT_REPO: "owner/my-staging",
+      PR_CREATE_REPO_FLAG: '--repo "owner/my-staging"',
     });
     expect(rendered).toContain('gh pr create --repo "owner/my-staging"');
   });
@@ -566,6 +579,8 @@ describe("skills", () => {
       expect(ctx["PROJECT_REPO"]).toBe("owner/my-proj-staging");
       expect(ctx["PROJECT_UPSTREAM_REPO"]).toBe("upstream/my-proj");
       expect(ctx["PROJECT_PROPOSALS_PATH"]).toBe("docs/proposals");
+      // PR_CREATE_REPO_FLAG is computed from PROJECT_REPO
+      expect(ctx["PR_CREATE_REPO_FLAG"]).toBe('--repo "owner/my-proj-staging"');
       // Non-string fields should NOT be injected (e.g., boolean issues)
       expect(ctx["PROJECT_ISSUES"]).toBeUndefined();
     } finally {

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -207,6 +207,56 @@ describe("skills", () => {
     expect(rendered).not.toContain("UPSTREAM_PR_FILE");
   });
 
+  test("pr-create template includes --repo with PROJECT_REPO", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pr-create.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROJECT_REPO: "owner/my-staging",
+    });
+    expect(rendered).toContain('gh pr create --repo "owner/my-staging"');
+  });
+
+  test("pair-coder-pr-create template includes --repo with PROJECT_REPO", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-pr-create.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROJECT_REPO: "owner/my-staging",
+    });
+    expect(rendered).toContain('gh pr create --repo "owner/my-staging"');
+  });
+
+  test("forward-pr template clears gh-resolved after adding upstream remote", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/forward-pr.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      UPSTREAM_REPO: "upstream/repo",
+      PROJECT_REPO: "owner/staging",
+    });
+    expect(rendered).toContain("git config --unset remote.upstream.gh-resolved");
+    const remoteAddIdx = rendered.indexOf("git remote add upstream");
+    const unsetIdx = rendered.indexOf("git config --unset remote.upstream.gh-resolved");
+    expect(remoteAddIdx).toBeGreaterThanOrEqual(0);
+    expect(unsetIdx).toBeGreaterThan(remoteAddIdx);
+  });
+
+  test("upstream-final-merge template clears gh-resolved after adding upstream remote", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/upstream-final-merge.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      UPSTREAM_REPO: "upstream/repo",
+      PROJECT_REPO: "owner/staging",
+    });
+    expect(rendered).toContain("git config --unset remote.upstream.gh-resolved");
+    const remoteAddIdx = rendered.indexOf("git remote add upstream");
+    const unsetIdx = rendered.indexOf("git config --unset remote.upstream.gh-resolved");
+    expect(remoteAddIdx).toBeGreaterThanOrEqual(0);
+    expect(unsetIdx).toBeGreaterThan(remoteAddIdx);
+  });
+
   test("buildSkillContext: hierarchical duo suppresses UPSTREAM_REPO when duoPeerSlot is set", async () => {
     const tmpCfg = "/tmp/ludics-skills-duo-upstream-test.yaml";
     writeFileSync(tmpCfg, [

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -293,6 +293,11 @@ export function buildSkillContext(
     }
   }
 
+  // Conditional --repo flag for gh pr create: avoids --repo "" when PROJECT_REPO is unavailable.
+  result.PR_CREATE_REPO_FLAG = result.PROJECT_REPO
+    ? `--repo "${result.PROJECT_REPO}"`
+    : "";
+
   // Cross-slot context for hierarchical-duo merge phases
   if (state.duoPeerSlot != null) {
     const peerState = readDuoPeerState(state);


### PR DESCRIPTION
## Summary

- All orchestration `gh pr create` invocations now explicitly pass `--repo` to target the correct working/staging repo (`PROJECT_REPO`), preventing misdirection by poisoned `gh-resolved` git config
- `validateAndFixPrFile()` accepts an optional `repo` parameter, threaded from `findProjectConfig()` in `validateAgentPrFiles()`
- Defense-in-depth: `forward-pr.md` and `upstream-final-merge.md` clear `remote.upstream.gh-resolved` after adding the upstream remote

## Test plan

- [x] 4 new template regression tests verify `--repo` rendering and `gh-resolved` cleanup ordering
- [x] 2 new unit tests verify `validateAndFixPrFile` passes/omits `--repo` based on argument
- [x] 6 existing `validateAgentPrFiles` tests updated with `configSpy` and 4th-arg assertions
- [x] `bun run typecheck` passes
- [x] `bun test` passes (944 pass, 1 pre-existing fail)

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)