### PR TITLE
Inline networkMode(), export findTailscaleCli, remove redundant which-tailscale

### DIFF
--- a/src/network.test.ts
+++ b/src/network.test.ts
@@ -2,10 +2,11 @@
 
 import { describe, it, expect, spyOn } from "bun:test";
 import * as network from "./network.ts";
+import * as config from "./config.ts";
 
 describe("networkHostname", () => {
   it("returns localhost when mode is localhost", () => {
-    const spy = spyOn(network, "networkMode").mockReturnValue("localhost");
+    const spy = spyOn(config, "loadConfigSync").mockReturnValue({} as any);
     try {
       expect(network.networkHostname()).toBe("localhost");
     } finally {
@@ -23,12 +24,12 @@ describe("networkHostname", () => {
   });
 
   it("uses tailscale hostname when available", () => {
-    const modeSpy = spyOn(network, "networkMode").mockReturnValue("tailscale");
+    const configSpy = spyOn(config, "loadConfigSync").mockReturnValue({ cluster: { transport: "tailscale" } } as any);
     const tsSpy = spyOn(network, "hostnameTailscale").mockReturnValue("myhost.tailnet.ts.net");
     try {
       expect(network.networkHostname()).toBe("myhost.tailnet.ts.net");
     } finally {
-      modeSpy.mockRestore();
+      configSpy.mockRestore();
       tsSpy.mockRestore();
     }
   });
@@ -36,8 +37,9 @@ describe("networkHostname", () => {
 
 describe("networkStatus", () => {
   it("does not print a Config hostname line", () => {
-    const modeSpy = spyOn(network, "networkMode").mockReturnValue("tailscale");
+    const configSpy = spyOn(config, "loadConfigSync").mockReturnValue({ cluster: { transport: "tailscale" } } as any);
     const tsSpy = spyOn(network, "hostnameTailscale").mockReturnValue("host.ts.net");
+    const findSpy = spyOn(network, "findTailscaleCli").mockReturnValue("/usr/bin/tailscale");
     const lines: string[] = [];
     const logSpy = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
       lines.push(args.map(String).join(" "));
@@ -47,8 +49,9 @@ describe("networkStatus", () => {
       const configLine = lines.find((l) => l.includes("Config hostname"));
       expect(configLine).toBeUndefined();
     } finally {
-      modeSpy.mockRestore();
+      configSpy.mockRestore();
       tsSpy.mockRestore();
+      findSpy.mockRestore();
       logSpy.mockRestore();
     }
   });

--- a/src/network.ts
+++ b/src/network.ts
@@ -3,12 +3,7 @@
 import { loadConfigSync } from "./config.ts";
 import { safeSyncOutput } from "./spawn.ts";
 
-export function networkMode(): string {
-  const config = loadConfigSync();
-  return config.cluster?.transport ?? "localhost";
-}
-
-function findTailscaleCli(): string | null {
+export function findTailscaleCli(): string | null {
   const which = safeSyncOutput(["which", "tailscale"]);
   if (which.ok) return which.stdout;
   // macOS: Tailscale app bundle CLI
@@ -41,7 +36,7 @@ export function hostnameTailscale(): string | null {
 }
 
 export function networkHostname(): string {
-  const mode = networkMode();
+  const mode = loadConfigSync().cluster?.transport ?? "localhost";
 
   if (mode === "localhost") return "localhost";
 
@@ -69,13 +64,13 @@ export function getUrl(port: number | string, protocol: string = "http"): string
 
 
 export function networkStatus(): void {
-  const mode = networkMode();
+  const mode = loadConfigSync().cluster?.transport ?? "localhost";
   console.log("=== Network Status ===");
   console.log("");
   console.log(`Mode: ${mode}`);
 
   if (mode === "tailscale") {
-    const hasTailscale = safeSyncOutput(["which", "tailscale"]).ok;
+    const hasTailscale = findTailscaleCli() !== null;
     if (hasTailscale) {
       console.log("Tailscale CLI: available");
       const tsHost = hostnameTailscale();


### PR DESCRIPTION
## Summary
- Remove `networkMode()` function — inline `loadConfigSync().cluster?.transport ?? "localhost"` at both call sites in `networkHostname()` and `networkStatus()`
- Export `findTailscaleCli()` and use it in `networkStatus()` instead of spawning a redundant `which tailscale` subprocess (also fixes correctness gap for macOS app bundle path)
- Update all 3 tests to mock `loadConfigSync` instead of `networkMode`

Closes task-8d1dc3b0.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run build` succeeds
- [x] `bun test src/network.test.ts` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)