### PR TITLE
feat(dashboard): task.html renderer and task-link migration

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -366,6 +366,73 @@ describe("deferred-launch sorting", () => {
   });
 });
 
+describe("tasks-tree link renders task.html", () => {
+  function writeTask(id: string, title: string, overrides: string = ""): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nstatus: in-progress\npriority: B\ncreated: "2026-04-10"\ncontext: ludics\n${overrides}---\n\n# ${title}\n`,
+    );
+  }
+
+  function collectTaskNodes(nodes: unknown[]): Record<string, unknown>[] {
+    const out: Record<string, unknown>[] = [];
+    const walk = (arr: unknown[]): void => {
+      for (const n of arr) {
+        if (!n || typeof n !== "object") continue;
+        const node = n as Record<string, unknown>;
+        if (node.kind === "task") out.push(node);
+        if (Array.isArray(node.children)) walk(node.children as unknown[]);
+      }
+    };
+    walk(nodes);
+    return out;
+  }
+
+  test("task tree link points to /task.html?task=ID, not raw markdown", async () => {
+    writeTask("task-abc123", "Example task");
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      dashboardGenerate();
+    } finally {
+      console.error = origErr;
+    }
+
+    const outFile = join(harnessDir(), "dashboard", "data", "tasks-tree.json");
+    const tree = JSON.parse(readFileSync(outFile, "utf-8")) as unknown[];
+    const tasks = collectTaskNodes(tree);
+    const task = tasks.find((t) => t.id === "task-abc123");
+    expect(task).toBeDefined();
+    expect(task!.link).toBe("/task.html?task=task-abc123");
+    // Regression guard: must not link to raw markdown endpoint.
+    expect(String(task!.link)).not.toContain("/task-files/");
+  });
+
+  test("task IDs are URL-encoded in the generated link", async () => {
+    writeTask("task-with space", "Needs encoding");
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      dashboardGenerate();
+    } finally {
+      console.error = origErr;
+    }
+
+    const outFile = join(harnessDir(), "dashboard", "data", "tasks-tree.json");
+    const tree = JSON.parse(readFileSync(outFile, "utf-8")) as unknown[];
+    const tasks = collectTaskNodes(tree);
+    const task = tasks.find((t) => t.id === "task-with space");
+    expect(task).toBeDefined();
+    expect(task!.link).toBe("/task.html?task=task-with%20space");
+  });
+});
+
 // Note: /api/slot-resume follows the exact same pattern as /api/slot-start
 // (validate slot 1-6, spawnSync `ludics slot N resume`, return OK/error).
 // slotResume() itself is already tested in src/slots/index.test.ts.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -645,7 +645,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
     const hasActiveProposal = task.hasProposal && !task.isCompleted;
     const subtreeHasActiveProposal = hasActiveProposal || descendantHasActiveProposal;
     const highlighted = !task.isCompleted && subtreeHasActiveProposal;
