### PR TITLE
refactor(dashboard): centralize task/proposal URL builders via taskLink/proposalLink

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -468,6 +468,32 @@ describe("tasks-tree link renders task.html", () => {
   });
 });
 
+describe("taskLink / proposalLink round-trip", () => {
+  const ids = ["plain", "task&x", "task#x", "task?x", "task+x", "task with space", "tâsk-ünîcödé"];
+
+  for (const id of ids) {
+    test(`taskLink(${JSON.stringify(id)}) round-trips through URL`, async () => {
+      const { taskLink } = await import("./dashboard.ts");
+      const url = new URL(taskLink(id), "http://x/");
+      expect(url.pathname).toBe("/task.html");
+      expect(url.searchParams.get("task")).toBe(id);
+    });
+
+    test(`proposalLink(${JSON.stringify(id)}) round-trips through URL`, async () => {
+      const { proposalLink } = await import("./dashboard.ts");
+      const url = new URL(proposalLink(id), "http://x/");
+      expect(url.pathname).toBe("/proposal.html");
+      expect(url.searchParams.get("task")).toBe(id);
+    });
+  }
+
+  test("both helpers return absolute paths with a leading slash", async () => {
+    const { taskLink, proposalLink } = await import("./dashboard.ts");
+    expect(taskLink("t").startsWith("/")).toBe(true);
+    expect(proposalLink("t").startsWith("/")).toBe(true);
+  });
+});
+
 // Note: /api/slot-resume follows the exact same pattern as /api/slot-start
 // (validate slot 1-6, spawnSync `ludics slot N resume`, return OK/error).
 // slotResume() itself is already tested in src/slots/index.test.ts.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -30,6 +30,18 @@ function dashboardDataDir(): string {
   return join(harnessDir(), "dashboard", "data");
 }
 
+// Centralized URL builders for the dashboard's task/proposal link patterns.
+// Every server- and client-side call site routes through these so the
+// encoding choice (encodeURIComponent) and path shape (absolute, leading `/`)
+// live in one place. Client-side mirrors live in templates/dashboard/links.js.
+export function taskLink(id: string): string {
+  return `/task.html?task=${encodeURIComponent(id)}`;
+}
+
+export function proposalLink(id: string): string {
+  return `/proposal.html?task=${encodeURIComponent(id)}`;
+}
+
 // --- Generate slots.json ---
 
 interface SlotJson {
@@ -262,7 +274,7 @@ function generateSlots(): SlotJson[] {
     const taskContent = taskMeta.content;
     const taskEffort = taskMeta.effort;
     const slotHasProposal = taskMeta.hasProposal;
-    const slotProposalLink = slotHasProposal && taskId ? `/proposal.html?task=${encodeURIComponent(taskId)}` : null;
+    const slotProposalLink = slotHasProposal && taskId ? proposalLink(taskId) : null;
     const githubUrl = taskMeta.githubUrl;
 
     const machineName = data.machine ?? "";
@@ -650,8 +662,8 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
     const hasActiveProposal = task.hasProposal && !task.isCompleted;
     const subtreeHasActiveProposal = hasActiveProposal || descendantHasActiveProposal;
     const highlighted = !task.isCompleted && subtreeHasActiveProposal;
-    const taskFileLink = `/task.html?task=${encodeURIComponent(task.id)}`;
-    const proposalLink = task.proposalPath ? `/proposal.html?task=${encodeURIComponent(task.id)}` : null;
+    const taskFileLink = taskLink(task.id);
+    const taskProposalLink = task.proposalPath ? proposalLink(task.id) : null;
     const retroLink = task.hasRetrospective ? `retrospective.html?task=${encodeURIComponent(task.id)}` : null;
 
     return {
@@ -660,7 +672,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
         id: task.id,
         title: task.title || task.id,
         link: taskFileLink,
-        proposalLink,
+        proposalLink: taskProposalLink,
         retroLink,
         priority: task.priority,
         status: task.status,
@@ -972,7 +984,7 @@ function generateRecentlyCompleted(tasks: DashboardTask[]): RecentlyCompletedTas
       prUrl,
       prStatus,
       retrospectiveLink: `/retrospective.html?task=${encodeURIComponent(t.id)}`,
-      proposalLink: t.hasProposal ? `/proposal.html?task=${encodeURIComponent(t.id)}` : null,
+      proposalLink: t.hasProposal ? proposalLink(t.id) : null,
     };
   });
 }

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -10,6 +10,7 @@ import { emitEvent } from "./events.ts";
 import { readAllSlotJson } from "./slots/json.ts";
 import { getUrl } from "./network.ts";
 import { readFrontmatterField } from "./tasks/markdown.ts";
