### PR TITLE
docs(orchestration): document one-exclusion-source rule for worktrees

### DIFF
--- a/docs/testing-patterns.md
+++ b/docs/testing-patterns.md
@@ -170,3 +170,43 @@ delete-or-assign pattern shown above.
 
 - `src/queue.test.ts` — manual save/restore via a small `restoreHarnessDir` helper.
 - `src/test-utils.test.ts` — contract tests for `withTestHarness()`.
+
+## Orchestration Worktree Exclusions
+
+Orchestration worktrees use `ensureGitExcludes()` (in
+`src/orchestration/worktrees.ts`), which appends
+[`GIT_EXCLUDE_ENTRIES`](../src/orchestration/worktrees.ts) to
+`.git/info/exclude`, as the **sole** source of truth for paths that must
+never be committed from a worktree (`.peer-sync`,
+`.ludics-orchestration.json`, `.claude`, `.agents`, `.agent-sessions`,
+`node_modules`, `_build_review*`). Tests that exercise the auto-commit
+path must mirror this: call `ensureGitExcludes(repo)` directly, rather
+than passing pathspec excludes to `git add`.
+
+**Rule**: do not combine `.git/info/exclude` entries with
+`:(exclude)pattern` pathspecs on the same `git add` invocation. When the
+excluded directory physically exists, git exits 1 even though the partial
+add succeeds, which surfaces as a `runGit` throw inside
+`autoCommitWorktree()`. Pick one mechanism — for orchestration, that is
+always `ensureGitExcludes()`.
+
+**Fallback**: if a one-off command elsewhere in the codebase genuinely
+needs a pathspec exclude (no current call site does — see audit below),
+use the long form `:(exclude)pattern`. Never use the short form
+`:!pattern`: git's pathspec-magic parser fails when `pattern` contains
+`*` with `fatal: Unimplemented pathspec magic '_' in ':!_build_review*'`.
+
+Note that `ORCHESTRATION_RESET_PATHS`, passed to `git reset HEAD --`
+inside `autoCommitWorktree()`, is a pathspec *inclusion* for unstaging —
+not a pathspec exclude on `git add`. It does not trigger this failure
+mode and is unrelated to the rule above.
+
+**Precedent**: PR [#320](https://github.com/lukstafi/ludics/pull/320)
+removed the `ORCHESTRATION_EXCLUDES` constant that was being passed as
+`:(exclude)…` pathspecs inside `autoCommitWorktree()`, making
+`ensureGitExcludes()` the sole exclusion source; five tests were updated
+to call `ensureGitExcludes(repo)` explicitly rather than rely on the
+removed pathspec behavior. Background: issue
+[#329](https://github.com/lukstafi/ludics/issues/329). A repo-wide grep
+for `:(exclude)` and `:!` pathspec magic across `src/`, `tests/`,
+`scripts/`, `bin/` returns zero matches.

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -39,6 +39,10 @@ export const GIT_EXCLUDE_ENTRIES = [
  * file that git actually reads (not the per-worktree git dir).
  * Idempotent: only appends entries that are not already present.
  * Throws on failure — this is required setup, not best-effort.
+ *
+ * This is the sole source of truth for orchestration-worktree exclusions;
+ * do not combine it with `:(exclude)` pathspecs on `git add`. See
+ * `docs/testing-patterns.md` § "Orchestration Worktree Exclusions".
  */
 export function ensureGitExcludes(repoPath: string): void {
   const commonDir = runGit(repoPath, ["rev-parse", "--git-common-dir"]);
@@ -310,6 +314,11 @@ export interface AutoCommitResult {
  * Additionally unstages any already-tracked orchestration paths via
  * {@link ORCHESTRATION_RESET_PATHS} to prevent them from being committed.
  * Returns a structured result. Safe to call on clean worktrees (no-op).
+ *
+ * Do NOT add `:(exclude)` pathspecs to the `git add -A` call below — doing
+ * so while the same pattern is in `.git/info/exclude` causes git to exit 1
+ * when the excluded directory exists, which `runGit` then throws. See
+ * `docs/testing-patterns.md` § "Orchestration Worktree Exclusions".
  */
 export function autoCommitWorktree(
   worktreePath: string,


### PR DESCRIPTION
## Summary

- Add new "Orchestration Worktree Exclusions" section to `docs/testing-patterns.md` documenting the rule that `ensureGitExcludes()` / `.git/info/exclude` is the sole source of truth for orchestration worktree exclusions, never to be combined with `:(exclude)pattern` pathspecs on `git add` (causes spurious exit 1 when the excluded dir exists), and that if pathspec excludes are ever needed elsewhere the long-form `:(exclude)pattern` must be used (short-form `:!pattern` fails parsing when the pattern contains `*`).
- Add one-line JSDoc cross-references on `ensureGitExcludes` and `autoCommitWorktree` in `src/orchestration/worktrees.ts` pointing at the new doc section, so a future author reaching for a pathspec exclude finds the rule at the call site.
- Audit recorded in the doc: repo-wide grep for `:(exclude)` and `:!` pathspec magic across `src/`, `tests/`, `scripts/`, `bin/` returns zero matches — no remaining conflicting call sites.

Documentation-only; no runtime behavior change. The underlying bug was fixed in PR #320; this closes the preventive follow-up from issue #329.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bunx eslint src/orchestration/worktrees.ts` clean (no new lint errors)
- [x] `bun test src/orchestration/worktrees.test.ts` — 35 pass
- [x] Audit grep `:(exclude)` and `:!` across src/ tests/ scripts/ bin/ — zero matches

Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)