### PR TITLE
feat(orchestration): structural Regression Tests section in plan templates

### DIFF
--- a/skills/orchestration/pair-coder-plan-merge.md
+++ b/skills/orchestration/pair-coder-plan-merge.md
@@ -32,6 +32,8 @@ Now merge the two independent plans for `{{TASK_ID}}` into one at `{{MERGED_PLAN
 
 Use numbered lists for structured data; avoid wide tables (they get truncated between agents). Pick the strongest approach from each plan, fold in feedback, keep it concrete.
 
+**Regression tests**: The merged plan MUST include a `## Regression Tests` section with one entry per file changed in this round. For every behaviour-affecting change, write a named regression test using the format `- <file> — <test description> (in <test-file>)`. For every modified file with no behaviour change, write an explicit `- <file> — No regression test needed — <reason>`. Preserve the per-file accounting: do not deduplicate by target test file, because multiple changed files may legitimately share a test target and each changed file still needs its own line. If neither input plan enumerated regression tests, do that enumeration now during the merge rather than carrying the omission forward.
+
 ```sh
 printf '%s|%s|merged plan written\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/skills/orchestration/pair-coder-plan.md
+++ b/skills/orchestration/pair-coder-plan.md
@@ -8,7 +8,17 @@ Write an implementation plan for `{{TASK_ID}}` to `{{PLAN_FILE}}` from `{{WORKTR
 
 Before any code changes, run `bun test` and record the exact failing test names under a `## Pre-existing test failures (baseline)` section in the plan (use `none` when clean). The reviewer treats this list as the non-blocking backdrop for the review — see [pre-existing failures baseline](../../docs/orchestration-patterns.md#pre-existing-failures-baseline) for how the list is used and what to write when planning was skipped.
 
-As you plan, name the regression tests each behaviour change needs (serialization, template rendering, validation, CLI output) and land them in the **first implementation round** — deferred tests drift to abandonment. See [regression test per behaviour change](../../docs/orchestration-patterns.md#regression-test-per-behaviour-change) for the common triggers.
+As you plan, include a dedicated `## Regression Tests` section in the plan output. For each file that this round modifies with a behaviour change, list the regression test and its target test file using the format:
+
+- `<file>` — <test description> (in `<test-file>`)
+
+For files you modify but that carry no behaviour change (pure refactor, doc-only edit, template reformatting with no rendered-output difference), list them with an explicit justification using the format:
+
+- `<file>` — No regression test needed — <reason>
+
+Land the tests in the **first implementation round** — deferred tests drift to abandonment. See [regression test per behaviour change](../../docs/orchestration-patterns.md#regression-test-per-behaviour-change) for the common triggers (serialization, template rendering, validation, CLI output).
+
+This section is REQUIRED. The reviewer will REQUEST_CHANGES if it is missing.
 
 Use numbered lists for structured data; avoid wide markdown tables — they get truncated between agents and right-hand columns silently vanish. Be concrete about files, expected behavior, edge cases, and validation steps.
 

--- a/skills/orchestration/pair-reviewer-plan-review.md
+++ b/skills/orchestration/pair-reviewer-plan-review.md
@@ -25,7 +25,12 @@ For data-shape changes (field extraction, JSON migration, section restructuring)
 
 For every symbol or pattern the plan modifies, check that occurrences are enumerated project-wide — including inline reimplementations (regex patterns, copy-pasted logic, string literals), not just canonical function references. A single-site change that misses a doppelganger reads next round as a partial fix. If something's missing, REQUEST_CHANGES and include the grep commands you ran plus the occurrences the plan missed. See [exhaustive occurrence search](../../docs/orchestration-patterns.md#exhaustive-occurrence-search).
 
-On regression tests: each behaviour change (serialization, rendering, validation, CLI output) should have a named test planned for the first implementation round, not deferred — deferral drifts to abandonment. If behaviour changes lack test coverage, REQUEST_CHANGES with specifics on what needs tests. See [regression test per behaviour change](../../docs/orchestration-patterns.md#regression-test-per-behaviour-change).
+On regression tests, verify the merged plan structurally:
+
+- Does the merged plan contain a top-level `## Regression Tests` section?
+- Does that section list at least one named test (or an explicit "No regression test needed — <reason>" justification) for each behaviour-affecting file change enumerated elsewhere in the plan?
+
+If the section is missing, or if a behaviour-affecting change has no corresponding test entry and no explicit justification, REQUEST_CHANGES with specifics on what needs tests. Deferred tests drift to abandonment — require them in the first implementation round. See [regression test per behaviour change](../../docs/orchestration-patterns.md#regression-test-per-behaviour-change).
 
 {{PEER_PLAN}}
 

--- a/skills/orchestration/pair-reviewer-plan.md
+++ b/skills/orchestration/pair-reviewer-plan.md
@@ -8,6 +8,18 @@ Write an implementation plan for `{{TASK_ID}}` to `{{PLAN_FILE}}` from `{{WORKTR
 
 Use numbered lists for structured data; avoid wide tables (they get truncated between agents). Be concrete about files, expected behavior, edge cases, and validation steps.
 
+As you plan, include a dedicated `## Regression Tests` section in your plan output. For each file that this round modifies with a behaviour change, list the regression test and its target test file using the format:
+
+- `<file>` — <test description> (in `<test-file>`)
+
+For files you modify but that carry no behaviour change, list them with an explicit justification using the format:
+
+- `<file>` — No regression test needed — <reason>
+
+Land the tests in the **first implementation round** — deferred tests drift to abandonment. See [regression test per behaviour change](../../docs/orchestration-patterns.md#regression-test-per-behaviour-change) for the common triggers.
+
+This section is REQUIRED in your plan output. The plan-review step will REQUEST_CHANGES if it is missing.
+
 Don't implement yet — the coder is planning in parallel and the two plans get merged next.
 
 ```sh

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -1295,6 +1295,45 @@ describe("skills", () => {
     expect(unresolved).toEqual([]);
   });
 
+  describe("regression-test section contract (gh-ludics-310)", () => {
+    const tplDir = join(import.meta.dir, "../../skills/orchestration");
+    const read = (name: string) => readFileSync(join(tplDir, name), "utf-8");
+
+    test("pair-coder-plan.md requires a structural `## Regression Tests` section", () => {
+      const content = read("pair-coder-plan.md");
+      expect(content).toContain("## Regression Tests");
+      expect(content).toMatch(/No regression test needed/);
+      expect(content).toMatch(/REQUEST_CHANGES if it is missing/);
+      expect(content).not.toMatch(
+        /As you plan, call out the regression tests each behavior change needs/,
+      );
+    });
+
+    test("pair-coder-plan-merge.md requires preservation of the `## Regression Tests` section with per-file accounting", () => {
+      const content = read("pair-coder-plan-merge.md");
+      expect(content).toContain("## Regression Tests");
+      expect(content).toMatch(/Preserve the per-file accounting: do not deduplicate/);
+      expect(content).not.toMatch(
+        /As you plan, call out the regression tests each behavior change needs/,
+      );
+    });
+
+    test("pair-reviewer-plan-review.md checks for the structural section and preserves REQUEST_CHANGES", () => {
+      const content = read("pair-reviewer-plan-review.md");
+      expect(content).toMatch(
+        /Does the merged plan contain a top-level `?## Regression Tests`? section\?/,
+      );
+      expect(content).toContain("REQUEST_CHANGES");
+    });
+
+    test("pair-reviewer-plan.md carries the same `## Regression Tests` contract as the coder plan", () => {
+      const content = read("pair-reviewer-plan.md");
+      expect(content).toContain("## Regression Tests");
+      expect(content).toMatch(/No regression test needed/);
+      expect(content).toMatch(/plan-review step will REQUEST_CHANGES/);
+    });
+  });
+
   test("TASK_AC: extracts body of ## Acceptance Criteria with multiple bullets", async () => {
     const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
     const { join: j } = await import("path");


### PR DESCRIPTION
## Summary

- Convert the advisory regression-test prose in `pair-coder-plan.md` into a required `## Regression Tests` output section with per-file format (`- <file> — <test description> (in <test-file>)`) and an explicit `No regression test needed — <reason>` justification for no-behaviour-change files. The section is REQUIRED; the reviewer will `REQUEST_CHANGES` if it is missing.
- Add regression-test preservation to `pair-coder-plan-merge.md` (previously had none) so the merged plan cannot silently drop test coverage during merge. One entry per changed file; no deduplication by test-file target; enumerate tests during the merge if neither input plan did.
- Replace the prose-only reviewer check in `pair-reviewer-plan-review.md` with a structural checklist (section exists + per-file completeness); preserves the `REQUEST_CHANGES` consequence.
- Add equivalent guidance to `pair-reviewer-plan.md` (previously had none) so the reviewer's own plan output arrives pre-aligned with the coder's; requirement + consequence attach to the reviewer's own plan output ("in your plan output").
- Add a `regression-test section contract (gh-ludics-310)` describe block in `src/orchestration/skills.test.ts` with one assertion per template (plus negative guards against the superseded advisory wording "As you plan, call out the regression tests each behavior change needs") so the structural contract is locked in against silent drift.

Closes #310.

## Background

gh-ludics-219 (completed 2026-04-14) added advisory regression-test text to three templates. The very next task (gh-ludics-302, 2026-04-15) still hit the same failure mode — the initial merged plan omitted template regression tests, the reviewer caught it in `REQUEST_CHANGES`, and an extra plan-merge round was burned. The fix: make the expectation structural (a specific section heading the reviewer can look for) rather than advisory prose that can be overlooked.

## Test plan

- [x] `bun run typecheck` — passes.
- [x] `bun test src/orchestration/skills.test.ts` — 86/86 pass (existing rendering + anchor-validity tests, plus 4 new assertions in the new `regression-test section contract (gh-ludics-310)` block).
- [x] `bun test` (full suite) — 1135/1135 pass (baseline was 1131 pre-change; the 4 new tests account for the delta, no regressions).
- [x] Diff-scope check against `origin/main`: only the four in-scope template files and `src/orchestration/skills.test.ts` are modified. No runner changes, no edits to `pair-coder-work.md`, `pair-reviewer-review.md`, or `solo-work.md`.
- [ ] Future task using the new templates should produce a merged plan with a `## Regression Tests` section from the first merge attempt, without reviewer `REQUEST_CHANGES` on that axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)