### PR TITLE
queue: add file lock to mutation paths (task-9a5d2344)

### DIFF
--- a/src/mag.ts
+++ b/src/mag.ts
@@ -9,7 +9,7 @@ import { isPlainObject } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, recentResults } from "./queue.ts";
+import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, recentResults } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName, clusterMachine } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -1227,43 +1227,8 @@ async function launchSessionFromNotification(taskId: string, adapterArgs: string
   console.error(`ludics: launched t3code for ${taskId} in slot ${slotNum} (${actionLabel})`);
 }
 
-type QueueDequeueResult =
-  | { status: "empty" }
-  | { status: "mismatch" }
-  | { status: "popped"; line: string; request: Record<string, unknown> | null };
-
-function queueFilePath(): string {
-  return join(harnessDir(), "mag", "queue.jsonl");
-}
-
-function dequeueQueueHead(expectedLine?: string): QueueDequeueResult {
-  const queueFile = queueFilePath();
-  if (!existsSync(queueFile)) return { status: "empty" };
-
-  const content = readFileSync(queueFile, "utf-8").trim();
-  if (!content) return { status: "empty" };
-
-  const lines = content.split("\n");
-  const first = lines[0]!;
-
-  if (expectedLine !== undefined && first !== expectedLine) {
-    return { status: "mismatch" };
-  }
-
-  writeFileSync(queueFile, lines.slice(1).join("\n") + (lines.length > 1 ? "\n" : ""));
-
-  try {
-    return { status: "popped", line: first, request: JSON.parse(first) as Record<string, unknown> };
-  } catch {
-    return { status: "popped", line: first, request: null };
-  }
-}
-
 async function queuePopSkill(): Promise<{ command: string; line: string } | null> {
-  const queueFile = join(harnessDir(), "mag", "queue.jsonl");
-  if (!existsSync(queueFile)) return null;
-
-  const popped = dequeueQueueHead();
+  const popped = queuePopExpected();
   if (popped.status !== "popped") return null;
 
   if (!popped.request) {
@@ -1443,7 +1408,7 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
 }
 
 async function drainProgrammaticQueueHead(): Promise<boolean> {
-  const queueFile = queueFilePath();
+  const queueFile = join(harnessDir(), "mag", "queue.jsonl");
 
   while (true) {
     if (!existsSync(queueFile)) return false;
@@ -1456,7 +1421,7 @@ async function drainProgrammaticQueueHead(): Promise<boolean> {
     try {
       request = JSON.parse(first) as Record<string, unknown>;
     } catch {
-      const dropped = dequeueQueueHead(first);
+      const dropped = queuePopExpected(first);
       if (dropped.status === "mismatch") continue;
       if (dropped.status === "popped") {
         console.error("ludics: mag queue-pop: invalid request in queue");
@@ -1467,7 +1432,7 @@ async function drainProgrammaticQueueHead(): Promise<boolean> {
     const command = await resolveQueueRequestCommand(request, false);
     if (command) return true;
 
-    const popped = dequeueQueueHead(first);
+    const popped = queuePopExpected(first);
     if (popped.status === "mismatch") continue;
     if (popped.status !== "popped" || !popped.request) continue;
     await resolveQueueRequestCommand(popped.request, true);

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync, symlinkSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, utimesSync, symlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -346,6 +346,194 @@ describe("queueRequest includes extra fields", () => {
     const parsed = JSON.parse(content);
     expect(parsed.action).toBe("feedback-digest");
     expect(parsed.repo).toBe("ludics");
+  });
+});
+
+describe("withQueueLock", () => {
+  test("releases lock directory after normal execution", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+
+    const result = withQueueLock(() => {
+      expect(existsSync(lockDir)).toBe(true);
+      return 42;
+    });
+
+    expect(result).toBe(42);
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  test("releases lock directory even when fn throws", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+
+    expect(() => withQueueLock(() => { throw new Error("boom"); })).toThrow("boom");
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  test("owner file records current process PID", async () => {
+    const { withQueueLock } = await loadQueue();
+    const ownerFile = join(tmpDir, "mag", "queue.jsonl.lock", "owner");
+    withQueueLock(() => {
+      const owner = readFileSync(ownerFile, "utf-8");
+      const [pidStr] = owner.split("\n");
+      expect(Number(pidStr)).toBe(process.pid);
+    });
+  });
+
+  test("concurrent holder would see EEXIST on mkdirSync", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+
+    let sawEexist = false;
+    withQueueLock(() => {
+      expect(existsSync(lockDir)).toBe(true);
+      try {
+        mkdirSync(lockDir);
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "EEXIST") sawEexist = true;
+      }
+    });
+    expect(sawEexist).toBe(true);
+  });
+
+  test("breaks stale lock held by dead PID", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+    const ownerFile = join(lockDir, "owner");
+
+    // Plant a stale lock with an unreachable PID and a recent timestamp.
+    // PID 999999 is unlikely to exist; process.kill will throw ESRCH.
+    mkdirSync(lockDir);
+    writeFileSync(ownerFile, `999999\n${Date.now()}`);
+
+    const result = withQueueLock(() => "done");
+    expect(result).toBe("done");
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  test("breaks stale lock older than threshold even if PID still exists", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+    const ownerFile = join(lockDir, "owner");
+
+    // Age the timestamp past the 30s threshold; use current PID so liveness alone won't break it.
+    mkdirSync(lockDir);
+    writeFileSync(ownerFile, `${process.pid}\n${Date.now() - 60_000}`);
+
+    const result = withQueueLock(() => "done");
+    expect(result).toBe("done");
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  test("breaks lock dir with missing owner file (half-initialized)", async () => {
+    const { withQueueLock } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+    mkdirSync(lockDir);
+    // No owner file written — treat as stale to avoid deadlock.
+
+    const result = withQueueLock(() => "done");
+    expect(result).toBe("done");
+    expect(existsSync(lockDir)).toBe(false);
+  });
+});
+
+describe("queueRequest holds the queue lock", () => {
+  test("concurrent mkdirSync on lock dir fails during append", async () => {
+    // Can't easily interpose, but verify lock dir is cleaned up after queueRequest.
+    const { queueRequest } = await loadQueue();
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+    queueRequest({ action: "briefing" });
+    expect(existsSync(lockDir)).toBe(false);
+    // And queue entry persisted.
+    const content = readFileSync(join(tmpDir, "mag", "queue.jsonl"), "utf-8").trim();
+    expect(content.length).toBeGreaterThan(0);
+  });
+});
+
+describe("queuePopExpected", () => {
+  test("returns empty for missing queue file", async () => {
+    const { queuePopExpected } = await loadQueue();
+    expect(queuePopExpected()).toEqual({ status: "empty" });
+  });
+
+  test("returns empty for blank queue file", async () => {
+    writeFileSync(join(tmpDir, "mag", "queue.jsonl"), "");
+    const { queuePopExpected } = await loadQueue();
+    expect(queuePopExpected()).toEqual({ status: "empty" });
+  });
+
+  test("pops first line when no expectedLine is given", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n{"id":"b"}\n');
+    const { queuePopExpected } = await loadQueue();
+    const result = queuePopExpected();
+    expect(result.status).toBe("popped");
+    if (result.status === "popped") {
+      expect(result.line).toBe('{"id":"a"}');
+      expect(result.request).toEqual({ id: "a" });
+    }
+    expect(readFileSync(qf, "utf-8")).toBe('{"id":"b"}\n');
+  });
+
+  test("pops first line when expectedLine matches", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n{"id":"b"}\n');
+    const { queuePopExpected } = await loadQueue();
+    const result = queuePopExpected('{"id":"a"}');
+    expect(result.status).toBe("popped");
+    expect(readFileSync(qf, "utf-8")).toBe('{"id":"b"}\n');
+  });
+
+  test("returns mismatch and leaves file unchanged when expectedLine differs", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    const initial = '{"id":"a"}\n{"id":"b"}\n';
+    writeFileSync(qf, initial);
+    const { queuePopExpected } = await loadQueue();
+    expect(queuePopExpected('{"id":"zzz"}')).toEqual({ status: "mismatch" });
+    expect(readFileSync(qf, "utf-8")).toBe(initial);
+  });
+
+  test("returns popped with null request for malformed JSON line", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, "not-json\n");
+    const { queuePopExpected } = await loadQueue();
+    const result = queuePopExpected();
+    expect(result.status).toBe("popped");
+    if (result.status === "popped") {
+      expect(result.line).toBe("not-json");
+      expect(result.request).toBeNull();
+    }
+  });
+
+  test("releases lock dir after each call", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"a"}\n');
+    const { queuePopExpected } = await loadQueue();
+    queuePopExpected();
+    expect(existsSync(qf + ".lock")).toBe(false);
+  });
+});
+
+describe("queue mutation paths release the lock", () => {
+  test("queueReinsertHead cleans up lock dir", async () => {
+    const { queueReinsertHead } = await loadQueue();
+    queueReinsertHead('{"id":"x"}');
+    expect(existsSync(join(tmpDir, "mag", "queue.jsonl.lock"))).toBe(false);
+  });
+
+  test("queuePopOne cleans up lock dir", async () => {
+    writeFileSync(join(tmpDir, "mag", "queue.jsonl"), '{"id":"a"}\n');
+    const { queuePopOne } = await loadQueue();
+    queuePopOne();
+    expect(existsSync(join(tmpDir, "mag", "queue.jsonl.lock"))).toBe(false);
+  });
+
+  test("queuePopAll cleans up lock dir", async () => {
+    writeFileSync(join(tmpDir, "mag", "queue.jsonl"), '{"id":"a"}\n{"id":"b"}\n');
+    const { queuePopAll } = await loadQueue();
+    queuePopAll();
+    expect(existsSync(join(tmpDir, "mag", "queue.jsonl.lock"))).toBe(false);
   });
 });
 

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -491,16 +491,75 @@ appendFileSync(eventsFile, \`child-done \${Date.now()}\\n\`);
     expect(existsSync(lockDir)).toBe(false);
   });
 
-  test("breaks lock dir with missing owner file (half-initialized)", async () => {
+  test("breaks ownerless lock dir aged past stale threshold", async () => {
     const { withQueueLock } = await loadQueue();
     const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
     mkdirSync(lockDir);
-    // No owner file written — treat as stale to avoid deadlock.
+    // No owner file (crash between mkdir and writeFileSync). Backdate the
+    // directory mtime past the 30s threshold so breakStaleLock treats it
+    // as orphaned rather than as a freshly contended lock.
+    const aged = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, aged, aged);
 
     const result = withQueueLock(() => "done");
     expect(result).toBe("done");
     expect(existsSync(lockDir)).toBe(false);
   });
+
+  test("does NOT break freshly-created ownerless lock (grace window preserves mutual exclusion)", async () => {
+    // Simulates: process A mkdir'd the lock dir but was preempted before
+    // writing the owner file. A contender must NOT break this lock; doing
+    // so lets both A and the contender enter the critical section.
+    const { withQueueLock } = await loadQueue();
+    const queueModulePath = new URL("./queue.ts", import.meta.url).pathname;
+    const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
+    const eventsFile = join(tmpDir, "grace-events.log");
+    writeFileSync(eventsFile, "");
+
+    // Plant a fresh ownerless lock (mtime = now).
+    mkdirSync(lockDir);
+
+    const childFile = join(tmpDir, "child-grace.ts");
+    writeFileSync(childFile, `import { appendFileSync } from "fs";
+const eventsFile = process.argv[2];
+appendFileSync(eventsFile, \`child-start \${Date.now()}\\n\`);
+const { withQueueLock } = await import(${JSON.stringify(queueModulePath)});
+try {
+  withQueueLock(() => {
+    appendFileSync(eventsFile, \`child-acquired \${Date.now()}\\n\`);
+  });
+} catch (e) {
+  appendFileSync(eventsFile, \`child-error \${(e instanceof Error ? e.message : String(e))}\\n\`);
+}
+`);
+
+    const child = Bun.spawn({
+      cmd: [process.execPath, "run", childFile, eventsFile],
+      env: { ...process.env, LUDICS_HARNESS_DIR: tmpDir },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Wait 1.2s — well past several retry cycles (100ms each). A correct
+    // implementation still hasn't broken our fresh ownerless lock.
+    Bun.sleepSync(1200);
+    const midEvents = readFileSync(eventsFile, "utf-8");
+    expect(midEvents).toContain("child-start");
+    expect(midEvents).not.toContain("child-acquired");
+    expect(existsSync(lockDir)).toBe(true);  // still held
+
+    // Now simulate the grace window elapsing: backdate the lock dir mtime.
+    const aged = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, aged, aged);
+
+    // Child should now break the stale lock and acquire within the remaining retry budget.
+    await child.exited;
+    expect(child.exitCode).toBe(0);
+    const finalEvents = readFileSync(eventsFile, "utf-8");
+    expect(finalEvents).toContain("child-acquired");
+    expect(finalEvents).not.toContain("child-error");
+    expect(existsSync(lockDir)).toBe(false);
+  }, 15_000);
 });
 
 describe("queueRequest holds the queue lock", () => {

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -381,7 +381,7 @@ describe("withQueueLock", () => {
     });
   });
 
