### PR TITLE
Sort Deferred Launch tile chronologically (newest first)

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -329,6 +329,39 @@ describe("generateT3code shape guard", () => {
   });
 });
 
+describe("deferred-launch sorting", () => {
+  function writeDeferredTask(id: string, title: string, created: string | null): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const createdLine = created ? `created: "${created}"` : "created: null";
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nstatus: deferred\npriority: B\n${createdLine}\ncontext: ludics\nproposal: docs/proposals/${id}.md\n---\n\n# ${title}\n`,
+    );
+  }
+
+  test("tasks sorted by created date descending, null last", async () => {
+    writeDeferredTask("task-oldest", "Oldest", "2026-01-01");
+    writeDeferredTask("task-newest", "Newest", "2026-04-15");
+    writeDeferredTask("task-middle", "Middle", "2026-03-10");
+    writeDeferredTask("task-no-date", "No date", null);
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      dashboardGenerate();
+    } finally {
+      console.error = origErr;
+    }
+
+    const outFile = join(harnessDir(), "dashboard", "data", "deferred-launch.json");
+    const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
+    const ids = items.map((item) => item.id);
+    expect(ids).toEqual(["task-newest", "task-middle", "task-oldest", "task-no-date"]);
+  });
+});
+
 // Note: /api/slot-resume follows the exact same pattern as /api/slot-start
 // (validate slot 1-6, spawnSync `ludics slot N resume`, return OK/error).
 // slotResume() itself is already tested in src/slots/index.test.ts.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -377,6 +377,7 @@ interface DashboardTask {
 interface FilteredTaskTileConfig {
   filter: (task: DashboardTask) => boolean;
   extraFields: (task: DashboardTask) => Record<string, unknown>;
+  sort?: (a: DashboardTask, b: DashboardTask) => number;
 }
 
 interface TasksTreeNode {
@@ -527,15 +528,15 @@ function generateReady(tasks: DashboardTask[]): ReadyTask[] {
 }
 
 function generateFilteredTaskList(tasks: DashboardTask[], config: FilteredTaskTileConfig): Record<string, unknown>[] {
-  return tasks
-    .filter(config.filter)
-    .map((task) => ({
-      id: task.id,
-      title: task.title,
-      project: task.project,
-      priority: task.priority,
-      ...config.extraFields(task),
-    }));
+  const filtered = tasks.filter(config.filter);
+  if (config.sort) filtered.sort(config.sort);
+  return filtered.map((task) => ({
+    id: task.id,
+    title: task.title,
+    project: task.project,
+    priority: task.priority,
+    ...config.extraFields(task),
+  }));
 }
 
 const needsConfirmationConfig: FilteredTaskTileConfig = {
@@ -554,6 +555,7 @@ const deferredLaunchConfig: FilteredTaskTileConfig = {
     hasProposal: task.hasProposal,
     proposalPath: task.proposalPath,
   }),
+  sort: (a, b) => (b.created ?? "").localeCompare(a.created ?? ""),
 };
 
 function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {


### PR DESCRIPTION
## Summary
- Add optional `sort` comparator to `FilteredTaskTileConfig` interface for generic server-side sorting of filtered task tiles
- Apply sort in `generateFilteredTaskList()` between filter and map steps
- Configure `deferredLaunchConfig` to sort by `created` date descending (newest first), with null dates at the end

Closes task-002bddd8.

## Test plan
- [ ] Run `bun run typecheck` — passes
- [ ] Verify `deferred-launch.json` output is sorted by `created` descending
- [ ] Verify `needs-confirmation.json` and `unanswered-questions.json` are unchanged (no sort configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)