-    const taskFileLink = `/task-files/${encodeURIComponent(task.id)}.md`;
+    const taskFileLink = `/task.html?task=${encodeURIComponent(task.id)}`;
     const proposalLink = task.proposalPath ? `/proposal.html?task=${encodeURIComponent(task.id)}` : null;
     const retroLink = task.hasRetrospective ? `retrospective.html?task=${encodeURIComponent(task.id)}` : null;
 

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -598,7 +598,7 @@ function fetchNeedsConfirmation() {
             return `
             <li class="needs-confirm-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title needs-confirm-link" href="task.html?task=${escapeHtml(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
+                <a class="task-title needs-confirm-link" href="task.html?task=${encodeURIComponent(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
                 <span class="confirm-actions">
                     <button class="confirm-btn" onclick="confirmTask('${escapeHtml(task.id)}')" title="Confirm: move to ready">&#x2713;</button>
                     <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
@@ -619,7 +619,7 @@ function fetchUnansweredQuestions() {
             return `
             <li class="unanswered-q-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title unanswered-q-link" href="task.html?task=${escapeHtml(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
+                <a class="task-title unanswered-q-link" href="task.html?task=${encodeURIComponent(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
             </li>`;
         },
     });

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -598,7 +598,7 @@ function fetchNeedsConfirmation() {
             return `
             <li class="needs-confirm-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title needs-confirm-link" href="task-files/${escapeHtml(task.id)}.md" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
+                <a class="task-title needs-confirm-link" href="task.html?task=${escapeHtml(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
                 <span class="confirm-actions">
                     <button class="confirm-btn" onclick="confirmTask('${escapeHtml(task.id)}')" title="Confirm: move to ready">&#x2713;</button>
                     <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
@@ -619,7 +619,7 @@ function fetchUnansweredQuestions() {
             return `
             <li class="unanswered-q-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title unanswered-q-link" href="task-files/${escapeHtml(task.id)}.md" target="_blank">${escapeHtml(task.title || task.id)}</a>
+                <a class="task-title unanswered-q-link" href="task.html?task=${escapeHtml(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
             </li>`;
         },
     });
