### PR TITLE
fix: harden recentResults against statSync race and non-object JSON

### DIFF
--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync, unlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -273,6 +273,41 @@ describe("recentResults", () => {
 
     const { recentResults } = await loadQueue();
     expect(recentResults()).toHaveLength(1);
+  });
+
+  test("survives statSync race when file is deleted between readdir and stat", async () => {
+    const resultsDir = join(tmpDir, "mag", "results");
+    mkdirSync(resultsDir, { recursive: true });
+
+    writeFileSync(join(resultsDir, "req-keep.json"), JSON.stringify({ id: "keep", status: "ok" }));
+    writeFileSync(join(resultsDir, "req-gone.json"), JSON.stringify({ id: "gone", status: "ok" }));
+    // Delete one file before calling recentResults — simulates race
+    unlinkSync(join(resultsDir, "req-gone.json"));
+
+    const { recentResults } = await loadQueue();
+    const results = recentResults();
+    expect(results).toHaveLength(1);
+    expect(results[0]!.data.id).toBe("keep");
+  });
+
+  test("returns error entry for non-object JSON (null, number, array)", async () => {
+    const resultsDir = join(tmpDir, "mag", "results");
+    mkdirSync(resultsDir, { recursive: true });
+
+    writeFileSync(join(resultsDir, "req-null.json"), "null");
+    writeFileSync(join(resultsDir, "req-num.json"), "42");
+    writeFileSync(join(resultsDir, "req-arr.json"), "[1,2]");
+
+    const { recentResults } = await loadQueue();
+    const results = recentResults();
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      expect(r.data.error).toBe("non-object result");
+    }
+    const byFile = Object.fromEntries(results.map(r => [r.file.split("/").pop(), r.data]));
+    expect(byFile["req-null.json"]!.raw).toBe("object");  // typeof null === "object"
+    expect(byFile["req-num.json"]!.raw).toBe("number");
+    expect(byFile["req-arr.json"]!.raw).toBe("object");    // typeof [] === "object"
   });
 
   test("round-trip: writeResult then recentResults preserves key fields", async () => {

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync, unlinkSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync, symlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -280,9 +280,8 @@ describe("recentResults", () => {
     mkdirSync(resultsDir, { recursive: true });
 
     writeFileSync(join(resultsDir, "req-keep.json"), JSON.stringify({ id: "keep", status: "ok" }));
-    writeFileSync(join(resultsDir, "req-gone.json"), JSON.stringify({ id: "gone", status: "ok" }));
-    // Delete one file before calling recentResults — simulates race
-    unlinkSync(join(resultsDir, "req-gone.json"));
+    // Dangling symlink: readdirSync lists it, but statSync throws ENOENT
+    symlinkSync("/nonexistent-target", join(resultsDir, "req-gone.json"));
 
     const { recentResults } = await loadQueue();
     const results = recentResults();

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -208,13 +208,22 @@ export function recentResults(limit: number = 20): { file: string; data: Record<
     .filter((f: string) => f.endsWith(".json"))
     .map((f: string) => {
       const full = join(dir, f);
-      return { file: full, mtimeMs: statSync(full).mtimeMs };
+      try {
+        return { file: full, mtimeMs: statSync(full).mtimeMs };
+      } catch {
+        return null;
+      }
     })
+    .filter((x): x is { file: string; mtimeMs: number } => x !== null)
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
     .slice(0, limit);
   return files.map(({ file, mtimeMs }) => {
     try {
-      return { file, data: JSON.parse(readFileSync(file, "utf-8")) as Record<string, unknown>, mtimeMs };
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      const data = parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : ({ error: "non-object result", raw: typeof parsed } as Record<string, unknown>);
+      return { file, data, mtimeMs };
     } catch {
       return { file, data: { error: "parse error" } as Record<string, unknown>, mtimeMs };
     }


### PR DESCRIPTION
## Summary
- Wrap `statSync` in per-file try/catch in `recentResults()` so files deleted between `readdirSync` and `statSync` are silently skipped instead of crashing the function
- Add object shape guard after `JSON.parse` so non-object values (`null`, numbers, strings, arrays) return `{ error: "non-object result", raw: <typeof> }` instead of being cast to `Record<string, unknown>`
- Add two new test cases covering both fixes

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test src/queue.test.ts` — all 32 tests pass including new statSync race and non-object JSON tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)