### PR TITLE
test(isolation): fix LUDICS_HARNESS_DIR teardown bugs + add withTestHarness helper

### DIFF
--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -99,3 +99,74 @@ from local pass results.
 Test servers should bind to `hostname: "127.0.0.1"` to avoid IPv6-related
 failures. Production servers that need to accept remote connections (e.g., the
 dashboard server serving cluster traffic) should not restrict to loopback.
+
+## Harness Isolation
+
+Tests that call `harnessDir()` from `src/config.ts` — directly, or transitively
+through helpers like `emitEvent`, `readSlotJson`, `queuePath`, etc. — must
+isolate `LUDICS_HARNESS_DIR` so they never read or write the real harness
+directory. A preload in `src/test-setup.ts` (configured via `bunfig.toml`) sets
+`LUDICS_HARNESS_DIR` to a shared tmpdir if unset, but individual test files
+should not silently depend on that preload: they must save, set, and restore
+the env var themselves so later files in the same Bun process are not affected.
+
+### The quick way: `withTestHarness()`
+
+```typescript
+import { beforeEach, afterEach, test, expect } from "bun:test";
+import { withTestHarness } from "./test-utils.ts";
+
+const getHarness = withTestHarness(beforeEach, afterEach);
+
+test("writes a slot file under an isolated harness", () => {
+  const harness = getHarness(); // fresh tmpdir, cleaned up after the test
+  // ... test body ...
+});
+```
+
+The helper saves the current `LUDICS_HARNESS_DIR`, swaps in a fresh tmpdir per
+`beforeEach`, and in `afterEach` restores the original value (deleting if it
+was unset) before removing the tmpdir.
+
+### Manual pattern (when you also need HOME / LUDICS_CONFIG)
+
+```typescript
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+let TMP = "";
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-my-test-"));
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfigUnder(TMP);
+  process.env.LUDICS_HARNESS_DIR = join(TMP, "harness");
+  mkdirSync(join(TMP, "harness"), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(TMP, { recursive: true, force: true });
+});
+```
+
+### Do not do this
+
+**Never** `delete process.env.LUDICS_HARNESS_DIR` unconditionally in
+`afterEach` — this destroys the preload safety net for every subsequent test
+file in the same Bun process. Always save the original value and restore it.
+
+**Never** use `process.env.X = original ?? undefined` to restore an env var —
+assigning `undefined` via `process.env` sets the variable to the literal string
+`"undefined"` (in Node.js; Bun's behaviour is similar). Use the conditional
+delete-or-assign pattern shown above.
+
+### Reference examples
+
+- `src/queue.test.ts` — manual save/restore via a small `restoreHarnessDir` helper.
+- `src/test-utils.test.ts` — contract tests for `withTestHarness()`.

--- a/src/adapters/manual.test.ts
+++ b/src/adapters/manual.test.ts
@@ -8,6 +8,7 @@ import type { AdapterContext } from "./types.ts";
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
 let TMP = "";
 
 function writeConfig(homeDir: string): string {
@@ -26,6 +27,7 @@ beforeEach(() => {
   TMP = mkdtempSync(join(tmpdir(), "ludics-manual-adapter-"));
   process.env.HOME = TMP;
   process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = join(TMP, "ludics-state", "harness");
 });
 
 afterEach(() => {
@@ -33,6 +35,8 @@ afterEach(() => {
   else process.env.HOME = ORIGINAL_HOME;
   if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
   else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
   rmSync(TMP, { recursive: true, force: true });
 });
 

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -8,6 +8,15 @@ const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
 const ORIGINAL_HOME = process.env.HOME;
 let TMP = "";
 
+function restoreEnv(vars: { home: string | undefined; config: string | undefined; harness: string | undefined }): void {
+  if (vars.home === undefined) delete process.env.HOME;
+  else process.env.HOME = vars.home;
+  if (vars.config === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = vars.config;
+  if (vars.harness === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = vars.harness;
+}
+
 function harnessDir(): string {
   return join(TMP, "harness");
 }
@@ -46,9 +55,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.env.HOME = ORIGINAL_HOME ?? undefined;
-  process.env.LUDICS_CONFIG = ORIGINAL_CONFIG ?? undefined;
-  process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR ?? undefined;
+  restoreEnv({ home: ORIGINAL_HOME, config: ORIGINAL_CONFIG, harness: ORIGINAL_HARNESS_DIR });
   rmSync(TMP, { recursive: true, force: true });
 });
 
@@ -130,5 +137,44 @@ describe("eventsQuery validation", () => {
     writeEvents(["{bad json", JSON.stringify(makeEvent())]);
     const output = await captureOutput([]);
     expect(output.length).toBe(1);
+  });
+});
+
+describe("env teardown restoration", () => {
+  test("restoreEnv restores all three sentinel values", () => {
+    const preHome = process.env.HOME;
+    const preConfig = process.env.LUDICS_CONFIG;
+    const preHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      process.env.HOME = "/tmp/mutated-home";
+      process.env.LUDICS_CONFIG = "/tmp/mutated-config";
+      process.env.LUDICS_HARNESS_DIR = "/tmp/mutated-harness";
+      restoreEnv({ home: "/sentinel-home", config: "/sentinel-config", harness: "/sentinel-harness" });
+      expect(process.env.HOME).toBe("/sentinel-home");
+      expect(process.env.LUDICS_CONFIG).toBe("/sentinel-config");
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/sentinel-harness");
+    } finally {
+      restoreEnv({ home: preHome, config: preConfig, harness: preHarness });
+    }
+  });
+
+  test("restoreEnv(undefined) deletes rather than setting literal 'undefined'", () => {
+    const preHome = process.env.HOME;
+    const preConfig = process.env.LUDICS_CONFIG;
+    const preHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      process.env.HOME = "/tmp/mutated-home";
+      process.env.LUDICS_CONFIG = "/tmp/mutated-config";
+      process.env.LUDICS_HARNESS_DIR = "/tmp/mutated-harness";
+      restoreEnv({ home: undefined, config: undefined, harness: undefined });
+      expect(process.env.HOME).toBeUndefined();
+      expect(process.env.LUDICS_CONFIG).toBeUndefined();
+      expect(process.env.LUDICS_HARNESS_DIR).toBeUndefined();
+      expect(process.env.HOME).not.toBe("undefined");
+      expect(process.env.LUDICS_CONFIG).not.toBe("undefined");
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("undefined");
+    } finally {
+      restoreEnv({ home: preHome, config: preConfig, harness: preHarness });
+    }
   });
 });

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -11,9 +11,11 @@ import { defaultOrchestrationConfig, initAgentRuntimeState, migrateState, type O
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
 let TEST_TMP = "";
 
-// Isolate tests from real harness state (evaluateTransition reads peer slot state via harnessDir)
+// Isolate HOME, LUDICS_CONFIG, and LUDICS_HARNESS_DIR under TEST_TMP so evaluateTransition / emitEvent
+// never read or write real harness state.
 beforeEach(() => {
   TEST_TMP = mkdtempSync(join(tmpdir(), "ludics-phases-test-"));
   process.env.HOME = TEST_TMP;
@@ -21,6 +23,8 @@ beforeEach(() => {
   mkdirSync(configDir, { recursive: true });
   writeFileSync(join(configDir, "config.yaml"), `state_repo: test/ludics-state\nstate_path: harness\n`);
   process.env.LUDICS_CONFIG = join(configDir, "config.yaml");
+  process.env.LUDICS_HARNESS_DIR = join(TEST_TMP, "harness");
+  mkdirSync(join(TEST_TMP, "harness"), { recursive: true });
 });
 
 afterEach(() => {
@@ -29,6 +33,11 @@ afterEach(() => {
     delete process.env.LUDICS_CONFIG;
   } else {
     process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  }
+  if (ORIGINAL_HARNESS === undefined) {
+    delete process.env.LUDICS_HARNESS_DIR;
+  } else {
+    process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
   }
 });
 
@@ -1081,5 +1090,15 @@ describe("migrateState — solo invariants", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe("harness isolation regression", () => {
+  test("LUDICS_HARNESS_DIR is set to the explicit path under TEST_TMP", () => {
+    const harness = process.env.LUDICS_HARNESS_DIR;
+    expect(harness).toBeDefined();
+    expect(harness!.startsWith(TEST_TMP)).toBe(true);
+    expect(harness).toBe(join(TEST_TMP, "harness"));
+    expect(existsSync(harness!)).toBe(true);
   });
 });

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -4,6 +4,12 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 let tmpDir: string;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+
+function restoreHarnessDir(saved: string | undefined): void {
+  if (saved === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = saved;
+}
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "ludics-queue-test-"));
@@ -13,7 +19,7 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(tmpDir, { recursive: true, force: true });
-  delete process.env.LUDICS_HARNESS_DIR;
+  restoreHarnessDir(ORIGINAL_HARNESS_DIR);
 });
 
 // Re-import after env is set — queue.ts reads harnessDir() at call time
@@ -340,5 +346,32 @@ describe("queueRequest includes extra fields", () => {
     const parsed = JSON.parse(content);
     expect(parsed.action).toBe("feedback-digest");
     expect(parsed.repo).toBe("ludics");
+  });
+});
+
+describe("harness teardown restoration", () => {
+  test("restoreHarnessDir restores a captured sentinel value", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    try {
+      process.env.LUDICS_HARNESS_DIR = "/tmp/mutated-value";
+      restoreHarnessDir("/sentinel-pre-queue");
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/sentinel-pre-queue");
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+
+  test("restoreHarnessDir(undefined) deletes rather than setting literal 'undefined'", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    try {
+      process.env.LUDICS_HARNESS_DIR = "/tmp/mutated-value";
+      restoreHarnessDir(undefined);
+      expect(process.env.LUDICS_HARNESS_DIR).toBeUndefined();
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("undefined");
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
   });
 });

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -8,6 +8,7 @@ const TMP = join(import.meta.dir, ".test-tmp-sync");
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
 
 function writeConfig(homeDir: string): string {
   const configDir = join(homeDir, ".config", "ludics");
@@ -80,6 +81,7 @@ beforeEach(() => {
   mkdirSync(TMP, { recursive: true });
   process.env.HOME = TMP;
   process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = join(TMP, "ludics-state", "harness");
 });
 
 afterEach(() => {
@@ -93,6 +95,12 @@ afterEach(() => {
     delete process.env.LUDICS_CONFIG;
   } else {
     process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  }
+
+  if (ORIGINAL_HARNESS === undefined) {
+    delete process.env.LUDICS_HARNESS_DIR;
+  } else {
+    process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
   }
 
   rmSync(TMP, { recursive: true, force: true });

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { withTestHarness } from "./test-utils.ts";
+
+function captureHooks(): {
+  before: (fn: () => void) => void;
+  after: (fn: () => void) => void;
+  runBefore: () => void;
+  runAfter: () => void;
+} {
+  const beforeFns: Array<() => void> = [];
+  const afterFns: Array<() => void> = [];
+  return {
+    before: (fn) => { beforeFns.push(fn); },
+    after: (fn) => { afterFns.push(fn); },
+    runBefore: () => { for (const fn of beforeFns) fn(); },
+    runAfter: () => { for (const fn of afterFns) fn(); },
+  };
+}
+
+describe("withTestHarness", () => {
+  test("sets LUDICS_HARNESS_DIR to a fresh tmpdir matching the getter", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    const hooks = captureHooks();
+    const getHarness = withTestHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getHarness();
+      expect(dir).not.toBe("");
+      expect(existsSync(dir)).toBe(true);
+      expect(process.env.LUDICS_HARNESS_DIR).toBe(dir);
+    } finally {
+      hooks.runAfter();
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+
+  test("restores a captured sentinel value and removes the tmpdir", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = "/sentinel";
+    const hooks = captureHooks();
+    const getHarness = withTestHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getHarness();
+      expect(existsSync(dir)).toBe(true);
+      hooks.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/sentinel");
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+
+  test("restores undefined when original was unset (not the literal 'undefined')", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    delete process.env.LUDICS_HARNESS_DIR;
+    const hooks = captureHooks();
+    const getHarness = withTestHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getHarness();
+      expect(existsSync(dir)).toBe(true);
+      hooks.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBeUndefined();
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("undefined");
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+
+  test("returns a fresh tmpdir on each before/after cycle", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    const hooks = captureHooks();
+    const getHarness = withTestHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const first = getHarness();
+      hooks.runAfter();
+      hooks.runBefore();
+      const second = getHarness();
+      hooks.runAfter();
+      expect(first).not.toBe(second);
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+});

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -90,4 +90,28 @@ describe("withTestHarness", () => {
       else process.env.LUDICS_HARNESS_DIR = pre;
     }
   });
+
+  test("double registration: each helper restores the real original, not a sibling's temp dir", () => {
+    const pre = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = "/real-original";
+    const hooksA = captureHooks();
+    const hooksB = captureHooks();
+    try {
+      // Both helpers register at the same "real original" — i.e. before any before() runs.
+      withTestHarness(hooksA.before, hooksA.after);
+      withTestHarness(hooksB.before, hooksB.after);
+
+      // Simulate per-test lifecycle with both helpers active.
+      hooksA.runBefore();
+      hooksB.runBefore();
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("/real-original");
+      // Teardown in either order must land back on the real original, never a sibling's tmpdir.
+      hooksA.runAfter();
+      hooksB.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/real-original");
+    } finally {
+      if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
 });

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,9 @@
 // Shared test utilities for the ludics test suite.
 
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
 /**
  * Whether this environment can bind a loopback socket.
  * Use with `describe.if(canBindSocket)(...)` to skip network tests
@@ -15,4 +19,24 @@ try {
   probe.stop(true);
 } catch {
   canBindSocket = false;
+}
+
+/** Isolate LUDICS_HARNESS_DIR to a fresh tmpdir per test; returns a getter for the current path. */
+export function withTestHarness(
+  before: (fn: () => void) => void,
+  after: (fn: () => void) => void,
+): () => string {
+  let saved: string | undefined;
+  let dir = "";
+  before(() => {
+    saved = process.env.LUDICS_HARNESS_DIR;
+    dir = mkdtempSync(join(tmpdir(), "ludics-test-harness-"));
+    process.env.LUDICS_HARNESS_DIR = dir;
+  });
+  after(() => {
+    if (saved === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = saved;
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return () => dir;
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -26,10 +26,13 @@ export function withTestHarness(
   before: (fn: () => void) => void,
   after: (fn: () => void) => void,
 ): () => string {
-  let saved: string | undefined;
+  // Capture the real original at registration time, not inside `before`. If a file
+  // registers the helper twice, capturing inside `before` would let the second
+  // registration save the first helper's temp path and leak a stale (deleted) dir
+  // into later tests.
+  const saved = process.env.LUDICS_HARNESS_DIR;
   let dir = "";
   before(() => {
-    saved = process.env.LUDICS_HARNESS_DIR;
     dir = mkdtempSync(join(tmpdir(), "ludics-test-harness-"));
     process.env.LUDICS_HARNESS_DIR = dir;
   });


### PR DESCRIPTION
## Summary
- Fix three `LUDICS_HARNESS_DIR` teardown bugs (`queue.test.ts` unconditional `delete`, `events.test.ts` `?? undefined`, `phases.test.ts` missing env setup).
- Add shared `withTestHarness(beforeEach, afterEach)` helper in `src/test-utils.ts` for the standard save/tmpdir/restore pattern.
- Document the pattern and its prohibitions in `docs/testing-patterns.md`.
- Add named regressions in the same round: helper contract tests in `src/test-utils.test.ts`; in-file teardown restoration tests in the three fixed files.

Closes gh-ludics-306.

## Scope expansion (second commit)

Fixing `queue.test.ts` exposed two latent bugs of the same class in files the plan's occurrence search missed:

1. `src/tasks/sync.test.ts` — sets HOME + LUDICS_CONFIG but not `LUDICS_HARNESS_DIR`; relied on `queue.test.ts`'s unconditional `delete` to leave the env var unset so `harnessDir()` fell through to config.yaml resolution.
2. `src/adapters/manual.test.ts` — same pattern; `adapterStateDir()` calls `harnessDir()` from config.ts internally, bypassing `ctx.harnessDir`.

Both now isolate `LUDICS_HARNESS_DIR` under their existing `TMP` directory, matching the `state_path` their config.yaml writes. Declared in the commit as `scope-expansion` — fixing them is required to keep `bun test` green post-fix.

## Out of scope / candidate bonuses

1. `src/orchestration/phases.test.ts:27` — `process.env.HOME = ORIGINAL_HOME` is unconditional (same bug class as the `events.test.ts` fix). Not patched here; acceptance criterion 3 is scoped to `LUDICS_HARNESS_DIR`.
2. The 12 other correctly-patterned files are not migrated to `withTestHarness()` — optional/incremental per proposal.
3. No CI lint rule for missing isolation — explicit out-of-scope per proposal.

## Test plan

- [x] `bun run typecheck` — clean
- [x] Targeted: `bun test src/test-utils.test.ts src/queue.test.ts src/events.test.ts src/orchestration/phases.test.ts` — 131 pass / 0 fail
- [x] Full suite: `bun test` — 1091 pass / 0 fail (baseline was 1082/0; +9 named regression tests added this round)
- [x] `rg "Harness Isolation" docs/testing-patterns.md` — section landed
- [x] All four named regression blocks present in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)