+import { proposalLink } from "./dashboard.ts";
 
 function notificationLogFile(): string {
   return join(harnessDir(), "journal", "notifications.jsonl");
@@ -505,7 +506,7 @@ export function notifyProposal(
   const config = loadConfigSync();
   const dashboardPort = config.dashboard?.port ?? 7678;
   const dashboardBaseUrl = getUrl(dashboardPort);
-  const proposalViewUrl = `${dashboardBaseUrl}/proposal.html?task=${encodeURIComponent(taskId)}`;
+  const proposalViewUrl = `${dashboardBaseUrl}${proposalLink(taskId)}`;
 
   const resolvedPath = resolveProposalFilePath(taskId, filePath);
   if (!resolvedPath) {

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -598,7 +598,7 @@ function fetchNeedsConfirmation() {
             return `
             <li class="needs-confirm-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title needs-confirm-link" href="task.html?task=${encodeURIComponent(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
+                <a class="task-title needs-confirm-link" href="${taskLink(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>${source}
                 <span class="confirm-actions">
                     <button class="confirm-btn" onclick="confirmTask('${escapeHtml(task.id)}')" title="Confirm: move to ready">&#x2713;</button>
                     <button class="dismiss-btn" onclick="dismissTask('${escapeHtml(task.id)}')" title="Dismiss: abandon">&#x2715;</button>
@@ -619,7 +619,7 @@ function fetchUnansweredQuestions() {
             return `
             <li class="unanswered-q-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
-                <a class="task-title unanswered-q-link" href="task.html?task=${encodeURIComponent(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
+                <a class="task-title unanswered-q-link" href="${taskLink(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
             </li>`;
         },
     });
@@ -634,8 +634,8 @@ function fetchDeferredLaunch() {
             const priority = task.priority || '-';
             const priorityClass = `priority-${priority}`;
             const viewLink = task.hasProposal
-                ? `proposal.html?task=${encodeURIComponent(task.id)}`
-                : `task.html?task=${encodeURIComponent(task.id)}`;
+                ? proposalLink(task.id)
+                : taskLink(task.id);
             return `
             <li class="deferred-launch-item">
                 <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -171,6 +171,7 @@
     </footer>
 
     <script src="markdown.js"></script>
+    <script src="links.js"></script>
     <script src="dashboard.js"></script>
 </body>
 </html>

--- a/templates/dashboard/links.js
+++ b/templates/dashboard/links.js
@@ -1,0 +1,18 @@
+// links.js -- centralized URL builders for dashboard task/proposal links
+//
+// Every client-side call site that emits a link to task.html or proposal.html
+// routes through these helpers so the encoding choice (encodeURIComponent)
+// and absolute-path shape live in one place. Server-side mirrors live in
+// src/dashboard.ts (taskLink / proposalLink).
+//
+// Loaded as a classic <script> before dashboard.js / inline scripts that need
+// the helpers. Top-level function declarations so callers don't have to
+// plumb them through closures.
+
+function taskLink(id) {
+    return `/task.html?task=${encodeURIComponent(id)}`;
+}
+
+function proposalLink(id) {
+    return `/proposal.html?task=${encodeURIComponent(id)}`;
+}

--- a/templates/dashboard/retrospective.html
+++ b/templates/dashboard/retrospective.html
@@ -47,6 +47,7 @@
     </footer>
 
     <script src="markdown.js"></script>
+    <script src="links.js"></script>
     <script>
         const params = new URLSearchParams(window.location.search);
         const taskId = params.get('task') || '';
@@ -112,7 +113,7 @@
 
             // Links bar
             const links = [];
-            if (data.proposalPath) links.push(`<a href="proposal.html?task=${encodeURIComponent(data.taskId)}">Proposal</a>`);
+            if (data.proposalPath) links.push(`<a href="${proposalLink(data.taskId)}">Proposal</a>`);
             if (data.prUrl) links.push(`<a href="${escapeHtml(data.prUrl)}" target="_blank">Pull Request</a>`);
             if (data.githubUrl) links.push(`<a href="${escapeHtml(data.githubUrl)}" target="_blank">GitHub Issue</a>`);
             if (links.length > 0) html += `<div class="retro-links">${links.join('')}</div>`;

--- a/templates/dashboard/task.html
+++ b/templates/dashboard/task.html
@@ -49,6 +49,7 @@
     </footer>
 
     <script src="markdown.js"></script>
+    <script src="links.js"></script>
     <script>
         const params = new URLSearchParams(window.location.search);
         const taskId = params.get('task') || '';
@@ -123,7 +124,7 @@
             if (!container) return;
             const links = [];
             if (meta.proposal) {
-                links.push(`<a href="proposal.html?task=${encodeURIComponent(taskId)}">View Proposal</a>`);
+                links.push(`<a href="${proposalLink(taskId)}">View Proposal</a>`);
             }
             if (links.length === 0) {
                 container.hidden = true;

--- a/templates/dashboard/task.test.ts
+++ b/templates/dashboard/task.test.ts
@@ -172,7 +172,7 @@ describe("task.html template", () => {
   });
 
   test("links back to the proposal renderer when frontmatter has a proposal field", () => {
-    expect(template).toContain("proposal.html?task=");
+    expect(template).toContain("proposalLink(taskId)");
     expect(template).toContain("meta.proposal");
   });
 
@@ -185,26 +185,33 @@ describe("dashboard.js task links", () => {
   const templatePath = join(import.meta.dir, "dashboard.js");
   const template = readFileSync(templatePath, "utf-8");
 
-  test("needs-confirmation link points to task.html with URL-encoded id", () => {
-    expect(template).toContain('needs-confirm-link" href="task.html?task=${encodeURIComponent(task.id)}"');
+  test("needs-confirmation link uses taskLink helper", () => {
+    expect(template).toContain('needs-confirm-link" href="${taskLink(task.id)}"');
   });
 
-  test("unanswered-questions link points to task.html with URL-encoded id", () => {
-    expect(template).toContain('unanswered-q-link" href="task.html?task=${encodeURIComponent(task.id)}"');
+  test("unanswered-questions link uses taskLink helper", () => {
+    expect(template).toContain('unanswered-q-link" href="${taskLink(task.id)}"');
   });
 
-  test("deferred-launch fallback points to task.html (not raw markdown)", () => {
-    expect(template).toContain("`task.html?task=${encodeURIComponent(task.id)}`");
+  test("deferred-launch fallback uses taskLink/proposalLink helpers", () => {
+    expect(template).toContain("proposalLink(task.id)");
+    expect(template).toContain("taskLink(task.id)");
   });
 
   test("task-link query params use encodeURIComponent, never escapeHtml", () => {
     // Regression guard: escapeHtml(id) protects against attribute injection
     // but does NOT percent-encode URL-delimiter characters like `&`, `#`,
     // `?`, or `+`. A task id containing any of those would break query-param
-    // parsing on task.html. Only encodeURIComponent is safe here. (Both
-    // approaches are safe for attribute-escaping because encodeURIComponent
-    // also percent-encodes `"`, `'`, `<`, `>`, and `&`.)
+    // parsing on task.html. Only encodeURIComponent is safe here (now routed
+    // through the taskLink/proposalLink helpers in links.js). Both approaches
+    // are safe for attribute-escaping because encodeURIComponent also
+    // percent-encodes `"`, `'`, `<`, `>`, and `&`.
     expect(template).not.toMatch(/task\.html\?task=\$\{escapeHtml\(task\.id\)\}/);
+    // Also guard that the inline `task.html?task=${...}` pattern has been
+    // fully replaced with the helper — a regression where a new call site
+    // spells the URL inline would slip past the helper's centralization.
+    expect(template).not.toMatch(/task\.html\?task=\$\{/);
+    expect(template).not.toMatch(/proposal\.html\?task=\$\{/);
   });
 
   test("no raw task-files/ links remain in client-side rendering", () => {
@@ -213,5 +220,48 @@ describe("dashboard.js task links", () => {
     // test flags it so the migration stays exhaustive.
     expect(template).not.toMatch(/href="task-files\//);
     expect(template).not.toMatch(/`task-files\//);
+  });
+});
+
+describe("links.js taskLink / proposalLink helpers", () => {
+  const linksPath = join(import.meta.dir, "links.js");
+  const linksSource = readFileSync(linksPath, "utf-8");
+
+  // links.js is a classic <script> file with no exports. Evaluate its source
+  // in a fresh Function scope and return the helpers out for direct testing.
+  // This is the same readFileSync + new Function pattern used by other
+  // template-asset tests.
+  const helpers = new Function(
+    `${linksSource}\nreturn { taskLink, proposalLink };`,
+  )() as { taskLink: (id: string) => string; proposalLink: (id: string) => string };
+
+  const ids = ["plain", "task&x", "task#x", "task?x", "task+x", "task with space", "tâsk-ünîcödé"];
+
+  for (const id of ids) {
+    test(`taskLink(${JSON.stringify(id)}) round-trips through URL`, () => {
+      const url = new URL(helpers.taskLink(id), "http://x/");
+      expect(url.pathname).toBe("/task.html");
+      expect(url.searchParams.get("task")).toBe(id);
+    });
+
+    test(`proposalLink(${JSON.stringify(id)}) round-trips through URL`, () => {
+      const url = new URL(helpers.proposalLink(id), "http://x/");
+      expect(url.pathname).toBe("/proposal.html");
+      expect(url.searchParams.get("task")).toBe(id);
+    });
+  }
+
+  test("both helpers return absolute paths with a leading slash", () => {
+    expect(helpers.taskLink("t").startsWith("/")).toBe(true);
+    expect(helpers.proposalLink("t").startsWith("/")).toBe(true);
+  });
+
+  test("index.html, task.html, and retrospective.html load links.js", () => {
+    const indexSrc = readFileSync(join(import.meta.dir, "index.html"), "utf-8");
+    const taskSrc = readFileSync(join(import.meta.dir, "task.html"), "utf-8");
+    const retroSrc = readFileSync(join(import.meta.dir, "retrospective.html"), "utf-8");
+    expect(indexSrc).toContain('<script src="links.js"></script>');
+    expect(taskSrc).toContain('<script src="links.js"></script>');
+    expect(retroSrc).toContain('<script src="links.js"></script>');
   });
 });


### PR DESCRIPTION
## Summary

- Extracts `taskLink(id)` / `proposalLink(id)` helpers so the
  `/task.html?task=…` and `/proposal.html?task=…` URL shape and
  `encodeURIComponent` choice live in one place per side. Exports the
  pair from `src/dashboard.ts`; mirrors them in a new
  `templates/dashboard/links.js` classic `<script>` module loaded by
  `index.html`, `task.html`, and `retrospective.html`.
- Migrates nine call sites: four in `src/dashboard.ts`
  (`generateSlots`, `generateTasksTree`, `generateRecentlyCompleted`),
  one in `src/notify.ts` (`proposalViewUrl`), three in
  `dashboard.js` (needs-confirmation, unanswered-questions, deferred-
  launch ternary), and one each in `task.html` (`View Proposal`) and
  `retrospective.html` (retro links bar). Client-side call sites
  switch from relative to absolute paths for cross-side consistency.
- Adds delimiter-suite round-trip tests on both sides
  (`["plain", "task&x", "task#x", "task?x", "task+x", "task with space",
  "tâsk-ünîcödé"]`), parsing via `new URL(href, "http://x/")` and
  asserting `searchParams.get("task")` round-trips. Strengthens the
  existing "never `escapeHtml`" guard with negative regexes against
  any new inline `task.html?task=${` or `proposal.html?task=${`
  spelling — reintroducing the inline pattern now fails the test
  rather than the next unencoded delimiter character in a task id.

Motivation: item #1 of the `task-c5937037` retrospective — four call
sites spelled the same URL, two using `escapeHtml` and two using
`encodeURIComponent` (the Codex review caught the divergence). The
mixed encoding was fixed in PR #333; this refactor locks the correct
pattern in by making it the only pattern.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test` — 1113 pass / 0 fail
- [x] Targeted: `bun test src/dashboard.test.ts templates/dashboard/task.test.ts templates/dashboard/dashboard.test.ts src/notify.test.ts`
- [ ] Post-merge: `bun run build; ludics init --no-triggers` on a
      dashboard install; open the dashboard and spot-check that the
      needs-confirmation, unanswered-questions, deferred-launch,
      task-tree, recently-completed, task.html → Proposal, and
      retrospective.html → Proposal links all resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)