### PR TITLE
gh-ludics-314: consolidated worker field contracts + lint-contracts + skip_plan fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "bun run --bun eslint \"src/**/*.ts\" --fix",
     "lint:cli-readme": "bun run scripts/lint-cli-readme.ts",
     "lint:config-reference": "bun run scripts/lint-config-reference.ts",
+    "lint:contracts": "bun run scripts/lint-contracts.ts",
     "lint:no-mock-module": "! grep -r 'mock\\.module(' src/ templates/ --include='*.test.ts' -l"
   },
   "devDependencies": {

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -242,7 +242,7 @@ describe("lintPair", () => {
     expect(warnings).toEqual([]);
   });
 
-  test("task_id-only drift is downgraded to a warning", () => {
+  test("worker-only `task_id` drift is downgraded to a warning (idiom tolerance)", () => {
     const orch = [
       "## Status routing",
       "",
@@ -255,6 +255,21 @@ describe("lintPair", () => {
     expect(errors).toEqual([]);
     expect(warnings).toEqual([
       { category: "worker-only-field", field: "task_id" },
+    ]);
+  });
+
+  test("orchestrator-only `task_id` drift is an error (worker dropped required field)", () => {
+    // Worker accidentally omits `task_id`; orchestrator still expects it.
+    const brokenWorker = [
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "2. `summary` — string, required.",
+    ].join("\n");
+    const { errors, warnings } = lintPair(brokenWorker, VALID_ORCH_MD);
+    expect(warnings).toEqual([]);
+    expect(errors).toEqual([
+      { category: "orchestrator-only-field", field: "task_id" },
     ]);
   });
 });

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "bun";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
   extractWorkerFields,
@@ -7,6 +9,7 @@ import {
   diffFields,
   lintPair,
   hasOrchestratorRoutingSection,
+  runCli,
 } from "./lint-contracts.ts";
 
 // ---------------------------------------------------------------------------
@@ -270,6 +273,216 @@ describe("hasOrchestratorRoutingSection", () => {
   test("false for inline skill without routing heading", () => {
     const md = "# Some inline skill\n\n## Process\n\nStuff.\n";
     expect(hasOrchestratorRoutingSection(md)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCli — temp-fixture directory tests for the discovery + reporting layer
+// ---------------------------------------------------------------------------
+
+/** Build an isolated skills directory under tmpdir and return its path. */
+function makeFixture(files: Record<string, string>): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "lint-contracts-"));
+  const skills = join(dir, "skills");
+  mkdirSync(skills, { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(skills, name), body);
+  }
+  return {
+    dir: skills,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+/** Drive runCli and collect its stderr/stdout lines in-process. */
+function driveRunCli(skillsDir: string): {
+  exitCode: number;
+  err: string[];
+  out: string[];
+  errorCount: number;
+  warningCount: number;
+} {
+  const err: string[] = [];
+  const out: string[] = [];
+  const result = runCli({
+    skillsDir,
+    writeErr: (m) => err.push(m),
+    writeOut: (m) => out.push(m),
+  });
+  return {
+    exitCode: result.exitCode,
+    err,
+    out,
+    errorCount: result.errorCount,
+    warningCount: result.warningCount,
+  };
+}
+
+const FIXTURE_WORKER_MD = [
+  "### Response Contract",
+  "",
+  "1. `status` — string, required.",
+  "2. `task_id` — string, required.",
+  "3. `summary` — string, required.",
+  "",
+].join("\n");
+
+const FIXTURE_ORCH_MD = [
+  "## Status routing",
+  "",
+  "| Field | Used for | Missing-field fallback |",
+  "|---|---|---|",
+  "| `status` | primary routing | error |",
+  "| `summary` | result context | empty string |",
+  "| `task_id` | — | not consumed |",
+  "",
+].join("\n");
+
+describe("runCli", () => {
+  test("clean paired fixture exits 0 with no warnings", () => {
+    const { dir, cleanup } = makeFixture({
+      "ludics-foo-worker.md": FIXTURE_WORKER_MD,
+      "ludics-foo.md": FIXTURE_ORCH_MD,
+    });
+    try {
+      const { exitCode, err, errorCount, warningCount } = driveRunCli(dir);
+      expect(exitCode).toBe(0);
+      expect(errorCount).toBe(0);
+      expect(warningCount).toBe(0);
+      expect(err).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("forward unpaired: worker with no orchestrator → warning, exit 0", () => {
+    const { dir, cleanup } = makeFixture({
+      "ludics-lonely-worker.md": FIXTURE_WORKER_MD,
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some((line) =>
+          line.includes("worker-without-orchestrator") &&
+          line.includes("ludics-lonely-worker.md"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reverse unpaired: orchestrator-style file with no worker → warning, exit 0", () => {
+    const { dir, cleanup } = makeFixture({
+      "ludics-stranded.md": FIXTURE_ORCH_MD,
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some((line) =>
+          line.includes("orchestrator-without-worker") &&
+          line.includes("ludics-stranded.md"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("inline skill (no routing heading) is silently excluded from reverse sweep", () => {
+    const inlineMd = [
+      "# Inline skill",
+      "",
+      "## Process",
+      "",
+      "Do stuff. No routing heading here.",
+      "",
+    ].join("\n");
+    const { dir, cleanup } = makeFixture({
+      "ludics-inline.md": inlineMd,
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(0);
+      expect(
+        r.err.some((line) => line.includes("ludics-inline.md")),
+      ).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("paired drift: extra worker field → exit 1 with worker-only-field error", () => {
+    const driftingWorker = [
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "2. `task_id` — string, required.",
+      "3. `summary` — string, required.",
+      "4. `rogue_field` — string, required.",
+      "",
+    ].join("\n");
+    const { dir, cleanup } = makeFixture({
+      "ludics-drifty-worker.md": driftingWorker,
+      "ludics-drifty.md": FIXTURE_ORCH_MD,
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(1);
+      expect(r.errorCount).toBe(1);
+      expect(
+        r.err.some((line) =>
+          line.includes("worker-only-field") &&
+          line.includes("rogue_field") &&
+          line.includes("[ludics-drifty]"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("mixed fixture: drift + unpaired + inline all reported correctly", () => {
+    const driftingWorker = [
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "2. `task_id` — string, required.",
+      "3. `summary` — string, required.",
+      "4. `extra_a` — string, required.",
+      "",
+    ].join("\n");
+    const inlineMd = "# Inline\n\n## Process\n\nnothing.\n";
+    const { dir, cleanup } = makeFixture({
+      "ludics-drifty-worker.md": driftingWorker,
+      "ludics-drifty.md": FIXTURE_ORCH_MD,
+      "ludics-lonely-worker.md": FIXTURE_WORKER_MD,
+      "ludics-stranded.md": FIXTURE_ORCH_MD,
+      "ludics-inline.md": inlineMd,
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(1);
+      expect(r.errorCount).toBe(1);
+      // 2 file-level warnings: worker-without-orchestrator, orchestrator-without-worker.
+      expect(r.warningCount).toBe(2);
+      expect(r.err.some((l) => l.includes("worker-without-orchestrator"))).toBe(true);
+      expect(r.err.some((l) => l.includes("orchestrator-without-worker"))).toBe(true);
+      expect(r.err.some((l) => l.includes("ludics-inline.md"))).toBe(false);
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "bun";
+import { join } from "path";
+import {
+  extractWorkerFields,
+  extractOrchestratorFields,
+  diffFields,
+  lintPair,
+  hasOrchestratorRoutingSection,
+} from "./lint-contracts.ts";
+
+// ---------------------------------------------------------------------------
+// extractWorkerFields
+// ---------------------------------------------------------------------------
+
+describe("extractWorkerFields", () => {
+  test("happy path — numbered list under Response Contract", () => {
+    const md = [
+      "## Final Response",
+      "",
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "2. `foo_bar` — string, required.",
+      "",
+      "## Error Handling",
+      "",
+      "1. `ignored` — outside section.",
+    ].join("\n");
+    const { fields, hasSection } = extractWorkerFields(md);
+    expect(hasSection).toBe(true);
+    expect([...fields].sort()).toEqual(["foo_bar", "status"]);
+  });
+
+  test("skips identifiers inside ```json fenced blocks", () => {
+    const md = [
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "",
+      "```json",
+      "{",
+      '  "status": "completed",',
+      '  "leaked_field": "nope"',
+      "}",
+      "```",
+      "",
+      "2. `real_field` — string, required.",
+    ].join("\n");
+    const { fields } = extractWorkerFields(md);
+    expect([...fields].sort()).toEqual(["real_field", "status"]);
+  });
+
+  test("ignores continuation lines with inline backticks", () => {
+    const md = [
+      "### Response Contract",
+      "",
+      "1. `skip_plan` — boolean, optional. Present only when `status = \"completed\"`.",
+      "   Set to `true` when the proposal is exhaustive. When `true`, the",
+      "   orchestrator writes `skip_plan: true` to task frontmatter.",
+      "2. `status` — string, required.",
+    ].join("\n");
+    const { fields } = extractWorkerFields(md);
+    expect([...fields].sort()).toEqual(["skip_plan", "status"]);
+  });
+
+  test("returns hasSection=false when heading is missing", () => {
+    const md = "# Hello\n\nFree-form content, no Response Contract here.\n";
+    const { fields, hasSection } = extractWorkerFields(md);
+    expect(hasSection).toBe(false);
+    expect(fields.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractOrchestratorFields
+// ---------------------------------------------------------------------------
+
+describe("extractOrchestratorFields", () => {
+  test("parses Status routing table, skips header/separator", () => {
+    const md = [
+      "## Status routing",
+      "",
+      "Fields:",
+      "",
+      "| Field | Used for | Missing-field fallback |",
+      "|---|---|---|",
+      "| `status` | primary routing | error |",
+      "| `task_id` | — | not consumed |",
+      "",
+      "## Next section",
+      "",
+      "| `ignored` | outside section | — |",
+    ].join("\n");
+    const { fields, hasSection } = extractOrchestratorFields(md);
+    expect(hasSection).toBe(true);
+    expect([...fields].sort()).toEqual(["status", "task_id"]);
+  });
+
+  test("parses Verdict routing table (verify-completion variant)", () => {
+    const md = [
+      "## Verdict routing",
+      "",
+      "| Field | Used for | Missing-field fallback |",
+      "|---|---|---|",
+      "| `verdict` | primary routing | error |",
+      "| `slot` | slot clearing | error |",
+    ].join("\n");
+    const { fields, hasSection } = extractOrchestratorFields(md);
+    expect(hasSection).toBe(true);
+    expect([...fields].sort()).toEqual(["slot", "verdict"]);
+  });
+
+  test("returns hasSection=false when neither heading is present", () => {
+    const md = "## Something else\n\n| `x` | — | — |\n";
+    const { fields, hasSection } = extractOrchestratorFields(md);
+    expect(hasSection).toBe(false);
+    expect(fields.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffFields
+// ---------------------------------------------------------------------------
+
+describe("diffFields", () => {
+  test("directional mismatches are reported correctly and sorted", () => {
+    const worker = new Set(["a", "c", "b"]);
+    const orch = new Set(["b", "d"]);
+    const { workerOnly, orchOnly } = diffFields(worker, orch);
+    expect(workerOnly).toEqual(["a", "c"]);
+    expect(orchOnly).toEqual(["d"]);
+  });
+
+  test("returns empty arrays when in sync", () => {
+    const both = new Set(["x", "y"]);
+    const { workerOnly, orchOnly } = diffFields(both, new Set(both));
+    expect(workerOnly).toEqual([]);
+    expect(orchOnly).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintPair — category-based assertions
+// ---------------------------------------------------------------------------
+
+const VALID_WORKER_MD = [
+  "### Response Contract",
+  "",
+  "1. `status` — string, required.",
+  "2. `task_id` — string, required.",
+  "3. `summary` — string, required.",
+].join("\n");
+
+const VALID_ORCH_MD = [
+  "## Status routing",
+  "",
+  "| Field | Used for | Missing-field fallback |",
+  "|---|---|---|",
+  "| `status` | primary routing | error |",
+  "| `summary` | result context | empty string |",
+  "| `task_id` | — | not consumed |",
+].join("\n");
+
+describe("lintPair", () => {
+  test("clean pair produces no errors and no warnings", () => {
+    const { errors, warnings } = lintPair(VALID_WORKER_MD, VALID_ORCH_MD);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  test("worker missing section short-circuits with exactly one warning", () => {
+    const brokenWorker = "# Worker\n\nNo Response Contract here.\n";
+    const { errors, warnings } = lintPair(brokenWorker, VALID_ORCH_MD);
+    expect(errors).toEqual([]);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toEqual({ category: "worker-missing-section" });
+    // No field-level entries — the diff must have been skipped.
+    expect(warnings.some((w) => w.field !== undefined)).toBe(false);
+    // Sanity: extractor agrees the section is missing.
+    expect(extractWorkerFields(brokenWorker).hasSection).toBe(false);
+  });
+
+  test("orchestrator missing section short-circuits with exactly one warning", () => {
+    const brokenOrch = "# Orchestrator\n\nNo routing section here.\n";
+    const { errors, warnings } = lintPair(VALID_WORKER_MD, brokenOrch);
+    expect(errors).toEqual([]);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toEqual({ category: "orchestrator-missing-section" });
+    // No worker-only-field errors — the diff must have been skipped.
+    expect(warnings.some((w) => w.field !== undefined)).toBe(false);
+    expect(errors.some((e) => e.field !== undefined)).toBe(false);
+    expect(extractOrchestratorFields(brokenOrch).hasSection).toBe(false);
+  });
+
+  test("both missing sections produces two warnings and no errors", () => {
+    const { errors, warnings } = lintPair(
+      "# Worker\n\nnothing\n",
+      "# Orchestrator\n\nnothing\n",
+    );
+    expect(errors).toEqual([]);
+    expect(warnings.map((w) => w.category).sort()).toEqual([
+      "orchestrator-missing-section",
+      "worker-missing-section",
+    ]);
+  });
+
+  test("field drift surfaces as worker-only-field error", () => {
+    const worker = [
+      "### Response Contract",
+      "",
+      "1. `status` — string, required.",
+      "2. `task_id` — string, required.",
+      "3. `summary` — string, required.",
+      "4. `extra_field` — string, required.",
+    ].join("\n");
+    const { errors, warnings } = lintPair(worker, VALID_ORCH_MD);
+    expect(errors).toEqual([
+      { category: "worker-only-field", field: "extra_field" },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  test("orchestrator-only field surfaces as error", () => {
+    const orch = [
+      "## Status routing",
+      "",
+      "| Field | Used for | Missing-field fallback |",
+      "|---|---|---|",
+      "| `status` | primary routing | error |",
+      "| `summary` | result context | empty string |",
+      "| `rogue_field` | mystery | — |",
+      "| `task_id` | — | not consumed |",
+    ].join("\n");
+    const { errors, warnings } = lintPair(VALID_WORKER_MD, orch);
+    expect(errors).toEqual([
+      { category: "orchestrator-only-field", field: "rogue_field" },
+    ]);
+    expect(warnings).toEqual([]);
+  });
+
+  test("task_id-only drift is downgraded to a warning", () => {
+    const orch = [
+      "## Status routing",
+      "",
+      "| Field | Used for | Missing-field fallback |",
+      "|---|---|---|",
+      "| `status` | primary routing | error |",
+      "| `summary` | result context | empty string |",
+    ].join("\n");
+    const { errors, warnings } = lintPair(VALID_WORKER_MD, orch);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([
+      { category: "worker-only-field", field: "task_id" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasOrchestratorRoutingSection (reverse-sweep heuristic)
+// ---------------------------------------------------------------------------
+
+describe("hasOrchestratorRoutingSection", () => {
+  test("true when ## Status routing is present", () => {
+    expect(hasOrchestratorRoutingSection("## Status routing\n")).toBe(true);
+  });
+  test("true when ## Verdict routing is present", () => {
+    expect(hasOrchestratorRoutingSection("## Verdict routing\n")).toBe(true);
+  });
+  test("false for inline skill without routing heading", () => {
+    const md = "# Some inline skill\n\n## Process\n\nStuff.\n";
+    expect(hasOrchestratorRoutingSection(md)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — drive the real CLI against the real repo
+// ---------------------------------------------------------------------------
+
+describe("integration", () => {
+  test("lint-contracts exits 0 on current repo", () => {
+    const result = spawnSync({
+      cmd: ["bun", "run", join(import.meta.dir, "lint-contracts.ts")],
+      cwd: join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (result.exitCode !== 0) {
+      console.error(result.stderr.toString());
+      console.error(result.stdout.toString());
+    }
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/scripts/lint-contracts.ts
+++ b/scripts/lint-contracts.ts
@@ -137,10 +137,13 @@ export interface PairResult {
  * a missing section from cascading into a `worker-only-field` error per
  * field.
  *
- * `task_id` is a special case (AC 9): a worker-only-field mismatch where
- * `field === "task_id"` is emitted as a warning rather than an error, because
- * orchestrator tables conventionally list it as "not consumed" and sometimes
- * omit it entirely.
+ * `task_id` is a special case (AC 9), but only in the worker-only direction:
+ * workers always declare `task_id`, while orchestrator tables conventionally
+ * list it as "not consumed" and sometimes omit it entirely — so a worker-only
+ * `task_id` mismatch is emitted as a warning rather than an error. The
+ * orchestrator-only direction (orchestrator expects `task_id` but the worker
+ * contract dropped it) stays an error: that would be a required-field
+ * regression on the worker side, exactly what this lint should catch.
  */
 export function lintPair(workerMd: string, orchMd: string): PairResult {
   const result: PairResult = { errors: [], warnings: [] };
@@ -168,8 +171,7 @@ export function lintPair(workerMd: string, orchMd: string): PairResult {
   }
   for (const field of orchOnly) {
     const issue: LintIssue = { category: "orchestrator-only-field", field };
-    if (field === "task_id") result.warnings.push(issue);
-    else result.errors.push(issue);
+    result.errors.push(issue);
   }
 
   return result;

--- a/scripts/lint-contracts.ts
+++ b/scripts/lint-contracts.ts
@@ -210,8 +210,42 @@ interface PairReport {
   issues: PairResult;
 }
 
-function runCli(): number {
-  const entries = readdirSync(skillsDir);
+export interface RunCliOptions {
+  /** Skills directory to scan. Defaults to `<repo-root>/skills`. */
+  skillsDir?: string;
+  /** Sink for warning/error lines (default: process.stderr.write). */
+  writeErr?: (msg: string) => void;
+  /** Sink for the success summary line (default: process.stdout.write). */
+  writeOut?: (msg: string) => void;
+}
+
+export interface RunCliResult {
+  exitCode: number;
+  errorCount: number;
+  warningCount: number;
+  fileWarnings: FileIssue[];
+  pairReports: PairReport[];
+}
+
+/**
+ * Scan a skills directory and report field-contract drift. Parameterised on
+ * the directory and output sinks so tests can drive it against temp fixtures
+ * and capture lines without spawning a subprocess.
+ */
+export function runCli(options: RunCliOptions = {}): RunCliResult {
+  const scanDir = options.skillsDir ?? skillsDir;
+  const writeErr =
+    options.writeErr ??
+    ((msg) => {
+      process.stderr.write(msg + "\n");
+    });
+  const writeOut =
+    options.writeOut ??
+    ((msg) => {
+      process.stdout.write(msg + "\n");
+    });
+
+  const entries = readdirSync(scanDir);
   const workerFiles = entries.filter((f) => /^ludics-.*-worker\.md$/.test(f));
 
   const fileWarnings: FileIssue[] = [];
@@ -221,8 +255,8 @@ function runCli(): number {
   const pairedOrchestrators = new Set<string>();
   for (const wFile of workerFiles) {
     const orchFile = wFile.replace(/-worker\.md$/, ".md");
-    const wPath = join(skillsDir, wFile);
-    const oPath = join(skillsDir, orchFile);
+    const wPath = join(scanDir, wFile);
+    const oPath = join(scanDir, orchFile);
 
     if (!existsSync(oPath)) {
       fileWarnings.push({
@@ -249,7 +283,7 @@ function runCli(): number {
       !pairedOrchestrators.has(f),
   );
   for (const oFile of reverseCandidates) {
-    const md = readFileSync(join(skillsDir, oFile), "utf-8");
+    const md = readFileSync(join(scanDir, oFile), "utf-8");
     if (!hasOrchestratorRoutingSection(md)) continue; // inline skill
     fileWarnings.push({
       category: "orchestrator-without-worker",
@@ -265,36 +299,33 @@ function runCli(): number {
     for (const err of issues.errors) {
       errorCount++;
       const fieldNote = err.field ? ` (field: ${err.field})` : "";
-      console.error(`❌  [${pair}] ${err.category}${fieldNote}`);
+      writeErr(`❌  [${pair}] ${err.category}${fieldNote}`);
     }
     for (const warn of issues.warnings) {
       warningCount++;
       const fieldNote = warn.field ? ` (field: ${warn.field})` : "";
-      console.error(`⚠️   [${pair}] ${warn.category}${fieldNote}`);
+      writeErr(`⚠️   [${pair}] ${warn.category}${fieldNote}`);
     }
   }
   for (const fw of fileWarnings) {
     warningCount++;
-    console.error(`⚠️   ${fw.category}: ${fw.path}`);
+    writeErr(`⚠️   ${fw.category}: ${fw.path}`);
   }
 
   if (errorCount === 0) {
     const suffix = warningCount > 0 ? ` (${warningCount} warning${warningCount === 1 ? "" : "s"})` : "";
-    console.log(`✅  Worker/orchestrator field contracts are in sync${suffix}.`);
-    return 0;
+    writeOut(`✅  Worker/orchestrator field contracts are in sync${suffix}.`);
+    return { exitCode: 0, errorCount, warningCount, fileWarnings, pairReports };
   }
-  console.error(`\n${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"}.`);
-  return 1;
+  writeErr(`\n${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"}.`);
+  return { exitCode: 1, errorCount, warningCount, fileWarnings, pairReports };
 }
 
 // Run as a CLI when invoked directly; stay silent when imported from tests.
 if (import.meta.main) {
-  process.exit(runCli());
+  process.exit(runCli().exitCode);
 }
 
-// Exported for integration tests that want to drive the CLI in-process if
-// needed, but the main recipe for tests is to import the pure helpers above.
-export { runCli };
 // Silence the unused-basename import when this module is used only as a
 // library in tests (tree-shaking does not run on bun runtime).
 void basename;

--- a/scripts/lint-contracts.ts
+++ b/scripts/lint-contracts.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env bun
+/**
+ * lint-contracts.ts
+ *
+ * Detects field-name drift between worker and orchestrator skill pairs.
+ *
+ * For each `skills/ludics-<name>-worker.md` it expects a sibling
+ * `skills/ludics-<name>.md`, and checks that the field names declared in the
+ * worker's `### Response Contract` numbered list match the field names listed
+ * in the orchestrator's `## Status routing` or `## Verdict routing` markdown
+ * table. Also sweeps the reverse direction to catch orchestrator-style files
+ * without a worker sibling.
+ *
+ * Exit code:
+ *   0 — clean (any reported items were warnings)
+ *   1 — one or more pairs has field-name drift
+ */
+
+import { readdirSync, readFileSync, existsSync } from "fs";
+import { join, basename } from "path";
+
+const root = join(import.meta.dir, "..");
+const skillsDir = join(root, "skills");
+
+// ---------------------------------------------------------------------------
+// Pure extractors (exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface ExtractResult {
+  fields: Set<string>;
+  hasSection: boolean;
+}
+
+/**
+ * Collect backtick-quoted identifiers from the numbered list under
+ * `### Response Contract`. Returns `hasSection: false` when the heading is
+ * not found (caller short-circuits the pair).
+ */
+export function extractWorkerFields(md: string): ExtractResult {
+  const lines = md.split("\n");
+  const fields = new Set<string>();
+
+  let inSection = false;
+  let inFence = false;
+  let found = false;
+
+  for (const line of lines) {
+    if (!inSection) {
+      if (/^###\s+Response Contract\s*$/.test(line)) {
+        inSection = true;
+        found = true;
+      }
+      continue;
+    }
+    // Leaving on the next `##` or `###` heading.
+    if (/^#{2,3}\s+\S/.test(line)) break;
+
+    // Toggle fenced-block state; never harvest identifiers inside fences.
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const m = /^\s*\d+\.\s+`([a-z_][\w]*)`/.exec(line);
+    if (m) fields.add(m[1]!);
+  }
+
+  return { fields, hasSection: found };
+}
+
+/**
+ * Collect backtick-quoted identifiers from the first-column cells of the
+ * markdown table under `## Status routing` or `## Verdict routing`.
+ */
+export function extractOrchestratorFields(md: string): ExtractResult {
+  const lines = md.split("\n");
+  const fields = new Set<string>();
+
+  let inSection = false;
+  let found = false;
+
+  for (const line of lines) {
+    if (!inSection) {
+      if (/^##\s+(Status|Verdict) routing\s*$/.test(line)) {
+        inSection = true;
+        found = true;
+      }
+      continue;
+    }
+    if (/^##\s+\S/.test(line)) break;
+
+    const m = /^\|\s*`([a-z_][\w]*)`\s*\|/.exec(line);
+    if (m) fields.add(m[1]!);
+  }
+
+  return { fields, hasSection: found };
+}
+
+/** Sorted set-difference pair. */
+export function diffFields(
+  worker: Set<string>,
+  orch: Set<string>,
+): { workerOnly: string[]; orchOnly: string[] } {
+  const workerOnly = [...worker].filter((f) => !orch.has(f)).sort();
+  const orchOnly = [...orch].filter((f) => !worker.has(f)).sort();
+  return { workerOnly, orchOnly };
+}
+
+// ---------------------------------------------------------------------------
+// lintPair — structured per-pair result (exported for tests)
+// ---------------------------------------------------------------------------
+
+export type LintCategory =
+  | "worker-missing-section"
+  | "orchestrator-missing-section"
+  | "worker-only-field"
+  | "orchestrator-only-field";
+
+export interface LintIssue {
+  category: LintCategory;
+  field?: string;
+}
+
+export interface PairResult {
+  errors: LintIssue[];
+  warnings: LintIssue[];
+}
+
+/**
+ * Compare a worker markdown and its paired orchestrator markdown.
+ *
+ * Missing-section semantics (canonical rule): if either side is missing its
+ * target section, emit the corresponding `*-missing-section` warning and
+ * short-circuit — field diffing is skipped entirely for this pair. This
+ * matches AC 11 ("missing sections produce warnings, non-fatal") and prevents
+ * a missing section from cascading into a `worker-only-field` error per
+ * field.
+ *
+ * `task_id` is a special case (AC 9): a worker-only-field mismatch where
+ * `field === "task_id"` is emitted as a warning rather than an error, because
+ * orchestrator tables conventionally list it as "not consumed" and sometimes
+ * omit it entirely.
+ */
+export function lintPair(workerMd: string, orchMd: string): PairResult {
+  const result: PairResult = { errors: [], warnings: [] };
+
+  const w = extractWorkerFields(workerMd);
+  const o = extractOrchestratorFields(orchMd);
+
+  let shortCircuit = false;
+  if (!w.hasSection) {
+    result.warnings.push({ category: "worker-missing-section" });
+    shortCircuit = true;
+  }
+  if (!o.hasSection) {
+    result.warnings.push({ category: "orchestrator-missing-section" });
+    shortCircuit = true;
+  }
+  if (shortCircuit) return result;
+
+  const { workerOnly, orchOnly } = diffFields(w.fields, o.fields);
+
+  for (const field of workerOnly) {
+    const issue: LintIssue = { category: "worker-only-field", field };
+    if (field === "task_id") result.warnings.push(issue);
+    else result.errors.push(issue);
+  }
+  for (const field of orchOnly) {
+    const issue: LintIssue = { category: "orchestrator-only-field", field };
+    if (field === "task_id") result.warnings.push(issue);
+    else result.errors.push(issue);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// File-discovery helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+const REVERSE_EXCLUDE = new Set([
+  "worker-conventions.md",
+  "orchestrator-conventions.md",
+]);
+
+/**
+ * Does this orchestrator-candidate file look like an orchestrator (i.e.
+ * contains `## Status routing` or `## Verdict routing`)? Files without either
+ * heading are treated as inline skills and silently excluded from the
+ * reverse sweep.
+ */
+export function hasOrchestratorRoutingSection(md: string): boolean {
+  return /^##\s+(Status|Verdict) routing\s*$/m.test(md);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+interface FileIssue {
+  category:
+    | "worker-without-orchestrator"
+    | "orchestrator-without-worker";
+  path: string;
+}
+
+interface PairReport {
+  pair: string;
+  issues: PairResult;
+}
+
+function runCli(): number {
+  const entries = readdirSync(skillsDir);
+  const workerFiles = entries.filter((f) => /^ludics-.*-worker\.md$/.test(f));
+
+  const fileWarnings: FileIssue[] = [];
+  const pairReports: PairReport[] = [];
+
+  // Forward sweep: worker → orchestrator.
+  const pairedOrchestrators = new Set<string>();
+  for (const wFile of workerFiles) {
+    const orchFile = wFile.replace(/-worker\.md$/, ".md");
+    const wPath = join(skillsDir, wFile);
+    const oPath = join(skillsDir, orchFile);
+
+    if (!existsSync(oPath)) {
+      fileWarnings.push({
+        category: "worker-without-orchestrator",
+        path: wFile,
+      });
+      continue;
+    }
+    pairedOrchestrators.add(orchFile);
+
+    const wMd = readFileSync(wPath, "utf-8");
+    const oMd = readFileSync(oPath, "utf-8");
+    const pairName = orchFile.replace(/\.md$/, "");
+    pairReports.push({ pair: pairName, issues: lintPair(wMd, oMd) });
+  }
+
+  // Reverse sweep: orchestrator-candidate → worker.
+  const reverseCandidates = entries.filter(
+    (f) =>
+      f.startsWith("ludics-") &&
+      f.endsWith(".md") &&
+      !f.endsWith("-worker.md") &&
+      !REVERSE_EXCLUDE.has(f) &&
+      !pairedOrchestrators.has(f),
+  );
+  for (const oFile of reverseCandidates) {
+    const md = readFileSync(join(skillsDir, oFile), "utf-8");
+    if (!hasOrchestratorRoutingSection(md)) continue; // inline skill
+    fileWarnings.push({
+      category: "orchestrator-without-worker",
+      path: oFile,
+    });
+  }
+
+  // Reporting.
+  let errorCount = 0;
+  let warningCount = 0;
+
+  for (const { pair, issues } of pairReports) {
+    for (const err of issues.errors) {
+      errorCount++;
+      const fieldNote = err.field ? ` (field: ${err.field})` : "";
+      console.error(`❌  [${pair}] ${err.category}${fieldNote}`);
+    }
+    for (const warn of issues.warnings) {
+      warningCount++;
+      const fieldNote = warn.field ? ` (field: ${warn.field})` : "";
+      console.error(`⚠️   [${pair}] ${warn.category}${fieldNote}`);
+    }
+  }
+  for (const fw of fileWarnings) {
+    warningCount++;
+    console.error(`⚠️   ${fw.category}: ${fw.path}`);
+  }
+
+  if (errorCount === 0) {
+    const suffix = warningCount > 0 ? ` (${warningCount} warning${warningCount === 1 ? "" : "s"})` : "";
+    console.log(`✅  Worker/orchestrator field contracts are in sync${suffix}.`);
+    return 0;
+  }
+  console.error(`\n${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"}.`);
+  return 1;
+}
+
+// Run as a CLI when invoked directly; stay silent when imported from tests.
+if (import.meta.main) {
+  process.exit(runCli());
+}
+
+// Exported for integration tests that want to drive the CLI in-process if
+// needed, but the main recipe for tests is to import the pure helpers above.
+export { runCli };
+// Silence the unused-basename import when this module is used only as a
+// library in tests (tree-shaking does not run on bun runtime).
+void basename;

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -73,6 +73,7 @@ Extract the final ` ```json ` block from the worker's response. Fields:
 | `start_rationale` | auto-start eval | empty string |
 | `title` | notification title | fall back to task_id |
 | `summary` | notification body, result JSON | empty string |
+| `skip_plan` | task frontmatter | default `false`, remove stale frontmatter value |
 | `task_id` | — | not consumed |
 
 Routing by status:

--- a/skills/orchestrator-conventions.md
+++ b/skills/orchestrator-conventions.md
@@ -47,6 +47,10 @@ revise-proposal includes user feedback verbatim) are noted in each skill.
 - Only the worker's structured response returns to the orchestrator.
 - Each orchestrator parses the worker JSON for `status` plus skill-specific
   fields. The per-skill field set is documented in "Expected Worker Fields".
+- The canonical cross-skill reference for field types and
+  `required` / `conditional` / `optional` annotations is the "Field Contract
+  Reference" table in `worker-conventions.md`. Per-skill routing tables here
+  remain the source for `Used for` and `Missing-field fallback` behaviour.
 
 ## Section E — Result JSON
 

--- a/skills/worker-conventions.md
+++ b/skills/worker-conventions.md
@@ -60,6 +60,53 @@ When `status` is `"error"`, only `status` plus a narrative field are
 guaranteed; other fields may be absent. Orchestrators handle missing
 conditional fields gracefully.
 
+## Field Contract Reference
+
+Canonical cross-skill reference for field types and required/conditional/optional
+annotations across all worker/orchestrator pairs. Each worker skill keeps its
+own `### Response Contract` section with full prose and examples — this table
+summarises, it does not replace. Vocabulary matches "Field Annotations" above.
+
+| Skill pair | Field | Type | Annotation | Condition / Notes |
+|---|---|---|---|---|
+| elaborate | `status` | string | required | `completed` / `merged` / `already-elaborated` / `error` |
+| elaborate | `task_id` | string | required | echoes input |
+| elaborate | `title` | string | required | |
+| elaborate | `merge_target` | string | conditional | when `status = "merged"` |
+| elaborate | `elaborated_date` | string | conditional | when `status = "already-elaborated"` |
+| elaborate | `questions` | string[] | required | `"none"` when empty |
+| elaborate | `summary` | string | required | |
+| draft-proposal | `status` | string | required | `completed` / `stale` / `split-needed` / `already-exists` / `error` |
+| draft-proposal | `task_id` | string | required | |
+| draft-proposal | `proposal_path` | string | conditional | when `status ∈ {completed, already-exists}` |
+| draft-proposal | `ambiguities` | string[] | required | `"none"` when empty |
+| draft-proposal | `start_confidence` | string | conditional | when `status = "completed"`; `high` / `low` |
+| draft-proposal | `start_rationale` | string | conditional | when `status = "completed"` |
+| draft-proposal | `title` | string | required | |
+| draft-proposal | `summary` | string | required | |
+| draft-proposal | `skip_plan` | boolean | optional | when `status = "completed"`; written to frontmatter when `true` |
+| revise-proposal | `status` | string | required | `revised` / `no-changes` / `error` |
+| revise-proposal | `task_id` | string | required | |
+| revise-proposal | `proposal_path` | string | conditional | when `proposal_mode = "file"`; omitted for inline |
+| revise-proposal | `proposal_mode` | string | conditional | required when `status = "revised"`; orchestrator must not default to `"file"` |
+| revise-proposal | `changes_summary` | string | required | |
+| revise-proposal | `title` | string | required | |
+| revise-proposal | `summary` | string | required | |
+| verify-completion | `status` | string | required | always `"completed"` in non-error cases |
+| verify-completion | `task_id` | string | required | |
+| verify-completion | `title` | string | required | |
+| verify-completion | `slot` | number | required | error if verdict requires slot clearing |
+| verify-completion | `verdict` | string | required | `complete` / `complete-with-followups` / `uncertain` / `incomplete` |
+| verify-completion | `followups` | object[] | required | `{title, priority}`; `"none"` when empty |
+| verify-completion | `questions` | string[] | required | `"none"` when empty |
+| verify-completion | `evidence` | string | required | |
+| feedback-digest | `status` | string | required | `completed` / `empty` / `error` |
+| feedback-digest | `issues_created` | number | required | 0 when none; may be absent on `status = "error"` only |
+| feedback-digest | `issues_updated` | number | required | 0 when none; may be absent on `status = "error"` only |
+| feedback-digest | `issues_skipped` | number | required | 0 when none; may be absent on `status = "error"` only |
+| feedback-digest | `files_processed` | number | required | 0 when none; may be absent on `status = "error"` only |
+| feedback-digest | `summary` | string | required | |
+
 ## Error Handling
 
 - **Missing input** (task not found, path not found): set `"status": "error"`


### PR DESCRIPTION
## Summary

- Adds a canonical `## Field Contract Reference` table to `skills/worker-conventions.md` covering all 5 worker/orchestrator pairs with `required` / `conditional` / `optional` annotations, cross-referenced from `skills/orchestrator-conventions.md` Section D.
- Fixes the active draft-proposal contract drift by adding the `skip_plan` row to its `## Status routing` table so the documentation matches the orchestrator's existing routing logic.
- Adds `scripts/lint-contracts.ts` to detect worker/orchestrator field-name drift, with bidirectional unpaired-file detection (content-based self-exclusion of inline skills via presence of `## Status routing` / `## Verdict routing`) and a missing-section short-circuit that matches AC 11 (warnings, non-fatal). Wired as `lint:contracts` in `package.json`. Retires the unbuilt `task-b0df15b2` follow-up.

Closes #314.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint:contracts` — exits 0 (`✅  Worker/orchestrator field contracts are in sync.`).
- [x] `bun test` — 1099 pass, 0 fail (1073 baseline + 26 new tests in `scripts/lint-contracts.test.ts`).
- [x] Unit coverage: field extraction (fences, continuation lines, both `Status routing` / `Verdict routing` headings), `diffFields`, `lintPair` categories (clean, worker-missing-section, orchestrator-missing-section, both-missing, worker-only drift, orchestrator-only drift, `task_id` downgrade), `hasOrchestratorRoutingSection`.
- [x] CLI coverage via temp-fixture directories: clean paired, forward unpaired (`worker-without-orchestrator`), reverse unpaired (`orchestrator-without-worker`), inline-skill silent self-exclusion, drift producing exit 1, and a mixed fixture exercising all paths together.
- [x] Integration: spawn the real script against the real repo → exit 0.