### PR TITLE
feat(orchestration): scope declaration + salvage flow for agent changes

### DIFF
--- a/skills/orchestration/pair-coder-plan.md
+++ b/skills/orchestration/pair-coder-plan.md
@@ -16,6 +16,10 @@ When the task changes data shapes (field extraction, JSON migration, section res
 
 For every symbol, pattern, or function you plan to touch, run a project-wide grep/ripgrep and list occurrences with a disposition (modify / skip with reason / N/A). Canonical-name search alone misses inline reimplementations — regex patterns, copy-pasted logic, string literals that duplicate the same behavior — and the bug looks like a partial fix the next round. See [exhaustive occurrence search](../../docs/orchestration-patterns.md#exhaustive-occurrence-search) for the disposition-list shape.
 
+{{#IF PROPOSAL_PATH}}
+**Scope declaration**: Cross-reference your file list against the `## Scope` section of the proposal at `{{PROPOSAL_PATH}}`. If the plan includes any out-of-scope files, list them explicitly as scope expansions with a one-line justification each — the reviewer will decide per-expansion whether to accept or redirect to a follow-up task. See [scope declaration and salvage](../../docs/orchestration-patterns.md#scope-declaration-and-salvage).
+{{/IF}}
+
 Don't implement yet — the reviewer is planning in parallel and the two plans get merged next.
 
 ```sh

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -21,6 +21,20 @@ For data-shape changes or format-compat serializers, add a round-trip fidelity t
 Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
 
 {{#IF PROPOSAL_PATH}}
+**Scope discipline**: If you realize a change touches a file outside the proposal's `## Scope`, do not include it silently. Either:
+- **Declare it** — add a `scope-expansion: <one-line reason>` trailer to the commit message so the reviewer sees it and can decide per-expansion, or
+- **Defer it** — leave the file untouched and jot the idea in the task's `Notes` section (or open a follow-up task directly).
+
+"While I'm here" cleanups (dead code, reformatting, adjacent refactors) should normally be deferred to a separate parallel task rather than absorbed here. See [scope declaration and salvage](../../docs/orchestration-patterns.md#scope-declaration-and-salvage).
+
+**Salvage on rejection**: If the reviewer rejects a declared scope expansion, capture the diff before reverting so nothing useful is lost:
+
+1. `git diff -- <rejected-paths> > /tmp/salvage-{{TASK_ID}}.patch` — snapshot the rejected changes.
+2. `ludics tasks create "<short description of the deferred work>" <project> C` — create the follow-up task. Then edit the new task file's frontmatter to set `status: needs-confirmation` and `relates_to: [{{TASK_ID}}]`, and paste the captured patch + one-line justification into the task body. (Mirrors `ludics-process-suggestions` — the `ludics tasks create` CLI does not accept `--relates-to`, so the frontmatter edit is required.)
+3. `git checkout -- <rejected-paths>` — revert the files in this worktree, then continue with the in-scope work. The new task flows through the existing needs-confirmation surface (dashboard + briefing).
+{{/IF}}
+
+{{#IF PROPOSAL_PATH}}
 Before signaling done, re-read `{{PROPOSAL_PATH}}` and walk through each acceptance criterion, stating explicitly (in your thinking) how the implementation satisfies it — AC drift is the long-tail failure mode. Write the status file only once every criterion is met. See [AC self-check](../../docs/orchestration-patterns.md#ac-self-check) for why the walk is visible rather than implicit.
 {{/IF}}
 

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -30,7 +30,7 @@ Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
 **Salvage on rejection**: If the reviewer rejects a declared scope expansion, capture the diff before reverting so nothing useful is lost:
 
 1. `git diff -- <rejected-paths> > /tmp/salvage-{{TASK_ID}}.patch` — snapshot the rejected changes.
-2. `ludics tasks create "<short description of the deferred work>" <project> C` — create the follow-up task. Then edit the new task file's frontmatter to set `status: needs-confirmation` and `relates_to: [{{TASK_ID}}]`, and paste the captured patch + one-line justification into the task body. (Mirrors `ludics-process-suggestions` — the `ludics tasks create` CLI does not accept `--relates-to`, so the frontmatter edit is required.)
+2. `ludics tasks create "<short description of the deferred work>" <project> C` — create the follow-up task. Then edit the new task file's frontmatter to set `status: needs-confirmation` and, under the existing `dependencies:` block, replace `relates_to: []` with `relates_to: [{{TASK_ID}}]` (the field lives under `dependencies:`; a top-level `relates_to` is ignored by parsers). Paste the captured patch + one-line justification into the task body. (Mirrors `ludics-process-suggestions` — the `ludics tasks create` CLI does not accept `--relates-to`, so the frontmatter edit is required.)
 3. `git checkout -- <rejected-paths>` — revert the files in this worktree, then continue with the in-scope work. The new task flows through the existing needs-confirmation surface (dashboard + briefing).
 {{/IF}}
 

--- a/skills/orchestration/pair-reviewer-plan-review.md
+++ b/skills/orchestration/pair-reviewer-plan-review.md
@@ -10,6 +10,10 @@ Check the merged plan against the proposal and the codebase:
 - Are the proposed code changes feasible as-is?
 - If plan-merge found gaps, are they documented with ASSUMPTION GAP markers?
 
+{{#IF PROPOSAL_PATH}}
+- **Scope declarations**: are all out-of-scope files in the merged plan accompanied by a one-line scope-expansion justification? Flag missing justifications. Scope itself is not a blocker; undeclared expansions are a discipline issue. See [scope declaration and salvage](../../docs/orchestration-patterns.md#scope-declaration-and-salvage).
+{{/IF}}
+
 If alignment gaps remain, use REQUEST_CHANGES with a concrete remediation — for example:
 - "Proposal needs revision to account for X."
 - "Plan should add an intermediate refactoring step before Y."

--- a/skills/orchestration/pair-reviewer-review.md
+++ b/skills/orchestration/pair-reviewer-review.md
@@ -10,6 +10,15 @@ If the implementation changes data shapes, check that helpers consuming the chan
 
 Before treating a failing test as blocking, cross-check the merged plan's `## Pre-existing test failures (baseline)` section — the point is to separate pre-existing noise from regressions introduced this round. See [pre-existing failures baseline](../../docs/orchestration-patterns.md#pre-existing-failures-baseline) for how to handle the cases where the baseline is absent, incomplete, or notes planning was skipped.
 
+{{#IF PROPOSAL_PATH}}
+**Scope review (discretion)**: Cross-reference the coder's changes against the proposal's `## Scope` section at `{{PROPOSAL_PATH}}`. Scope expansions are not automatic blockers — decide per-expansion whether the change belongs in this PR or should be salvaged to a follow-up:
+
+- **Accept as-is** if the expansion is small, directly supports the goal, and doesn't materially broaden the PR's review surface.
+- **Reject and ask for salvage** if the expansion is valuable but belongs in its own task. In the review body, explicitly ask the coder to salvage the rejected diff into a needs-confirmation follow-up (capture patch → revert → new task with `relates_to`) before continuing. Do not just tell them to revert — that throws away useful work.
+
+Flag **undeclared** out-of-scope changes (no `scope-expansion:` trailer in any commit, no mention in the plan) as a discipline issue in the review body even when you accept the content. See [scope declaration and salvage](../../docs/orchestration-patterns.md#scope-declaration-and-salvage).
+{{/IF}}
+
 If the coder wrote a `bail-out` status and you agree the task is already resolved or obsolete (verify against the base branch), confirm the bail-out (see [bail-out contract](../../docs/orchestration-patterns.md#bail-out-contract)):
 
 ```sh

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -905,6 +905,94 @@ describe("skills", () => {
     expect(withoutProposal).not.toContain("Step 0");
   });
 
+  test("pair-coder-plan template renders scope-declaration block when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-plan.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(withProposal).toContain("Scope declaration");
+    expect(withProposal).toContain("docs/proposals/my-feature.md");
+    expect(withProposal).toContain("scope-declaration-and-salvage");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(withoutProposal).not.toContain("Scope declaration");
+  });
+
+  test("pair-coder-work template renders scope-discipline + salvage block when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-work.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      TASK_ID: "task-xyz",
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(withProposal).toContain("Scope discipline");
+    expect(withProposal).toContain("Salvage on rejection");
+    expect(withProposal).toContain("scope-expansion:");
+    expect(withProposal).toContain("/tmp/salvage-task-xyz.patch");
+    expect(withProposal).toContain("relates_to: [task-xyz]");
+    expect(withProposal).toContain("scope-declaration-and-salvage");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(withoutProposal).not.toContain("Scope discipline");
+    expect(withoutProposal).not.toContain("Salvage on rejection");
+  });
+
+  test("pair-reviewer-review template renders scope-review-discretion block when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-reviewer-review.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(withProposal).toContain("Scope review (discretion)");
+    expect(withProposal).toContain("docs/proposals/my-feature.md");
+    expect(withProposal).toContain("not automatic blockers");
+    expect(withProposal).toContain("Accept as-is");
+    expect(withProposal).toContain("Reject and ask for salvage");
+    expect(withProposal).toContain("scope-declaration-and-salvage");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(withoutProposal).not.toContain("Scope review (discretion)");
+  });
+
+  test("pair-reviewer-plan-review template renders scope-declarations bullet when PROPOSAL_PATH is set", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-reviewer-plan-review.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(withProposal).toContain("Scope declarations");
+    expect(withProposal).toContain("scope-expansion");
+    expect(withProposal).toContain("scope-declaration-and-salvage");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(withoutProposal).not.toContain("Scope declarations");
+  });
+
   test("substituteTemplate renders pr-conflict-resolve.md correctly", () => {
     const ctx = baseCtx();
     ctx["PR_FILE"] = "/tmp/peer-sync/coder.pr";

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -939,6 +939,7 @@ describe("skills", () => {
     expect(withProposal).toContain("scope-expansion:");
     expect(withProposal).toContain("/tmp/salvage-task-xyz.patch");
     expect(withProposal).toContain("relates_to: [task-xyz]");
+    expect(withProposal).toContain("under `dependencies:`");
     expect(withProposal).toContain("scope-declaration-and-salvage");
 
     const withoutProposal = substituteTemplate(template, {


### PR DESCRIPTION
## Summary

- Adds declaration + reviewer-discretion + salvage guidance to four orchestration templates, guarded by `{{#IF PROPOSAL_PATH}}` so non-proposal tasks are unaffected.
- Coder declares out-of-scope touches either in the plan or via a `scope-expansion: <reason>` commit trailer; silent inclusion is explicitly prohibited.
- Reviewer decides per-expansion: accept-as-is (small, supports the goal) or reject-and-salvage into a `needs-confirmation` follow-up with `relates_to`. Undeclared expansions are flagged as a discipline issue either way.
- Salvage procedure reuses the existing `ludics-process-suggestions` shape (no new machinery, no new CLI). Corrected the proposal's `--relates-to` CLI hint: the actual `ludics tasks create` CLI doesn't take that flag, so the template uses the create-then-edit-frontmatter pattern.

Closes gh-ludics-305. Complements gh-ludics-220 (technical assumption alignment) by extending the same pattern to declared scope. Rationale lives in `docs/orchestration-patterns.md#scope-declaration-and-salvage` — templates link to it rather than duplicate.

## Declared scope expansion

`src/orchestration/skills.test.ts` (four per-template rendering assertions) is declared as a scope expansion. Justification: the plan-prompt requires landing regression tests in the first round, `docs/orchestration-patterns.md#regression-test-per-behaviour-change` names template rendering as a behaviour-change category, and the file already contains ~12 same-shape per-template tests. Reviewer may accept as-is or ask for salvage under the new discipline.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/orchestration/skills.test.ts` — 65 pass (61 → 65)
- [x] `bun test` — 1077 pass / 0 fail (baseline 1073)
- [x] Rendered each of the four edited templates with `PROPOSAL_PATH=""`; guarded blocks are absent.
- [x] Rendered with `PROPOSAL_PATH` set; blocks expand with `{{PROPOSAL_PATH}}` and `{{TASK_ID}}` interpolated correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)