### PR TITLE
refactor(slots): extract autoFillAdapterArgs helper to de-flake t3code tests

### DIFF
--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext } from "./index.ts";
 import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, type OrchestrationState } from "../orchestration/state.ts";
 import { tmuxKillSession, tmuxHasSession } from "../adapters/tmux.ts";
 import { existsSync } from "fs";
@@ -441,14 +441,23 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     writeTask(tasksDir, "task-empty-args-1", "Empty args test");
     // slotAssign with no adapterArgs stores "null" which makeAdapterContext converts to ""
     slotAssign(1, "task-empty-args-1", "t3code");
-    // slotStart auto-fills flags then proceeds to adapter start (which fails in test env)
-    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
-    // Verify auto-filled flags were written back to slot block
+    const data = readSlotJson(1, harness);
+    const ctx = makeAdapterContext(1, data);
+
+    // (a) computes correct args
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    expect(result!.args).toContain("--pair");
+    expect(result!.args).toContain("--coder");
+    expect(result!.args).toContain("--reviewer");
+
+    // (b) persists them — writeback via writeSlotJson round-trip
+    writeSlotJson(1, result!.updatedData, harness);
     const args = readAdapterArgsFromSlots();
     expect(args).toContain("--pair");
     expect(args).toContain("--coder");
     expect(args).toContain("--reviewer");
-  }, 15_000);
+  });
 
   test("auto-fills orchestration flags when adapterArgs is whitespace-only", async () => {
     const harness = join(TMP, "ludics-state", "harness");
@@ -459,14 +468,23 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     writeTask(tasksDir, "task-whitespace-args-1", "Whitespace args test");
     // Assign with whitespace adapterArgs — stored as-is since "   " is truthy
     slotAssign(1, "task-whitespace-args-1", "t3code", "", "", "   ");
-    // slotStart auto-fills flags then proceeds to adapter start (which fails in test env)
-    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
-    // Verify auto-filled flags were written back to slot block
+    const data = readSlotJson(1, harness);
+    const ctx = makeAdapterContext(1, data);
+
+    // (a) computes correct args
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    expect(result!.args).toContain("--pair");
+    expect(result!.args).toContain("--coder");
+    expect(result!.args).toContain("--reviewer");
+
+    // (b) persists them
+    writeSlotJson(1, result!.updatedData, harness);
     const args = readAdapterArgsFromSlots();
     expect(args).toContain("--pair");
     expect(args).toContain("--coder");
     expect(args).toContain("--reviewer");
-  }, 15_000);
+  });
 
   test("throws when no task is assigned and adapterArgs is empty", async () => {
     // Assign with no task — slotAssign requires a task, so use slotSetMode instead
@@ -486,11 +504,21 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     writeSlotJson(2, emptySlotData(2), harness);
     writeTask(tasksDir, "task-medium-plan-1", "Medium plan test");
     slotAssign(1, "task-medium-plan-1", "t3code");
-    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
+    const data = readSlotJson(1, harness);
+    const ctx = makeAdapterContext(1, data);
+
+    // (a) computes correct args
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    expect(result!.args).toContain("--plan");
+    expect(result!.args).toContain("--pair");
+
+    // (b) persists them
+    writeSlotJson(1, result!.updatedData, harness);
     const args = readAdapterArgsFromSlots();
     expect(args).toContain("--plan");
     expect(args).toContain("--pair");
-  }, 15_000);
+  });
 
   test("auto-fills medium task with skip_plan: true — omits --plan", async () => {
     const harness = join(TMP, "ludics-state", "harness");
@@ -527,13 +555,25 @@ describe("slotStart — t3code empty-args auto-fill", () => {
       "",
     ].join("\n"));
     slotAssign(1, "task-skip-plan-1", "t3code");
-    try { await slotStart(1); } catch { /* adapter startup fails in test env */ }
+    const data = readSlotJson(1, harness);
+    const ctx = makeAdapterContext(1, data);
+
+    // (a) computes correct args
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    expect(result!.args).not.toContain("--plan");
+    expect(result!.args).toContain("--pair");
+    expect(result!.args).toContain("--coder");
+    expect(result!.args).toContain("--reviewer");
+
+    // (b) persists them
+    writeSlotJson(1, result!.updatedData, harness);
     const args = readAdapterArgsFromSlots();
     expect(args).not.toContain("--plan");
     expect(args).toContain("--pair");
     expect(args).toContain("--coder");
     expect(args).toContain("--reviewer");
-  }, 15_000);
+  });
 });
 
 describe("markSlotSetupFailed", () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -709,7 +709,7 @@ export async function slotSetMode(slotNum: number, mode: string): Promise<void> 
   stateMarkDirty();
 }
 
