### PR TITLE
Add `tiny` effort level and `solo` workflow mode

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -977,6 +977,7 @@ ludics/
 │   └── pair-reviewer-review.md       # Pair mode: reviewer review
 │   # Solo mode resolves templates via:
 │   #   solo-<phase>.md > pair-coder-<phase>.md > <phase>.md
+│   # Solo ignores hasUpstream — its phase graph never forwards PRs upstream.
 │   # Only solo-work.md has reviewer-specific differences; other solo phases
 │   # reuse the pair-coder or mode-agnostic templates.
 ├── templates/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -290,7 +290,7 @@ Phases in brackets are optional, gated by configuration flags (`enableClarify`, 
 interface OrchestrationState {
   slot: number;
   feature: string;
-  mode: "duo" | "pair";           // duo = same roles, pair = coder + reviewer
+  mode: "duo" | "pair" | "solo";  // duo = two paired slots, pair = coder + reviewer, solo = coder only
   phase: PhaseId;
   round: number;
   agents: AgentConfig[];          // name, provider, role, model, branch, worktreePath
@@ -328,7 +328,7 @@ The `.peer-sync/` directory in the root worktree serves as the coordination chan
 ```
 .peer-sync/
 ├── feature           # Feature/task name
-├── mode              # duo or pair
+├── mode              # duo, pair, or solo
 ├── phase             # Current phase ID
 ├── phase-token       # Unique token per phase entry
 ├── round             # Current round number
@@ -375,7 +375,7 @@ Phase-specific templates exist for each role (`pair-coder-*.md`, `pair-reviewer-
 
 **Hierarchical duo mode** (`src/slots/duo-expand.ts`, `src/orchestration/cross-slot.ts`):
 
-The `--duo` flag now expands into two paired slots via `expandDuoSlots()`. Each slot runs a full pair-mode orchestration with swapped roles. State fields:
+The `--duo` flag now expands into two paired slots via `expandDuoSlots()`. Each slot runs a full pair-mode orchestration with swapped roles. Solo mode (`--solo`) runs a single coder with no reviewer; it uses the pair-style root worktree but skips the review loop (see §Solo mode below). State fields:
 
 - `duoPeerSlot` — partner slot number for cross-slot coordination
 - `duoAwaitingPeer` — sync flag for merge coordination
@@ -434,14 +434,15 @@ ludics ──WebSocket──> t3code server ──spawns──> AI agents (Claud
 The t3code adapter supports two modes:
 
 1. **Single-thread mode** (`slot start -a t3code`): Creates one t3code thread for manual coding
-2. **Orchestrated mode** (`slot start -a t3code --duo/--pair`): Creates multiple threads + spawns orchestration subprocess
+2. **Orchestrated mode** (`slot start -a t3code --duo/--pair/--solo`): Creates one or more threads + spawns orchestration subprocess
 
 Orchestrated mode argument parsing:
 ```
---duo                     # Two agents, same roles
---pair                    # Coder + reviewer roles
+--duo                     # Two paired slots (expanded via expandDuoSlots)
+--pair                    # Coder + reviewer roles in a single slot
+--solo                    # Single coder, no reviewer (for tiny-effort tasks)
 --coder <provider>        # e.g., claude-code, codex
---reviewer <provider>
+--reviewer <provider>     # not used with --solo
 --feature <name>          # Feature branch name
 --enable-clarify          # Enable clarify phase
 --enable-plan             # Enable plan phase
@@ -961,6 +962,7 @@ ludics/
 │   ├── suggest-refactor.md           # Post-merge refactoring suggestions
 │   ├── pr-conflict-resolve.md        # PR merge conflict resolution
 │   ├── final-merge.md                # Final merge
+│   ├── solo-work.md                  # Solo mode: coder work (no reviewer guidance)
 │   ├── pair-coder-clarify.md         # Pair mode: coder clarify
 │   ├── pair-coder-plan.md            # Pair mode: coder plan
 │   ├── pair-coder-plan-merge.md      # Pair mode: coder merges independent plans
@@ -973,6 +975,10 @@ ludics/
 │   ├── pair-reviewer-plan-review.md  # Pair mode: reviewer votes on merged plan
 │   ├── pair-reviewer-pushback.md     # Pair mode: reviewer pushback
 │   └── pair-reviewer-review.md       # Pair mode: reviewer review
+│   # Solo mode resolves templates via:
+│   #   solo-<phase>.md > pair-coder-<phase>.md > <phase>.md
+│   # Only solo-work.md has reviewer-specific differences; other solo phases
+│   # reuse the pair-coder or mode-agnostic templates.
 ├── templates/
 │   ├── config.reference.yaml         # Example config
 │   ├── slots.example.md

--- a/skills/ludics-briefing.md
+++ b/skills/ludics-briefing.md
@@ -41,7 +41,7 @@ The context file contains these sections:
 - **Upstream vs Staging Lag**: *(optional — only for projects with `upstream_repo`)* Per-project commits AHEAD of upstream (primary signal — merges on staging not yet forwarded upstream) and commits behind upstream (secondary), plus last-merge commit lines on each side. Surface this verbatim in the briefing under a dedicated heading when present.
 - **Sessions Report**: All discovered agent sessions with classification
 - **Session-Project Matches**: Pre-computed matching of unclassified sessions to projects, with ready tasks per project and slot availability
-- **Active Unconcluded Agent-Duo Slots**: Case-A slots precomputed from `sessions.json` + task completion state
+- **Active Unconcluded Slots**: Case-A slots precomputed from `sessions.json` + task completion state (covers pair, duo, and solo modes)
 - **Flow: Ready Queue**: Priority-sorted ready tasks
 - **Flow: Critical Items**: Deadlines, high-priority ready
 - **Tasks Needing Elaboration**: Task IDs that lack elaboration
@@ -130,7 +130,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
    - **manual**: include observations only
 
 7. **Nudge stalled slotted tasks**:
-   - Read the `## Active Unconcluded Agent-Duo Slots` section first.
+   - Read the `## Active Unconcluded Slots` section first.
      - Treat listed slots as **Case A** (active, unconcluded): do **not** re-send
        launch buttons for those slots.
    - For each slot that has a task assigned with a proposal (`proposal:` field in

--- a/skills/orchestration/solo-work.md
+++ b/skills/orchestration/solo-work.md
@@ -1,0 +1,33 @@
+# Solo Work (Coder)
+
+{{PROPOSAL_INSTRUCTION}}
+
+Implement the task in `{{WORKTREE_PATH}}`.
+
+{{TASK_SPEC}}
+
+Commit in small batches (4-6 files), and include a regression test alongside each behavior change in the same batch. Build, lint, and run targeted tests before signaling done.
+
+Before modifying any symbol, re-run a project-wide grep for it — including inline reimplementations (regex patterns, copy-pasted logic) — and handle any occurrences the plan missed in this round rather than deferring.
+
+A few places where drift tends to creep in:
+- Config types (`src/config.ts`) or CLI commands (`src/index.ts` USAGE) — update `templates/config.reference.yaml` and/or the README CLI Reference. CI (`lint:config-reference`, `lint:cli-readme`) will flag drift.
+- Data-shape changes or format-compat serializers — add a round-trip fidelity test (serialize → deserialize → compare key fields) so silent field omissions show up early.
+
+Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
+
+{{#IF PROPOSAL_PATH}}
+Before signaling done, re-read `{{PROPOSAL_PATH}}` and walk through each acceptance criterion, stating explicitly (in your thinking) how the implementation satisfies it. Write the status file only once every criterion is met.
+{{/IF}}
+
+If the task is already resolved on the base branch (fix already merged, no meaningful changes needed), don't make empty commits — signal bail-out instead:
+
+```sh
+printf 'bail-out|%s|<describe why task is obsolete>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+Solo bail-out is terminal — the runner transitions straight to `done` with no reviewer confirmation. Use bail-out only when there's genuinely nothing to do. Partially-done tasks still finish normally.
+
+```sh
+printf '%s|%s|coder work complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
+```

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -352,3 +352,81 @@ describe("selectOrchestrationFlagsForTask — skip_plan from frontmatter", () =>
     expect(args).toContain("--gather");
   });
 });
+
+describe("parseT3CodeAdapterArgs — --solo", () => {
+  test("parses --solo with --coder into a single-agent orchestration", () => {
+    // Token format: name:provider:model
+    const parsed = parseT3CodeAdapterArgs("--solo --coder coder:claude-code:claude-sonnet-4-6");
+    expect(parsed.orchestration).not.toBeNull();
+    expect(parsed.orchestration!.mode).toBe("solo");
+    expect(parsed.orchestration!.agents).toHaveLength(1);
+    expect(parsed.orchestration!.agents[0]!.role).toBe("coder");
+    expect(parsed.orchestration!.agents[0]!.provider).toBe("claude-code");
+    expect(parsed.orchestration!.agents[0]!.model).toBe("claude-sonnet-4-6");
+    expect(parsed.orchestration!.agents[0]!.name).toBe("coder");
+  });
+
+  test("parses --solo --coder <provider> (bare provider) with default model", () => {
+    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code");
+    expect(parsed.orchestration!.mode).toBe("solo");
+    expect(parsed.orchestration!.agents).toHaveLength(1);
+    expect(parsed.orchestration!.agents[0]!.provider).toBe("claude-code");
+  });
+
+  test("--solo without --coder throws", () => {
+    expect(() => parseT3CodeAdapterArgs("--solo")).toThrow(/--solo requires --coder/);
+  });
+
+  test("--solo combined with --reviewer throws", () => {
+    expect(() =>
+      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer codex")
+    ).toThrow(/--solo is incompatible with --reviewer/);
+  });
+
+  test("--solo combined with --duo-peer-slot throws", () => {
+    expect(() =>
+      parseT3CodeAdapterArgs("--solo --coder claude-code --duo-peer-slot=2")
+    ).toThrow(/--solo is incompatible with --duo-peer-slot/);
+  });
+
+  test("--solo supports --plan / --clarify config flags (orthogonal to mode)", () => {
+    // Even though auto-select for tiny omits pre-work phases, explicit --solo --plan
+    // is valid: config flags are orthogonal to mode.
+    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --plan");
+    expect(parsed.orchestration!.config.enablePlan).toBe(true);
+  });
+});
+
+describe("selectOrchestrationFlags — tiny effort", () => {
+  test("tiny effort emits --solo with Sonnet for claude-code default", () => {
+    const { adapter, args, isDuo } = selectOrchestrationFlags("tiny");
+    expect(args).toContain("--solo");
+    expect(args).toContain("--coder claude-code");
+    expect(args).toContain(":claude-sonnet-4-6");
+    expect(args).not.toContain("--pair");
+    expect(args).not.toContain("--reviewer");
+    expect(args).not.toContain("--plan");
+    expect(args).not.toContain("--gather");
+    expect(isDuo).toBe(false);
+    expect(adapter).toMatch(/t3code|tmux/);
+  });
+
+  test("tiny effort ignores orchCfg.default_mode (forces solo)", () => {
+    const fakeConfig = {
+      mag: { orchestration: { default_mode: "pair", default_coder: "claude-code", default_reviewer: "codex" } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    const { args, isDuo } = selectOrchestrationFlags("tiny", fakeConfig);
+    expect(args).toContain("--solo");
+    expect(args).not.toContain("--pair");
+    expect(isDuo).toBe(false);
+  });
+
+  test("tiny effort with codex coder emits no model suffix", () => {
+    const fakeConfig = {
+      mag: { orchestration: { default_coder: "codex", default_reviewer: "codex" } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    const { args } = selectOrchestrationFlags("tiny", fakeConfig);
+    expect(args).toContain("--solo --coder codex");
+    expect(args).not.toContain(":claude-sonnet");
+  });
+});

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -389,6 +389,41 @@ describe("parseT3CodeAdapterArgs — --solo", () => {
     ).toThrow(/--solo is incompatible with --duo-peer-slot/);
   });
 
+  test("--solo combined with --reviewer-model throws (reviewer-only override)", () => {
+    expect(() =>
+      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-model gpt-5.4")
+    ).toThrow(/--solo is incompatible with --reviewer-model/);
+  });
+
+  test("--solo combined with --reviewer-effort throws", () => {
+    expect(() =>
+      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-effort low")
+    ).toThrow(/--solo is incompatible with --reviewer-effort/);
+  });
+
+  test("--solo combined with --reviewer-thinking-effort throws", () => {
+    expect(() =>
+      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-thinking-effort low")
+    ).toThrow(/--solo is incompatible with --reviewer-thinking-effort/);
+  });
+
+  test("--solo accepts shared --effort flag (coder half applied)", () => {
+    // --effort is a shared flag that sets both coder and reviewer effort.
+    // In solo the reviewer half is discarded; this is not a reviewer-only flag
+    // so it must not be rejected.
+    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --effort high");
+    expect(parsed.orchestration!.mode).toBe("solo");
+    expect(parsed.orchestration!.coderThinkingEffort).toBe("high");
+    expect(parsed.orchestration!.reviewerThinkingEffort).toBeUndefined();
+  });
+
+  test("--solo accepts --coder-model and --coder-effort", () => {
+    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --coder-model claude-opus-4-6 --coder-effort high");
+    expect(parsed.orchestration!.mode).toBe("solo");
+    expect(parsed.orchestration!.coderModelOverride).toBe("claude-opus-4-6");
+    expect(parsed.orchestration!.coderThinkingEffort).toBe("high");
+  });
+
   test("--solo supports --plan / --clarify config flags (orthogonal to mode)", () => {
     // Even though auto-select for tiny omits pre-work phases, explicit --solo --plan
     // is valid: config flags are orthogonal to mode.

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -262,6 +262,9 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
       case "--pair":
         mode = "pair";
         break;
+      case "--solo":
+        mode = "solo";
+        break;
       case "--agent":
         // Legacy duo --agent flag is no longer supported; use --coder/--reviewer instead.
         throw new Error("t3code adapter args: --agent is no longer supported (duo mode now uses --coder/--reviewer). Use --coder and --reviewer instead.");
@@ -378,6 +381,32 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
   }
 
   if (!mode) return parsed;
+
+  if (mode === "solo") {
+    if (!coderToken) {
+      throw new Error("t3code adapter args: --solo requires --coder provider[:model[:name]]");
+    }
+    if (reviewerToken) {
+      throw new Error("t3code adapter args: --solo is incompatible with --reviewer");
+    }
+    if (duoPeerSlot != null) {
+      throw new Error("t3code adapter args: --solo is incompatible with --duo-peer-slot");
+    }
+    const coderParsed = parseProviderToken(coderToken, "coder", parsed.model);
+    parsed.orchestration = {
+      mode: "solo",
+      config: orchestrationConfig,
+      agents: [
+        { ...coderParsed, role: "coder", modelExplicit: coderParsed.modelExplicit },
+      ],
+      coderModelOverride,
+      reviewerModelOverride: undefined,
+      coderThinkingEffort,
+      reviewerThinkingEffort: undefined,
+      duoPeerSlot: undefined,
+    };
+    return parsed;
+  }
 
   // For pair mode: modelExplicit is only true when the user explicitly provided the token
   // (i.e. --coder/--reviewer flag was given) AND that token included an explicit model.
@@ -649,12 +678,16 @@ const CLAUDE_OPUS_MODEL = "claude-opus-4-6";
  * Auto-select orchestration flags for the t3code adapter based on task effort.
  *
  * Effort-based selection (when coder is claude-code):
+ * - tiny:   solo mode, no pre-work phases, Claude coder model = Sonnet (no reviewer)
  * - small:  pair mode, no pre-work phases, Claude coder model = Sonnet
  * - medium: pair mode, enable plan phase, Claude coder model = Opus
  * - large:  pair mode, enable plan + gather phases, Claude coder model = Opus
  *
  * For non-Claude coder providers (e.g. codex), no model suffix is emitted so the
  * provider's own default applies (and coder_model config fallback remains active).
+ *
+ * `tiny` effort implies `--solo` unconditionally, bypassing `orchCfg.default_mode`
+ * (resolved during task-da8b6dff elaboration).
  *
  * Config keys (mag.orchestration): default_mode, default_coder, default_reviewer
  * These can be overridden by explicit -A adapter args at assign time.
@@ -675,6 +708,15 @@ export function selectOrchestrationFlags(
   const isDuo = mode === "duo";
 
   const norm = (effort ?? "").toLowerCase().trim();
+
+  // `tiny` effort implies solo mode unconditionally (ignores orchCfg.default_mode).
+  // Single coder, no pre-work phases, Sonnet for claude-code providers.
+  if (norm === "tiny") {
+    const modelSuffix = coder === "claude-code" ? `:${DEFAULT_CLAUDE_MODEL}` : "";
+    const args = `--solo --coder ${coder}${modelSuffix}`;
+    return { adapter: globalAdapter(), args, isDuo: false };
+  }
+
   const phaseFlags: string[] = [];
 
   // Only apply effort-based model selection for Claude providers; other providers

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -59,7 +59,7 @@ interface ParsedAgentToken {
 }
 
 interface ParsedOrchestrationArgs {
-  mode: "pair";
+  mode: "duo" | "pair" | "solo";
   config: Partial<OrchestrationConfig>;
   agents: ParsedAgentToken[];
   /** Explicit coder model override from --coder-model flag. */
@@ -1068,7 +1068,9 @@ async function stop(ctx: AdapterContext, options?: { preserveState?: boolean }):
       }));
       removeOrchestrationState(ctx.slot, ctx.harnessDir);
     } else if (threadIds.length > 0) {
-      // Non-orchestrated single-thread sessions: defer thread deletion only
+      // Non-orchestrated single-thread sessions: defer thread deletion only.
+      // `mode` is a placeholder here (no orchestration state exists); value is never
+      // consulted for mode dispatch because the cleanup entry has no agents.
       recordDeferredCleanup({
         timestamp: new Date().toISOString(),
         projectDir: "",

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -224,6 +224,10 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
   let coderThinkingEffort: string | undefined;
   let reviewerThinkingEffort: string | undefined;
   let duoPeerSlot: number | undefined;
+  // Track the first reviewer-only override flag seen (excluding the shared
+  // --effort / --thinking-effort flags). Used to reject reviewer-specific
+  // overrides in --solo mode, where no reviewer agent exists.
+  let reviewerOnlyFlag: string | null = null;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]!;
@@ -286,6 +290,7 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
       case "--reviewer-model":
         if (!next) throw new Error("t3code adapter args: --reviewer-model requires a model ID");
         reviewerModelOverride = next;
+        if (!reviewerOnlyFlag) reviewerOnlyFlag = arg;
         i++;
         break;
       case "--coder-effort":
@@ -298,6 +303,7 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
       case "--reviewer-thinking-effort":
         if (!next) throw new Error(`t3code adapter args: ${arg} requires low|medium|high|max`);
         reviewerThinkingEffort = next;
+        if (!reviewerOnlyFlag) reviewerOnlyFlag = arg;
         i++;
         break;
       case "--effort":
@@ -391,6 +397,9 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
     }
     if (duoPeerSlot != null) {
       throw new Error("t3code adapter args: --solo is incompatible with --duo-peer-slot");
+    }
+    if (reviewerOnlyFlag) {
+      throw new Error(`t3code adapter args: --solo is incompatible with ${reviewerOnlyFlag} (no reviewer exists in solo mode)`);
     }
     const coderParsed = parseProviderToken(coderToken, "coder", parsed.model);
     parsed.orchestration = {

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -190,3 +190,29 @@ describe("tmux adapter stop — preserveState", () => {
     expect(existsSync(join(harness, "orchestration", "tmux-slot-1.json"))).toBe(false);
   });
 });
+
+describe("tmux adapter — missing orchestration error mentions --solo", () => {
+  test("error text lists --solo reassignment as first option", async () => {
+    const { start } = await import("./tmux-adapter.ts");
+    const ctx: AdapterContext = {
+      slot: 7,
+      harnessDir: "/tmp/no-op-harness",
+      adapterArgs: "", // no orchestration flags
+      taskId: "task-x",
+      slotId: "s7",
+      path: "/tmp/project",
+      projectDir: "/tmp/project",
+      session: "",
+    };
+    let thrown: Error | null = null;
+    try {
+      await start(ctx);
+    } catch (e) {
+      thrown = e as Error;
+    }
+    expect(thrown).not.toBeNull();
+    expect(thrown!.message).toContain("tmux adapter requires orchestration flags");
+    expect(thrown!.message).toContain("--solo --coder");
+    expect(thrown!.message).toContain("--pair --coder");
+  });
+});

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -196,13 +196,14 @@ describe("tmux adapter — missing orchestration error mentions --solo", () => {
     const { start } = await import("./tmux-adapter.ts");
     const ctx: AdapterContext = {
       slot: 7,
-      harnessDir: "/tmp/no-op-harness",
-      adapterArgs: "", // no orchestration flags
-      taskId: "task-x",
-      slotId: "s7",
-      path: "/tmp/project",
-      projectDir: "/tmp/project",
+      mode: "tmux",
       session: "",
+      path: "/tmp/project",
+      taskId: "task-x",
+      adapterArgs: "", // no orchestration flags
+      process: "(empty)",
+      harnessDir: "/tmp/no-op-harness",
+      stateRepoDir: "/tmp/state",
     };
     let thrown: Error | null = null;
     try {

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -449,6 +449,7 @@ async function start(ctx: AdapterContext): Promise<string> {
     throw new Error(
       `slot ${ctx.slot}: tmux adapter requires orchestration flags.\n` +
       `  Reassign with one of:\n` +
+      `    ludics slot ${ctx.slot} assign <task> -a tmux --solo --coder <provider>\n` +
       `    ludics slot ${ctx.slot} assign <task> -a tmux --pair --coder <provider> --reviewer <provider>\n` +
       `    ludics slot ${ctx.slot} assign <task> -a tmux -A "<flags>"`
     );

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -50,7 +50,7 @@ interface TmuxSlotState {
   ttydPids: Record<string, number>; // agent name → ttyd PID
   orchestration?: {
     stateFile: string;
-    mode: "duo" | "pair";
+    mode: "duo" | "pair" | "solo";
     pid?: number;
   };
 }

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -504,7 +504,7 @@ export function startDashboardServer(
         }
         const project = typeof body.project === "string" ? body.project.trim() || "personal" : "personal";
         const priority = typeof body.priority === "string" && /^[A-CS]$/.test(body.priority) ? body.priority : "B";
-        const effort = typeof body.effort === "string" && ["small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
+        const effort = typeof body.effort === "string" && ["tiny", "small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
         const usesBrowser = body.usesBrowser === true;
         const taskBody = typeof body.body === "string" ? body.body.trim() : "";
 

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -15,7 +15,7 @@ export interface CleanupEntry {
   taskId: string;
   slot: number;
   agents: Array<{ name: string }>;
-  mode: "duo" | "pair";
+  mode: "duo" | "pair" | "solo";
   branches: string[];
   worktreePaths: string[];
   tmuxSessionNames: string[];

--- a/src/orchestration/peer-sync.ts
+++ b/src/orchestration/peer-sync.ts
@@ -55,7 +55,7 @@ function writeFile(path: string, value: string): void {
 export function initPeerSync(
   peerSyncDir: string,
   taskId: string,
-  mode: "duo" | "pair",
+  mode: "duo" | "pair" | "solo",
   projectDir: string,
   agents: OrchestrationState["agents"],
   worktrees: Record<string, string>,

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -7,7 +7,7 @@ import { agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDon
 import { statusFileFingerprint } from "./peer-sync.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
 import { applyPhaseSideEffects } from "./runner.ts";
-import { defaultOrchestrationConfig, initAgentRuntimeState, type OrchestrationState } from "./state.ts";
+import { defaultOrchestrationConfig, initAgentRuntimeState, migrateState, type OrchestrationState } from "./state.ts";
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
@@ -1033,5 +1033,53 @@ describe("isSoloBailedOut / isBailedOut", () => {
     state.agentStates.coder.status = "bail-out";
     state.agentStates.reviewer.status = "done";
     expect(isBailedOut(state)).toBe(false);
+  });
+});
+
+describe("migrateState — solo invariants", () => {
+  test("returns valid solo state unchanged without warning", () => {
+    const state = makeSoloState();
+    const warnings: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((msg: string) => { warnings.push(msg); });
+    try {
+      const result = migrateState(state, 1);
+      expect(result).toBe(state);
+      expect(warnings.filter((w) => w.includes("solo"))).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("warns but returns state unchanged when solo state has duoPeerSlot set", () => {
+    const state = makeSoloState({ duoPeerSlot: 2 });
+    const warnings: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((msg: string) => { warnings.push(msg); });
+    try {
+      const result = migrateState(state, 3);
+      expect(result).toBe(state);
+      expect(result.duoPeerSlot).toBe(2); // state unchanged
+      expect(warnings.some((w) => w.includes("solo") && w.includes("duoPeerSlot"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("warns but returns state unchanged when solo state has wrong agent count", () => {
+    const state = makeSoloState({
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "claude-sonnet-4-6", branch: "a", worktreePath: "/tmp/a" },
+        { name: "reviewer", provider: "codex", role: "reviewer", model: "gpt-5.4", branch: "b", worktreePath: "/tmp/b" },
+      ],
+    });
+    const warnings: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((msg: string) => { warnings.push(msg); });
+    try {
+      const result = migrateState(state, 4);
+      expect(result).toBe(state);
+      expect(result.agents).toHaveLength(2); // state unchanged
+      expect(warnings.some((w) => w.includes("solo") && w.includes("2 agents"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -3,7 +3,7 @@ import * as peerSyncMod from "./peer-sync.ts";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, PHASE_CATEGORIES, phaseTimeoutExpired } from "./phases.ts";
+import { agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, isPairBailedOut, isSoloBailedOut, PHASE_CATEGORIES, phaseTimeoutExpired } from "./phases.ts";
 import { statusFileFingerprint } from "./peer-sync.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
 import { applyPhaseSideEffects } from "./runner.ts";
@@ -827,5 +827,211 @@ describe("applyPhaseSideEffects — stub plan creation (gh-ludics-254)", () => {
     applyPhaseSideEffects(state, "work");
     const stubPath = mergedPlanFilePath(tmpDir, 1, 0);
     expect(existsSync(stubPath)).toBe(false);
+  });
+});
+
+function makeSoloState(overrides: Partial<OrchestrationState> = {}): OrchestrationState {
+  return {
+    slot: 1,
+    taskId: "feat",
+    mode: "solo",
+    phase: "setup",
+    round: 1,
+    mergeRound: 0,
+    agents: [
+      { name: "coder", provider: "claude-code", role: "coder", model: "claude-sonnet-4-6", branch: "a", worktreePath: "/tmp/a" },
+    ],
+    agentStates: initAgentRuntimeState(["coder"]),
+    config: defaultOrchestrationConfig(),
+    phaseStartedAt: 0,
+    startedAt: "2026-04-22T00:00:00Z",
+    projectDir: "/tmp/project",
+    rootWorktree: "/tmp/project-feat",
+    peerSyncDir: "/tmp/project-feat/.peer-sync",
+    threadIds: { coder: "t1" },
+    ...overrides,
+  };
+}
+
+describe("solo mode — evaluateTransition", () => {
+  test("setup → work (unconditional; skips gather/clarify/plan)", () => {
+    const state = makeSoloState({
+      config: defaultOrchestrationConfig({ enableClarify: true, enablePushback: true, enablePlan: true, enableGather: true }),
+    });
+    expect(evaluateTransition(state)).toBe("work");
+  });
+
+  test("work → update-docs when coder done and no PR exists", () => {
+    const state = makeSoloState({ phase: "work" });
+    state.agentStates.coder.status = "done";
+    expect(evaluateTransition(state)).toBe("update-docs");
+  });
+
+  test("work → pr-comments when PR already exists", () => {
+    const state = makeSoloState({ phase: "work" });
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.prUrl = "https://github.com/o/r/pull/1";
+    expect(evaluateTransition(state)).toBe("pr-comments");
+  });
+
+  test("work stalls (null) when coder is not done", () => {
+    const state = makeSoloState({ phase: "work", phaseStartedAt: Math.floor(Date.now() / 1000) });
+    state.agentStates.coder.status = "idle";
+    expect(evaluateTransition(state)).toBeNull();
+  });
+
+  test("update-docs → pr-create when no PR exists", () => {
+    const state = makeSoloState({ phase: "update-docs" });
+    state.agentStates.coder.status = "update-docs-done";
+    expect(evaluateTransition(state)).toBe("pr-create");
+  });
+
+  test("update-docs → pr-comments when PR already exists", () => {
+    const state = makeSoloState({ phase: "update-docs" });
+    state.agentStates.coder.status = "update-docs-done";
+    state.agentStates.coder.prUrl = "https://github.com/o/r/pull/2";
+    expect(evaluateTransition(state)).toBe("pr-comments");
+  });
+
+  test("pr-create → pr-comments when PR URL present", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ludics-solo-prcreate-"));
+    mkdirSync(join(dir, "plans"), { recursive: true });
+    mkdirSync(join(dir, "reviews"), { recursive: true });
+    const state = makeSoloState({ phase: "pr-create", peerSyncDir: dir });
+    state.agentStates.coder.status = "pr-created";
+    state.agentStates.coder.prUrl = "https://github.com/o/r/pull/3";
+    // Also write the required .pr artifact for isAgentDone
+    writeFileSync(join(dir, "coder.pr"), "https://github.com/o/r/pull/3\n");
+    expect(evaluateTransition(state)).toBe("pr-comments");
+  });
+
+  test("pr-create blocks (null) without PR URL (defense-in-depth)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ludics-solo-prcreate-block-"));
+    const state = makeSoloState({
+      phase: "pr-create",
+      peerSyncDir: dir,
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+    });
+    state.agentStates.coder.status = "pr-created";
+    // no prUrl set, no artifact → isAgentDone returns false → allAgentsDone false
+    expect(evaluateTransition(state)).toBeNull();
+  });
+
+  test("pr-comments → final-merge via coder-dispatched shortcut", () => {
+    const state = makeSoloState({ phase: "pr-comments" });
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.prUrl = "https://github.com/o/r/pull/4";
+    state.prCommentsCoderDispatched = true;
+    state.prCommentsQuietSince = Math.floor(Date.now() / 1000) - 5;
+    expect(evaluateTransition(state)).toBe("final-merge");
+  });
+
+  test("pr-comments stalls (null) without a PR URL", () => {
+    const state = makeSoloState({
+      phase: "pr-comments",
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+    });
+    state.agentStates.coder.status = "done";
+    expect(evaluateTransition(state)).toBeNull();
+  });
+
+  test("final-merge → done when coder done (skips suggest-refactor)", () => {
+    const state = makeSoloState({ phase: "final-merge" });
+    state.agentStates.coder.status = "merged";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("solo bail-out short-circuits every non-terminal phase to done", () => {
+    const phases: Array<OrchestrationState["phase"]> = [
+      "work", "update-docs", "pr-create", "pr-comments", "final-merge",
+    ];
+    for (const phase of phases) {
+      const state = makeSoloState({ phase });
+      state.agentStates.coder.status = "bail-out";
+      expect(evaluateTransition(state)).toBe("done");
+    }
+  });
+
+  test("done is terminal (returns done)", () => {
+    const state = makeSoloState({ phase: "done" });
+    expect(evaluateTransition(state)).toBe("done");
+  });
+});
+
+describe("solo mode — agentParticipatesInPhase", () => {
+  const activePhases: Array<OrchestrationState["phase"]> = [
+    "work", "update-docs", "pr-create", "pr-comments", "final-merge",
+  ];
+  const neverPhases: Array<OrchestrationState["phase"]> = ["setup", "done"];
+
+  test("coder participates in every solo active phase", () => {
+    const state = makeSoloState();
+    for (const phase of activePhases) {
+      state.phase = phase;
+      expect(agentParticipatesInPhase(state, state.agents[0])).toBe(true);
+    }
+  });
+
+  test("coder never participates in setup or done", () => {
+    const state = makeSoloState();
+    for (const phase of neverPhases) {
+      state.phase = phase;
+      expect(agentParticipatesInPhase(state, state.agents[0])).toBe(false);
+    }
+  });
+
+  test("hypothetical reviewer never participates in solo mode", () => {
+    const reviewer = {
+      name: "reviewer", provider: "codex" as const, role: "reviewer" as const,
+      model: "gpt-5.4", branch: "b", worktreePath: "/tmp/b",
+    };
+    // Solo normally has one agent, but this test exercises the defensive check
+    // that even if a reviewer is somehow present, they don't participate.
+    const state = makeSoloState({ agents: [...makeSoloState().agents, reviewer] });
+    for (const phase of activePhases) {
+      state.phase = phase;
+      expect(agentParticipatesInPhase(state, reviewer)).toBe(false);
+    }
+  });
+});
+
+describe("isSoloBailedOut / isBailedOut", () => {
+  test("isSoloBailedOut: true when solo coder status is bail-out", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.status = "bail-out";
+    expect(isSoloBailedOut(state)).toBe(true);
+  });
+
+  test("isSoloBailedOut: false when mode is pair (delegation only via isBailedOut)", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "bail-out";
+    expect(isSoloBailedOut(state)).toBe(false);
+  });
+
+  test("isSoloBailedOut: false when coder status is not bail-out", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.status = "done";
+    expect(isSoloBailedOut(state)).toBe(false);
+  });
+
+  test("isBailedOut: true for solo coder bail-out", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.status = "bail-out";
+    expect(isBailedOut(state)).toBe(true);
+  });
+
+  test("isBailedOut: true for pair handshake (delegates to isPairBailedOut)", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "bail-out-confirmed";
+    expect(isBailedOut(state)).toBe(true);
+    expect(isPairBailedOut(state)).toBe(true);
+  });
+
+  test("isBailedOut: false for lone coder bail-out in pair mode", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "bail-out";
+    state.agentStates.reviewer.status = "done";
+    expect(isBailedOut(state)).toBe(false);
   });
 });

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -154,6 +154,9 @@ export function agentParticipatesInPhase(
   agent: AgentConfig,
 ): boolean {
   if (state.phase === "setup" || state.phase === "done") return false;
+  // Solo mode: only the coder participates, in every non-setup/done phase.
+  // No reviewer agent exists; reviewer-keyed role checks must return false.
+  if (state.mode === "solo") return agent.role === "coder";
   // Strict role separation for all slots (pair and hierarchical-duo)
   switch (state.phase) {
     case "gather":
@@ -189,10 +192,11 @@ export function agentParticipatesInPhase(
 /** Check done-status + required artifact. Shared by both lifecycle branches of isAgentDone. */
 function validateDoneStatus(state: OrchestrationState, agent: AgentConfig, runtime: AgentRuntimeState): boolean {
   if (!DONE_STATUSES.has(runtime.status)) return false;
-  // Bail-out statuses bypass artifact validation only when the full pair bail-out
-  // contract is satisfied (coder=bail-out + reviewer=bail-out-confirmed). A lone
+  // Bail-out statuses bypass artifact validation when the bail-out contract is
+  // satisfied for the current mode: pair requires coder=bail-out +
+  // reviewer=bail-out-confirmed; solo requires a lone coder=bail-out. A lone
   // bail-out-confirmed without the coder side must not skip artifact checks.
-  if ((runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") && isPairBailedOut(state)) return true;
+  if ((runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") && isBailedOut(state)) return true;
   if (!hasRequiredArtifact(state, agent)) {
     emitEvent({
       event_type: "orchestration_warning",
@@ -341,6 +345,21 @@ export function isPairBailedOut(state: OrchestrationState): boolean {
   return cs === "bail-out" && rs === "bail-out-confirmed";
 }
 
+/** True when a solo-mode slot's coder has signaled bail-out. Solo has no reviewer,
+ * so a lone "bail-out" is the terminal signal (no bail-out-confirmed partner). */
+export function isSoloBailedOut(state: OrchestrationState): boolean {
+  if (state.mode !== "solo") return false;
+  const coder = state.agents.find(a => a.role === "coder");
+  if (!coder) return false;
+  return (state.agentStates[coder.name]?.status ?? "") === "bail-out";
+}
+
+/** Unified bail-out check covering both pair and solo contracts. Pair requires the
+ * full two-agent handshake; solo treats a lone coder "bail-out" as terminal. */
+export function isBailedOut(state: OrchestrationState): boolean {
+  return isPairBailedOut(state) || isSoloBailedOut(state);
+}
+
 function hasAnyPr(state: OrchestrationState): boolean {
   return state.agents.some((agent) => {
     const url = state.agentStates[agent.name]?.prUrl;
@@ -417,7 +436,86 @@ export function findPlanFiles(
   return { files, coderPlanExists };
 }
 
+/**
+ * Shared readiness check for `pr-comments → final-merge` in the non-upstream,
+ * non-duo-peer path. Extracted so the pair/duo main switch and the solo
+ * dispatcher cannot drift apart.
+ */
+export function prCommentsReadyForFinalMerge(state: OrchestrationState): boolean {
+  if (!hasAnyPr(state)) return false;
+
+  // Shortcut: coder has responded to PR comments — skip quiet period wait.
+  if (
+    state.prCommentsCoderDispatched
+    && allAgentsDone(state)
+    && state.prCommentsQuietSince
+    && !state.prCodexReviewDeferredSince
+  ) {
+    return true;
+  }
+
+  // Quiet-period advancement.
+  const quietPeriod = state.config.prCommentsTimeout;
+  if (
+    state.prCommentsQuietSince
+    && nowEpoch() - state.prCommentsQuietSince >= quietPeriod
+  ) {
+    return true;
+  }
+
+  return phaseTimeoutExpired(state);
+}
+
+/**
+ * Solo-mode transition dispatcher. Traverses a strict subset of `Phase`:
+ * setup → work → [update-docs?] → pr-create → pr-comments → final-merge → done.
+ * No reviewer participates; bail-out is the lone coder status signal.
+ * Phases outside this subset are unreachable in solo mode.
+ */
+function evaluateTransitionSolo(state: OrchestrationState): Phase | null {
+  // Bail-out short-circuits to done from any non-terminal solo phase.
+  if (isBailedOut(state) && state.phase !== "done") return "done";
+
+  switch (state.phase) {
+    case "setup":
+      return "work";
+
+    case "work":
+      if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (hasAnyPr(state)) return "pr-comments";
+      return "update-docs";
+
+    case "update-docs":
+      if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (hasAnyPr(state)) return "pr-comments";
+      return "pr-create";
+
+    case "pr-create":
+      if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      if (!hasAnyPr(state)) return null; // defense-in-depth: need a PR URL
+      return "pr-comments";
+
+    case "pr-comments":
+      // Solo skips suggest-refactor; a pre-merged agent goes straight to done.
+      if (isMerged(state)) return "done";
+      if (prCommentsReadyForFinalMerge(state)) return "final-merge";
+      return null;
+
+    case "final-merge":
+      if (allAgentsDone(state) || phaseTimeoutExpired(state)) return "done";
+      return null;
+
+    case "done":
+      return "done";
+
+    default:
+      // Defensive: solo should never visit review/plan/merge/gather/etc.
+      return null;
+  }
+}
+
 export function evaluateTransition(state: OrchestrationState): Phase | null {
+  if (state.mode === "solo") return evaluateTransitionSolo(state);
   switch (state.phase) {
     case "setup":
       return nextAfterPrework(state);
@@ -474,14 +572,14 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
 
     case "work":
       if (allAgentsDone(state) || phaseTimeoutExpired(state)) {
-        if (isPairBailedOut(state)) return "done";
+        if (isBailedOut(state)) return "done";
         return "review";
       }
       return null;
 
     case "review":
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
-      if (isPairBailedOut(state)) return "done";
+      if (isBailedOut(state)) return "done";
       {
         const reviewVerdict = pairReviewVerdict(state);
         if (reviewVerdict === "request_changes") return "work";
@@ -490,7 +588,7 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
 
     case "update-docs":
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
-      if (isPairBailedOut(state)) return "done";
+      if (isBailedOut(state)) return "done";
       if (hasAnyPr(state)) return "pr-comments";
       return "pr-create";
 
@@ -498,7 +596,7 @@ export function evaluateTransition(state: OrchestrationState): Phase | null {
       // NOTE: Runner verifies PR exists on GitHub before agents reach done state here.
       // See verifyPhaseOutcome() in runner.ts.
       if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
-      if (isPairBailedOut(state)) return "done";
+      if (isBailedOut(state)) return "done";
       if (!hasAnyPr(state)) return null; // Block advancement without a PR URL (defense in depth)
       return "pr-comments";
 

--- a/src/orchestration/runner.test.ts
+++ b/src/orchestration/runner.test.ts
@@ -2959,6 +2959,25 @@ describe("checkZeroCommitsAutoBailOut", () => {
     expect(eventSpy).not.toHaveBeenCalled();
   });
 
+  test("fast-paths to done for solo bail-out (single coder, no reviewer)", () => {
+    // Solo mode: lone coder "bail-out" must trigger the same fast-path to done
+    // that pair's coder+reviewer handshake triggers. Regression for task-da8b6dff.
+    const state = makeState({
+      phase: "pr-create",
+      mode: "solo",
+      duoPeerSlot: null,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "claude-sonnet-4-6", branch: "a", worktreePath: "/tmp/a" },
+      ],
+    });
+    state.agentStates = { coder: { ...state.agentStates.coder!, status: "bail-out" } };
+    const result = checkZeroCommitsAutoBailOut(state);
+    expect(result).toBe(true);
+    expect(state.phase).toBe("done");
+    // No event emitted — fast path doesn't re-emit
+    expect(eventSpy).not.toHaveBeenCalled();
+  });
+
   test("idempotent: event emitted only once on repeated calls", () => {
     const repoDir = makeGitRepo();
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1272,7 +1272,13 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
   if (next === "pr-comments") {
     resetPrCommentsState(state);
   }
-  if (state.phase === "review" && next === "update-docs" && !shouldRunUpdateDocs(state)) {
+  // Learning-gate bookkeeping: solo skips the review phase, so the gate fires on
+  // work → update-docs instead of review → update-docs.
+  if (
+    next === "update-docs"
+    && (state.phase === "review" || (state.mode === "solo" && state.phase === "work"))
+    && !shouldRunUpdateDocs(state)
+  ) {
     state.lastLearningAt = state.lastLearningAt ?? 0;
   }
   if ((state.phase === "update-docs" || state.phase === "review") && next === "work") {
@@ -1379,7 +1385,12 @@ export function maybePostCodexReviewRequests(
 }
 
 function maybeOverrideTransition(state: OrchestrationState, next: OrchestrationState["phase"] | null) {
-  if (state.phase === "review" && next === "update-docs" && !shouldRunUpdateDocs(state)) {
+  // Solo skips review: the work→update-docs override mirrors pair's review→update-docs.
+  if (
+    next === "update-docs"
+    && (state.phase === "review" || (state.mode === "solo" && state.phase === "work"))
+    && !shouldRunUpdateDocs(state)
+  ) {
     return state.agents.some((agent) => !!state.agentStates[agent.name]?.prUrl)
       ? "pr-comments"
       : "pr-create";

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -2,7 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFi
 import { join } from "path";
 import { emitEvent } from "../events.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
-import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isPairBailedOut, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
+import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
 import {
   clearInterrupt, readAgentStatus, readMarker, readPhaseToken, readPrUrl,
   statusFileFingerprint, touchStatusFile, writeInterrupt, writePeerSync,
@@ -1442,8 +1442,9 @@ export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean 
   const coder = state.agents.find(a => a.role === "coder");
   if (!coder) return false;
 
-  // Fast path: bail-out already confirmed by reviewer from an earlier phase.
-  if (isPairBailedOut(state)) {
+  // Fast path: bail-out already confirmed — pair contract (coder+reviewer) or
+  // solo contract (lone coder). Skip PR creation and transition directly to done.
+  if (isBailedOut(state)) {
     state.phase = "done";
     persistState(state);
     return true;

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -134,6 +134,33 @@ describe("skills", () => {
     expect(path.endsWith("pair-coder-work.md")).toBe(true);
   });
 
+  test("resolveTemplatePath: solo IGNORES hasUpstream (never picks upstream-*.md)", () => {
+    // Solo's phase graph never visits forward-pr and never writes upstream-pr /
+    // forwarded markers, so upstream-final-merge.md (which assumes those
+    // artifacts) would run the wrong workflow. Solo must fall through to the
+    // non-upstream tier regardless of hasUpstream.
+    const path = resolveTemplatePath("final-merge", "solo", "coder", true);
+    expect(path.endsWith("final-merge.md")).toBe(true);
+    expect(path).not.toContain("upstream");
+  });
+
+  test("resolveTemplatePath: solo with hasUpstream still prefers solo-<phase> for work", () => {
+    const path = resolveTemplatePath("work", "solo", "coder", true);
+    expect(path.endsWith("solo-work.md")).toBe(true);
+  });
+
+  test("resolveTemplatePath: pair + hasUpstream for final-merge falls through to generic (post-d1932b8f)", () => {
+    // After task-d1932b8f removed upstream-final-merge.md, pair mode with
+    // hasUpstream=true should fall through the generic `final-merge.md`.
+    // Companion to the solo test above: both modes now resolve to the same
+    // generic template for final-merge, but solo reaches it by skipping the
+    // upstream tier entirely while pair reaches it by having no upstream
+    // template on disk.
+    const path = resolveTemplatePath("final-merge", "pair", "coder", true);
+    expect(path.endsWith("final-merge.md")).toBe(true);
+    expect(path).not.toContain("upstream");
+  });
+
   test("substitutes placeholders", () => {
     const text = substituteTemplate("hello {{AGENT_NAME}} {{DONE_STATUS}}", baseCtx());
     expect(text).toContain("agent1");

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -101,6 +101,39 @@ describe("skills", () => {
     expect(path.endsWith("pair-reviewer-review.md")).toBe(true);
   });
 
+  test("resolveTemplatePath: solo/work resolves to solo-work.md (solo tier)", () => {
+    const path = resolveTemplatePath("work", "solo", "coder");
+    expect(path.endsWith("solo-work.md")).toBe(true);
+  });
+
+  test("resolveTemplatePath: solo/pr-create falls through to pair-coder-pr-create.md", () => {
+    const path = resolveTemplatePath("pr-create", "solo", "coder");
+    expect(path.endsWith("pair-coder-pr-create.md")).toBe(true);
+  });
+
+  test("resolveTemplatePath: solo/update-docs falls through to pair-coder-update-docs.md", () => {
+    const path = resolveTemplatePath("update-docs", "solo", "coder");
+    expect(path.endsWith("pair-coder-update-docs.md")).toBe(true);
+  });
+
+  test("resolveTemplatePath: solo/pr-comments falls through to generic pr-comments.md", () => {
+    const path = resolveTemplatePath("pr-comments", "solo", "coder");
+    expect(path.endsWith("pr-comments.md")).toBe(true);
+    expect(path).not.toContain("pair-coder");
+    expect(path).not.toContain("solo-");
+  });
+
+  test("resolveTemplatePath: solo/final-merge falls through to generic final-merge.md", () => {
+    const path = resolveTemplatePath("final-merge", "solo", "coder");
+    expect(path.endsWith("final-merge.md")).toBe(true);
+    expect(path).not.toContain("upstream");
+  });
+
+  test("resolveTemplatePath: pair/work still resolves to pair-coder-work.md (regression)", () => {
+    const path = resolveTemplatePath("work", "pair", "coder");
+    expect(path.endsWith("pair-coder-work.md")).toBe(true);
+  });
+
   test("substitutes placeholders", () => {
     const text = substituteTemplate("hello {{AGENT_NAME}} {{DONE_STATUS}}", baseCtx());
     expect(text).toContain("agent1");

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -154,16 +154,14 @@ export function resolveTemplatePath(
 ): string {
   const root = templateRoot();
   // Solo resolution: solo-<phase>.md > pair-coder-<phase>.md > <phase>.md
-  // (with upstream variants stacked ahead of each tier).
+  //
+  // Solo intentionally ignores `hasUpstream`. The upstream-* templates assume
+  // the forward-pr workflow (writing `*.upstream-pr`, `*.forwarded` markers,
+  // `*.upstream-merged` etc.) which solo's phase graph never enters —
+  // evaluateTransitionSolo does not visit `forward-pr` and does not consult
+  // state.upstreamRepo. Picking upstream-final-merge.md here would run the
+  // wrong workflow and stall the solo slot.
   if (mode === "solo") {
-    if (hasUpstream) {
-      const soloUp = join(root, `solo-upstream-${phase}.md`);
-      if (existsSync(soloUp)) return soloUp;
-      const pairCoderUp = join(root, `pair-coder-upstream-${phase}.md`);
-      if (existsSync(pairCoderUp)) return pairCoderUp;
-      const upstreamPath = join(root, `upstream-${phase}.md`);
-      if (existsSync(upstreamPath)) return upstreamPath;
-    }
     const soloPath = join(root, `solo-${phase}.md`);
     if (existsSync(soloPath)) return soloPath;
     const pairCoderPath = join(root, `pair-coder-${phase}.md`);

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -153,6 +153,25 @@ export function resolveTemplatePath(
   hasUpstream?: boolean,
 ): string {
   const root = templateRoot();
+  // Solo resolution: solo-<phase>.md > pair-coder-<phase>.md > <phase>.md
+  // (with upstream variants stacked ahead of each tier).
+  if (mode === "solo") {
+    if (hasUpstream) {
+      const soloUp = join(root, `solo-upstream-${phase}.md`);
+      if (existsSync(soloUp)) return soloUp;
+      const pairCoderUp = join(root, `pair-coder-upstream-${phase}.md`);
+      if (existsSync(pairCoderUp)) return pairCoderUp;
+      const upstreamPath = join(root, `upstream-${phase}.md`);
+      if (existsSync(upstreamPath)) return upstreamPath;
+    }
+    const soloPath = join(root, `solo-${phase}.md`);
+    if (existsSync(soloPath)) return soloPath;
+    const pairCoderPath = join(root, `pair-coder-${phase}.md`);
+    if (existsSync(pairCoderPath)) return pairCoderPath;
+    const genericPath = join(root, `${phase}.md`);
+    if (existsSync(genericPath)) return genericPath;
+    throw new Error(`missing orchestration template for solo:${phase}`);
+  }
   // Upstream-aware resolution: check upstream-specific templates first when upstream is configured.
   // Priority: pair-<role>-upstream-<phase>.md > upstream-<phase>.md > pair-<role>-<phase>.md > <phase>.md
   if (hasUpstream) {

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -148,7 +148,7 @@ function templateRoot(): string {
 
 export function resolveTemplatePath(
   phase: Phase,
-  mode: "duo" | "pair",
+  mode: "duo" | "pair" | "solo",
   role?: "coder" | "reviewer",
   hasUpstream?: boolean,
 ): string {

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -7,7 +7,7 @@ import type { Phase } from "./phases.ts";
 
 export interface OrchestrationRef {
   stateFile: string;
-  mode: "duo" | "pair";
+  mode: "duo" | "pair" | "solo";
   pid?: number;
 }
 
@@ -106,7 +106,7 @@ export interface OrchestrationConfig {
 export interface OrchestrationState {
   slot: number;
   taskId: string;
-  mode: "duo" | "pair";
+  mode: "duo" | "pair" | "solo";
   phase: Phase;
   round: number;
   mergeRound: number;
@@ -260,6 +260,14 @@ function migrateState(state: OrchestrationState, slot: number): OrchestrationSta
   }
   if (state.mode === "duo" && state.duoPeerSlot == null) {
     console.error(`ludics: slot ${slot} has legacy mode="duo" without duoPeerSlot — should be cleared and re-assigned`);
+  }
+  if (state.mode === "solo") {
+    if (state.duoPeerSlot != null) {
+      console.error(`ludics: slot ${slot} has mode="solo" with duoPeerSlot=${state.duoPeerSlot} — invariant violation (solo must be single-slot)`);
+    }
+    if (state.agents && state.agents.length !== 1) {
+      console.error(`ludics: slot ${slot} has mode="solo" with ${state.agents.length} agents — invariant violation (solo must have exactly one agent)`);
+    }
   }
   return state;
 }

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -254,7 +254,7 @@ function isWorkerContext(): boolean {
   }
 }
 
-function migrateState(state: OrchestrationState, slot: number): OrchestrationState {
+export function migrateState(state: OrchestrationState, slot: number): OrchestrationState {
   if (!state.taskId && (state as unknown as Record<string, unknown>).feature) {
     state.taskId = String((state as unknown as Record<string, unknown>).feature);
   }

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -46,6 +46,36 @@ describe("worktrees", () => {
 
     cleanupWorktrees(repo, "feat", [{ name: "agent1" }, { name: "agent2" }], 3);
   });
+
+  test("solo mode: single agent shares the root worktree (no sibling created)", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "repo-solo");
+    mkdirSync(repo, { recursive: true });
+    run(["git", "init", "-b", "main"], repo);
+    run(["git", "config", "user.email", "test@example.com"], repo);
+    run(["git", "config", "user.name", "Test User"], repo);
+    writeFileSync(join(repo, "README.md"), "hello\n");
+    run(["git", "add", "README.md"], repo);
+    run(["git", "commit", "-m", "init"], repo);
+
+    const setup = createWorktrees(repo, "solo-feat", [{ name: "coder" }], "main", 5, "solo");
+    expect(existsSync(setup.rootWorktree)).toBe(true);
+    // Coder's worktree is the root worktree (pair-style layout reused for solo)
+    expect(setup.agentWorktrees.coder).toBe(setup.rootWorktree);
+    // No per-agent sibling worktree: the duo-style path "<stem>-coder" must NOT exist.
+    const siblingPath = `${setup.rootWorktree}-coder`;
+    expect(existsSync(siblingPath)).toBe(false);
+    // Coder's branch equals the root branch
+    expect(setup.branches.coder).toBe(setup.branches.root);
+
+    // symlinkPeerSync deduplicates; only one .peer-sync symlink should exist (root)
+    mkdirSync(setup.peerSyncDir, { recursive: true });
+    symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
+    expect(existsSync(join(setup.rootWorktree, ".peer-sync"))).toBe(true);
+
+    cleanupWorktrees(repo, "solo-feat", [{ name: "coder" }], 5, "solo");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -170,7 +170,7 @@ export function createWorktrees(
   agents: Array<{ name: string }>,
   mainBranch: string = defaultMainBranch(projectDir),
   slot?: number,
-  mode: "duo" | "pair" = "duo",
+  mode: "duo" | "pair" | "solo" = "duo",
 ): WorktreeSetup {
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));
@@ -253,7 +253,7 @@ export function cleanupWorktrees(
   taskId: string,
   agents: Array<{ name: string }>,
   slot?: number,
-  mode: "duo" | "pair" = "duo",
+  mode: "duo" | "pair" | "solo" = "duo",
 ): void {
   const featureSlug = slugify(taskId);
   const parentDir = dirname(resolve(projectDir));

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -183,8 +183,9 @@ export function createWorktrees(
   addWorktree(projectDir, rootWorktree, branches.root, mainBranch);
 
   const agentWorktrees: Record<string, string> = {};
-  if (mode === "pair") {
-    // Pair mode: both agents share the root worktree and branch
+  if (mode === "pair" || mode === "solo") {
+    // Pair / solo: all agents share the root worktree and branch.
+    // Solo has a single agent; pair has coder + reviewer sharing one worktree.
     for (const agent of agents) {
       branches[agent.name] = branches.root;
       agentWorktrees[agent.name] = rootWorktree;

--- a/src/sessions/enrich.ts
+++ b/src/sessions/enrich.ts
@@ -20,7 +20,11 @@ function enrichFromT3codeSlots(): Map<string, Orchestration> {
 
     const orch = slotState.orchestration;
     // Map t3code orchestration modes to Orchestration type
-    const type = orch.mode === "pair" ? "t3code-pair" : "t3code-duo";
+    const type = orch.mode === "pair"
+      ? "t3code-pair"
+      : orch.mode === "solo"
+        ? "t3code-solo"
+        : "t3code-duo";
 
     for (const thread of slotState.threads) {
       const cwd = (thread.worktreePath ?? "").replace(/\/+$/, "");

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -389,6 +389,40 @@ describe("slot assign — direct orchestration flags", () => {
     writeSlotJson(2, emptySlotData(2), harness);
     await expect(runSlot(["1", "assign", "My task", "-a", "t3code", "--reviewer", "--plan"])).rejects.toThrow("got a flag instead");
   });
+
+  test("--solo shorthand preserved; no --pair auto-injection", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    await runSlot(["1", "assign", "My task", "-a", "t3code", "--solo", "--coder", "claude-code"]);
+    const args = readAdapterArgs();
+    expect(args).toBe("--solo --coder claude-code");
+    expect(args).not.toContain("--pair");
+  });
+
+  test("--solo via -A fragment preserved; no --pair auto-injection", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    await runSlot(["1", "assign", "My task", "-a", "t3code", "-A", "--solo --coder claude-code"]);
+    const args = readAdapterArgs();
+    expect(args).toContain("--solo");
+    expect(args).not.toContain("--pair");
+  });
+
+  test("--solo does not route through duo expansion (single-slot assign only)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    await runSlot(["1", "assign", "My task", "-a", "t3code", "--solo", "--coder", "claude-code"]);
+    // Slot 1 assigned; slot 2 must remain empty (no duo expansion)
+    const slot2 = readSlotJson(2, harness);
+    expect(slot2.process).toBe("(empty)");
+    expect(slot2.adapterArgs ?? "").toBe("");
+  });
 });
 
 describe("slotStart — t3code empty-args auto-fill", () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1258,6 +1258,10 @@ export async function runSlot(args: string[]): Promise<void> {
             hasDirectOrchFlags = true;
             adapterArgFragments.push("--duo");
             break;
+          case "--solo":
+            hasDirectOrchFlags = true;
+            adapterArgFragments.push("--solo");
+            break;
           case "--coder": {
             const val = args[++i];
             if (!val || val.startsWith("-")) throw new Error("--coder requires a provider value (got a flag instead)");
@@ -1284,11 +1288,11 @@ export async function runSlot(args: string[]): Promise<void> {
 
       if (hasDirectOrchFlags && adapter !== "t3code" && adapter !== "tmux") {
         throw new Error(
-          `--pair/--coder/--reviewer/--plan flags require adapter "t3code" or "tmux" (got "${adapter}")`
+          `--pair/--solo/--coder/--reviewer/--plan flags require adapter "t3code" or "tmux" (got "${adapter}")`
         );
       }
 
-      if (hasDirectOrchFlags || adapterArgFragments.some(f => /--(?:pair|duo)/.test(f))) {
+      if (hasDirectOrchFlags || adapterArgFragments.some(f => /--(?:pair|duo|solo)/.test(f))) {
         const expected = globalAdapter();
         if ((adapter === "t3code" || adapter === "tmux") && adapter !== expected) {
           throw new Error(
@@ -1326,9 +1330,9 @@ export async function runSlot(args: string[]): Promise<void> {
         slotAssign(secondSlot, taskOrDesc, adapter, "", path, expansion.slotB.args, machine);
         console.error(`ludics: duo assign → slots ${slotNum}+${secondSlot}`);
       } else {
-        const hasModeDirectFlag = adapterArgFragments.includes("--pair");
+        const hasModeDirectFlag = adapterArgFragments.includes("--pair") || adapterArgFragments.includes("--solo");
         const hasModeInRawFragments = adapterArgFragments.some(
-          f => /(?:^|\s)--(?:pair|duo)(?:\s|$)/.test(f)
+          f => /(?:^|\s)--(?:pair|duo|solo)(?:\s|$)/.test(f)
         );
         if (hasDirectOrchFlags && !hasModeDirectFlag && !hasModeInRawFragments && firstDirectOrchFlagIdx !== -1) {
           adapterArgFragments.splice(firstDirectOrchFlagIdx, 0, "--pair");

--- a/src/t3code/types.ts
+++ b/src/t3code/types.ts
@@ -238,7 +238,7 @@ export interface T3CodeThreadRecord {
 
 export interface T3CodeOrchestrationRef {
   stateFile: string;
-  mode: "duo" | "pair";
+  mode: "duo" | "pair" | "solo";
   pid?: number;
 }
 

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -451,3 +451,27 @@ describe("parseTaskFrontmatter skip_plan", () => {
     expect(fm.skip_plan).toBe(true);
   });
 });
+
+describe("parseTaskFrontmatter effort: tiny", () => {
+  test("parses effort: tiny as the string 'tiny'", () => {
+    const content = "---\nid: task-1\ntitle: Test\neffort: tiny\n---\n";
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.effort).toBe("tiny");
+  });
+
+  test("round-trips effort: tiny via readFrontmatterField", () => {
+    const content = "---\nid: task-1\ntitle: Test\neffort: tiny\n---\n\nbody\n";
+    expect(readFrontmatterField(content, "effort")).toBe("tiny");
+  });
+
+  test("updateFrontmatterField preserves effort: tiny on write", () => {
+    const tmpFile = `/tmp/ludics-tiny-roundtrip-${Date.now()}.md`;
+    const content = "---\nid: task-1\ntitle: Test\neffort: tiny\n---\n\nbody\n";
+    require("fs").writeFileSync(tmpFile, content);
+    // Update an unrelated field; verify effort stays "tiny"
+    updateFrontmatterField(tmpFile, "priority", "A");
+    const after = require("fs").readFileSync(tmpFile, "utf-8");
+    expect(readFrontmatterField(after, "effort")).toBe("tiny");
+    require("fs").unlinkSync(tmpFile);
+  });
+});

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -13,7 +13,7 @@ export interface TaskFrontmatter {
     relates_to: string[];
     subtask_of: string | null;
   };
-  effort: string; // small, medium, large
+  effort: string; // tiny, small, medium, large
   skip_plan?: boolean;
   requirements?: { os?: string; gpu?: string };
   context: string;


### PR DESCRIPTION
## Summary

- Introduce a new workflow mode **`solo`** alongside `duo`/`pair`: a single coder agent runs `setup → work → [update-docs?] → pr-create → pr-comments → final-merge → done`. No reviewer, no review loop, no `suggest-refactor`.
- Introduce a new effort level **`tiny`** below `small`. Tasks with `effort: tiny` auto-select `solo` mode (Sonnet coder, no pre-work phases) unconditionally, regardless of `orchCfg.default_mode`.
- The two mechanisms are independent: `--solo` works at any effort; `tiny` with explicit `-A "--pair …"` is legal.

## Highlights

- **Mode union widened** to `"duo" | "pair" | "solo"` across 9 type/function signatures; compiler-driven fan-out caught every call site.
- **Phase graph**: solo-mode dispatcher (`evaluateTransitionSolo`) at the top of `evaluateTransition`; the pair/duo switch is untouched. `Phase` enum is unchanged — solo traverses a subset.
- **Agent participation**: top-level short-circuit `if (mode === "solo") return agent.role === "coder"`.
- **Bail-out**: new `isSoloBailedOut` helper, `isBailedOut` wrapper; all 6 `isPairBailedOut` call sites (5 in `phases.ts`, 1 in `runner.ts:checkZeroCommitsAutoBailOut`) now use `isBailedOut`. Pair contract (coder + reviewer handshake) unchanged.
- **Adapter parsing**: `--solo` accepts `--coder`, rejects `--reviewer`, `--duo-peer-slot`, and all reviewer-only override flags (`--reviewer-model`, `--reviewer-effort`, `--reviewer-thinking-effort`). Shared `--effort` still accepted.
- **Worktree layout**: solo reuses pair-style shared root worktree (no per-agent sibling).
- **Templates**: `resolveTemplatePath` for solo is `solo-<phase>.md > pair-coder-<phase>.md > <phase>.md`. Only `solo-work.md` is new — `pair-coder-{pr-create,update-docs}.md` are already reviewer-free (grep-verified) so the fallback is safe.
- **Runner**: solo's `work → update-docs` learning gate added to `maybeOverrideTransition` and the side-effect bookkeeping, mirroring pair's `review → update-docs`.
- **Briefing**: renamed "Active Unconcluded Agent-Duo Slots" → "Active Unconcluded Slots" (mode-agnostic).
- **Docs**: `docs/ARCHITECTURE.md` updated in 6 places (mode union snippet, peer-sync file comment, flag paragraph, orchestrated-mode example, argument parsing block, template inventory); tmux adapter help text now lists `--solo --coder` alongside the pair form.

## Proposal

Full scope and acceptance criteria: [`docs/proposals/solo-mode-and-tiny-effort.md`](docs/proposals/solo-mode-and-tiny-effort.md). All 7 elaboration questions were resolved by the user on 2026-04-22 and are implemented as specified.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 1023 pass / 3 fail (the 3 are pre-existing baseline failures unrelated to orchestration modes/effort; same 3 failed before this branch started)
- [x] 54 new tests added across 8 files (`phases`, `skills`, `worktrees`, `t3code`, `tmux-adapter`, `runner`, `tasks/markdown`, `slots/index`)
- [x] Parser CLI repros re-verified: `--solo --coder claude-code --reviewer-model X` now throws; `--solo --coder claude-code --effort high` still works
- [ ] Exercise a live `--solo` orchestration end-to-end (not done in this PR — solo runs single-slot and doesn't interact with cross-slot merge, but a smoke run would confirm the full `setup → work → pr-create → pr-comments → final-merge → done` path)

## Sequencing notes

- `task-d1932b8f` (remove `forward-pr` / `upstream-final-merge`) has NOT landed. Solo's graph models skipping both explicitly; when d1932b8f merges, those skip-branches collapse to natural fall-through — mechanical merge.
- `task-21b4c850` (principles-with-rationale template refactor) has NOT landed. `solo-work.md` is written in the current terse-instructional style; if/when 21b4c850 merges first, solo-work.md should get the same style pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)