### PR TITLE
rename: parseT3CodeAdapterArgs -> parseOrchestrationAdapterArgs

### DIFF
--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -335,7 +335,7 @@ See also [regression-test-per-behaviour-change](#regression-test-per-behaviour-c
 
 **Why.** Shared flags (`--effort`) and role-specific flags (`--reviewer-effort`) often assign the same underlying variable. Variable-state inference after parsing ("was `reviewerEffort` set?") silently drops role-specific flags whose value happened to equal a default or was overwritten by a subsequent shared flag. Rejection must be keyed on *which flag was provided*, with an error message naming the offending flag so the caller knows which invocation-site to fix.
 
-**Worked pattern.** `parseT3CodeAdapterArgs` in `src/adapters/t3code.ts` uses `reviewerOnlyFlag: string | null`, set to the flag name the first time a reviewer-only flag is parsed. At the mode-gate, a non-null `reviewerOnlyFlag` in solo mode produces an error like `--reviewer-effort is not accepted in solo mode`. The error text carries the flag string, not a derived concept like "reviewer override".
+**Worked pattern.** `parseOrchestrationAdapterArgs` in `src/adapters/t3code.ts` uses `reviewerOnlyFlag: string | null`, set to the flag name the first time a reviewer-only flag is parsed. At the mode-gate, a non-null `reviewerOnlyFlag` in solo mode produces an error like `--reviewer-effort is not accepted in solo mode`. The error text carries the flag string, not a derived concept like "reviewer override".
 
 See also [caller-audit-on-signature-change](#caller-audit-on-signature-change).
 
@@ -378,7 +378,7 @@ See also [regression-test-per-behaviour-change](#regression-test-per-behaviour-c
 
 ### Re-run reviewer repro
 
-**Principle.** When the reviewer files a contract bug at a specific invocation (`parseT3CodeAdapterArgs(<exact args>)`, `curl <exact URL>`, `bun run <exact script>`), the round-N+1 fix re-runs *that exact invocation* in addition to any new unit test.
+**Principle.** When the reviewer files a contract bug at a specific invocation (`parseOrchestrationAdapterArgs(<exact args>)`, `curl <exact URL>`, `bun run <exact script>`), the round-N+1 fix re-runs *that exact invocation* in addition to any new unit test.
 
 **Why.** A new unit test encodes the author's interpretation of the bug. The reviewer's repro is the contract the author might have misread. Running both closes the interpretation gap: if the unit test passes but the reviewer's repro still fails, the fix targeted the wrong thing.
 

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { canReuseSlotThread, orchestratedThreadTitle, parseT3CodeAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask } from "./t3code.ts";
+import { canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -74,16 +74,16 @@ describe("canReuseSlotThread", () => {
   });
 });
 
-describe("parseT3CodeAdapterArgs", () => {
+describe("parseOrchestrationAdapterArgs", () => {
   test("parses classic single-thread options", () => {
-    const parsed = parseT3CodeAdapterArgs("--model gpt-5.5 --title test --runtime-mode full-access");
+    const parsed = parseOrchestrationAdapterArgs("--model gpt-5.5 --title test --runtime-mode full-access");
     expect(parsed.model).toBe("gpt-5.5");
     expect(parsed.title).toBe("test");
     expect(parsed.orchestration).toBeNull();
   });
 
   test("--duo is treated as --pair (hierarchical duo expansion happens at slot level)", () => {
-    const parsed = parseT3CodeAdapterArgs("--duo --clarify --plan");
+    const parsed = parseOrchestrationAdapterArgs("--duo --clarify --plan");
     expect(parsed.orchestration?.mode).toBe("pair");
     expect(parsed.orchestration?.config.enableClarify).toBe(true);
     expect(parsed.orchestration?.config.enablePlan).toBe(true);
@@ -94,7 +94,7 @@ describe("parseT3CodeAdapterArgs", () => {
   });
 
   test("parses pair role overrides", () => {
-    const parsed = parseT3CodeAdapterArgs("--pair --coder codex:gpt-5.6 --reviewer reviewer:claude-code:gpt-5.7");
+    const parsed = parseOrchestrationAdapterArgs("--pair --coder codex:gpt-5.6 --reviewer reviewer:claude-code:gpt-5.7");
     expect(parsed.orchestration?.mode).toBe("pair");
     expect(parsed.orchestration?.agents[0]?.role).toBe("coder");
     expect(parsed.orchestration?.agents[0]?.provider).toBe("codex");
@@ -385,10 +385,10 @@ describe("selectOrchestrationFlagsForTask — skip_plan from frontmatter", () =>
   });
 });
 
-describe("parseT3CodeAdapterArgs — --solo", () => {
+describe("parseOrchestrationAdapterArgs — --solo", () => {
   test("parses --solo with --coder into a single-agent orchestration", () => {
     // Token format: name:provider:model
-    const parsed = parseT3CodeAdapterArgs("--solo --coder coder:claude-code:claude-sonnet-4-6");
+    const parsed = parseOrchestrationAdapterArgs("--solo --coder coder:claude-code:claude-sonnet-4-6");
     expect(parsed.orchestration).not.toBeNull();
     expect(parsed.orchestration!.mode).toBe("solo");
     expect(parsed.orchestration!.agents).toHaveLength(1);
@@ -399,43 +399,43 @@ describe("parseT3CodeAdapterArgs — --solo", () => {
   });
 
   test("parses --solo --coder <provider> (bare provider) with default model", () => {
-    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code");
+    const parsed = parseOrchestrationAdapterArgs("--solo --coder claude-code");
     expect(parsed.orchestration!.mode).toBe("solo");
     expect(parsed.orchestration!.agents).toHaveLength(1);
     expect(parsed.orchestration!.agents[0]!.provider).toBe("claude-code");
   });
 
   test("--solo without --coder throws", () => {
-    expect(() => parseT3CodeAdapterArgs("--solo")).toThrow(/--solo requires --coder/);
+    expect(() => parseOrchestrationAdapterArgs("--solo")).toThrow(/--solo requires --coder/);
   });
 
   test("--solo combined with --reviewer throws", () => {
     expect(() =>
-      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer codex")
+      parseOrchestrationAdapterArgs("--solo --coder claude-code --reviewer codex")
     ).toThrow(/--solo is incompatible with --reviewer/);
   });
 
   test("--solo combined with --duo-peer-slot throws", () => {
     expect(() =>
-      parseT3CodeAdapterArgs("--solo --coder claude-code --duo-peer-slot=2")
+      parseOrchestrationAdapterArgs("--solo --coder claude-code --duo-peer-slot=2")
     ).toThrow(/--solo is incompatible with --duo-peer-slot/);
   });
 
   test("--solo combined with --reviewer-model throws (reviewer-only override)", () => {
     expect(() =>
-      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-model gpt-5.4")
+      parseOrchestrationAdapterArgs("--solo --coder claude-code --reviewer-model gpt-5.4")
     ).toThrow(/--solo is incompatible with --reviewer-model/);
   });
 
   test("--solo combined with --reviewer-effort throws", () => {
     expect(() =>
-      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-effort low")
+      parseOrchestrationAdapterArgs("--solo --coder claude-code --reviewer-effort low")
     ).toThrow(/--solo is incompatible with --reviewer-effort/);
   });
 
   test("--solo combined with --reviewer-thinking-effort throws", () => {
     expect(() =>
-      parseT3CodeAdapterArgs("--solo --coder claude-code --reviewer-thinking-effort low")
+      parseOrchestrationAdapterArgs("--solo --coder claude-code --reviewer-thinking-effort low")
     ).toThrow(/--solo is incompatible with --reviewer-thinking-effort/);
   });
 
@@ -443,14 +443,14 @@ describe("parseT3CodeAdapterArgs — --solo", () => {
     // --effort is a shared flag that sets both coder and reviewer effort.
     // In solo the reviewer half is discarded; this is not a reviewer-only flag
     // so it must not be rejected.
-    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --effort high");
+    const parsed = parseOrchestrationAdapterArgs("--solo --coder claude-code --effort high");
     expect(parsed.orchestration!.mode).toBe("solo");
     expect(parsed.orchestration!.coderThinkingEffort).toBe("high");
     expect(parsed.orchestration!.reviewerThinkingEffort).toBeUndefined();
   });
 
   test("--solo accepts --coder-model and --coder-effort", () => {
-    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --coder-model claude-opus-4-6 --coder-effort high");
+    const parsed = parseOrchestrationAdapterArgs("--solo --coder claude-code --coder-model claude-opus-4-6 --coder-effort high");
     expect(parsed.orchestration!.mode).toBe("solo");
     expect(parsed.orchestration!.coderModelOverride).toBe("claude-opus-4-6");
     expect(parsed.orchestration!.coderThinkingEffort).toBe("high");
@@ -459,7 +459,7 @@ describe("parseT3CodeAdapterArgs — --solo", () => {
   test("--solo supports --plan / --clarify config flags (orthogonal to mode)", () => {
     // Even though auto-select for tiny omits pre-work phases, explicit --solo --plan
     // is valid: config flags are orthogonal to mode.
-    const parsed = parseT3CodeAdapterArgs("--solo --coder claude-code --plan");
+    const parsed = parseOrchestrationAdapterArgs("--solo --coder claude-code --plan");
     expect(parsed.orchestration!.config.enablePlan).toBe(true);
   });
 });

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -166,7 +166,7 @@ function parseArgs(raw: string): string[] {
   }
 
   if (escaping) current += "\\";
-  if (inSingle || inDouble) throw new Error("unterminated quote in t3code adapter args");
+  if (inSingle || inDouble) throw new Error("unterminated quote in orchestration adapter args");
   pushCurrent();
   return args;
 }
@@ -179,13 +179,13 @@ function parseProviderToken(raw: string, defaultName: string, defaultModel: stri
 } {
   const parts = raw.split(":").map((part) => part.trim()).filter(Boolean);
   if (parts.length === 0) {
-    throw new Error("t3code adapter args: empty provider token");
+    throw new Error("orchestration adapter args: empty provider token");
   }
 
   if (parts.length === 1) {
     const provider = parts[0];
     if (provider !== "codex" && provider !== "claude-code") {
-      throw new Error(`t3code adapter args: unsupported provider ${provider}`);
+      throw new Error(`orchestration adapter args: unsupported provider ${provider}`);
     }
     const model = provider === "claude-code" ? DEFAULT_CLAUDE_MODEL : defaultModel;
     return { name: defaultName, provider, model, modelExplicit: false };
@@ -194,19 +194,19 @@ function parseProviderToken(raw: string, defaultName: string, defaultModel: stri
   if (parts.length === 2) {
     const [provider, model] = parts;
     if (provider !== "codex" && provider !== "claude-code") {
-      throw new Error(`t3code adapter args: unsupported provider ${provider}`);
+      throw new Error(`orchestration adapter args: unsupported provider ${provider}`);
     }
     return { name: defaultName, provider, model, modelExplicit: true };
   }
 
   const [name, provider, model] = parts;
   if (provider !== "codex" && provider !== "claude-code") {
-    throw new Error(`t3code adapter args: unsupported provider ${provider}`);
+    throw new Error(`orchestration adapter args: unsupported provider ${provider}`);
   }
   return { name, provider, model: model ?? defaultModel, modelExplicit: !!model };
 }
 
-export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
+export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
   const args = parseArgs(raw);
   const parsed: ParsedAdapterArgs = {
     model: DEFAULT_MODEL,
@@ -247,25 +247,25 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
     const next = args[i + 1];
     switch (arg) {
       case "--model":
-        if (!next) throw new Error("t3code adapter args: --model requires a value");
+        if (!next) throw new Error("orchestration adapter args: --model requires a value");
         parsed.model = next;
         i++;
         break;
       case "--title":
-        if (!next) throw new Error("t3code adapter args: --title requires a value");
+        if (!next) throw new Error("orchestration adapter args: --title requires a value");
         parsed.title = next;
         i++;
         break;
       case "--runtime-mode":
         if (next !== "approval-required" && next !== "full-access") {
-          throw new Error("t3code adapter args: --runtime-mode must be approval-required or full-access");
+          throw new Error("orchestration adapter args: --runtime-mode must be approval-required or full-access");
         }
         parsed.runtimeMode = next;
         i++;
         break;
       case "--interaction-mode":
         if (next !== "default" && next !== "plan") {
-          throw new Error("t3code adapter args: --interaction-mode must be default or plan");
+          throw new Error("orchestration adapter args: --interaction-mode must be default or plan");
         }
         parsed.interactionMode = next;
         i++;
@@ -284,44 +284,44 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
         break;
       case "--agent":
         // Legacy duo --agent flag is no longer supported; use --coder/--reviewer instead.
-        throw new Error("t3code adapter args: --agent is no longer supported (duo mode now uses --coder/--reviewer). Use --coder and --reviewer instead.");
+        throw new Error("orchestration adapter args: --agent is no longer supported (duo mode now uses --coder/--reviewer). Use --coder and --reviewer instead.");
       case "--coder":
-        if (!next) throw new Error("t3code adapter args: --coder requires provider[:model[:name]]");
+        if (!next) throw new Error("orchestration adapter args: --coder requires provider[:model[:name]]");
         coderToken = next;
         i++;
         break;
       case "--reviewer":
-        if (!next) throw new Error("t3code adapter args: --reviewer requires provider[:model[:name]]");
+        if (!next) throw new Error("orchestration adapter args: --reviewer requires provider[:model[:name]]");
         reviewerToken = next;
         i++;
         break;
       case "--coder-model":
-        if (!next) throw new Error("t3code adapter args: --coder-model requires a model ID");
+        if (!next) throw new Error("orchestration adapter args: --coder-model requires a model ID");
         coderModelOverride = next;
         i++;
         break;
       case "--reviewer-model":
-        if (!next) throw new Error("t3code adapter args: --reviewer-model requires a model ID");
+        if (!next) throw new Error("orchestration adapter args: --reviewer-model requires a model ID");
         reviewerModelOverride = next;
         if (!reviewerOnlyFlag) reviewerOnlyFlag = arg;
         i++;
         break;
       case "--coder-effort":
       case "--coder-thinking-effort":
-        if (!next) throw new Error(`t3code adapter args: ${arg} requires low|medium|high|max`);
+        if (!next) throw new Error(`orchestration adapter args: ${arg} requires low|medium|high|max`);
         coderThinkingEffort = next;
         i++;
         break;
       case "--reviewer-effort":
       case "--reviewer-thinking-effort":
-        if (!next) throw new Error(`t3code adapter args: ${arg} requires low|medium|high|max`);
+        if (!next) throw new Error(`orchestration adapter args: ${arg} requires low|medium|high|max`);
         reviewerThinkingEffort = next;
         if (!reviewerOnlyFlag) reviewerOnlyFlag = arg;
         i++;
         break;
       case "--effort":
       case "--thinking-effort":
-        if (!next) throw new Error(`t3code adapter args: ${arg} requires low|medium|high|max`);
+        if (!next) throw new Error(`orchestration adapter args: ${arg} requires low|medium|high|max`);
         coderThinkingEffort = next;
         reviewerThinkingEffort = next;
         i++;
@@ -345,43 +345,43 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
         orchestrationConfig.useMagTailoring = true;
         break;
       case "--poll-interval":
-        if (!next) throw new Error("t3code adapter args: --poll-interval requires seconds");
+        if (!next) throw new Error("orchestration adapter args: --poll-interval requires seconds");
         orchestrationConfig.pollInterval = parseInt(next, 10);
         i++;
         break;
       case "--learning-interval":
-        if (!next) throw new Error("t3code adapter args: --learning-interval requires seconds");
+        if (!next) throw new Error("orchestration adapter args: --learning-interval requires seconds");
         orchestrationConfig.learningInterval = parseInt(next, 10);
         i++;
         break;
       case "--learning-gap":
-        if (!next) throw new Error("t3code adapter args: --learning-gap requires rounds");
+        if (!next) throw new Error("orchestration adapter args: --learning-gap requires rounds");
         orchestrationConfig.learningProductiveRoundsGap = parseInt(next, 10);
         i++;
         break;
       case "--work-timeout": {
-        if (!next) throw new Error("t3code adapter args: --work-timeout requires seconds");
+        if (!next) throw new Error("orchestration adapter args: --work-timeout requires seconds");
         const workSecs = parseInt(next, 10);
-        if (isNaN(workSecs)) throw new Error(`t3code adapter args: --work-timeout requires a valid number, got "${next}"`);
+        if (isNaN(workSecs)) throw new Error(`orchestration adapter args: --work-timeout requires a valid number, got "${next}"`);
         orchestrationConfig.timeouts = { ...orchestrationConfig.timeouts, work: workSecs };
         i++;
         break;
       }
       case "--review-timeout": {
-        if (!next) throw new Error("t3code adapter args: --review-timeout requires seconds");
+        if (!next) throw new Error("orchestration adapter args: --review-timeout requires seconds");
         const reviewSecs = parseInt(next, 10);
-        if (isNaN(reviewSecs)) throw new Error(`t3code adapter args: --review-timeout requires a valid number, got "${next}"`);
+        if (isNaN(reviewSecs)) throw new Error(`orchestration adapter args: --review-timeout requires a valid number, got "${next}"`);
         orchestrationConfig.timeouts = { ...orchestrationConfig.timeouts, review: reviewSecs };
         i++;
         break;
       }
       case "--phase-timeout": {
-        if (!next) throw new Error("t3code adapter args: --phase-timeout requires phase:seconds");
+        if (!next) throw new Error("orchestration adapter args: --phase-timeout requires phase:seconds");
         const sep = next.indexOf(":");
-        if (sep < 1) throw new Error("t3code adapter args: --phase-timeout format is phase:seconds");
+        if (sep < 1) throw new Error("orchestration adapter args: --phase-timeout format is phase:seconds");
         const phase = next.slice(0, sep);
         const secs = parseInt(next.slice(sep + 1), 10);
-        if (isNaN(secs)) throw new Error(`t3code adapter args: --phase-timeout invalid seconds in "${next}"`);
+        if (isNaN(secs)) throw new Error(`orchestration adapter args: --phase-timeout invalid seconds in "${next}"`);
         orchestrationConfig.timeouts = { ...orchestrationConfig.timeouts, [phase]: secs };
         i++;
         break;
@@ -391,11 +391,11 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
         if (arg.startsWith("--duo-peer-slot=")) {
           const val = arg.slice("--duo-peer-slot=".length);
           const n = parseInt(val, 10);
-          if (isNaN(n) || n < 1) throw new Error(`t3code adapter args: --duo-peer-slot requires a positive integer, got "${val}"`);
+          if (isNaN(n) || n < 1) throw new Error(`orchestration adapter args: --duo-peer-slot requires a positive integer, got "${val}"`);
           duoPeerSlot = n;
           break;
         }
-        throw new Error(`t3code adapter args: unsupported flag ${arg}`);
+        throw new Error(`orchestration adapter args: unsupported flag ${arg}`);
     }
   }
 
@@ -403,16 +403,16 @@ export function parseT3CodeAdapterArgs(raw: string): ParsedAdapterArgs {
 
   if (mode === "solo") {
     if (!coderToken) {
-      throw new Error("t3code adapter args: --solo requires --coder provider[:model[:name]]");
+      throw new Error("orchestration adapter args: --solo requires --coder provider[:model[:name]]");
     }
     if (reviewerToken) {
-      throw new Error("t3code adapter args: --solo is incompatible with --reviewer");
+      throw new Error("orchestration adapter args: --solo is incompatible with --reviewer");
     }
     if (duoPeerSlot != null) {
-      throw new Error("t3code adapter args: --solo is incompatible with --duo-peer-slot");
+      throw new Error("orchestration adapter args: --solo is incompatible with --duo-peer-slot");
     }
     if (reviewerOnlyFlag) {
-      throw new Error(`t3code adapter args: --solo is incompatible with ${reviewerOnlyFlag} (no reviewer exists in solo mode)`);
+      throw new Error(`orchestration adapter args: --solo is incompatible with ${reviewerOnlyFlag} (no reviewer exists in solo mode)`);
     }
     const coderParsed = parseProviderToken(coderToken, "coder", parsed.model);
     parsed.orchestration = {
@@ -1000,7 +1000,7 @@ async function startOrchestratedThreads(
 async function start(ctx: AdapterContext): Promise<string> {
   const record = await ensureServer({ harnessDir: ctx.harnessDir });
   const workspaceRoot = normalizeWorkspacePath(ctx);
-  const options = parseT3CodeAdapterArgs(ctx.adapterArgs);
+  const options = parseOrchestrationAdapterArgs(ctx.adapterArgs);
 
   if (!options.orchestration) {
     return await startSingleThread(ctx, record, options, workspaceRoot);

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -34,7 +34,7 @@ import { createWorktrees, cleanupWorktrees, symlinkPeerSync } from "../orchestra
 import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/deferred-cleanup.ts";
 import { isoNow, makeId, nowEpoch } from "../orchestration/util.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
-import { parseT3CodeAdapterArgs } from "./t3code.ts";
+import { parseOrchestrationAdapterArgs } from "./t3code.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -117,7 +117,7 @@ function agentPortRole(agent: { role?: string; name: string }, index: number): "
 }
 
 // ---------------------------------------------------------------------------
-// Workspace & feature helpers (shared with t3code adapter)
+// Workspace & feature helpers (shared across orchestration adapters)
 // ---------------------------------------------------------------------------
 
 function normalizeWorkspacePath(ctx: AdapterContext): string {
@@ -154,8 +154,8 @@ function loadConfigOrchestration(config?: LudicsFullConfig): Record<string, unkn
 }
 
 // ---------------------------------------------------------------------------
-// Agent model / effort resolution (duplicated from t3code adapter — these are
-// orchestration-generic but not yet extracted to a shared module)
+// Agent model / effort resolution (shared across orchestration adapters —
+// these are orchestration-generic but not yet extracted to a shared module)
 // ---------------------------------------------------------------------------
 
 interface ParsedAgentToken {
@@ -444,7 +444,7 @@ export async function sendPromptToAgent(
 
 async function start(ctx: AdapterContext): Promise<string> {
   const workspaceRoot = normalizeWorkspacePath(ctx);
-  const options = parseT3CodeAdapterArgs(ctx.adapterArgs);
+  const options = parseOrchestrationAdapterArgs(ctx.adapterArgs);
 
   if (!options.orchestration) {
     throw new Error(


### PR DESCRIPTION
## Summary

- Renames `parseT3CodeAdapterArgs` → `parseOrchestrationAdapterArgs` in `src/adapters/t3code.ts`; updates the self-use + tmux-adapter import/call (both adapters consume this parser — the t3code-first name was historical).
- Updates the two `describe(...)` titles in `src/adapters/t3code.test.ts` and all invocations so `bun test --grep parseOrchestrationAdapterArgs` matches.
- Updates the `"t3code adapter args: …"` error-message prefix (33 occurrences incl. one un-prefixed `unterminated quote` case) to `"orchestration adapter args: …"`.
- Rephrases two `shared with t3code adapter` / `duplicated from t3code adapter` section comments in `tmux-adapter.ts` so they read as peer-shared.
- Updates the live `docs/orchestration-patterns.md` pattern-catalog references. Historical proposal docs under `docs/proposals/` are deliberately left untouched per scope.

Closes task-67853321. Proposal: `docs/proposals/rename-parse-t3code-adapter-args.md`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` succeeds
- [x] `bun test` — 1204/1204 pass
- [x] `grep -rn parseT3CodeAdapterArgs src/` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)