### PR TITLE
fix: gate Mag skill delivery on pane-based readiness check

### DIFF
--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -317,6 +317,61 @@ export function tmuxPaneOutputHash(target: string, lines: number = 50): string |
   return hasher.digest("hex");
 }
 
+/**
+ * Extract the "last message" region of a Claude Code pane: everything from
+ * the last "⏺" (assistant message marker) up to the last "❯" (input prompt)
+ * line, excluding the prompt itself and any "─────" separators. Deliberately
+ * excludes the footer below the prompt (token counts, bypass-permissions
+ * line, new-task hint) — those update for cosmetic reasons even when Claude
+ * is idle, which is noise for stall/readiness detection.
+ *
+ * Returns the cleaned snippet, or null if the capture failed or the snippet
+ * is empty.
+ */
+export function captureLastMessage(target: string, lines: number = 50): string | null {
+  const raw = tmuxCapture(target, lines);
+  if (!raw) return null;
+
+  const allLines = raw.split("\n");
+
+  let startIdx = 0;
+  for (let i = allLines.length - 1; i >= 0; i--) {
+    if (allLines[i]!.includes("⏺")) {
+      startIdx = i;
+      break;
+    }
+  }
+
+  let endIdx = allLines.length;
+  for (let i = allLines.length - 1; i >= startIdx; i--) {
+    if (allLines[i]!.includes("❯")) {
+      endIdx = i;
+      break;
+    }
+  }
+
+  const snippet = allLines
+    .slice(startIdx, endIdx)
+    .filter((l) => !l.match(/^[─]{4,}/))
+    .join("\n")
+    .trim();
+
+  return snippet || null;
+}
+
+/**
+ * Hash of the "last message" region — stable across cosmetic footer updates.
+ * Preferred signal for Mag stall/readiness detection. Returns null if
+ * capture fails or the extracted snippet is empty.
+ */
+export function captureLastMessageHash(target: string, lines: number = 50): string | null {
+  const snippet = captureLastMessage(target, lines);
+  if (!snippet) return null;
+  const hasher = new Bun.CryptoHasher("md5");
+  hasher.update(snippet);
+  return hasher.digest("hex");
+}
+
 /** Get the CLI launch command for an agent provider */
 export function agentCliCommand(provider: string): string {
   if (provider === "claude-code") return "claude --dangerously-skip-permissions";

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -325,8 +325,11 @@ export function tmuxPaneOutputHash(target: string, lines: number = 50): string |
  * line, new-task hint) — those update for cosmetic reasons even when Claude
  * is idle, which is noise for stall/readiness detection.
  *
- * Returns the cleaned snippet, or null if the capture failed or the snippet
- * is empty.
+ * Requires the "❯" prompt marker to be present. Returns null if the capture
+ * failed, no "❯" is found (splash/init, bare shell, crashed Claude), or the
+ * extracted snippet is empty. Callers downstream (e.g. isMagReady) treat a
+ * null result as "pane is not in a known-ready state", which prevents silent
+ * queue delivery into a non-Claude pane.
  */
 export function captureLastMessage(target: string, lines: number = 50): string | null {
   const raw = tmuxCapture(target, lines);
@@ -342,13 +345,14 @@ export function captureLastMessage(target: string, lines: number = 50): string |
     }
   }
 
-  let endIdx = allLines.length;
+  let endIdx = -1;
   for (let i = allLines.length - 1; i >= startIdx; i--) {
     if (allLines[i]!.includes("❯")) {
       endIdx = i;
       break;
     }
   }