@@ -635,7 +635,7 @@ function fetchDeferredLaunch() {
             const priorityClass = `priority-${priority}`;
             const viewLink = task.hasProposal
                 ? `proposal.html?task=${encodeURIComponent(task.id)}`
-                : `task-files/${encodeURIComponent(task.id)}.md`;
+                : `task.html?task=${encodeURIComponent(task.id)}`;
             return `
             <li class="deferred-launch-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>

--- a/templates/dashboard/task.html
+++ b/templates/dashboard/task.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ludics Task</title>
+    <script>document.documentElement.dataset.theme=localStorage.getItem('ludics-theme')||'night'</script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="content.css">
+</head>
+<body>
+    <header>
+        <div class="nav-links">
+            <h1>ludics</h1>
+            <a href="index.html">Dashboard</a>
+            <a href="mag.html">Mag</a>
+            <a href="#" id="t3code-link">t3code</a>
+            <a href="terminals.html">Terminals</a>
+            <a href="ntfy.html">ntfy</a>
+            <a href="tasks.html">Tasks</a>
+            <a href="briefing.html">Briefing</a>
+        </div>
+        <div class="status-bar">
+            <span id="last-update">Last update: --</span>
+            <span id="connection-status" class="connected">Connected</span>
+        </div>
+    </header>
+    <script src="nav.js"></script>
+
+    <main class="content-container">
+        <div class="content-header">
+            <span class="proposal-task-id" id="task-task-id"></span>
+            <span class="task-header-badges" id="task-header-badges"></span>
+        </div>
+        <div class="retro-links" id="task-links" hidden></div>
+        <div class="rendered-content" id="task-content">
+            <div class="content-placeholder">
+                <span class="icon">&#x1F4C4;</span>
+                <span class="text">Loading task...</span>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <p>ludics v0.1 | <a href="https://github.com/lukstafi/ludics">GitHub</a></p>
+    </footer>
+
+    <script src="markdown.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const taskId = params.get('task') || '';
+
+        if (taskId) {
+            document.title = `ludics Task: ${taskId}`;
+            const taskIdEl = document.getElementById('task-task-id');
+            if (taskIdEl) taskIdEl.textContent = taskId;
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            fetchTask();
+        });
+
+        // Strip leading YAML frontmatter (between two --- fences) and return
+        // { frontmatter: string, body: string }. If there is no frontmatter, the
+        // frontmatter is empty and body is the original input.
+        function splitFrontmatter(text) {
+            const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)*/);
+            if (!match) return { frontmatter: '', body: text };
+            return { frontmatter: match[1], body: text.slice(match[0].length) };
+        }
+
+        // Parse a minimal YAML frontmatter, extracting only top-level scalar
+        // keys (string/number/null). Nested blocks are skipped. This is
+        // sufficient for the fields we display: status, priority, project,
+        // proposal. Quoted values have their surrounding quotes stripped.
+        function parseFrontmatter(yaml) {
+            const result = {};
+            if (!yaml) return result;
+            const lines = yaml.split(/\r?\n/);
+            for (const line of lines) {
+                // Skip comments and empty lines
+                if (!line || /^\s*#/.test(line)) continue;
+                // Skip indented lines (nested values)
+                if (/^\s/.test(line)) continue;
+                const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+                if (!m) continue;
+                const key = m[1];
+                let value = m[2].trim();
+                // Strip inline comments
+                if (!/^["']/.test(value)) {
+                    const hashIdx = value.indexOf(' #');
+                    if (hashIdx >= 0) value = value.slice(0, hashIdx).trim();
+                }
+                // Empty value means the key opens a block; skip it.
+                if (value === '') continue;
+                // Normalize null
+                if (value === 'null' || value === '~') { result[key] = null; continue; }
+                // Strip matching quotes
+                if ((value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+                    (value.startsWith("'") && value.endsWith("'") && value.length >= 2)) {
+                    value = value.slice(1, -1);
+                }
+                result[key] = value;
+            }
+            return result;
+        }
+
+        function renderBadges(meta) {
+            const container = document.getElementById('task-header-badges');
+            if (!container) return;
+            const parts = [];
+            if (meta.status) parts.push(`<span class="task-badge">${escapeHtml(String(meta.status))}</span>`);
+            if (meta.priority) parts.push(`<span class="task-badge">P${escapeHtml(String(meta.priority))}</span>`);
+            if (meta.project) parts.push(`<span class="task-badge">${escapeHtml(String(meta.project))}</span>`);
+            container.innerHTML = parts.join(' ');
+        }
+
+        function renderLinks(meta) {
+            const container = document.getElementById('task-links');
+            if (!container) return;
+            const links = [];
+            if (meta.proposal) {
+                links.push(`<a href="proposal.html?task=${encodeURIComponent(taskId)}">View Proposal</a>`);
+            }
+            if (links.length === 0) {
+                container.hidden = true;
+                container.innerHTML = '';
+                return;
+            }
+            container.hidden = false;
+            container.innerHTML = links.join('');
+        }
+
+        async function fetchTask() {
+            const container = document.getElementById('task-content');
+            if (!container) return;
+
+            if (!taskId) {
+                container.innerHTML = `
+                    <div class="content-placeholder">
+                        <span class="icon">&#x1F4C4;</span>
+                        <span class="text">No task specified</span>
+                        <span class="hint">Use ?task=TASK-ID in the URL</span>
+                    </div>
+                `;
+                return;
+            }
+
+            try {
+                const response = await fetch(`/task-files/${encodeURIComponent(taskId)}.md`);
+                if (response.status === 404) {
+                    container.innerHTML = `
+                        <div class="content-placeholder">
+                            <span class="icon">&#x1F4C4;</span>
+                            <span class="text">Task file not found</span>
+                            <span class="hint">No task file available for ${escapeHtml(taskId)}</span>
+                        </div>
+                    `;
+                    setConnectionStatus(true);
+                    updateTimestamp();
+                    return;
+                }
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const text = await response.text();
+                const { frontmatter, body } = splitFrontmatter(text);
+                const meta = parseFrontmatter(frontmatter);
+                renderBadges(meta);
+                renderLinks(meta);
+                container.innerHTML = markdownToHtml(body);
+                updateTimestamp();
+                setConnectionStatus(true);
+            } catch (error) {
+                console.warn('Failed to fetch task:', error);
+                container.innerHTML = `
+                    <div class="content-placeholder">
+                        <span class="icon">&#x26A0;</span>
+                        <span class="text">Failed to load task</span>
+                        <span class="hint">${escapeHtml(String(error))}</span>
+                    </div>
+                `;
+                setConnectionStatus(false);
+            }
+        }
+
+        function updateTimestamp() {
+            const el = document.getElementById('last-update');
+            if (el) {
+                el.textContent = `Last update: ${new Date().toLocaleTimeString()}`;
+            }
+        }
+
+        function setConnectionStatus(connected) {
+            const el = document.getElementById('connection-status');
+            if (el) {
+                el.className = connected ? 'connected' : 'disconnected';
+                el.textContent = connected ? 'Connected' : 'Disconnected';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/templates/dashboard/task.test.ts
+++ b/templates/dashboard/task.test.ts
@@ -185,16 +185,26 @@ describe("dashboard.js task links", () => {
   const templatePath = join(import.meta.dir, "dashboard.js");
   const template = readFileSync(templatePath, "utf-8");
 
-  test("needs-confirmation link points to task.html", () => {
-    expect(template).toContain('needs-confirm-link" href="task.html?task=${escapeHtml(task.id)}"');
+  test("needs-confirmation link points to task.html with URL-encoded id", () => {
+    expect(template).toContain('needs-confirm-link" href="task.html?task=${encodeURIComponent(task.id)}"');
   });
 
-  test("unanswered-questions link points to task.html", () => {
-    expect(template).toContain('unanswered-q-link" href="task.html?task=${escapeHtml(task.id)}"');
+  test("unanswered-questions link points to task.html with URL-encoded id", () => {
+    expect(template).toContain('unanswered-q-link" href="task.html?task=${encodeURIComponent(task.id)}"');
   });
 
   test("deferred-launch fallback points to task.html (not raw markdown)", () => {
     expect(template).toContain("`task.html?task=${encodeURIComponent(task.id)}`");
+  });
+
+  test("task-link query params use encodeURIComponent, never escapeHtml", () => {
+    // Regression guard: escapeHtml(id) protects against attribute injection
+    // but does NOT percent-encode URL-delimiter characters like `&`, `#`,
+    // `?`, or `+`. A task id containing any of those would break query-param
+    // parsing on task.html. Only encodeURIComponent is safe here. (Both
+    // approaches are safe for attribute-escaping because encodeURIComponent
+    // also percent-encodes `"`, `'`, `<`, `>`, and `&`.)
+    expect(template).not.toMatch(/task\.html\?task=\$\{escapeHtml\(task\.id\)\}/);
   });
 
   test("no raw task-files/ links remain in client-side rendering", () => {

--- a/templates/dashboard/task.test.ts
+++ b/templates/dashboard/task.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression tests for the task.html renderer and dashboard.js task links.
+ *
+ * These tests re-implement the frontmatter handling inline (like
+ * dashboard.test.ts does for the pending-action badge) so the same logic
+ * can be verified without a browser. They also guard the dashboard.js
+ * template against reintroducing raw task-files/ links.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function splitFrontmatter(text: string): { frontmatter: string; body: string } {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)*/);
+  if (!match) return { frontmatter: "", body: text };
+  return { frontmatter: match[1], body: text.slice(match[0].length) };
+}
+
+function parseFrontmatter(yaml: string): Record<string, string | null> {
+  const result: Record<string, string | null> = {};
+  if (!yaml) return result;
+  const lines = yaml.split(/\r?\n/);
+  for (const line of lines) {
+    if (!line || /^\s*#/.test(line)) continue;
+    if (/^\s/.test(line)) continue;
+    const m = line.match(/^([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let value = m[2].trim();
+    if (!/^["']/.test(value)) {
+      const hashIdx = value.indexOf(" #");
+      if (hashIdx >= 0) value = value.slice(0, hashIdx).trim();
+    }
+    if (value === "") continue;
+    if (value === "null" || value === "~") {
+      result[key] = null;
+      continue;
+    }
+    if (
+      (value.startsWith('"') && value.endsWith('"') && value.length >= 2) ||
+      (value.startsWith("'") && value.endsWith("'") && value.length >= 2)
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+describe("splitFrontmatter", () => {
+  test("extracts YAML frontmatter and returns body without it", () => {
+    const input = "---\nid: task-1\nstatus: in-progress\n---\n\n# Title\n\nBody text\n";
+    const { frontmatter, body } = splitFrontmatter(input);
+    expect(frontmatter).toBe("id: task-1\nstatus: in-progress");
+    expect(body).toBe("# Title\n\nBody text\n");
+  });
+
+  test("returns empty frontmatter and original body when no fence is present", () => {
+    const input = "# Just markdown\n\nNo frontmatter here.\n";
+    const { frontmatter, body } = splitFrontmatter(input);
+    expect(frontmatter).toBe("");
+    expect(body).toBe(input);
+  });
+
+  test("handles CRLF line endings", () => {
+    const input = "---\r\nid: task-crlf\r\n---\r\nBody\r\n";
+    const { frontmatter, body } = splitFrontmatter(input);
+    expect(frontmatter).toBe("id: task-crlf");
+    expect(body).toBe("Body\r\n");
+  });
+
+  test("does not strip a --- that appears only mid-document", () => {
+    const input = "# Heading\n\n---\n\nSome text after hr\n";
+    const { frontmatter, body } = splitFrontmatter(input);
+    expect(frontmatter).toBe("");
+    expect(body).toBe(input);
+  });
+});
+
+describe("parseFrontmatter", () => {
+  test("extracts scalar keys used by the renderer", () => {
+    const yaml = 'id: task-1\nstatus: in-progress\npriority: B\nproject: Ludics\nproposal: docs/proposals/task-1.md';
+    const meta = parseFrontmatter(yaml);
+    expect(meta.status).toBe("in-progress");
+    expect(meta.priority).toBe("B");
+    expect(meta.project).toBe("Ludics");
+    expect(meta.proposal).toBe("docs/proposals/task-1.md");
+  });
+
+  test("strips surrounding single and double quotes", () => {
+    const yaml = `title: "Task with spaces"\ncontext: 'Ludics'`;
+    const meta = parseFrontmatter(yaml);
+    expect(meta.title).toBe("Task with spaces");
+    expect(meta.context).toBe("Ludics");
+  });
+
+  test("recognises null and ~ as null", () => {
+    const yaml = "deadline: null\ncompleted: ~";
+    const meta = parseFrontmatter(yaml);
+    expect(meta.deadline).toBeNull();
+    expect(meta.completed).toBeNull();
+  });
+
+  test("skips nested block children (indented lines)", () => {
+    const yaml = "dependencies:\n  blocks: []\n  blocked_by: []\nstatus: ready";
+    const meta = parseFrontmatter(yaml);
+    // The `dependencies:` line has no scalar value (opens a block) and is skipped.
+    expect(meta.dependencies).toBeUndefined();
+    expect(meta.blocks).toBeUndefined();
+    expect(meta.blocked_by).toBeUndefined();
+    expect(meta.status).toBe("ready");
+  });
+
+  test("ignores comment and blank lines", () => {
+    const yaml = "# header comment\n\nstatus: ready\n# trailing comment";
+    const meta = parseFrontmatter(yaml);
+    expect(meta.status).toBe("ready");
+  });
+
+  test("round-trip: split then parse yields the expected fields", () => {
+    const raw = [
+      "---",
+      "id: task-round-trip",
+      'title: "Round trip"',
+      "status: in-progress",
+      "priority: A",
+      "project: Ludics",
+      "proposal: docs/proposals/task-round-trip.md",
+      "dependencies:",
+      "  blocks: []",
+      "  blocked_by: []",
+      "---",
+      "",
+      "# Round trip",
+      "",
+      "Body content.",
+      "",
+    ].join("\n");
+
+    const { frontmatter, body } = splitFrontmatter(raw);
+    const meta = parseFrontmatter(frontmatter);
+    expect(meta.id).toBe("task-round-trip");
+    expect(meta.title).toBe("Round trip");
+    expect(meta.status).toBe("in-progress");
+    expect(meta.priority).toBe("A");
+    expect(meta.project).toBe("Ludics");
+    expect(meta.proposal).toBe("docs/proposals/task-round-trip.md");
+    expect(body).toContain("# Round trip");
+    expect(body).toContain("Body content.");
+    // The frontmatter fence itself must not leak into the body.
+    expect(body.startsWith("---")).toBe(false);
+  });
+});
+
+describe("task.html template", () => {
+  const templatePath = join(import.meta.dir, "task.html");
+  const template = readFileSync(templatePath, "utf-8");
+
+  test("fetches from the /task-files/ endpoint", () => {
+    expect(template).toContain("/task-files/${encodeURIComponent(taskId)}.md");
+  });
+
+  test("calls markdownToHtml on the stripped body", () => {
+    expect(template).toContain("markdownToHtml(body)");
+  });
+
+  test("renders status, priority, and project badges", () => {
+    expect(template).toContain("meta.status");
+    expect(template).toContain("meta.priority");
+    expect(template).toContain("meta.project");
+  });
+
+  test("links back to the proposal renderer when frontmatter has a proposal field", () => {
+    expect(template).toContain("proposal.html?task=");
+    expect(template).toContain("meta.proposal");
+  });
+
+  test("sets the document title to include the task ID", () => {
+    expect(template).toContain("ludics Task: ${taskId}");
+  });
+});
+
+describe("dashboard.js task links", () => {
+  const templatePath = join(import.meta.dir, "dashboard.js");
+  const template = readFileSync(templatePath, "utf-8");
+
+  test("needs-confirmation link points to task.html", () => {
+    expect(template).toContain('needs-confirm-link" href="task.html?task=${escapeHtml(task.id)}"');
+  });
+
+  test("unanswered-questions link points to task.html", () => {
+    expect(template).toContain('unanswered-q-link" href="task.html?task=${escapeHtml(task.id)}"');
+  });
+
+  test("deferred-launch fallback points to task.html (not raw markdown)", () => {
+    expect(template).toContain("`task.html?task=${encodeURIComponent(task.id)}`");
+  });
+
+  test("no raw task-files/ links remain in client-side rendering", () => {
+    // Regression guard: the original plan moved all three link patterns off
+    // `task-files/` to `task.html`. If a new link is introduced later, this
+    // test flags it so the migration stays exhaustive.
+    expect(template).not.toMatch(/href="task-files\//);
+    expect(template).not.toMatch(/`task-files\//);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `templates/dashboard/task.html`, a client-side renderer analogous to `proposal.html`/`retrospective.html`. Fetches from the existing `/task-files/ID.md` endpoint, strips YAML frontmatter, renders the body through `markdownToHtml()`, and displays `status`/`priority`/`project` as badges plus a "View Proposal" link when the frontmatter names one.
- Routes the Tasks-tree link (`generateTasksTree()` in `src/dashboard.ts`) and three `dashboard.js` panels (Needs Confirmation, Unanswered Questions, Deferred Launch fallback) through `task.html?task=ID` instead of the raw `/task-files/ID.md` endpoint. The server endpoint is unchanged.
- Ships regression tests: `src/dashboard.test.ts` verifies `tasks-tree.json` uses `/task.html?task=ID` with URL-encoded IDs; `templates/dashboard/task.test.ts` covers `splitFrontmatter`/`parseFrontmatter` (including a round-trip fidelity test) and guards `dashboard.js` against reintroducing raw `task-files/` links.

Closes task-c5937037.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test templates/dashboard/task.test.ts` (19 pass)
- [x] `bun test src/dashboard.test.ts` (new tests pass; 2 pre-existing `generateRecentlyCompleted` failures confirmed unrelated via `git stash` baseline)
- [ ] Manual: `ludics dashboard install && ludics dashboard generate && ludics dashboard serve`, open `/task.html?task=<some-id>` and confirm badges, frontmatter-stripped body, and proposal link render; click a Tasks-tree row and a Needs-Confirmation / Unanswered-Questions / Deferred-Launch item and confirm each opens the renderer, not raw markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)