### PR TITLE
docs(t3code): name flag-name-keyed-rejection rule near reviewerOnlyFlag

### DIFF
--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -224,9 +224,22 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
   let coderThinkingEffort: string | undefined;
   let reviewerThinkingEffort: string | undefined;
   let duoPeerSlot: number | undefined;
-  // Track the first reviewer-only override flag seen (excluding the shared
-  // --effort / --thinking-effort flags). Used to reject reviewer-specific
-  // overrides in --solo mode, where no reviewer agent exists.
+  // Anti-pattern being prevented: "recorded but discarded" — accepting
+  // --reviewer-* flags into a target variable that a later mode branch
+  // (here, --solo) silently overwrites or ignores, so the flag parses
+  // successfully but has no effect. The fix is to key rejection on the
+  // flag NAME recorded during parsing, not on whether the target variable
+  // is set afterwards: shared flags like --effort assign the same target
+  // as role-specific flags like --reviewer-effort, so post-parse variable
+  // state cannot distinguish the two cases.
+  //
+  // See docs/orchestration-patterns.md#flag-name-keyed-rejection for the
+  // full pattern entry and the reusable recipe for future adapter parsers
+  // that gain role-specific flags.
+  //
+  // reviewerOnlyFlag records the first --reviewer-* flag seen (excluding
+  // the shared --effort / --thinking-effort flags). Checked at the --solo
+  // mode gate below to throw with a specific error naming the offending flag.
   let reviewerOnlyFlag: string | null = null;
 
   for (let i = 0; i < args.length; i++) {


### PR DESCRIPTION
## Summary

- Extends the comment block above `reviewerOnlyFlag` in `parseT3CodeAdapterArgs` to name the "recorded but discarded" anti-pattern and cite `docs/orchestration-patterns.md#flag-name-keyed-rejection`.
- Comment-only change; no behavior change, no test change.
- Implements Option B of the task-8f5a78a1 audit (retrospective of task-da8b6dff). Audit confirmed `parseT3CodeAdapterArgs` is the only in-repo parser with role-specific flags.

Proposal: `docs/proposals/t3code-reviewer-only-flag-comment.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src/adapters/t3code.test.ts` (43 pass)
- [x] `bun run lint` — error count unchanged from base (653 pre-existing, unrelated)
- [x] Verified `flag-name-keyed-rejection` anchor exists in `docs/orchestration-patterns.md` (line 332)

🤖 Generated with [Claude Code](https://claude.com/claude-code)