-function makeAdapterContext(slotNum: number, data: SlotData): AdapterContext {
+export function makeAdapterContext(slotNum: number, data: SlotData): AdapterContext {
   let resolvedPath = data.path ?? "";
 
   // If path is empty, try to resolve from the task's project config
@@ -776,6 +776,56 @@ async function ensureRemoteMachineReachable(
   emitEvent({ event_type: `slot_${action}_queued`, source: "cli", scope: "slot", slot: slotNum, adapter, machine, message: `${action} intent recorded for ${machine}` });
 }
 
+/**
+ * Pure helper extracted from `slotStart`: computes the orchestration flags to
+ * auto-fill for an orchestrated slot whose `adapterArgs` is empty/whitespace,
+ * and returns the updated `SlotData` so the caller can persist it.
+ *
+ * Returns `null` when auto-fill does not apply (mode other than t3code/tmux,
+ * or `ctx.adapterArgs` already non-empty). Throws the same three errors as
+ * the original inline block. Does *not* call `runAdapterAction`, `t3code.start`,
+ * or `ensureServer`, and does not persist or journal — that is the caller's job.
+ */
+export async function autoFillAdapterArgs(
+  ctx: AdapterContext,
+  data: SlotData,
+): Promise<{ args: string; effort: string; updatedData: SlotData } | null> {
+  if (!(ctx.mode === "t3code" || ctx.mode === "tmux") || ctx.adapterArgs.trim()) {
+    return null;
+  }
+
+  const taskId = ctx.taskId;
+  if (!taskId) {
+    throw new Error(`slot ${ctx.slot}: ${ctx.mode} adapter requires orchestration flags but no task is assigned`);
+  }
+
+  // Read task content — on worker, fetch via HTTP; on controller, read locally
+  let content: string | null = null;
+  if (isWorkerContext()) {
+    try {
+      const { clusterGetTask } = await import("../cluster-http.ts");
+      const result = await clusterGetTask(taskId);
+      if (result.ok && typeof result.data === "string") content = result.data;
+    } catch { /* ignore */ }
+  } else {
+    const tf = taskFilePath(taskId);
+    if (existsSync(tf)) content = readFileSync(tf, "utf-8");
+  }
+  if (!content) {
+    throw new Error(`slot ${ctx.slot}: ${ctx.mode} adapter requires orchestration flags but task file not found`);
+  }
+
+  const effortMatch = content.match(/^effort:\s*(.+)/m);
+  const effort = effortMatch ? effortMatch[1]!.trim() || "small" : "small";
+  const { args: autoArgs } = selectOrchestrationFlagsForTask(content, effort);
+  if (!autoArgs.trim()) {
+    throw new Error(`slot ${ctx.slot}: selectOrchestrationFlagsForTask returned empty args for effort="${effort}"`);
+  }
+
+  const updatedData: SlotData = { ...data, adapterArgs: autoArgs };
+  return { args: autoArgs, effort, updatedData };
+}
+
 export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = true }: { startTtyd?: boolean } = {}): Promise<void> {
   ensureSlotsDir();
   const count = slotsCount();
@@ -795,49 +845,19 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
 
   // --- LOCAL EXECUTION ONLY (worker side or local slot) ---
 
-  if ((ctx.mode === "t3code" || ctx.mode === "tmux") && !ctx.adapterArgs.trim()) {
-    // Auto-fill orchestration flags from task effort instead of throwing
-    const taskId = ctx.taskId;
-    if (!taskId) {
-      throw new Error(`slot ${slotNum}: ${ctx.mode} adapter requires orchestration flags but no task is assigned`);
-    }
-
-    // Read task content — on worker, fetch via HTTP; on controller, read locally
-    let content: string | null = null;
-    if (isWorkerContext()) {
-      try {
-        const { clusterGetTask } = await import("../cluster-http.ts");
-        const result = await clusterGetTask(taskId);
-        if (result.ok && typeof result.data === "string") content = result.data;
-      } catch { /* ignore */ }
-    } else {
-      const tf = taskFilePath(taskId);
-      if (existsSync(tf)) content = readFileSync(tf, "utf-8");
-    }
-    if (!content) {
-      throw new Error(`slot ${slotNum}: ${ctx.mode} adapter requires orchestration flags but task file not found`);
-    }
-
-    const effortMatch = content.match(/^effort:\s*(.+)/m);
-    const effort = effortMatch ? effortMatch[1]!.trim() || "small" : "small";
-    const { args: autoArgs } = selectOrchestrationFlagsForTask(content, effort);
-    if (!autoArgs.trim()) {
-      throw new Error(`slot ${slotNum}: selectOrchestrationFlagsForTask returned empty args for effort="${effort}"`);
-    }
-
-    // Write auto-filled flags back to the slot
-    data.adapterArgs = autoArgs;
+  const autoFill = await autoFillAdapterArgs(ctx, data);
+  if (autoFill) {
+    data = autoFill.updatedData;
+    ctx.adapterArgs = autoFill.args;
     if (isWorkerContext()) {
       import("../cluster-http.ts").then(({ clusterPostSlotUpdate }) => {
-        clusterPostSlotUpdate(slotNum, { adapterArgs: autoArgs }).catch(() => {});
+        clusterPostSlotUpdate(slotNum, { adapterArgs: autoFill.args }).catch(() => {});
       }).catch(() => {});
     } else {
       writeSlotJson(slotNum, data);
     }
-    ctx.adapterArgs = autoArgs;
-
-    console.error(`ludics: slot ${slotNum}: auto-filled adapter args from task effort="${effort}": ${autoArgs}`);
-    journalAppend("slot", `Slot ${slotNum} auto-filled adapter args: ${autoArgs} (effort=${effort})`);
+    console.error(`ludics: slot ${slotNum}: auto-filled adapter args from task effort="${autoFill.effort}": ${autoFill.args}`);
+    journalAppend("slot", `Slot ${slotNum} auto-filled adapter args: ${autoFill.args} (effort=${autoFill.effort})`);
   }
 
   // Guard: check for recoverable orchestration state matching current task


### PR DESCRIPTION
## Summary

- Extracts a pure `autoFillAdapterArgs(ctx, data)` helper from `slotStart` in `src/slots/index.ts`. The helper computes orchestration flags from task effort and returns an updated `SlotData` without calling `runAdapterAction` / `t3code.start` / `ensureServer` — so it's safe to unit-test without spawning a subprocess.
- `slotStart` now delegates to the helper; all production side effects (`writeSlotJson` / `clusterPostSlotUpdate` / `console.error` / `journalAppend`) remain in `slotStart`. No production behaviour change.
- Migrates the four tests in the `slotStart — t3code empty-args auto-fill` describe block in `src/slots/index.test.ts` to call the helper directly. Each test splits assertions into (a) computes correct args (against `result.args`) and (b) persists them (via `writeSlotJson(result.updatedData)` + readback). The per-test 15s timeouts and `try { … } catch {}` wrappers are removed.
- The fifth test (`throws when no task is assigned and adapterArgs is empty`) is left unchanged — it exercises the pre-spawn rejection path and was never flake-prone.

Background: gh-ludics-308 retrospective (reviewer + coder both flagged the flake).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/slots/index.test.ts` — 57 pass / 0 fail in 1.3s (was 15s+ when flaky)
- [x] `bun test --rerun-each 5 src/slots/index.test.ts` — 285 pass / 0 fail in 6.3s (no 15s-timeout anywhere)
- [x] `bun test` (full suite) — 1198 pass / 0 fail
- [x] `bun run build` — compiles bin/ludics
- [x] `bun run lint` — no new errors in touched files (pre-existing unrelated errors unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)