+  if (endIdx === -1) return null;
 
   const snippet = allLines
     .slice(startIdx, endIdx)

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -29,7 +29,7 @@ import { addFrontmatterField, updateFrontmatterField, removeFrontmatterField, pa
 import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
-import { captureLastMessage, readTmuxSlotState, tmuxPaneOutputHash } from "./adapters/tmux-adapter.ts";
+import { captureLastMessage, captureLastMessageHash, readTmuxSlotState } from "./adapters/tmux-adapter.ts";
 import { resolveSkillCommand, hasRegisteredAction } from "./skill-queue-registry.ts";
 import { selectOrchestrationFlagsForTask } from "./adapters/t3code.ts";
 import YAML from "yaml";
@@ -170,7 +170,7 @@ function isMagReady(): boolean {
  */
 function clearStaleSettled(): void {
   if (!isMagSettled()) return;
-  const currentHash = tmuxPaneOutputHash(MAG_SESSION_NAME);
+  const currentHash = captureLastMessageHash(MAG_SESSION_NAME);
   if (currentHash === null) return;
   const previousHash = readPaneHash();
   if (previousHash !== null && currentHash !== previousHash) {
@@ -323,7 +323,7 @@ function maybeNudgeStalledMag(): void {
   if (isMagSettled()) return;
   if (!queuePending()) return;
 
-  const currentHash = tmuxPaneOutputHash(MAG_SESSION_NAME);
+  const currentHash = captureLastMessageHash(MAG_SESSION_NAME);
   if (currentHash === null) return; // tmux capture failed — don't treat as stall
 
   const previousHash = readPaneHash();

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2934,29 +2934,33 @@ export async function magStart(args: string[]): Promise<void> {
   // Optimistically marking settled here (the former behavior) races with
   // Claude's splash/init on cold boots: keepalive feeds the queue into a
   // pane that is not yet consuming input, so the skill text vanishes.
-  const readyDeadlineMs = Date.now() + 60_000;
-  let becameReady = false;
-  while (Date.now() < readyDeadlineMs) {
-    if (isMagReady()) {
-      becameReady = true;
-      break;
+  // Skip entirely when Claude isn't installed — isMagReady() could never
+  // become true, and there's no point feeding the queue into a bare shell.
+  if (hasClaude) {
+    const readyDeadlineMs = Date.now() + 60_000;
+    let becameReady = false;
+    while (Date.now() < readyDeadlineMs) {
+      if (isMagReady()) {
+        becameReady = true;
+        break;
+      }
+      safeSyncOutput(["sleep", "1"]);
     }
-    safeSyncOutput(["sleep", "1"]);
-  }
-  if (becameReady) {
-    markMagSettled();
-    clearStallState();
-    const fed = await maybeFeedMagQueue();
-    if (fed) {
-      console.error("ludics: Mag fresh start, delivered queued request via queue feed");
+    if (becameReady) {
+      markMagSettled();
+      clearStallState();
+      const fed = await maybeFeedMagQueue();
+      if (fed) {
+        console.error("ludics: Mag fresh start, delivered queued request via queue feed");
+      }
+    } else {
+      emitEvent({
+        event_type: "mag_startup_not_ready",
+        source: "cli",
+        scope: "mag",
+        message: "readiness timeout at 60s — stall detection will handle",
+      });
     }
-  } else {
-    emitEvent({
-      event_type: "mag_startup_not_ready",
-      source: "cli",
-      scope: "mag",
-      message: "readiness timeout at 60s — stall detection will handle",
-    });
   }
 }
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -266,28 +266,35 @@ function clearStallState(): void {
 // --- Queue feed and stall nudge helpers ---
 
 /**
- * When Mag is settled and queue has Mag-turn work, pop one item and deliver.
- * Returns true if a command was dispatched.
+ * When Mag is ready for input and queue has Mag-turn work, pop one item
+ * and deliver. "Ready" means either the settled sentinel is set (stop
+ * hook fired at end of last turn) or isMagReady() reports the pane has
+ * been quiet long enough (a fallback that doesn't require the stop hook
+ * to have fired, e.g. for queue requests arriving during idle periods
+ * where clearStaleSettled has cleared the sentinel). Returns true if a
+ * command was dispatched.
  */
 export async function maybeFeedMagQueue(): Promise<boolean> {
-  if (!isMagSettled()) return false;
-  if (!isMagReady()) return false;
+  if (!isMagSettled() && !isMagReady()) return false;
   if (!queuePending()) return false;
 
   // Drain programmatic entries first (they don't need a Mag turn)
   await drainProgrammaticQueueHead();
   if (!queuePending()) return false;
 
-  // Atomic claim: rename sentinel to in-progress marker so only one keepalive
-  // invocation can win the race. If rename fails, another tick already claimed it.
-  const claimPath = settledSentinelFile() + ".claiming";
-  try {
-    renameSync(settledSentinelFile(), claimPath);
-  } catch {
-    return false; // another tick already claimed
+  // Atomic claim: if settled, consume the sentinel so concurrent ticks
+  // see !settled. In the ready-only path there's no sentinel to consume;
+  // we rely on queuePopSkill's atomic dequeue below (and on the harness'
+  // single-writer invariant under federation v2).
+  if (isMagSettled()) {
+    const claimPath = settledSentinelFile() + ".claiming";
+    try {
+      renameSync(settledSentinelFile(), claimPath);
+    } catch {
+      return false; // another tick already claimed
+    }
+    try { unlinkSync(claimPath); } catch {}
   }
-  // Remove the claim marker now that we own the transition
-  try { unlinkSync(claimPath); } catch {}
 
   const popped = await queuePopSkill();
   if (!popped) return false;

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -151,6 +151,20 @@ function isMagSettled(): boolean {
 }
 
 /**
+ * Check whether the Mag tmux pane shows Claude Code's idle input prompt.
+ * During splash/init, Claude drains stdin but discards it — sending skill
+ * commands then makes them vanish without a trace (no shell error, no
+ * slash-command invocation visible in the pane). Gate delivery on this
+ * check so the request stays in the queue until the pane is actually
+ * consuming input.
+ */
+function isMagReady(): boolean {
+  const capture = tmuxCapture(MAG_SESSION_NAME, 30);
+  if (!capture) return false;
+  return /\n❯ *\n/.test(capture) && /bypass permissions/.test(capture);
+}
+
+/**
  * If pane output has advanced since the settled sentinel was written,
  * Mag has resumed running (e.g. a manual turn) — clear the stale sentinel.
  */
@@ -242,6 +256,7 @@ function clearStallState(): void {
  */
 export async function maybeFeedMagQueue(): Promise<boolean> {
   if (!isMagSettled()) return false;
+  if (!isMagReady()) return false;
   if (!queuePending()) return false;
 
   // Drain programmatic entries first (they don't need a Mag turn)
@@ -2915,13 +2930,33 @@ export async function magStart(args: string[]): Promise<void> {
   // Ensure t3code server on fresh start
   await ensureT3codeIfEnabled("fresh start");
 
-  // Treat fresh start as implicitly settled — deliver one queued request
-  markMagSettled();
-  clearStallState();
-  safeSyncOutput(["sleep", "5"]);
-  const fed = await maybeFeedMagQueue();
-  if (fed) {
-    console.error("ludics: Mag fresh start, delivered queued request via queue feed");
+  // Poll the pane for Claude Code's idle prompt before marking settled.
+  // Optimistically marking settled here (the former behavior) races with
+  // Claude's splash/init on cold boots: keepalive feeds the queue into a
+  // pane that is not yet consuming input, so the skill text vanishes.
+  const readyDeadlineMs = Date.now() + 60_000;
+  let becameReady = false;
+  while (Date.now() < readyDeadlineMs) {
+    if (isMagReady()) {
+      becameReady = true;
+      break;
+    }
+    safeSyncOutput(["sleep", "1"]);
+  }
+  if (becameReady) {
+    markMagSettled();
+    clearStallState();
+    const fed = await maybeFeedMagQueue();
+    if (fed) {
+      console.error("ludics: Mag fresh start, delivered queued request via queue feed");
+    }
+  } else {
+    emitEvent({
+      event_type: "mag_startup_not_ready",
+      source: "cli",
+      scope: "mag",
+      message: "readiness timeout at 60s — stall detection will handle",
+    });
   }
 }
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -108,6 +108,7 @@ function triggerSkill(session: string, cmd: string): boolean {
 
 const DEFAULT_STALL_THRESHOLD_MS = 120_000; // 2 minutes
 const DEFAULT_STALL_NUDGE_COOLDOWN_MS = 120_000; // 2 minutes between stall nudges
+const DEFAULT_READY_THRESHOLD_MS = 5_000; // pane must be stable this long to count as ready
 const DEFAULT_MAX_REQUEUE_RETRIES = 3;
 const DEFAULT_STARTUP_WATCHDOG_SECONDS = 60;
 const DEFAULT_STARTUP_HELPER_STUCK_SECONDS = 45;
@@ -151,17 +152,31 @@ function isMagSettled(): boolean {
 }
 
 /**
- * Check whether the Mag tmux pane shows Claude Code's idle input prompt.
- * During splash/init, Claude drains stdin but discards it — sending skill
- * commands then makes them vanish without a trace (no shell error, no
- * slash-command invocation visible in the pane). Gate delivery on this
- * check so the request stays in the queue until the pane is actually
- * consuming input.
+ * Check whether the Mag pane has been quiet long enough to be considered
+ * ready for a new skill. Uses the last-message hash (footer excluded), so
+ * Claude Code's cosmetic footer updates don't reset the clock. Returns
+ * true iff the hash has been stable for >= DEFAULT_READY_THRESHOLD_MS.
+ *
+ * Shares state with the stall-detection path (last-pane.hash and
+ * last-pane-change.epoch): both track the same "how long has the last
+ * message been static" signal, just with different thresholds. Calling
+ * isMagReady() also updates that state — safe to call from either the
+ * keepalive tick or from magStart's cold-boot poll before keepalive is
+ * running.
  */
 function isMagReady(): boolean {
-  const capture = tmuxCapture(MAG_SESSION_NAME, 30);
-  if (!capture) return false;
-  return /\n❯ *\n/.test(capture) && /bypass permissions/.test(capture);
+  const currentHash = captureLastMessageHash(MAG_SESSION_NAME);
+  if (currentHash === null) return false;
+
+  const previousHash = readPaneHash();
+  if (previousHash !== currentHash) {
+    writePaneHash(currentHash);
+    writePaneChangeEpoch();
+    return false;
+  }
+
+  const lastChangeMs = readPaneChangeEpoch();
+  return (Date.now() - lastChangeMs) >= DEFAULT_READY_THRESHOLD_MS;
 }
 
 /**
@@ -2911,6 +2926,10 @@ export async function magStart(args: string[]): Promise<void> {
   // Skip entirely when Claude isn't installed — isMagReady() could never
   // become true, and there's no point feeding the queue into a bare shell.
   if (hasClaude) {
+    // Clear stale stall state from any previous session before the poll —
+    // isMagReady() now tracks last-pane.hash and last-pane-change.epoch
+    // itself, so the loop builds up fresh state.
+    clearStallState();
     const readyDeadlineMs = Date.now() + 60_000;
     let becameReady = false;
     while (Date.now() < readyDeadlineMs) {
@@ -2922,7 +2941,6 @@ export async function magStart(args: string[]): Promise<void> {
     }
     if (becameReady) {
       markMagSettled();
-      clearStallState();
       const fed = await maybeFeedMagQueue();
       if (fed) {
         console.error("ludics: Mag fresh start, delivered queued request via queue feed");

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -29,7 +29,7 @@ import { addFrontmatterField, updateFrontmatterField, removeFrontmatterField, pa
 import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
-import { readTmuxSlotState, tmuxPaneOutputHash } from "./adapters/tmux-adapter.ts";
+import { captureLastMessage, readTmuxSlotState, tmuxPaneOutputHash } from "./adapters/tmux-adapter.ts";
 import { resolveSkillCommand, hasRegisteredAction } from "./skill-queue-registry.ts";
 import { selectOrchestrationFlagsForTask } from "./adapters/t3code.ts";
 import YAML from "yaml";
@@ -724,33 +724,7 @@ function adoptSessionsFingerprintData(
 }
 
 function publishTerminalState(): void {
-  const raw = tmuxCapture(MAG_SESSION_NAME, 50);
-  if (!raw) return;
-
-  const lines = raw.split("\n");
-
-  // Find last ⏺ line (Claude Code output marker)
-  let startIdx = 0;
-  for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i]!.includes("⏺")) {
-      startIdx = i;
-      break;
-    }
-  }
-
-  // Find last prompt line and cut there (drop status tagline below it)
-  let endIdx = lines.length;
-  for (let i = lines.length - 1; i >= startIdx; i--) {
-    if (lines[i]!.includes("❯")) {
-      endIdx = i; // exclude the prompt line itself
-      break;
-    }
-  }
-
-  const cleaned = lines.slice(startIdx, endIdx)
-    .filter((l) => !l.match(/^[─]{4,}/));  // drop line separators
-
-  const snippet = cleaned.join("\n").trim();
+  const snippet = captureLastMessage(MAG_SESSION_NAME, 50);
   if (!snippet) return;
 
   // Dedup: hash and compare to previous


### PR DESCRIPTION
## Summary

Fixes two related classes of Mag queue-delivery failure, both rooted in weak readiness signals:

1. **Cold-boot race** (today's observed loss): `magStart()` marked Mag settled optimistically after a blind 5s sleep, then tried to feed the queue. If Claude Code was still in splash/init, `tmux send-keys` silently dropped the skill text — no shell error, no slash-command invocation visible in the pane. `queuePopSkill()` had already removed the request, so it was permanently lost. Observed as `delivered: /ludics-briefing` logged without the briefing actually landing.

2. **Nudge-first pattern for idle Mag** (observed 2026-04-21T00:20 health-check and 06:20 briefing): when a queue request arrived while Mag was at the idle prompt but the settled sentinel was false, `maybeFeedMagQueue` couldn't deliver. Only stall detection could recover, via a 2-minute wait then a "Continue previous work" nudge rather than the actual skill. In the 00:20 case this broke entirely — 6 hours of silence after the nudge, probably because a subsequent stop hook was dropped.

Root cause common to both: the stall-detection hash (`tmuxPaneOutputHash`) hashes the raw 50-line capture including Claude Code's footer (token count, bypass-permissions line, new-task hint). Footer lines update for cosmetic reasons even during idle, which causes `clearStaleSettled` to over-clear and `maybeNudgeStalledMag`'s stall timer to spuriously reset. Meanwhile, there was no feed path besides the stop-hook-driven settled sentinel.

## Changes (6 commits)

1. `5ab05e2` — Initial cold-boot fix: replace optimistic settled-mark with 60s readiness poll.
2. `b012ee7` — Codex P2 fix: skip readiness poll when Claude CLI is unavailable.
3. `2390cb4` — Refactor: extract `captureLastMessage` + `captureLastMessageHash` helpers in `tmux-adapter.ts`; reuse in `publishTerminalState`. No behavior change.
4. `40d7356` — Switch Mag stall-detection hash to `captureLastMessageHash`. Footer updates no longer reset the stall timer or trigger `clearStaleSettled`. Slot panes (`transport-tmux.ts`) keep the full-capture hash.
5. `451ffaf` — Replace the regex-based `isMagReady` with a hash-stability check: ready iff the last-message hash has been stable for ≥ `DEFAULT_READY_THRESHOLD_MS` (5s). Shares state (`last-pane.hash`, `last-pane-change.epoch`) with stall detection. Moves `clearStallState()` in `magStart` to before the poll so fresh state accumulates.
6. `4abd4eb` — Relax `maybeFeedMagQueue` gate from `settled AND ready` to `settled OR ready`. The stop-hook fast path is untouched for snappy post-turn delivery; the ready-only path kicks in when the sentinel isn't set (queue requests during genuine idle). Settled-path atomic-claim rename preserved for concurrency; ready-only path relies on `queuePopSkill` atomicity + single-writer invariant.

`triggerSkill`'s literal-text + 0.5s gap + Enter pattern is **untouched** — that timing is a hard-won tmux quirk.

## Test plan

- [x] `bun run build` — clean on all commits
- [x] `bun run typecheck` — clean on all commits
- [x] `bun run lint src/mag.ts src/adapters/tmux-adapter.ts` — no new lint errors (pre-existing errors are outside edit regions)
- [ ] Next cold boot: verify briefing delivered after readiness; `mag_startup_not_ready` event if Claude takes >60s
- [ ] Warm idle: queue a request during an idle period, verify it's delivered without nudge (was: 2+ min nudge-then-feed)
- [ ] Cosmetic footer update: observe that token-count refreshes don't clear settled or reset the stall timer
- [ ] Active turn: last-message hash changes as expected, feed-on-ready doesn't fire mid-turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)