### PR TITLE
fix: drop redundant ORCHESTRATION_EXCLUDES pathspecs from autoCommitWorktree

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -223,6 +223,26 @@ describe("autoCommitWorktree", () => {
     expect(result.committed).toBe(false);
   });
 
+  test("excludes already-tracked orchestration files from commits", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "auto-commit-tracked-orch");
+    initRepo(repo);
+    // Simulate orchestration files that were tracked before ensureGitExcludes
+    mkdirSync(join(repo, ".agents"), { recursive: true });
+    writeFileSync(join(repo, ".agents", "marker"), "1\n");
+    run(["git", "add", "-A"], repo);
+    run(["git", "commit", "-m", "track agents"], repo);
+    // Now set up excludes (like createWorktrees would)
+    ensureGitExcludes(repo);
+    // Modify the tracked orchestration file
+    writeFileSync(join(repo, ".agents", "marker"), "2\n");
+
+    const result = autoCommitWorktree(repo, "should not commit");
+    expect(result.dirty).toBe(false);
+    expect(result.committed).toBe(false);
+    expect(gitLogCount(repo)).toBe(2); // init + track agents, no new commit
+  });
+
   test("excludes _build_review* dirs while committing real changes", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-build-review");

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -123,6 +123,7 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-exclude-peer-sync");
     initRepo(repo);
+    ensureGitExcludes(repo);
     mkdirSync(join(repo, ".peer-sync"), { recursive: true });
     writeFileSync(join(repo, ".peer-sync", "coder.status"), "done|123|finished\n");
 
@@ -135,6 +136,7 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-exclude-marker");
     initRepo(repo);
+    ensureGitExcludes(repo);
     writeFileSync(join(repo, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
 
     const result = autoCommitWorktree(repo, "should not commit");
@@ -146,6 +148,7 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-exclude-claude");
     initRepo(repo);
+    ensureGitExcludes(repo);
     mkdirSync(join(repo, ".claude"), { recursive: true });
     writeFileSync(join(repo, ".claude", "settings.local.json"), '{"hooks":{}}\n');
 
@@ -158,6 +161,7 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-mixed");
     initRepo(repo);
+    ensureGitExcludes(repo);
     // Real code change
     mkdirSync(join(repo, "src"), { recursive: true });
     writeFileSync(join(repo, "src", "main.ts"), "export const y = 2;\n");
@@ -202,7 +206,7 @@ describe("autoCommitWorktree", () => {
     expect(gitLogCount(repo)).toBe(2); // init + first, no second
   });
 
-  test("ignores .agents and node_modules (expanded ORCHESTRATION_EXCLUDES)", () => {
+  test("ignores .agents and node_modules via .git/info/exclude", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-expanded-excludes");
     initRepo(repo);
@@ -223,6 +227,7 @@ describe("autoCommitWorktree", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "auto-commit-build-review");
     initRepo(repo);
+    ensureGitExcludes(repo);
     // Build-review artifacts at root and nested — both should be excluded
     mkdirSync(join(repo, "_build_review"), { recursive: true });
     writeFileSync(join(repo, "_build_review", "artifact.o"), "obj\n");

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -282,6 +282,15 @@ export function cleanupWorktrees(
 // Auto-commit helpers
 // ---------------------------------------------------------------------------
 
+/** Pathspecs for unstaging orchestration-internal paths after `git add -A`.
+ *  `.git/info/exclude` prevents untracked files from being staged, but if any
+ *  orchestration path is already tracked, `git add -A` would still stage it.
+ *  These pathspecs are passed to `git reset HEAD --` to defensively unstage them.
+ *  Glob entries are expanded to match both top-level and nested occurrences. */
+const ORCHESTRATION_RESET_PATHS = GIT_EXCLUDE_ENTRIES.flatMap((e) =>
+  /[*?[]/.test(e) ? [e, `**/${e}`] : [e],
+);
+
 export interface AutoCommitResult {
   /** Whether the worktree had eligible uncommitted changes. */
   dirty: boolean;
@@ -296,7 +305,9 @@ export interface AutoCommitResult {
 /**
  * Auto-commit any uncommitted changes in the given directory.
  * Relies on {@link ensureGitExcludes} having been called to set up
- * `.git/info/exclude` with orchestration-internal paths.
+ * `.git/info/exclude` with orchestration-internal paths (handles untracked files).
+ * Additionally unstages any already-tracked orchestration paths via
+ * {@link ORCHESTRATION_RESET_PATHS} to prevent them from being committed.
  * Returns a structured result. Safe to call on clean worktrees (no-op).
  */
 export function autoCommitWorktree(
@@ -316,6 +327,11 @@ export function autoCommitWorktree(
 
   try {
     runGit(worktreePath, ["add", "-A"]);
+    // Defensive: unstage orchestration-internal paths in case any are tracked.
+    maybeGit(worktreePath, ["reset", "HEAD", "--", ...ORCHESTRATION_RESET_PATHS]);
+    // Re-check: if only orchestration files changed, nothing remains staged.
+    const staged = maybeGit(worktreePath, ["diff", "--cached", "--name-only"]);
+    if (!staged) return { dirty: false, committed: false };
     runGit(worktreePath, ["commit", "-m", commitMessage]);
     const sha = maybeGit(worktreePath, ["rev-parse", "--short", "HEAD"]);
     return { dirty: true, committed: true, commitSha: sha || undefined };

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -282,13 +282,6 @@ export function cleanupWorktrees(
 // Auto-commit helpers
 // ---------------------------------------------------------------------------
 
-/** Pathspec exclusions derived from {@link GIT_EXCLUDE_ENTRIES} for autoCommitWorktree. */
-const ORCHESTRATION_EXCLUDES = GIT_EXCLUDE_ENTRIES.flatMap((e) =>
-  /[*?[]/.test(e)
-    ? [`:(exclude)${e}`, `:(exclude)**/${e}`]
-    : [`:!${e}`],
-);
-
 export interface AutoCommitResult {
   /** Whether the worktree had eligible uncommitted changes. */
   dirty: boolean;
@@ -301,8 +294,9 @@ export interface AutoCommitResult {
 }
 
 /**
- * Auto-commit any uncommitted changes in the given directory, excluding
- * orchestration-internal paths listed in {@link GIT_EXCLUDE_ENTRIES}.
+ * Auto-commit any uncommitted changes in the given directory.
+ * Relies on {@link ensureGitExcludes} having been called to set up
+ * `.git/info/exclude` with orchestration-internal paths.
  * Returns a structured result. Safe to call on clean worktrees (no-op).
  */
 export function autoCommitWorktree(
@@ -313,9 +307,7 @@ export function autoCommitWorktree(
   // "clean tree" from "git command failed". maybeGit collapses both to "".
   let status: string;
   try {
-    status = runGit(worktreePath, [
-      "status", "--porcelain", "--", ".", ...ORCHESTRATION_EXCLUDES,
-    ]);
+    status = runGit(worktreePath, ["status", "--porcelain"]);
   } catch (err) {
     return { dirty: false, committed: false, error: `status check failed: ${err}` };
   }
@@ -323,7 +315,7 @@ export function autoCommitWorktree(
   if (!status) return { dirty: false, committed: false }; // clean tree
 
   try {
-    runGit(worktreePath, ["add", "-A", "--", ".", ...ORCHESTRATION_EXCLUDES]);
+    runGit(worktreePath, ["add", "-A"]);
     runGit(worktreePath, ["commit", "-m", commitMessage]);
     const sha = maybeGit(worktreePath, ["rev-parse", "--short", "HEAD"]);
     return { dirty: true, committed: true, commitSha: sha || undefined };


### PR DESCRIPTION
## Summary

- Remove `ORCHESTRATION_EXCLUDES` constant and pathspec arguments from `autoCommitWorktree()` — they conflict with `.git/info/exclude` when excluded directories exist, causing git exit code 1
- `autoCommitWorktree()` now relies solely on `.git/info/exclude` (set up by `ensureGitExcludes()` during `createWorktrees()`)
- Tests that relied on pathspec-based exclusion now call `ensureGitExcludes()` explicitly

Closes task-52fd8f03.

## Test plan

- [x] `bun run typecheck` passes
- [x] All 33 tests in `src/orchestration/worktrees.test.ts` pass
- [x] Exclusion tests (`.peer-sync`, `.claude/`, `.ludics-orchestration.json`, `_build_review*`, `.agents`, `node_modules`) verified working via `.git/info/exclude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)