### PR TITLE
fix(mag): timestamp-guard settled sentinel from stop-hook aftermath race

### DIFF
--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -532,10 +532,31 @@ describe("stale settled sentinel detection", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  function clearStaleSettled(currentHash: string | null): boolean {
+  // Mirror of the production clearStaleSettled() in src/mag.ts, with "now" and
+  // grace window parameterized so tests can drive the timestamp guard
+  // deterministically. Default grace of 90s matches the production default
+  // (keepalive_interval=60s × 1.5).
+  function clearStaleSettled(
+    currentHash: string | null,
+    opts: { nowMs?: number; graceMs?: number } = {},
+  ): boolean {
+    const nowMs = opts.nowMs ?? Date.now();
+    const graceMs = opts.graceMs ?? 90_000;
+
     const sentinelPath = join(tmpDir, "settled");
     const hashPath = join(tmpDir, "last-pane.hash");
     if (!existsSync(sentinelPath)) return false;
+
+    // Timestamp guard (mirrors production)
+    try {
+      const content = readFileSync(sentinelPath, "utf-8").trim();
+      const epoch = parseInt(content, 10);
+      if (Number.isFinite(epoch) && epoch > 0) {
+        const ageMs = nowMs - epoch * 1000;
+        if (ageMs < graceMs) return false;
+      }
+    } catch { /* fall through */ }
+
     if (currentHash === null) return false;
     let previousHash: string | null = null;
     try { previousHash = readFileSync(hashPath, "utf-8").trim() || null; } catch {}
@@ -548,6 +569,10 @@ describe("stale settled sentinel detection", () => {
     }
     return false;
   }
+
+  // Existing tests seed sentinel content "1234" (epoch 1970-01-01) — that age
+  // is trivially past the 90s grace window under any realistic Date.now(), so
+  // the new guard does not short-circuit these cases.
 
   test("clears settled when pane hash has changed", () => {
     writeFileSync(join(tmpDir, "settled"), "1234");
@@ -583,5 +608,68 @@ describe("stale settled sentinel detection", () => {
     const cleared = clearStaleSettled(null);
     expect(cleared).toBe(false);
     expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+  });
+
+  // gh-ludics-308: timestamp-guard regression tests
+
+  test("keeps settled when sentinel is young despite hash change", () => {
+    const now = Date.now();
+    writeFileSync(join(tmpDir, "settled"), String(Math.floor(now / 1000)));
+    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
+    const cleared = clearStaleSettled("newhash", { nowMs: now });
+    expect(cleared).toBe(false);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    // Prior hash is untouched — guard returns before any write
+    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("oldhash");
+  });
+
+  test("clears settled when sentinel is old and hash changed", () => {
+    const now = Date.now();
+    const oldEpoch = Math.floor((now - 5 * 60_000) / 1000); // 5 minutes ago
+    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
+    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
+    const cleared = clearStaleSettled("newhash", { nowMs: now });
+    expect(cleared).toBe(true);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(false);
+    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("newhash");
+  });
+
+  test("keeps settled when sentinel is old but hash unchanged", () => {
+    const now = Date.now();
+    const oldEpoch = Math.floor((now - 5 * 60_000) / 1000);
+    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
+    writeFileSync(join(tmpDir, "last-pane.hash"), "samehash");
+    const cleared = clearStaleSettled("samehash", { nowMs: now });
+    expect(cleared).toBe(false);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+  });
+
+  test("keeps settled on first observation regardless of sentinel age", () => {
+    const now = Date.now();
+    const oldEpoch = Math.floor((now - 5 * 60_000) / 1000);
+    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
+    // No prior hash written
+    const cleared = clearStaleSettled("firsthash", { nowMs: now });
+    expect(cleared).toBe(false);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("firsthash");
+  });
+
+  test("respects non-default keepalive interval (grace scales)", () => {
+    const now = Date.now();
+    // Sentinel written 100 seconds ago
+    const epoch = Math.floor((now - 100_000) / 1000);
+    writeFileSync(join(tmpDir, "settled"), String(epoch));
+    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
+
+    // keepalive_interval=120 → grace=180s → 100s is still within grace
+    const keptWithLargerGrace = clearStaleSettled("newhash", { nowMs: now, graceMs: 180_000 });
+    expect(keptWithLargerGrace).toBe(false);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+
+    // keepalive_interval=40 → grace=60s → 100s is past grace, clears on hash change
+    const clearedWithSmallerGrace = clearStaleSettled("newhash", { nowMs: now, graceMs: 60_000 });
+    expect(clearedWithSmallerGrace).toBe(true);
+    expect(existsSync(join(tmpDir, "settled"))).toBe(false);
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -184,9 +184,22 @@ function isMagReady(): boolean {
 /**
  * If pane output has advanced since the settled sentinel was written,
  * Mag has resumed running (e.g. a manual turn) — clear the stale sentinel.
+ *
+ * Grace window: a freshly written sentinel is protected for
+ * `keepalive_interval * 1.5` seconds. The stop hook's own response text keeps
+ * rendering into the pane after markMagSettled(), so without this guard the
+ * next keepalive tick would see a hash change and clear the sentinel before
+ * maybeFeedMagQueue could claim it for instant delivery (gh-ludics-308).
  */
 function clearStaleSettled(): void {
   if (!isMagSettled()) return;
+
+  const settledEpoch = readEpochFile(settledSentinelFile());
+  if (settledEpoch !== null) {
+    const ageMs = Date.now() - settledEpoch * 1000;
+    if (ageMs < keepaliveIntervalMs() * 1.5) return;
+  }
+
   const currentHash = captureLastMessageHash(MAG_SESSION_NAME);
   if (currentHash === null) return;
   const previousHash = readPaneHash();
@@ -210,6 +223,14 @@ function stallThresholdMs(): number {
   const configured = Number(mag?.stall_threshold_seconds);
   if (Number.isFinite(configured) && configured > 0) return configured * 1000;
   return DEFAULT_STALL_THRESHOLD_MS;
+}
+
+function keepaliveIntervalMs(): number {
+  const config = loadConfigSync();
+  const mag = config.mag as Record<string, unknown> | undefined;
+  const configured = Number(mag?.keepalive_interval);
+  if (Number.isFinite(configured) && configured > 0) return configured * 1000;
+  return 60_000; // matches templates/launchd and templates/systemd via triggers.ts
 }
 
 function stallNudgeCooldownMs(): number {


### PR DESCRIPTION
## Summary

- Add a grace window to `clearStaleSettled()` so the `mag/settled` sentinel survives the stop hook's own trailing pane output. Without this, the next keepalive tick cleared the sentinel before `maybeFeedMagQueue()` could claim it, breaking instant queue delivery via the stop hook and dashboard Send button (items waited 2+ minutes for the stall nudge instead).
- Guard threshold is `keepalive_interval * 1.5` (default 60s × 1.5 = 90s), read via a new `keepaliveIntervalMs()` helper in the same style as `stallThresholdMs()` / `stallNudgeCooldownMs()`. Older sentinels still clear on hash change exactly as before.
- No changes to `on-stop`, `maybeFeedMagQueue`, `maybeNudgeStalledMag`, dashboard endpoints, or config schema — they all benefit transparently from the sentinel surviving long enough to be claimed.

Closes #308.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/mag.test.ts` — 60/60 pass (includes 5 new regression tests)
- [x] `bun test` full suite — 1078 pass / 0 fail
- [x] New tests cover: young sentinel kept despite hash change; old sentinel cleared on hash change; old sentinel kept when hash unchanged; old sentinel + first observation keeps sentinel and records baseline; non-default keepalive interval scales the grace window both ways

🤖 Generated with [Claude Code](https://claude.com/claude-code)