### PR TITLE
Extract isPlainObject guard utility; add shape validation to readSlotJson

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
 import YAML from "yaml";
+import { isPlainObject } from "./json.ts";
 
 const DEFAULT_STALE_THRESHOLD = 86400; // 24 hours
 
@@ -121,7 +122,7 @@ export function pointerConfigPath(): string {
 function parseYamlFile(path: string): Record<string, unknown> {
   const text = readFileSync(path, "utf-8");
   const parsed: unknown = YAML.parse(text);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  if (!isPlainObject(parsed)) return {};
   return parsed as Record<string, unknown>;
 }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, copyFileSync, statSync } from "fs";
 import { join, dirname } from "path";
 import YAML from "yaml";
+import { isPlainObject } from "./json.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { globalAdapter, harnessDir, loadConfigSync, slotsCount, effectivePriorityValue, milestonesEnabledProjects } from "./config.ts";
 import { readAllSlotJson } from "./slots/json.ts";
@@ -924,7 +925,7 @@ function generateRecentlyCompleted(tasks: DashboardTask[]): RecentlyCompletedTas
         for (const line of content.split("\n")) {
           try {
             const parsed: unknown = JSON.parse(line);
-            if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+            if (!isPlainObject(parsed)) continue;
             const event = parsed as Record<string, unknown>;
             if (event.event_type === "pr_merged" && event.task) {
               mergedTasks.add(String(event.task));
@@ -941,7 +942,7 @@ function generateRecentlyCompleted(tasks: DashboardTask[]): RecentlyCompletedTas
     const retroFile = join(retroDir, `${t.id}.json`);
     try {
       const parsed: unknown = JSON.parse(readFileSync(retroFile, "utf-8"));
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      if (!isPlainObject(parsed)) continue;
       const data = parsed as Record<string, unknown>;
       if (data.prUrl && typeof data.prUrl === "string") {
         prUrls.set(t.id, data.prUrl);

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,7 @@
 import { existsSync, mkdirSync, readFileSync, appendFileSync } from "fs";
 import { join } from "path";
 import { harnessDir } from "./config.ts";
+import { isPlainObject } from "./json.ts";
 
 export interface LudicsEvent {
   ts: string;
@@ -104,7 +105,7 @@ function eventsQuery(opts: EventsQueryOptions): void {
   for (const line of lines) {
     try {
       const parsed: unknown = JSON.parse(line);
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      if (!isPlainObject(parsed)) continue;
       const rec = parsed as Record<string, unknown>;
       if (typeof rec.ts !== "string") continue;
       if (typeof rec.epoch !== "number") continue;

--- a/src/json.ts
+++ b/src/json.ts
@@ -3,12 +3,15 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { dirname } from "path";
 
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
 export function readJsonFile<T>(path: string): T | null {
   if (!existsSync(path)) return null;
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
-      return null;
+    if (!isPlainObject(parsed)) return null;
     return parsed as T;
   } catch {
     return null;

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { join } from "path";
 import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, stateRepoDir, effectivePriorityValue, milestonesEnabledProjects, milestoneKey, resolveProjectPath, postponedProjectSet, findProjectConfigByName, type LudicsFullConfig } from "./config.ts";
+import { isPlainObject } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
@@ -397,9 +398,9 @@ function loadStartupAlertState(): Record<string, number> {
   if (!existsSync(file)) return {};
   try {
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (!isPlainObject(parsed)) return {};
     const out: Record<string, number> = {};
-    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [k, v] of Object.entries(parsed)) {
       if (typeof v === "number" && Number.isFinite(v) && v > 0) out[k] = Math.floor(v);
     }
     return out;
@@ -583,10 +584,10 @@ function readFeedbackDigestQueueState(): Record<string, number> {
 
   try {
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (!isPlainObject(parsed)) return {};
 
     const state: Record<string, number> = {};
-    for (const [repo, epoch] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [repo, epoch] of Object.entries(parsed)) {
       if (typeof epoch === "number" && Number.isFinite(epoch)) {
         state[repo] = epoch;
       }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync, appendFileSync, writeFileSync, mkdirSync, statSync, readdirSync, unlinkSync } from "fs";
 import { basename, join, resolve } from "path";
 import { loadConfigSync, harnessDir, slotsCount } from "./config.ts";
+import { isPlainObject } from "./json.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { queueRequest } from "./queue.ts";
 import { emitEvent } from "./events.ts";
@@ -351,7 +352,7 @@ function loadSessionConclusionState(): Record<string, string> {
   if (!existsSync(file)) return {};
   try {
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    if (!isPlainObject(parsed)) return {};
     const obj = parsed as Record<string, unknown>;
     const out: Record<string, string> = {};
     for (const [k, v] of Object.entries(obj)) {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, ren
 import { join, dirname } from "path";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
+import { isPlainObject } from "./json.ts";
 
 function queueFile(): string {
   return join(harnessDir(), "mag", "queue.jsonl");
@@ -18,8 +19,8 @@ let requestCounter = 0;
 function parseJsonRecord(text: string): Record<string, unknown> | null {
   try {
     const parsed: unknown = JSON.parse(text);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-    return parsed as Record<string, unknown>;
+    if (!isPlainObject(parsed)) return null;
+    return parsed;
   } catch {
     return null;
   }
@@ -129,7 +130,7 @@ export function queueList(): Record<string, unknown>[] {
     .map(line => {
       try {
         const parsed: unknown = JSON.parse(line);
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        if (!isPlainObject(parsed)) {
           return { raw: line };
         }
         return parsed as Record<string, unknown>;

--- a/src/sessions/sweep-state.ts
+++ b/src/sessions/sweep-state.ts
@@ -5,6 +5,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 import { harnessDir } from "../config.ts";
+import { isPlainObject } from "../json.ts";
 import { isGitWorktree, getMainRepoFromWorktree } from "../adapters/base.ts";
 
 export type SweepMode = "agent-claude" | "agent-codex" | "t3code";
@@ -80,7 +81,7 @@ export function loadSessionSweepState(): SessionSweepState {
 
   try {
     const parsedUnknown = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-    if (!parsedUnknown || typeof parsedUnknown !== "object" || Array.isArray(parsedUnknown)) {
+    if (!isPlainObject(parsedUnknown)) {
       return { version: 1, sessions: {} };
     }
     const parsed = parsedUnknown as Record<string, unknown>;
@@ -91,7 +92,7 @@ export function loadSessionSweepState(): SessionSweepState {
 
     const sessions: Record<string, KnownSessionRecord> = {};
     for (const [, record] of Object.entries(parsedSessions)) {
-      if (!record || typeof record !== "object" || Array.isArray(record)) continue;
+      if (!isPlainObject(record)) continue;
       const recordData = record as Record<string, unknown>;
       const mode = String(recordData.mode);
       if (!SWEEP_TARGET_MODES.has(mode as SweepMode)) continue;

--- a/src/slots/json.ts
+++ b/src/slots/json.ts
@@ -3,6 +3,7 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, renameSync } from "fs";
 import { join } from "path";
 import { harnessDir } from "../config.ts";
+import { isPlainObject } from "../json.ts";
 import type { SlotData } from "./types.ts";
 
 export function slotJsonDir(harness?: string): string {
@@ -39,8 +40,13 @@ export function readSlotJson(slot: number, harness?: string): SlotData {
   if (!existsSync(file)) return emptySlotData(slot);
   const raw = readFileSync(file, "utf-8");
   try {
-    return JSON.parse(raw) as SlotData;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed)) {
+      throw new Error(`corrupt slot JSON: ${file}: parsed value is not an object`);
+    }
+    return parsed as unknown as SlotData;
   } catch (err) {
+    if (err instanceof Error && err.message.startsWith("corrupt slot JSON:")) throw err;
     throw new Error(`corrupt slot JSON: ${file}: ${err instanceof Error ? err.message : String(err)}`);
   }
 }


### PR DESCRIPTION
## Summary

- Extract duplicated `!v || typeof v !== "object" || Array.isArray(v)` guard pattern (12 occurrences across 8 files) into a single exported `isPlainObject` utility in `src/json.ts`
- Add missing object-shape validation to `readSlotJson` so non-object JSON primitives (`null`, `42`, `"string"`) throw `corrupt slot JSON` instead of silently producing bogus `SlotData`
- All call sites updated to import and use the shared utility; no behavioral changes for valid inputs

Closes task-15c3100e. Ref: gh-ludics-227 retrospective.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test --filter slot` — all 64 tests pass
- [x] Full `bun test` — no new failures (2 pre-existing dashboard test failures confirmed on base branch)
- [x] Project-wide grep confirms zero remaining inline instances of the pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)