### PR TITLE
Fix orchestration stuck at pr-create on zero-commit no-op

### DIFF
--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -825,6 +825,27 @@ describe("evaluateTransition — bail-out", () => {
     // Without a review file, artifact validation should block.
     expect(isAgentDone(state, state.agents[1])).toBe(false);
   });
+
+  test("pr-create phase transitions to done when both agents bail out", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ludics-phases-test-"));
+    mkdirSync(join(dir, "plans"), { recursive: true });
+    mkdirSync(join(dir, "reviews"), { recursive: true });
+    const state = makeState({ phase: "pr-create", peerSyncDir: dir });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("pr-create still blocks when bail-out is one-sided", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ludics-phases-test-"));
+    mkdirSync(join(dir, "plans"), { recursive: true });
+    mkdirSync(join(dir, "reviews"), { recursive: true });
+    const state = makeState({ phase: "pr-create", peerSyncDir: dir });
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "done";
+    // No PR URL, no full bail-out → blocks
+    expect(evaluateTransition(state)).toBe(null);
+  });
 });
 
 describe("PHASE_CATEGORIES split — pre-plan vs planning", () => {

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -521,6 +521,7 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
       // NOTE: Runner verifies PR exists on GitHub before agents reach done state here.
       // See verifyPhaseOutcome() in runner.ts.
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (isPairBailedOut(state)) return "done";
       if (!hasAnyPr(state)) return null; // Block advancement without a PR URL (defense in depth)
       return "pr-comments";
 

--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -4,7 +4,8 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { isAgentDone, pairReviewVerdict } from "./phases.ts";
 import { updateTurnLifecycle, T3CodeTransport } from "./transport-t3code.ts";
-import { refreshAgentStatuses, maybePostCodexReviewRequests, checkAndRedispatchPrComments, autoCommitAgent, autoCommitAllAgents, detectAndNudgeHungAgents, interruptAgent, applyPhaseSideEffects, verifyPhaseOutcome, PR_CREATE_GATE, FINAL_MERGE_GATE, handleVerifyFailure, getFirstPrUrl, preparePhaseRedispatch, skipToPhase, MAX_VERIFY_ATTEMPTS, checkZeroCommitsAutoBailOut, validatePreviousPhaseArtifacts, validateAgentPrFiles, resetPrCommentsState, type PreviousPhaseContext } from "./runner.ts";
+import { refreshAgentStatuses, maybePostCodexReviewRequests, checkAndRedispatchPrComments, autoCommitAgent, autoCommitAllAgents, detectAndNudgeHungAgents, interruptAgent, applyPhaseSideEffects, verifyPhaseOutcome, PR_CREATE_GATE, FINAL_MERGE_GATE, handleVerifyFailure, getFirstPrUrl, preparePhaseRedispatch, skipToPhase, MAX_VERIFY_ATTEMPTS, checkZeroCommitsAutoBailOut, isWorktreeNoOp, validatePreviousPhaseArtifacts, validateAgentPrFiles, resetPrCommentsState, type PreviousPhaseContext } from "./runner.ts";
+import { evaluateTransition } from "./phases.ts";
 import * as notify from "../notify.ts";
 import * as peerSync from "./peer-sync.ts";
 import * as events from "../events.ts";
@@ -31,6 +32,22 @@ setDefaultTimeout(20_000);
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), "ludics-runner-test-"));
+}
+
+/** Create a minimal git repo with one commit and an origin/main ref. */
+function makeGitRepo(): string {
+  const tmpDir = makeTmpDir();
+  const repoDir = join(tmpDir, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  Bun.spawnSync(["git", "init", "--initial-branch", "main"], { cwd: repoDir });
+  Bun.spawnSync(["git", "config", "user.email", "test@test.com"], { cwd: repoDir });
+  Bun.spawnSync(["git", "config", "user.name", "Test"], { cwd: repoDir });
+  writeFileSync(join(repoDir, "file.txt"), "hello");
+  Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+  Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repoDir });
+  // Create origin/main ref pointing to current HEAD
+  Bun.spawnSync(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], { cwd: repoDir });
+  return repoDir;
 }
 
 function makeLifecycle(overrides: Partial<AgentTurnLifecycle> = {}): AgentTurnLifecycle {
@@ -2765,24 +2782,14 @@ describe("checkZeroCommitsAutoBailOut", () => {
   });
 
   test("auto-bails when coder worktree has 0 commits ahead", () => {
-    // Create a real git repo where HEAD is on origin/HEAD (0 commits ahead)
-    const tmpDir = makeTmpDir();
-    const repoDir = join(tmpDir, "repo");
-    mkdirSync(repoDir, { recursive: true });
-    Bun.spawnSync(["git", "init", "--initial-branch", "main"], { cwd: repoDir });
-    Bun.spawnSync(["git", "config", "user.email", "test@test.com"], { cwd: repoDir });
-    Bun.spawnSync(["git", "config", "user.name", "Test"], { cwd: repoDir });
-    writeFileSync(join(repoDir, "file.txt"), "hello");
-    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
-    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repoDir });
-    // Create a fake origin/HEAD ref pointing to current HEAD
-    Bun.spawnSync(["git", "update-ref", "refs/remotes/origin/HEAD", "HEAD"], { cwd: repoDir });
+    const repoDir = makeGitRepo();
 
     const peerDir = makeTmpDir();
     mkdirSync(join(peerDir, "plans"), { recursive: true });
     mkdirSync(join(peerDir, "reviews"), { recursive: true });
     const state = makeState({
       phase: "pr-create",
+      projectDir: repoDir,
       agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
         { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
@@ -2792,22 +2799,13 @@ describe("checkZeroCommitsAutoBailOut", () => {
     const result = checkZeroCommitsAutoBailOut(state);
     expect(result).toBe(true);
     expect(state.phase).toBe("done");
+    expect(state.agentStates.coder!.status).toBe("bail-out");
     expect(eventSpy).toHaveBeenCalledTimes(1);
     expect(eventSpy.mock.calls[0][0].event_type).toBe("bail_out");
   });
 
   test("does not bail when coder worktree has commits ahead", () => {
-    const tmpDir = makeTmpDir();
-    const repoDir = join(tmpDir, "repo");
-    mkdirSync(repoDir, { recursive: true });
-    Bun.spawnSync(["git", "init", "--initial-branch", "main"], { cwd: repoDir });
-    Bun.spawnSync(["git", "config", "user.email", "test@test.com"], { cwd: repoDir });
-    Bun.spawnSync(["git", "config", "user.name", "Test"], { cwd: repoDir });
-    writeFileSync(join(repoDir, "file.txt"), "hello");
-    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
-    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repoDir });
-    // Set origin/HEAD to current commit
-    Bun.spawnSync(["git", "update-ref", "refs/remotes/origin/HEAD", "HEAD"], { cwd: repoDir });
+    const repoDir = makeGitRepo();
     // Add another commit (1 ahead)
     writeFileSync(join(repoDir, "file2.txt"), "world");
     Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
@@ -2818,6 +2816,7 @@ describe("checkZeroCommitsAutoBailOut", () => {
     mkdirSync(join(peerDir, "reviews"), { recursive: true });
     const state = makeState({
       phase: "pr-create",
+      projectDir: repoDir,
       agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
         { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
@@ -2828,6 +2827,212 @@ describe("checkZeroCommitsAutoBailOut", () => {
     expect(result).toBe(false);
     expect(state.phase).toBe("pr-create");
     expect(eventSpy).not.toHaveBeenCalled();
+  });
+
+  test("fast-paths to done when isPairBailedOut already true", () => {
+    const state = makeState({ phase: "pr-create" });
+    state.agentStates.coder!.status = "bail-out";
+    state.agentStates.reviewer!.status = "bail-out-confirmed";
+    const result = checkZeroCommitsAutoBailOut(state);
+    expect(result).toBe(true);
+    expect(state.phase).toBe("done");
+    // No event emitted — fast path doesn't re-emit
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+
+  test("idempotent: event emitted only once on repeated calls", () => {
+    const repoDir = makeGitRepo();
+
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "pr-create",
+      projectDir: repoDir,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    checkZeroCommitsAutoBailOut(state);
+    expect(eventSpy).toHaveBeenCalledTimes(1);
+
+    // Reset phase to pr-create for second call
+    state.phase = "pr-create" as any;
+    eventSpy.mockClear();
+    checkZeroCommitsAutoBailOut(state);
+    // Coder already has bail-out status — no new event
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWorktreeNoOp
+// ---------------------------------------------------------------------------
+
+describe("isWorktreeNoOp", () => {
+  test("returns true when zero commits ahead and clean worktree", () => {
+    const repoDir = makeGitRepo();
+    expect(isWorktreeNoOp(repoDir, repoDir)).toBe(true);
+  });
+
+  test("returns false when commits ahead", () => {
+    const repoDir = makeGitRepo();
+    writeFileSync(join(repoDir, "file2.txt"), "world");
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+    Bun.spawnSync(["git", "commit", "-m", "extra"], { cwd: repoDir });
+    expect(isWorktreeNoOp(repoDir, repoDir)).toBe(false);
+  });
+
+  test("returns false with uncommitted diffs but zero commits", () => {
+    const repoDir = makeGitRepo();
+    writeFileSync(join(repoDir, "dirty.txt"), "uncommitted");
+    expect(isWorktreeNoOp(repoDir, repoDir)).toBe(false);
+  });
+
+  test("returns false with staged-but-uncommitted changes", () => {
+    const repoDir = makeGitRepo();
+    writeFileSync(join(repoDir, "staged.txt"), "staged");
+    Bun.spawnSync(["git", "add", "staged.txt"], { cwd: repoDir });
+    expect(isWorktreeNoOp(repoDir, repoDir)).toBe(false);
+  });
+
+  test("returns true when origin/HEAD missing but origin/main exists", () => {
+    const repoDir = makeGitRepo();
+    // Verify origin/HEAD is NOT set (makeGitRepo only sets origin/main)
+    const headCheck = Bun.spawnSync(
+      ["git", "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
+      { cwd: repoDir },
+    );
+    expect(headCheck.exitCode).not.toBe(0); // origin/HEAD should not exist
+    expect(isWorktreeNoOp(repoDir, repoDir)).toBe(true);
+  });
+
+  test("returns false on git error (nonexistent path)", () => {
+    expect(isWorktreeNoOp("/nonexistent/path", "/nonexistent/path")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Early work-phase no-op detection regression (AC2 flow)
+// ---------------------------------------------------------------------------
+
+describe("early work-phase no-op detection", () => {
+  let eventSpy: ReturnType<typeof spyOn>;
+  let persistSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    persistSpy = spyOn(stateMod, "persistState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    eventSpy.mockRestore();
+    persistSpy.mockRestore();
+  });
+
+  test("work-phase no-op detection sets coder to bail-out", () => {
+    const repoDir = makeGitRepo();
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "work",
+      projectDir: repoDir,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    // Simulate the early detection logic from runOrchestration
+    const coder = state.agents.find(a => a.role === "coder")!;
+    if (isWorktreeNoOp(coder.worktreePath, state.projectDir)) {
+      const runtime = state.agentStates[coder.name]!;
+      runtime.status = "bail-out";
+      runtime.statusMessage = "no-op: zero commits ahead of base, no uncommitted diffs";
+    }
+
+    expect(state.agentStates.coder!.status).toBe("bail-out");
+  });
+
+  test("work-phase bail-out transitions to review, not directly to done", () => {
+    const repoDir = makeGitRepo();
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "work",
+      projectDir: repoDir,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+    state.agentStates.coder!.status = "bail-out";
+
+    // evaluateTransition for work: isPairBailedOut = false → review
+    expect(evaluateTransition(state)).toBe("review");
+  });
+
+  test("review-phase bail-out-confirmed transitions to done", () => {
+    const state = makeState({ phase: "review" });
+    state.agentStates.coder!.status = "bail-out";
+    state.agentStates.reviewer!.status = "bail-out-confirmed";
+
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("early detection path never touches verification retry budget", () => {
+    const repoDir = makeGitRepo();
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "work",
+      projectDir: repoDir,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    // Simulate full AC2 flow: early detection → review → done
+    state.agentStates.coder!.status = "bail-out";
+    expect(evaluateTransition(state)).toBe("review"); // work → review
+
+    state.phase = "review";
+    state.agentStates.reviewer!.status = "bail-out-confirmed";
+    expect(evaluateTransition(state)).toBe("done"); // review → done
+
+    // Verification retry budget was never consumed
+    expect(state.prCreateVerifyAttempts).toBeUndefined();
+  });
+
+  test("work-phase no-op detection does NOT fire when coder has commits", () => {
+    const repoDir = makeGitRepo();
+    // Add a commit to put the worktree ahead
+    writeFileSync(join(repoDir, "feature.txt"), "new feature");
+    Bun.spawnSync(["git", "add", "."], { cwd: repoDir });
+    Bun.spawnSync(["git", "commit", "-m", "feature"], { cwd: repoDir });
+
+    const peerDir = makeTmpDir();
+    mkdirSync(join(peerDir, "plans"), { recursive: true });
+    mkdirSync(join(peerDir, "reviews"), { recursive: true });
+    const state = makeState({
+      phase: "work",
+      projectDir: repoDir,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: repoDir },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    }, peerDir);
+
+    const coder = state.agents.find(a => a.role === "coder")!;
+    // isWorktreeNoOp should return false — no bail-out
+    expect(isWorktreeNoOp(coder.worktreePath, state.projectDir)).toBe(false);
+    expect(state.agentStates.coder!.status).not.toBe("bail-out");
   });
 });
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -2,7 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFi
 import { join } from "path";
 import { emitEvent } from "../events.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
-import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
+import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
 import {
   clearInterrupt, readAgentStatus, readMarker, readPhaseToken, readPrUrl,
   statusFileFingerprint, touchStatusFile, writeInterrupt, writePeerSync,
@@ -21,7 +21,7 @@ import { findProjectConfig, globalAdapter, harnessDir, ludicsRoot } from "../con
 import { notifyAgents } from "../notify.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
 import { clusterRole } from "../cluster.ts";
-import { autoCommitWorktree, pushBranch } from "./worktrees.ts";
+import { autoCommitWorktree, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 
 // --- Hung agent detection constants ---
@@ -1440,6 +1440,37 @@ function readFileIfExists(path: string): string | null {
 }
 
 /**
+ * Check whether a worktree has zero meaningful changes:
+ * no uncommitted diffs AND zero commits ahead of the base branch.
+ * Resolves base branch from projectDir (has correct remote refs)
+ * to avoid the stale origin/HEAD problem in worktrees.
+ */
+export function isWorktreeNoOp(worktreePath: string, projectDir: string): boolean {
+  try {
+    // Step 1: Check for uncommitted diffs (staged + unstaged).
+    // Orchestration paths (.peer-sync/ etc.) are in .git/info/exclude,
+    // so git status --porcelain won't include them.
+    const statusResult = Bun.spawnSync(
+      ["git", "status", "--porcelain"],
+      { cwd: worktreePath },
+    );
+    if (statusResult.exitCode !== 0) return false;
+    if (String(statusResult.stdout).trim().length > 0) return false;
+
+    // Step 2: Resolve base branch from projectDir (shared remote refs).
+    const baseBranch = defaultMainBranch(projectDir);
+    const revList = Bun.spawnSync(
+      ["git", "rev-list", "--count", `origin/${baseBranch}..HEAD`],
+      { cwd: worktreePath },
+    );
+    if (revList.exitCode !== 0) return false;
+    return parseInt(String(revList.stdout).trim(), 10) === 0;
+  } catch {
+    return false; // Fail closed on any error (e.g., nonexistent path)
+  }
+}
+
+/**
  * 0-commits-ahead auto-bail-out: if pr-create phase and the coder worktree has no commits
  * ahead of the base branch, skip PR creation and transition directly to done.
  * Returns true if bail-out was triggered (caller should break the loop).
@@ -1448,19 +1479,40 @@ export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean 
   if (state.phase !== "pr-create") return false;
   const coder = state.agents.find(a => a.role === "coder");
   if (!coder) return false;
-  const revList = Bun.spawnSync(
-    ["git", "rev-list", "--count", "origin/HEAD..HEAD"],
-    { cwd: coder.worktreePath },
-  );
-  const count = parseInt(String(revList.stdout).trim(), 10);
-  if (revList.exitCode !== 0 || count !== 0) return false;
-  emitEvent({
-    event_type: "bail_out",
-    source: "orchestration", scope: "slot",
-    slot: state.slot, task: state.taskId,
-    action: "pr-create auto-bail-out", status: "skipped",
-    message: "0 commits ahead of base branch — no PR possible, task obsolete",
-  });
+
+  // Fast path: bail-out already confirmed by reviewer from an earlier phase.
+  if (isPairBailedOut(state)) {
+    state.phase = "done";
+    persistState(state);
+    return true;
+  }
+
+  // Robust no-op detection (replaces fragile origin/HEAD..HEAD).
+  if (!isWorktreeNoOp(coder.worktreePath, state.projectDir)) return false;
+
+  const runtime = state.agentStates[coder.name];
+
+  // Idempotency: only emit event and write status on first detection.
+  if (runtime && runtime.status !== "bail-out") {
+    runtime.status = "bail-out";
+    runtime.statusEpoch = nowEpoch();
+    runtime.statusMessage = "no-op: zero commits ahead of base, no uncommitted diffs";
+    writeFileSync(
+      join(state.peerSyncDir, `${coder.name}.status`),
+      `bail-out|${runtime.statusEpoch}|${runtime.statusMessage}\n`,
+    );
+    emitEvent({
+      event_type: "bail_out",
+      source: "orchestration", scope: "slot",
+      slot: state.slot, task: state.taskId,
+      action: "pr-create auto-bail-out", status: "skipped",
+      message: "0 commits ahead of base branch — no PR possible, skipping to done",
+    });
+  }
+
+  // Safety-net: go directly to done. Reviewer cannot participate in pr-create
+  // (agentParticipatesInPhase returns false for reviewer), so waiting for
+  // bail-out-confirmed would deadlock.
   state.phase = "done";
   persistState(state);
   return true;
@@ -1485,6 +1537,32 @@ export async function runOrchestration(
     // Push=false here; push happens before PR-related phases below.
     const participating = state.agents.filter(a => agentParticipatesInPhase(state, a));
     autoCommitAllAgents(state, participating, /* push */ false);
+
+    // Early no-op detection: if coder's work phase produced nothing, trigger bail-out
+    // so the reviewer can confirm during the upcoming review phase (satisfies AC2).
+    if (state.phase === "work") {
+      const coder = state.agents.find(a => a.role === "coder");
+      if (coder && isWorktreeNoOp(coder.worktreePath, state.projectDir)) {
+        const runtime = state.agentStates[coder.name];
+        if (runtime && runtime.status !== "bail-out") {
+          runtime.status = "bail-out";
+          runtime.statusEpoch = nowEpoch();
+          runtime.statusMessage = "no-op: zero commits ahead of base, no uncommitted diffs";
+          writeFileSync(
+            join(state.peerSyncDir, `${coder.name}.status`),
+            `bail-out|${runtime.statusEpoch}|${runtime.statusMessage}\n`,
+          );
+          emitEvent({
+            event_type: "bail_out",
+            source: "orchestration", scope: "slot",
+            slot: state.slot, task: state.taskId,
+            action: "work-phase no-op detection", status: "bail-out",
+            message: "Coder worktree has 0 commits ahead and no uncommitted diffs — triggering bail-out protocol",
+          });
+          persistState(state);
+        }
+      }
+    }
 
     // Capture tmux pane output for retrospective (only runs when backend === "tmux")
     if (state.backend === "tmux") {

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -143,7 +143,7 @@ function addWorktree(projectDir: string, path: string, branch: string, base: str
   }
 }
 
-function defaultMainBranch(projectDir: string): string {
+export function defaultMainBranch(projectDir: string): string {
   const remoteHead = maybeGit(projectDir, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
   if (remoteHead.startsWith("origin/")) return remoteHead.slice("origin/".length);
   const local = maybeGit(projectDir, ["branch", "--show-current"]);


### PR DESCRIPTION
## Summary

- Replace fragile `origin/HEAD..HEAD` detection in `checkZeroCommitsAutoBailOut()` with robust `isWorktreeNoOp()` that resolves base branch from `projectDir` via exported `defaultMainBranch()`
- Add early no-op detection at work phase exit to trigger bail-out protocol before `pr-create` is reached (reviewer approves during review phase)
- Add `isPairBailedOut` escape hatch in `evaluateTransition` for `pr-create` phase as belt-and-suspenders

Closes #274

## Test plan

- [x] Updated existing `checkZeroCommitsAutoBailOut` tests for new detection + bail-out status
- [x] Added `isWorktreeNoOp` unit tests (clean, commits ahead, dirty, staged, missing origin/HEAD, git error)
- [x] Added `evaluateTransition` pr-create bail-out tests (full + one-sided)
- [x] Added early detection regression: work→review→done flow without entering pr-create
- [x] Added fast-path and idempotency tests for `checkZeroCommitsAutoBailOut`
- [x] 958 tests pass, 3 pre-existing failures unchanged, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)