-  test("concurrent holder would see EEXIST on mkdirSync", async () => {
+  test("in-process: nested mkdirSync on held lock dir fails with EEXIST", async () => {
     const { withQueueLock } = await loadQueue();
     const lockDir = join(tmpDir, "mag", "queue.jsonl.lock");
 
@@ -396,6 +396,71 @@ describe("withQueueLock", () => {
     });
     expect(sawEexist).toBe(true);
   });
+
+  test("serializes concurrent callers: child subprocess blocks until parent releases", async () => {
+    const { withQueueLock } = await loadQueue();
+    const queueModulePath = new URL("./queue.ts", import.meta.url).pathname;
+    const eventsFile = join(tmpDir, "lock-events.log");
+    writeFileSync(eventsFile, "");
+
+    // Child script: records timestamp on start, then tries to acquire the same lock.
+    // The child runs in a separate Bun process and shares LUDICS_HARNESS_DIR via env.
+    const childFile = join(tmpDir, "child-lock.ts");
+    writeFileSync(childFile, `import { appendFileSync } from "fs";
+const eventsFile = process.argv[2];
+appendFileSync(eventsFile, \`child-start \${Date.now()}\\n\`);
+const { withQueueLock } = await import(${JSON.stringify(queueModulePath)});
+withQueueLock(() => {
+  appendFileSync(eventsFile, \`child-acquired \${Date.now()}\\n\`);
+});
+appendFileSync(eventsFile, \`child-done \${Date.now()}\\n\`);
+`);
+
+    const holdMs = 500;
+    let lastHeldTs = 0;
+    let childProc: ReturnType<typeof Bun.spawn> | null = null;
+
+    withQueueLock(() => {
+      // Launch the child while we hold the lock. It must block on EEXIST until we release.
+      childProc = Bun.spawn({
+        cmd: [process.execPath, "run", childFile, eventsFile],
+        env: { ...process.env, LUDICS_HARNESS_DIR: tmpDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      // Hold long enough for the child to start, import, and attempt acquisition.
+      // Retry interval in queue.ts is 100ms, so several retries will happen.
+      Bun.sleepSync(holdMs);
+      lastHeldTs = Date.now();  // still inside critical section
+    });
+    // At this point the parent's finally block has released the lock.
+
+    await childProc!.exited;
+    expect(childProc!.exitCode).toBe(0);
+
+    const events = readFileSync(eventsFile, "utf-8").split("\n").filter(Boolean);
+    const firstTs = (tag: string): number | null => {
+      const line = events.find(l => l.startsWith(tag + " "));
+      return line ? Number(line.split(" ")[1]) : null;
+    };
+    const childStartTs = firstTs("child-start");
+    const childAcquiredTs = firstTs("child-acquired");
+    const childDoneTs = firstTs("child-done");
+
+    // Child actually ran and completed normally.
+    expect(childStartTs).not.toBeNull();
+    expect(childAcquiredTs).not.toBeNull();
+    expect(childDoneTs).not.toBeNull();
+
+    // Child started its attempt while parent still held the lock — proves contention occurred.
+    expect(childStartTs!).toBeLessThan(lastHeldTs);
+    // Serialization invariant: child could not have entered the critical section
+    // before the parent left it. `lastHeldTs` was captured while the parent still held.
+    expect(childAcquiredTs!).toBeGreaterThanOrEqual(lastHeldTs);
+
+    // Lock dir is clean at the end (both parent and child released).
+    expect(existsSync(join(tmpDir, "mag", "queue.jsonl.lock"))).toBe(false);
+  }, 15_000);
 
   test("breaks stale lock held by dead PID", async () => {
     const { withQueueLock } = await loadQueue();

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,6 +1,6 @@
 // Mag queue functions — queue-based communication with Claude Code Mag session
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, renameSync, readdirSync, statSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, renameSync, readdirSync, statSync, unlinkSync, rmdirSync } from "fs";
 import { join, dirname } from "path";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
@@ -8,6 +8,71 @@ import { isPlainObject } from "./json.ts";
 
 function queueFile(): string {
   return join(harnessDir(), "mag", "queue.jsonl");
+}
+
+const LOCK_MAX_ATTEMPTS = 50;
+const LOCK_RETRY_MS = 100;
+const LOCK_STALE_MS = 30_000;
+
+function breakStaleLock(lockDir: string, ownerFile: string): boolean {
+  let pid = 0;
+  let ts = 0;
+  try {
+    const owner = readFileSync(ownerFile, "utf-8");
+    const [pidStr, tsStr] = owner.split("\n");
+    pid = Number(pidStr);
+    ts = Number(tsStr);
+  } catch {
+    // Owner file missing or unreadable — lock dir exists without valid metadata.
+    // Treat as stale to avoid deadlock from a half-initialized lock.
+    try { rmdirSync(lockDir); return true; } catch { return false; }
+  }
+  const ageStale = Number.isFinite(ts) && ts > 0 && (Date.now() - ts > LOCK_STALE_MS);
+  let pidDead = false;
+  if (Number.isFinite(pid) && pid > 0) {
+    try { process.kill(pid, 0); } catch { pidDead = true; }
+  } else {
+    pidDead = true;
+  }
+  if (!ageStale && !pidDead) return false;
+  try { unlinkSync(ownerFile); } catch {}
+  try { rmdirSync(lockDir); } catch { return false; }
+  return true;
+}
+
+export function withQueueLock<T>(fn: () => T): T {
+  const file = queueFile();
+  mkdirSync(dirname(file), { recursive: true });
+  const lockDir = file + ".lock";
+  const ownerFile = join(lockDir, "owner");
+
+  let acquired = false;
+  for (let i = 0; i < LOCK_MAX_ATTEMPTS; i++) {
+    try {
+      mkdirSync(lockDir);
+      writeFileSync(ownerFile, `${process.pid}\n${Date.now()}`);
+      acquired = true;
+      break;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") throw e;
+      if (breakStaleLock(lockDir, ownerFile)) {
+        continue; // retry immediately after breaking stale lock
+      }
+      if (i === LOCK_MAX_ATTEMPTS - 1) break;
+      Bun.sleepSync(LOCK_RETRY_MS);
+    }
+  }
+  if (!acquired) {
+    throw new Error(`queue lock timeout after ${(LOCK_MAX_ATTEMPTS * LOCK_RETRY_MS) / 1000}s at ${lockDir}`);
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { unlinkSync(ownerFile); } catch {}
+    try { rmdirSync(lockDir); } catch {}
+  }
 }
 
 function resultsDir(): string {
@@ -62,23 +127,11 @@ export function queueRequest(req: QueueAction): string {
   const requestId = nextRequestId();
 
   const record = { id: requestId, ...req, timestamp };
-  appendFileSync(file, JSON.stringify(record) + "\n");
+  withQueueLock(() => {
+    appendFileSync(file, JSON.stringify(record) + "\n");
+  });
   emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action: req.action, message: requestId });
   return requestId;
-}
-
-export function queuePop(): string | null {
-  const file = queueFile();
-  if (!existsSync(file)) return null;
-
-  const content = readFileSync(file, "utf-8").trim();
-  if (!content) return null;
-
-  const lines = content.split("\n");
-  const first = lines[0]!;
-  writeFileSync(file, lines.slice(1).join("\n") + (lines.length > 1 ? "\n" : ""));
-  emitEvent({ event_type: "queue_pop", source: "keepalive", scope: "queue", message: first.slice(0, 200) });
-  return first;
 }
 
 function readQueueLines(): string[] {
@@ -99,30 +152,57 @@ function writeQueueLines(lines: string[]): void {
   renameSync(tmp, file);
 }
 
-// Note: same read-modify-write pattern as queuePopOne/queuePopAll.
-// Concurrent appendFileSync (from queueRequest) between read and rename
-// could theoretically be lost, but the window is tiny and a proper fix
-// requires a queue-wide lock (out of scope for this change).
 export function queueReinsertHead(line: string): void {
-  const lines = readQueueLines();
-  writeQueueLines([line, ...lines]);
+  withQueueLock(() => {
+    const lines = readQueueLines();
+    writeQueueLines([line, ...lines]);
+  });
 }
 
 export function queuePopOne(): string | null {
-  const lines = readQueueLines();
-  if (lines.length === 0) return null;
-  const first = lines[0]!;
-  writeQueueLines(lines.slice(1));
-  emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: first.slice(0, 200) });
-  return first;
+  const result = withQueueLock(() => {
+    const lines = readQueueLines();
+    if (lines.length === 0) return null;
+    const first = lines[0]!;
+    writeQueueLines(lines.slice(1));
+    return first;
+  });
+  if (result !== null) {
+    emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: result.slice(0, 200) });
+  }
+  return result;
 }
 
 export function queuePopAll(): string[] {
-  const lines = readQueueLines();
-  if (lines.length === 0) return [];
-  writeQueueLines([]);
-  emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: `popped ${lines.length} items` });
+  const lines = withQueueLock(() => {
+    const all = readQueueLines();
+    if (all.length === 0) return [];
+    writeQueueLines([]);
+    return all;
+  });
+  if (lines.length > 0) {
+    emitEvent({ event_type: "queue_pop", source: "cli", scope: "queue", message: `popped ${lines.length} items` });
+  }
   return lines;
+}
+
+export type QueueDequeueResult =
+  | { status: "empty" }
+  | { status: "mismatch" }
+  | { status: "popped"; line: string; request: Record<string, unknown> | null };
+
+export function queuePopExpected(expectedLine?: string): QueueDequeueResult {
+  return withQueueLock(() => {
+    const lines = readQueueLines();
+    if (lines.length === 0) return { status: "empty" };
+    const first = lines[0]!;
+    if (expectedLine !== undefined && first !== expectedLine) {
+      return { status: "mismatch" };
+    }
+    writeQueueLines(lines.slice(1));
+    const request = parseJsonRecord(first);
+    return { status: "popped", line: first, request };
+  });
 }
 
 export function queueList(): Record<string, unknown>[] {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -17,16 +17,35 @@ const LOCK_STALE_MS = 30_000;
 function breakStaleLock(lockDir: string, ownerFile: string): boolean {
   let pid = 0;
   let ts = 0;
+  let ownerMissing = false;
   try {
     const owner = readFileSync(ownerFile, "utf-8");
     const [pidStr, tsStr] = owner.split("\n");
     pid = Number(pidStr);
     ts = Number(tsStr);
   } catch {
-    // Owner file missing or unreadable — lock dir exists without valid metadata.
-    // Treat as stale to avoid deadlock from a half-initialized lock.
+    ownerMissing = true;
+  }
+
+  if (ownerMissing) {
+    // A rightful holder may have just mkdir'd the lock dir and been preempted
+    // before writing the owner file. Breaking the lock here would violate
+    // mutual exclusion (both holder and breaker would proceed). Fall back to
+    // the lock directory's own mtime: only break once the dir itself is older
+    // than the stale threshold, so a concurrent holder has had ample time to
+    // either finish writing the owner file or crash.
+    let dirMtimeMs = 0;
+    try {
+      dirMtimeMs = statSync(lockDir).mtimeMs;
+    } catch {
+      // Dir vanished between our EEXIST and the stat — nothing to break.
+      // Signal "retry" so the outer loop attempts mkdirSync again.
+      return true;
+    }
+    if (Date.now() - dirMtimeMs <= LOCK_STALE_MS) return false;
     try { rmdirSync(lockDir); return true; } catch { return false; }
   }
+
   const ageStale = Number.isFinite(ts) && ts > 0 && (Date.now() - ts > LOCK_STALE_MS);
   let pidDead = false;
   if (Number.isFinite(pid) && pid > 0) {


### PR DESCRIPTION
## Summary

- Adds a synchronous `withQueueLock<T>(fn)` helper in `src/queue.ts` that uses `mkdirSync` for atomic lock acquisition on `mag/queue.jsonl.lock`, with a 50×100ms retry backoff (~5s cap) and stale-lock recovery via PID liveness (`process.kill(pid, 0)`) and a 30s age threshold. The `owner` file inside the lock dir stores `pid\ntimestamp` for this detection; half-initialized locks (missing owner file) are also treated as stale to avoid crash-induced deadlocks.
- Wraps every queue-mutating path in the lock: `queueRequest`, `queueReinsertHead`, `queuePopOne`, `queuePopAll`. Read-only inspectors (`queueList`, `queuePending`, `queueHasPendingAction*`, `queueShow`) are intentionally left lock-free — stale reads are acceptable there.
- Consolidates `src/mag.ts`'s duplicate queue I/O: removes the local `dequeueQueueHead`, `queueFilePath`, and `QueueDequeueResult` and replaces them with a new `queuePopExpected(expectedLine?)` export from `src/queue.ts` that carries the weak CAS-style `expectedLine` semantics under the lock. `queuePopSkill` and `drainProgrammaticQueueHead` now call the shared helper.
- Removes the dead-code `queuePop()` export from `src/queue.ts`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` — standalone binary builds
- [x] `bun test src/queue.test.ts src/queue-reinsert.test.ts` — 60 pass, 0 fail (all prior tests unchanged)
- [x] Full `bun test` — 1217 pass, 0 fail
- [x] New tests cover:
  - Real two-process serialization: a child Bun subprocess attempts `withQueueLock` while the parent holds it for 500ms; asserts `child-start < parentLastHeldTs ≤ child-acquired`, proving contention and then handoff.
  - Stale-lock break paths: dead PID, age > 30s, missing owner file (half-initialized).
  - Lock cleanup on both normal and thrown execution.
  - `queuePopExpected` semantics: empty / unconditional pop / matching expectedLine / mismatch (no-op) / malformed-JSON line.
  - Lock-dir cleanup after each wrapped mutator (`queueRequest`, `queueReinsertHead`, `queuePopOne`, `queuePopAll`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)