### PR TITLE
feat(dashboard): expose created on deferred-launch and sort needs-confirmation newest-first

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -363,6 +363,41 @@ describe("deferred-launch sorting", () => {
     const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
     const ids = items.map((item) => item.id);
     expect(ids).toEqual(["task-newest", "task-middle", "task-oldest", "task-no-date"]);
+    expect(items.find((it) => it.id === "task-newest")).toHaveProperty("created", "2026-04-15");
+    expect(items.find((it) => it.id === "task-no-date")).toHaveProperty("created", null);
+  });
+});
+
+describe("needs-confirmation sorting", () => {
+  function writeNeedsConfirmationTask(id: string, title: string, created: string | null): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const createdLine = created ? `created: "${created}"` : "created: null";
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nstatus: needs-confirmation\npriority: B\n${createdLine}\ncontext: ludics\n---\n\n# ${title}\n`,
+    );
+  }
+
+  test("tasks sorted by created date descending, null last", async () => {
+    writeNeedsConfirmationTask("task-nc-oldest", "Oldest", "2026-01-01");
+    writeNeedsConfirmationTask("task-nc-newest", "Newest", "2026-04-15");
+    writeNeedsConfirmationTask("task-nc-middle", "Middle", "2026-03-10");
+    writeNeedsConfirmationTask("task-nc-no-date", "No date", null);
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      dashboardGenerate();
+    } finally {
+      console.error = origErr;
+    }
+
+    const outFile = join(harnessDir(), "dashboard", "data", "needs-confirmation.json");
+    const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
+    const ids = items.map((item) => item.id);
+    expect(ids).toEqual(["task-nc-newest", "task-nc-middle", "task-nc-oldest", "task-nc-no-date"]);
   });
 });
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -540,9 +540,13 @@ function generateFilteredTaskList(tasks: DashboardTask[], config: FilteredTaskTi
   }));
 }
 
+const byCreatedDescNullLast = (a: DashboardTask, b: DashboardTask): number =>
+  (b.created ?? "").localeCompare(a.created ?? "");
+
 const needsConfirmationConfig: FilteredTaskTileConfig = {
   filter: (task) => task.status === "needs-confirmation",
   extraFields: (task) => ({ created: task.created, relatesTo: task.dependencies.relates_to }),
+  sort: byCreatedDescNullLast,
 };
 
 const unansweredQuestionsConfig: FilteredTaskTileConfig = {
@@ -553,10 +557,11 @@ const unansweredQuestionsConfig: FilteredTaskTileConfig = {
 const deferredLaunchConfig: FilteredTaskTileConfig = {
   filter: (task) => task.status === "deferred",
   extraFields: (task) => ({
+    created: task.created,
     hasProposal: task.hasProposal,
     proposalPath: task.proposalPath,
   }),
-  sort: (a, b) => (b.created ?? "").localeCompare(a.created ?? ""),
+  sort: byCreatedDescNullLast,
 };
 
 function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {


### PR DESCRIPTION
## Summary
- Add `created` to the `deferred-launch` tile's `extraFields` so the date is available in the JSON for UI rendering and debugging.
- Apply the same newest-first / null-last comparator (extracted as `byCreatedDescNullLast`) to the `needs-confirmation` tile for parity with `deferred-launch` ordering.
- Extend `src/dashboard.test.ts`: assert `created` appears on deferred-launch items, and add a new `describe("needs-confirmation sorting")` block mirroring the deferred-launch test.

Implements `task-8d4ac1f6` (follow-up wiring from `task-002bddd8`'s generic `sort?` hook).

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/dashboard.test.ts`
- [x] `bun run build`
- [x] `ludics init --no-triggers` regenerates JSON without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)