### PR TITLE
fix(orchestration): line-1-wins verdict parser (gh-ludics-346)

### DIFF
--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -595,6 +595,35 @@ describe("isAgentDone — stale status detection (gh-ludics-122)", () => {
     expect(evaluateTransition(state)).toBe("work");
   });
 
+  // Regression for issue #346: APPROVE on line 1 + prose body that mentions
+  // the literal token REQUEST_CHANGES must parse as approve, not as a rejection.
+  // Mirrors the slot 6 / gh-ludics-310 incident where a review of a template
+  // change discussed "REQUEST_CHANGES consequences" in prose and looped the
+  // orchestrator back to work for 5 rounds.
+  test("regression: APPROVE line 1 + REQUEST_CHANGES in prose → review transitions to update-docs (gh-ludics-346)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "gh346-"));
+    mkdirSync(join(tmpDir, "reviews"), { recursive: true });
+    const state = makePairState(tmpDir, { phaseStartedAt: Math.floor(Date.now() / 1000) - 10 });
+
+    writeFileSync(join(tmpDir, "reviewer.status"), "idle|0|\n");
+    const baseline = statusFileFingerprint(tmpDir, "reviewer");
+
+    writeFileSync(join(tmpDir, "reviewer.status"), "review-done|0|done\n");
+    writeFileSync(
+      join(tmpDir, "reviews", "round-1-reviewer.md"),
+      "APPROVE\n\n"
+        + "All four templates now enforce the structural `## Regression Tests` "
+        + "requirement with the intended per-file accounting and "
+        + "REQUEST_CHANGES consequences.\n",
+    );
+
+    state.agentStates.reviewer.status = "review-done";
+    state.agentStates.reviewer.turnLifecycle = null;
+    state.agentStates.reviewer.dispatchStatusFingerprint = baseline;
+
+    expect(evaluateTransition(state)).toBe("update-docs");
+  });
+
   test("null lifecycle + no baseline (legacy) → trusts done status + artifact", () => {
     const tmpDir = mkdtempSync(join(tmpdir(), "gh122-"));
     mkdirSync(join(tmpDir, "reviews"), { recursive: true });

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -381,6 +381,27 @@ export function pairReviewVerdict(state: OrchestrationState): "approve" | "reque
     : reviewFilePath(state.peerSyncDir, "review", state.round, reviewer.name);
   if (!existsSync(reviewFile)) return null;
   const content = readFileSync(reviewFile, "utf-8").toUpperCase();
+
+  // Line-1-wins (issue #346): reviewer templates prescribe the verdict token
+  // on the first non-blank line. Trusting line 1 prevents prose further down
+  // that happens to mention REQUEST_CHANGES (quoted template text, filenames,
+  // consequence descriptions) from overriding an APPROVE verdict.
+  const headerOnlyLine = /^\s*(?:#{1,6}\s*VERDICT\s*:?\s*|\*\*\s*VERDICT\s*\*\*\s*:?\s*)$/;
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "") continue;
+    if (headerOnlyLine.test(line)) continue;
+    const stripped = line.replace(/^[`*\s]+/, "").replace(/[`*\s.:;,!?]+$/, "");
+    const tokenMatch = stripped.match(/^(APPROVE|REQUEST_CHANGES)\b/);
+    if (tokenMatch) {
+      return tokenMatch[1] === "APPROVE" ? "approve" : "request_changes";
+    }
+    break; // first verdict-bearing line reached; fall through to safety-net regex
+  }
+
+  // Fallback (silent safety net) for unusual layouts where the verdict token
+  // isn't on line 1. Vulnerable to prose contamination, so only consulted when
+  // line-1 detection above did not recognize a token.
   if (/\bAPPROVE\b/.test(content) && !/\bREQUEST_CHANGES\b/.test(content)) return "approve";
   if (/\bREQUEST_CHANGES\b/.test(content)) return "request_changes";
   return null;


### PR DESCRIPTION
## Summary

Closes #346.

`pairReviewVerdict()` in `src/orchestration/phases.ts` scanned the entire review body for word-boundary matches of `REQUEST_CHANGES`, so any APPROVE review whose prose mentioned the literal token — quoting template rules, filenames, consequence descriptions — was misread as a rejection. Slot 6 looped review → work five times on gh-ludics-310 for this reason, and this branch's own reviewer looped eight rounds writing APPROVE reviews whose non-blocking-observations described "APPROVE on line 1 with REQUEST_CHANGES later in prose" — the exact shape the fix eliminates.

Fix: trust line 1. Skip recognized `## Verdict` / `**Verdict**:` header prefixes, strip surrounding markup (`**`, backticks, trailing punctuation) from the first non-blank line, and return the verdict if the leading token matches `APPROVE` or `REQUEST_CHANGES`. Fall back to the legacy whole-body regex only when the first line isn't a verdict token, preserving behavior for unusual layouts. Empty/blank files still return `null`.

Applies to both `review` and `plan-review` phases since they share the same parser.

## Test plan

- [x] New regression test: `APPROVE` on line 1 + prose containing `REQUEST_CHANGES consequences` → `evaluateTransition` routes review → update-docs (not back to work).
- [x] Existing `## Verdict\nREQUEST_CHANGES\n` fixture keeps parsing as rejection.
- [x] Existing `APPROVE\n` / `## Verdict\nAPPROVE\n` fixtures unchanged.
- [x] `bun test src/orchestration/phases.test.ts` → 84 pass / 0 fail.

Loop-detector secondary fix is deliberately out of scope; an agent-initiated `bail-out: escalate` action is filed as the follow-up task (task-4cd94043).

🤖 Generated with [Claude Code](https://claude.com/claude-code)