### PR TITLE
feat(orchestration): unconditional AC self-check with visible artifact

### DIFF
--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -34,9 +34,21 @@ Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
 3. `git checkout -- <rejected-paths>` — revert the files in this worktree, then continue with the in-scope work. The new task flows through the existing needs-confirmation surface (dashboard + briefing).
 {{/IF}}
 
+**Acceptance Criteria self-check.** Before writing the done status, verify every acceptance criterion is satisfied. Produce a visible checklist — don't just think it through. AC drift is the long-tail failure mode of this workflow.
+
 {{#IF PROPOSAL_PATH}}
-Before signaling done, re-read `{{PROPOSAL_PATH}}` and walk through each acceptance criterion, stating explicitly (in your thinking) how the implementation satisfies it — AC drift is the long-tail failure mode. Write the status file only once every criterion is met. See [AC self-check](../../docs/orchestration-patterns.md#ac-self-check) for why the walk is visible rather than implicit.
+1. Re-read `{{PROPOSAL_PATH}}` in the project repo for the authoritative acceptance criteria.
 {{/IF}}
+{{#UNLESS PROPOSAL_PATH}}
+1. Re-read the task spec above (from context) for the acceptance criteria — no proposal file exists for this task.
+{{/UNLESS}}
+{{#IF TASK_AC}}
+Task acceptance criteria from the task file:
+
+{{TASK_AC}}
+{{/IF}}
+
+For each criterion, append a one-line confirmation to `{{WORKFLOW_FEEDBACK_FILE}}` under a `## AC Verification` heading (create the heading if absent), naming the evidence that satisfies it (file, test, commit). Only write the done status after every criterion has a confirmation line. See [AC self-check](../../docs/orchestration-patterns.md#ac-self-check).
 
 If the task is already resolved on the base branch (fix already merged, no meaningful changes needed), don't make empty commits — they waste a round and pollute git history. Signal bail-out instead (see [bail-out contract](../../docs/orchestration-patterns.md#bail-out-contract)):
 

--- a/skills/orchestration/pair-reviewer-review.md
+++ b/skills/orchestration/pair-reviewer-review.md
@@ -10,6 +10,17 @@ If the implementation changes data shapes, check that helpers consuming the chan
 
 Before treating a failing test as blocking, cross-check the merged plan's `## Pre-existing test failures (baseline)` section — the point is to separate pre-existing noise from regressions introduced this round. See [pre-existing failures baseline](../../docs/orchestration-patterns.md#pre-existing-failures-baseline) for how to handle the cases where the baseline is absent, incomplete, or notes planning was skipped.
 
+**Acceptance criteria verification.** Walk through each acceptance criterion and verify the implementation satisfies it. Treat any unmet criterion as a blocking action item listed explicitly in the review. Cross-check against the coder's `## AC Verification` entries in `{{PEER_SYNC_DIR}}/workflow-feedback-{{PEER_NAME}}.md`; a missing or hand-wavy entry is itself a blocker.
+
+{{#IF PROPOSAL_PATH}}
+Re-read `{{PROPOSAL_PATH}}` for the authoritative acceptance criteria.
+{{/IF}}
+{{#IF TASK_AC}}
+Task acceptance criteria from the task file:
+
+{{TASK_AC}}
+{{/IF}}
+
 {{#IF PROPOSAL_PATH}}
 **Scope review (discretion)**: Cross-reference the coder's changes against the proposal's `## Scope` section at `{{PROPOSAL_PATH}}`. Scope expansions are not automatic blockers — decide per-expansion whether the change belongs in this PR or should be salvaged to a follow-up:
 

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -64,6 +64,7 @@ function baseCtx(): Record<string, string> {
     PEER_SYNC_DIR: "/tmp/peer-sync",
     DONE_STATUS: "review-done",
     UPSTREAM_REPO: "",
+    TASK_AC: "",
   };
 }
 
@@ -1292,5 +1293,236 @@ describe("skills", () => {
       }
     }
     expect(unresolved).toEqual([]);
+  });
+
+  test("TASK_AC: extracts body of ## Acceptance Criteria with multiple bullets", async () => {
+    const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
+    const { join: j } = await import("path");
+    const tmpDir = mkdtempSync("/tmp/ludics-skills-task-ac-happy-");
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const harnessTasks = j(tmpDir, "harness", "tasks");
+      mkdir2(harnessTasks, { recursive: true });
+      write2(j(harnessTasks, "task-ac1.md"), [
+        "---", "id: task-ac1", "---",
+        "",
+        "## Context",
+        "",
+        "Some context.",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] Do thing A",
+        "- [ ] Do thing B",
+        "- [ ] Do thing C",
+        "",
+        "## Notes",
+        "",
+        "Additional notes.",
+      ].join("\n"));
+      process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = { ...makeState(), taskId: "task-ac1", projectDir: j(tmpDir, "project") };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+      expect(ctx["TASK_AC"]).toContain("Do thing A");
+      expect(ctx["TASK_AC"]).toContain("Do thing B");
+      expect(ctx["TASK_AC"]).toContain("Do thing C");
+      expect(ctx["TASK_AC"]).not.toContain("Additional notes");
+      expect(ctx["TASK_AC"]).not.toContain("Some context");
+      expect(ctx["TASK_AC"]).not.toContain("## Acceptance Criteria");
+      expect(ctx["TASK_AC"]).not.toContain("## Notes");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("TASK_AC: empty when task file has no ## Acceptance Criteria section", async () => {
+    const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
+    const { join: j } = await import("path");
+    const tmpDir = mkdtempSync("/tmp/ludics-skills-task-ac-missing-");
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const harnessTasks = j(tmpDir, "harness", "tasks");
+      mkdir2(harnessTasks, { recursive: true });
+      write2(j(harnessTasks, "task-ac2.md"), [
+        "---", "id: task-ac2", "---",
+        "",
+        "## Context",
+        "",
+        "Only a context section here.",
+      ].join("\n"));
+      process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = { ...makeState(), taskId: "task-ac2", projectDir: j(tmpDir, "project") };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+      expect(ctx["TASK_AC"]).toBe("");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("TASK_AC: empty when section contains only `- [ ] TBD` placeholder", async () => {
+    const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
+    const { join: j } = await import("path");
+    const tmpDir = mkdtempSync("/tmp/ludics-skills-task-ac-tbd-");
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const harnessTasks = j(tmpDir, "harness", "tasks");
+      mkdir2(harnessTasks, { recursive: true });
+      write2(j(harnessTasks, "task-ac3.md"), [
+        "---", "id: task-ac3", "---",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] TBD",
+        "",
+        "## Notes",
+      ].join("\n"));
+      process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = { ...makeState(), taskId: "task-ac3", projectDir: j(tmpDir, "project") };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+      expect(ctx["TASK_AC"]).toBe("");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("TASK_AC: AC section followed by ## heading does not bleed into next section", async () => {
+    const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
+    const { join: j } = await import("path");
+    const tmpDir = mkdtempSync("/tmp/ludics-skills-task-ac-trim-");
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const harnessTasks = j(tmpDir, "harness", "tasks");
+      mkdir2(harnessTasks, { recursive: true });
+      write2(j(harnessTasks, "task-ac4.md"), [
+        "---", "id: task-ac4", "---",
+        "",
+        "## Acceptance Criteria",
+        "",
+        "- [ ] first criterion",
+        "- [ ] second criterion",
+        "",
+        "## Notes",
+        "",
+        "note text that must not bleed into TASK_AC.",
+      ].join("\n"));
+      process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = { ...makeState(), taskId: "task-ac4", projectDir: j(tmpDir, "project") };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+      expect(ctx["TASK_AC"]).toContain("first criterion");
+      expect(ctx["TASK_AC"]).toContain("second criterion");
+      expect(ctx["TASK_AC"]).not.toContain("note text that must not bleed");
+      expect(ctx["TASK_AC"]).not.toContain("## Notes");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("pair-coder-work: unconditional AC self-check + no-proposal fallback renders when PROPOSAL_PATH is empty", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-work.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(rendered).toContain("Acceptance Criteria self-check");
+    // No-proposal fallback must fire explicitly (proposal AC #1).
+    expect(rendered).toContain("Re-read the task spec above");
+    expect(rendered).toContain("no proposal file exists");
+    // Proposal re-read branch must NOT render in this state.
+    expect(rendered).not.toMatch(/Re-read `[^`]+` in the project repo/);
+  });
+
+  test("pair-coder-work: AC self-check references PROPOSAL_PATH when set and omits the no-proposal fallback", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-work.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(rendered).toContain("Acceptance Criteria self-check");
+    expect(rendered).toContain("Re-read `docs/proposals/my-feature.md`");
+    // Fallback must NOT render when a proposal exists.
+    expect(rendered).not.toContain("Re-read the task spec above");
+    expect(rendered).not.toContain("no proposal file exists");
+  });
+
+  test("pair-coder-work: AC self-check references WORKFLOW_FEEDBACK_FILE and the visible-checklist heading", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-work.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      WORKFLOW_FEEDBACK_FILE: "/tmp/peer-sync/workflow-feedback-coder.md",
+    });
+    expect(rendered).toContain("/tmp/peer-sync/workflow-feedback-coder.md");
+    expect(rendered).toContain("## AC Verification");
+    expect(rendered).toContain("visible checklist");
+  });
+
+  test("pair-reviewer-review: AC verification section renders with and without PROPOSAL_PATH", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-reviewer-review.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const withProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "docs/proposals/my-feature.md",
+      PROPOSAL_INSTRUCTION: "(ignored)",
+    });
+    expect(withProposal).toContain("Acceptance criteria verification");
+    expect(withProposal).toContain("blocking action item");
+    expect(withProposal).toContain("Re-read `docs/proposals/my-feature.md` for the authoritative acceptance criteria");
+
+    const withoutProposal = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+    });
+    expect(withoutProposal).toContain("Acceptance criteria verification");
+    expect(withoutProposal).toContain("blocking action item");
+    // The re-read bullet only appears when PROPOSAL_PATH is set.
+    expect(withoutProposal).not.toMatch(/Re-read `[^`]+` for the authoritative/);
+  });
+
+  test("pair-reviewer-review: AC verification section inlines TASK_AC content when non-empty", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-reviewer-review.md");
+    const template = readFileSync(templatePath, "utf-8");
+    const rendered = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+      TASK_AC: "- [ ] criterion alpha\n- [ ] criterion beta",
+    });
+    expect(rendered).toContain("Task acceptance criteria from the task file");
+    expect(rendered).toContain("criterion alpha");
+    expect(rendered).toContain("criterion beta");
+
+    // Empty TASK_AC must collapse the inline block.
+    const empty = substituteTemplate(template, {
+      ...baseCtx(),
+      PROPOSAL_PATH: "",
+      PROPOSAL_INSTRUCTION: "",
+      TASK_AC: "",
+    });
+    expect(empty).not.toContain("Task acceptance criteria from the task file");
+  });
+
+  test("pair-coder-work: legacy invisible AC wording is gone from the raw template", () => {
+    const templatePath = join(import.meta.dir, "../../skills/orchestration/pair-coder-work.md");
+    const raw = readFileSync(templatePath, "utf-8");
+    // Negative regression for proposal AC #5: no duplicate / legacy AC path.
+    expect(raw).not.toContain("in your thinking");
+    expect(raw).not.toContain("stating explicitly");
   });
 });

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -166,6 +166,32 @@ function taskSpecText(state: OrchestrationState): string {
   return appendGhIssueBody(content);
 }
 
+/** Extract the body under `## Acceptance Criteria` from tasks/{taskId}.md.
+ *  Returns "" when the task file, the section, or the non-placeholder body
+ *  is missing. Stops at the next `##` heading or EOF. */
+function extractAcceptanceCriteria(taskId: string | undefined): string {
+  if (!taskId) return "";
+  const path = join(harnessDir(), "tasks", `${taskId}.md`);
+  const content = readFileIfExists(path);
+  if (!content) return "";
+  const headingMatch = content.match(/^##\s+Acceptance Criteria\s*$/m);
+  if (!headingMatch || headingMatch.index == null) return "";
+  const afterHeading = content.slice(headingMatch.index + headingMatch[0].length);
+  const nextHeading = afterHeading.match(/\n##\s+/);
+  const section = nextHeading ? afterHeading.slice(0, nextHeading.index) : afterHeading;
+  const body = section.trim();
+  if (!body) return "";
+  // Filter the `- [ ] TBD` placeholder that the task template seeds; if
+  // nothing else remains, treat the section as empty so templates can gate
+  // cleanly with `{{#IF TASK_AC}}`.
+  const leftover = body
+    .split("\n")
+    .filter((line) => !/^-\s*\[ \]\s*TBD\s*$/i.test(line))
+    .join("\n")
+    .trim();
+  return leftover;
+}
+
 function templateRoot(): string {
   return join(ludicsRoot(), "skills", "orchestration");
 }
@@ -288,6 +314,7 @@ export function buildSkillContext(
     PROPOSAL_PATH: proposalPath,
     PROPOSAL_INSTRUCTION: proposalInstruction,
     PROPOSAL_FRESHNESS_WARNING: proposalFreshnessWarningText,
+    TASK_AC: extractAcceptanceCriteria(state.taskId),
     PEER_REVIEW: peerReview ?? "(no review yet)",
     PEER_STATUS: peer ? (state.agentStates[peer.name]?.status ?? "unknown") : "unknown",
     PEER_PLAN: peerPlan ?? "(no plan yet)",


### PR DESCRIPTION
Closes #316.

## Summary

Addresses the most common source of avoidable review rounds (6 retrospective citations): agents signaling done without systematically verifying every acceptance criterion. Two changes on the coder side, one mirrored change on the reviewer side, and a new template variable so AC text is available in every round.

- `skills/orchestration/pair-coder-work.md` — the old `{{#IF PROPOSAL_PATH}}` "verify AC in your thinking" block is replaced by an unconditional **Acceptance Criteria self-check** section. A `{{#IF PROPOSAL_PATH}}` / `{{#UNLESS PROPOSAL_PATH}}` sibling pair directs the coder to re-read the proposal when one exists and the task spec from context when it does not. The instruction now requires a visible `## AC Verification` checklist written to `{{WORKFLOW_FEEDBACK_FILE}}` — one line per criterion naming the evidence (file, test, commit).
- `skills/orchestration/pair-reviewer-review.md` — new **Acceptance criteria verification** section before the scope-review block. Reviewer walks criterion-by-criterion, cross-checks against the coder's `## AC Verification` entries in `{{PEER_SYNC_DIR}}/workflow-feedback-{{PEER_NAME}}.md`, and treats unmet criteria (or missing / hand-wavy entries) as blocking action items.
- `src/orchestration/skills.ts` — new `extractAcceptanceCriteria(taskId)` helper + `TASK_AC` entry in `buildSkillContext()`. Reads `tasks/{taskId}.md`, extracts the `## Acceptance Criteria` section up to the next `##` heading or EOF, filters the `- [ ] TBD` placeholder so `{{#IF TASK_AC}}` gates cleanly. Available in all rounds, independent of the round-2+ `TASK_SPEC` brief form.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 1087 pass / 0 fail (was 1077; +10 new tests, +36 assertions).
- [x] New tests pin: `TASK_AC` extraction (happy / missing / TBD-only / next-heading trim), coder-work render with and without `PROPOSAL_PATH` (explicit fallback wording assertions), `WORKFLOW_FEEDBACK_FILE` mention, reviewer-review render in both states, reviewer `TASK_AC` inlining, and negative regression that the legacy "in your thinking" phrase is gone.
- [x] Dog-fooded: the round's own `## AC Verification` checklist is at `.peer-sync/workflow-feedback-coder.md`.

## Notes

- `skills/orchestration/solo-work.md:20` carries the same legacy AC wording but is intentionally out of scope per the proposal. Flagged as a follow-up in the workflow-feedback notes rather than absorbed silently.
- One mid-round regex bug (lookahead with `\s*$` under `/m` terminated after the first content line) caught by the regression tests before commit; rewrote as a two-step search-then-slice.