### PR TITLE
Add priority level D as new floor below C

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
 import YAML from "yaml";
 import { isPlainObject } from "./json.ts";
+import { PRIORITY_INCREASE, priorityValue } from "./tasks/markdown.ts";
 
 const DEFAULT_STALE_THRESHOLD = 86400; // 24 hours
 
@@ -458,31 +459,21 @@ function priorityProjectSet(): Set<string> {
 /**
  * Returns the effective (virtual) priority for a task, applying a one-level
  * boost when the task's project has `priority: true` in config:
- *   A → S, B → A, C → B (non-priority tasks keep their actual priority).
+ *   A → S, B → A, C → B, D → C (non-priority tasks keep their actual priority).
+ * Delegates to the shared PRIORITY_INCREASE table so future ladder changes
+ * only need to touch markdown.ts.
  */
 export function effectivePriority(priority: string, project: string): string {
   if (!priorityProjectSet().has(project.toLowerCase())) return priority;
-  switch (priority) {
-    case "A": return "S";
-    case "B": return "A";
-    case "C": return "B";
-    default: return priority;
-  }
+  return PRIORITY_INCREASE[priority] ?? priority;
 }
 
 /**
- * Numeric sort key for virtual priority: S=0, A=1, B=2, C=3, other=9.
+ * Numeric sort key for virtual priority: S=0, A=1, B=2, C=3, D=4, other=9.
  * Applies priority-project boost automatically.
  */
 export function effectivePriorityValue(priority: string, project: string): number {
-  const ep = effectivePriority(priority, project);
-  switch (ep) {
-    case "S": return 0;
-    case "A": return 1;
-    case "B": return 2;
-    case "C": return 3;
-    default: return 9;
-  }
+  return priorityValue(effectivePriority(priority, project));
 }
 
 /**

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -503,7 +503,7 @@ export function startDashboardServer(
           return new Response("Bad Request: title is required", { status: 400 });
         }
         const project = typeof body.project === "string" ? body.project.trim() || "personal" : "personal";
-        const priority = typeof body.priority === "string" && /^[A-DS]$/.test(body.priority) ? body.priority : "B";
+        const priority = typeof body.priority === "string" && /^[A-DS]$/.test(body.priority) ? body.priority : "C";
         const effort = typeof body.effort === "string" && ["tiny", "small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
         const usesBrowser = body.usesBrowser === true;
         const taskBody = typeof body.body === "string" ? body.body.trim() : "";

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -278,7 +278,7 @@ export function startDashboardServer(
         }
       }
 
-      // API: promote task priority one level (C→B→A→S)
+      // API: promote task priority one level (D→C→B→A→S)
       if (pathname === "/api/task-promote") {
         const taskParam = url.searchParams.get("task");
         if (!taskParam || !TASK_ID_RE.test(taskParam)) {
@@ -503,7 +503,7 @@ export function startDashboardServer(
           return new Response("Bad Request: title is required", { status: 400 });
         }
         const project = typeof body.project === "string" ? body.project.trim() || "personal" : "personal";
-        const priority = typeof body.priority === "string" && /^[A-CS]$/.test(body.priority) ? body.priority : "B";
+        const priority = typeof body.priority === "string" && /^[A-DS]$/.test(body.priority) ? body.priority : "B";
         const effort = typeof body.effort === "string" && ["tiny", "small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
         const usesBrowser = body.usesBrowser === true;
         const taskBody = typeof body.body === "string" ? body.body.trim() : "";

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -27,7 +27,7 @@ import {
   expirePendingRevises,
   expirePendingFollowupRevises,
 } from "./notify.ts";
-import { addFrontmatterField, updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, readFrontmatterField } from "./tasks/markdown.ts";
+import { addFrontmatterField, updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, readFrontmatterField, priorityValue } from "./tasks/markdown.ts";
 import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
@@ -1992,8 +1992,7 @@ function computeSessionProjectMatches(): string {
   for (const [, tasks] of tasksByProject) {
     tasks.sort((a, b) => {
       if (a.elaborated !== b.elaborated) return a.elaborated ? -1 : 1;
-      const pv = (p: string) => p === "A" ? 1 : p === "B" ? 2 : p === "C" ? 3 : 9;
-      return pv(a.priority) - pv(b.priority);
+      return priorityValue(a.priority) - priorityValue(b.priority);
     });
   }
 

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -8,16 +8,17 @@ import type { TaskFrontmatter } from "./types.ts";
 /** Regex for valid task IDs — used across all task-related endpoints. */
 export const TASK_ID_RE = /^[A-Za-z0-9._-]+$/;
 
-export const PRIORITY_INCREASE: Record<string, string> = { C: "B", B: "A", A: "S" };
-export const PRIORITY_DECREASE: Record<string, string> = { S: "A", A: "B", B: "C" };
+export const PRIORITY_INCREASE: Record<string, string> = { D: "C", C: "B", B: "A", A: "S" };
+export const PRIORITY_DECREASE: Record<string, string> = { S: "A", A: "B", B: "C", C: "D" };
 
-/** Numeric sort key for priority levels. S < A < B < C < anything else. */
+/** Numeric sort key for priority levels. S < A < B < C < D < anything else. */
 export function priorityValue(p: string): number {
   switch (p) {
     case "S": return 0;
     case "A": return 1;
     case "B": return 2;
     case "C": return 3;
+    case "D": return 4;
     default: return 9;
   }
 }
@@ -297,7 +298,8 @@ export function writeTaskFile(
     return false;
   }
 
-  // Infer priority from labels
+  // Infer priority from labels. Never produces D — D is reachable only via
+  // explicit demote/postpone on an existing C-priority task.
   let priority = "B";
   if (/urgent|critical|high|priority/i.test(labels)) {
     priority = "A";

--- a/src/tasks/priority-value.test.ts
+++ b/src/tasks/priority-value.test.ts
@@ -2,25 +2,28 @@ import { describe, test, expect } from "bun:test";
 import { priorityValue } from "./markdown.ts";
 
 describe("priorityValue", () => {
-  test("orders S < A < B < C", () => {
+  test("orders S < A < B < C < D", () => {
     expect(priorityValue("S")).toBeLessThan(priorityValue("A"));
     expect(priorityValue("A")).toBeLessThan(priorityValue("B"));
     expect(priorityValue("B")).toBeLessThan(priorityValue("C"));
+    expect(priorityValue("C")).toBeLessThan(priorityValue("D"));
   });
 
-  test("returns exact values: S=0, A=1, B=2, C=3", () => {
+  test("returns exact values: S=0, A=1, B=2, C=3, D=4", () => {
     expect(priorityValue("S")).toBe(0);
     expect(priorityValue("A")).toBe(1);
     expect(priorityValue("B")).toBe(2);
     expect(priorityValue("C")).toBe(3);
+    expect(priorityValue("D")).toBe(4);
   });
 
   test("unknown priority sorts last (returns 9)", () => {
     expect(priorityValue("X")).toBe(9);
-    expect(priorityValue("X")).toBeGreaterThan(priorityValue("C"));
+    expect(priorityValue("X")).toBeGreaterThan(priorityValue("D"));
+    expect(priorityValue("D")).toBeLessThan(priorityValue("X"));
   });
 
   test("empty string sorts last", () => {
-    expect(priorityValue("")).toBeGreaterThan(priorityValue("C"));
+    expect(priorityValue("")).toBeGreaterThan(priorityValue("D"));
   });
 });

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -5,7 +5,7 @@ export interface TaskFrontmatter {
   title: string;
   project: string;
   status: string; // ready, in-progress, deferred, preempted, done, abandoned, merged, needs-confirmation
-  priority: string; // A, B, C
+  priority: string; // S, A, B, C, D (D reached only via demote/postpone)
   deadline: string | null;
   dependencies: {
     blocks: string[];

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -528,7 +528,7 @@ async function slotActionPostpone(slotNum) {
     }
 }
 
-// Promote a ready queue task's priority one level (C→B→A→S)
+// Promote a ready queue task's priority one level (D→C→B→A→S)
 async function promoteTask(taskId) {
     const li = event.currentTarget;
     if (li.classList.contains('promoting')) return;

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -32,6 +32,7 @@
     --priority-a: #e85d4a;
     --priority-b: #f5a623;
     --priority-c: #6b6560;
+    --priority-d: #c4bfbb;
 
     --empty: #6b6560;
     --interrupted: #f87171;
@@ -81,6 +82,7 @@
     --priority-a: #c9362c;
     --priority-b: #ca8a04;
     --priority-c: #a8a29e;
+    --priority-d: #d6d3d1;
 
     --empty: #a8a29e;
     --interrupted: #ef4444;
@@ -119,6 +121,7 @@
     --priority-a: #ff4040;
     --priority-b: #ffaa00;
     --priority-c: #606060;
+    --priority-d: #909090;
 
     --empty: #606060;
     --interrupted: #ff5555;
@@ -1026,6 +1029,11 @@ main {
 .priority-S {
     background-color: var(--priority-s);
     color: white;
+}
+
+.priority-D {
+    background-color: var(--priority-d);
+    color: #000;
 }
 
 /* Ready queue clickable items */
@@ -2383,6 +2391,7 @@ textarea:focus-visible {
         --priority-a: #c9362c;
         --priority-b: #ca8a04;
         --priority-c: #a8a29e;
+        --priority-d: #d6d3d1;
         --empty: #a8a29e;
         --interrupted: #ef4444;
         --border: #d6d3d1;

--- a/templates/dashboard/task-creator.html
+++ b/templates/dashboard/task-creator.html
@@ -230,7 +230,7 @@
                     // Reset form
                     document.getElementById('task-title').value = '';
                     document.getElementById('task-body').value = '';
-                    document.getElementById('pri-b').checked = true;
+                    document.getElementById('pri-c').checked = true;
                     document.getElementById('eff-medium').checked = true;
                     document.getElementById('task-browser').checked = false;
                     updatePreview();

--- a/templates/dashboard/task-creator.html
+++ b/templates/dashboard/task-creator.html
@@ -49,6 +49,8 @@
 
             <div class="form-group">
                 <label>Priority</label>
+                <!-- D is intentionally omitted: D is reachable only via demote/postpone,
+                     not direct creation. See docs/proposals/priority-level-d-floor.md. -->
                 <div class="segmented-control">
                     <input type="radio" name="priority" id="pri-c" value="C">
                     <label for="pri-c">C</label>

--- a/templates/dashboard/task-creator.html
+++ b/templates/dashboard/task-creator.html
@@ -52,9 +52,9 @@
                 <!-- D is intentionally omitted: D is reachable only via demote/postpone,
                      not direct creation. See docs/proposals/priority-level-d-floor.md. -->
                 <div class="segmented-control">
-                    <input type="radio" name="priority" id="pri-c" value="C">
+                    <input type="radio" name="priority" id="pri-c" value="C" checked>
                     <label for="pri-c">C</label>
-                    <input type="radio" name="priority" id="pri-b" value="B" checked>
+                    <input type="radio" name="priority" id="pri-b" value="B">
                     <label for="pri-b">B</label>
                     <input type="radio" name="priority" id="pri-a" value="A">
                     <label for="pri-a">A</label>


### PR DESCRIPTION
## Summary

Implements the proposal at `docs/proposals/priority-level-d-floor.md`. Fixes the silent no-op where "postpone" on a C-priority task left the frontmatter unchanged (`PRIORITY_DECREASE["C"]` was `undefined`) while the slot-clear half of postpone still fired and `maybeFillEmptySlots` immediately re-picked the task. C is the most-populated tier, so this bug blocked the primary demote path.

- Add priority level **D** as the new floor: `PRIORITY_INCREASE: D→C`, `PRIORITY_DECREASE: C→D`, `priorityValue("D") = 4`.
- C stays the default at creation time (dashboard API fallback + task-creator radio now both default to C, matching the proposal).
- `effectivePriority` / `effectivePriorityValue` now delegate through `PRIORITY_INCREASE` + `priorityValue`, removing the duplicated ladder switch. Focus-project boost D→C falls out for free.
- `adoptSessions` in `mag.ts` now uses the shared `priorityValue` (the inline `pv` arrow mirror is gone).
- Dashboard create-task regex widened to `/^[A-DS]$/`; `task-creator.html` radios stay at C/B/A by design (D is demote-only) with an explanatory comment.
- Dashboard renders a D-priority badge (paler-than-C shade) in all four theme blocks — default, dark, high-contrast, and the `prefers-color-scheme: dark` media-query block.
- Promote tooltip updated: `C→B→A→S` → `D→C→B→A→S`.
- `TaskFrontmatter.priority` doc comment refreshed to include S/D.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 1082 pass / 0 fail / 2193 expect() calls.
- [x] `bun test src/tasks/priority-value.test.ts` — 4 pass / 0 fail (new D cases: exact value `4`, chained `S<A<B<C<D`, `C<D<unknown`, empty-string `>D`).
- [x] `bun run build` — compiles `bin/ludics` cleanly.
- [ ] Manual: dashboard postpone on a C-priority task writes `priority: D` to the frontmatter; promote on D writes `priority: C`; D badge renders with the paler-gray style in each theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)