### PR TITLE
Consolidate git helpers + withCheckout + ls-remote + sentinel unification (task-b0d4f45b)

### DIFF
--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -13,80 +13,19 @@
 import { existsSync, statSync } from "fs";
 import { join } from "path";
 import type { ProjectConfig } from "./config.ts";
+import { detectDefaultBranches, defaultRunGit, expandHome, hasRemote, type RunGit } from "./git-runner.ts";
 
-export interface RunGitResult {
-  stdout: string;
-  exitCode: number;
-}
-
-/** A minimal git runner: takes argv and a cwd, returns stdout + exit code. */
-export type RunGit = (args: string[], cwd: string) => RunGitResult;
+// Re-exports so existing importers of briefing-lag's public surface keep
+// working.
+export { detectDefaultBranches, defaultRunGit };
+export type { RunGit };
+export type { RunGitResult } from "./git-runner.ts";
 
 export interface FormatLagOptions {
   now: Date;
   runGit: RunGit;
   /** If set, treat `.git/FETCH_HEAD` mtime older than this many seconds as stale. Default 6h. */
   fetchStaleSeconds?: number;
-}
-
-interface DetectedBranches {
-  origin: string | null;
-  upstream: string | null;
-}
-
-function expandHome(path: string): string {
-  if (path.startsWith("~/")) return join(process.env.HOME ?? "~", path.slice(2));
-  return path;
-}
-
-/**
- * Detect the default branch name for each of origin and upstream.
- *
- * Primary path: `git symbolic-ref refs/remotes/<remote>/HEAD`. This ref exists
- * when the repo was cloned (git creates it automatically) or when the user has
- * explicitly run `git remote set-head <remote> -a`.
- *
- * Fallback: for manually-added remotes (`git remote add upstream … && git
- * fetch upstream`), git does NOT create `refs/remotes/upstream/HEAD`, so the
- * primary path returns null. Probe the two overwhelmingly common default
- * branches — `main` then `master` — via `git rev-parse --verify`. This is
- * local-only (no network round-trip) and covers the realistic cases without
- * asking users to know about `git remote set-head`.
- *
- * If neither the symbolic ref nor a `main`/`master` ref is present, return
- * null; the caller surfaces a "could not detect default branch" note so the
- * user can either set the symbolic ref or rename the branch.
- */
-export function detectDefaultBranches(cwd: string, runGit: RunGit): DetectedBranches {
-  const read = (remote: string): string | null => {
-    // Primary: symbolic-ref (present on clones and after `git remote set-head -a`)
-    const primary = runGit(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
-    if (primary.exitCode === 0) {
-      const line = primary.stdout.trim();
-      const prefix = `refs/remotes/${remote}/`;
-      if (line.startsWith(prefix)) {
-        const name = line.slice(prefix.length);
-        if (name) return name;
-      }
-    }
-    // Fallback: probe main then master locally. Ordering matters — newer
-    // projects default to `main`; legacy projects use `master`.
-    for (const candidate of ["main", "master"]) {
-      const verify = runGit(
-        ["rev-parse", "--verify", "--quiet", `refs/remotes/${remote}/${candidate}`],
-        cwd,
-      );
-      if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
-    }
-    return null;
-  };
-  return { origin: read("origin"), upstream: read("upstream") };
-}
-
-function hasRemote(cwd: string, name: string, runGit: RunGit): boolean {
-  const r = runGit(["remote"], cwd);
-  if (r.exitCode !== 0) return false;
-  return r.stdout.split(/\r?\n/).map((s) => s.trim()).includes(name);
 }
 
 /**
@@ -188,11 +127,3 @@ export function formatUpstreamLagSection(
   return blocks.join("\n");
 }
 
-/** Production git runner — wraps Bun.spawnSync. */
-export const defaultRunGit: RunGit = (args, cwd) => {
-  const res = Bun.spawnSync({ cmd: ["git", "-C", cwd, ...args] });
-  return {
-    stdout: res.stdout ? new TextDecoder().decode(res.stdout) : "",
-    exitCode: res.exitCode ?? -1,
-  };
-};

--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -19,7 +19,7 @@ import { detectDefaultBranches, defaultRunGit, expandHome, hasRemote, type RunGi
 // working.
 export { detectDefaultBranches, defaultRunGit };
 export type { RunGit };
-export type { RunGitResult } from "./git-runner.ts";
+export type { DetectedBranches, RunGitResult } from "./git-runner.ts";
 
 export interface FormatLagOptions {
   now: Date;

--- a/src/git-runner.test.ts
+++ b/src/git-runner.test.ts
@@ -220,6 +220,38 @@ describe("withCheckout", () => {
     expect(last).toEqual(["checkout", "topic"]);
   });
 
+  test("rejects async callbacks (Promise-returning) with a clear error and restores the branch", () => {
+    // Regression for PR #366 codex review: the finally-block runs as soon as
+    // the sync call returns, so an async fn's awaited git work would execute
+    // after checkout-back, on the wrong branch. Detect and throw.
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "topic\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    expect(() =>
+      withCheckout("/x", "master", run, () => Promise.resolve(42) as unknown as number),
+    ).toThrow(/async callbacks are not supported/);
+    // Restore must still run — the branch should be returned to `topic`.
+    const last = calls[calls.length - 1]!;
+    expect(last).toEqual(["checkout", "topic"]);
+  });
+
+  test("rejects async callbacks even when already on target branch (no checkout, no restore)", () => {
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "master\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    expect(() =>
+      withCheckout("/x", "master", run, () => Promise.resolve("ok") as unknown as string),
+    ).toThrow(/async callbacks are not supported/);
+    // No checkout was issued in this branch, which is correct (we never left).
+    expect(calls.some((c) => c[0] === "checkout")).toBe(false);
+  });
+
   test("checkout failure throws and does not invoke callback", () => {
     const { run, calls } = recordingGit((args) => {
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {

--- a/src/git-runner.test.ts
+++ b/src/git-runner.test.ts
@@ -1,0 +1,243 @@
+import { describe, test, expect } from "bun:test";
+import {
+  detectDefaultBranches,
+  detectDefaultBranchesAuthoritative,
+  expandHome,
+  hasRemote,
+  withCheckout,
+  type RunGit,
+} from "./git-runner.ts";
+
+/**
+ * Build a fake runGit that dispatches on argv prefix. Each rule matches a
+ * leading subsequence of argv; the first matching rule wins.
+ */
+function fakeGit(rules: Array<{ match: string[]; stdout: string; exitCode?: number }>): RunGit {
+  return (args) => {
+    for (const r of rules) {
+      if (r.match.every((m, i) => args[i] === m)) {
+        return { stdout: r.stdout, exitCode: r.exitCode ?? 0 };
+      }
+    }
+    return { stdout: "", exitCode: 128 };
+  };
+}
+
+describe("git-runner helpers", () => {
+  test("expandHome: expands ~/ prefix using $HOME", () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = "/home/alice";
+    try {
+      expect(expandHome("~/work/foo")).toBe("/home/alice/work/foo");
+      expect(expandHome("/abs/path")).toBe("/abs/path");
+      expect(expandHome("relative")).toBe("relative");
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  test("hasRemote: parses `git remote` output", () => {
+    const rg = fakeGit([{ match: ["remote"], stdout: "origin\nupstream\n" }]);
+    expect(hasRemote("/x", "origin", rg)).toBe(true);
+    expect(hasRemote("/x", "upstream", rg)).toBe(true);
+    expect(hasRemote("/x", "fork", rg)).toBe(false);
+  });
+
+  test("hasRemote: returns false on non-zero exit", () => {
+    const rg = fakeGit([{ match: ["remote"], stdout: "", exitCode: 128 }]);
+    expect(hasRemote("/x", "origin", rg)).toBe(false);
+  });
+
+  test("detectDefaultBranches: primary symbolic-ref wins", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref", "refs/remotes/origin/HEAD"], stdout: "refs/remotes/origin/master\n" },
+      { match: ["symbolic-ref", "refs/remotes/upstream/HEAD"], stdout: "refs/remotes/upstream/main\n" },
+    ]);
+    const b = detectDefaultBranches("/x", rg);
+    expect(b.origin).toBe("master");
+    expect(b.upstream).toBe("main");
+  });
+
+  test("detectDefaultBranches: falls back to main/master probe when no symbolic-ref", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref", "refs/remotes/upstream/HEAD"], stdout: "", exitCode: 128 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/main"], stdout: "abcdef\n" },
+    ]);
+    const b = detectDefaultBranches("/x", rg);
+    expect(b.upstream).toBe("main");
+  });
+
+  test("detectDefaultBranches: null when nothing matches", () => {
+    const rg = fakeGit([]);
+    const b = detectDefaultBranches("/x", rg);
+    expect(b.origin).toBeNull();
+    expect(b.upstream).toBeNull();
+  });
+
+  test("detectDefaultBranchesAuthoritative: prefers local symbolic-ref when present", () => {
+    // If symbolic-ref succeeds we should NOT call ls-remote (no network).
+    const calls: string[][] = [];
+    const rg: RunGit = (args) => {
+      calls.push(args.slice());
+      if (args[0] === "symbolic-ref" && args[1] === "refs/remotes/origin/HEAD") {
+        return { stdout: "refs/remotes/origin/main\n", exitCode: 0 };
+      }
+      if (args[0] === "symbolic-ref" && args[1] === "refs/remotes/upstream/HEAD") {
+        return { stdout: "refs/remotes/upstream/main\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    };
+    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    expect(b.origin).toBe("main");
+    expect(b.upstream).toBe("main");
+    expect(calls.some((c) => c[0] === "ls-remote")).toBe(false);
+  });
+
+  test("detectDefaultBranchesAuthoritative: falls back to ls-remote --symref when symbolic-ref fails", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
+      {
+        match: ["ls-remote", "--symref", "upstream", "HEAD"],
+        stdout: "ref: refs/heads/develop\tHEAD\n0123abc\tHEAD\n",
+      },
+      {
+        match: ["ls-remote", "--symref", "origin", "HEAD"],
+        stdout: "ref: refs/heads/trunk\tHEAD\n0123abc\tHEAD\n",
+      },
+    ]);
+    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    expect(b.origin).toBe("trunk");
+    expect(b.upstream).toBe("develop");
+  });
+
+  test("detectDefaultBranchesAuthoritative: ls-remote failure falls through to main/master probe", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
+      { match: ["ls-remote"], stdout: "", exitCode: 128 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/main"], stdout: "feedface\n" },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"], stdout: "deadbeef\n" },
+    ]);
+    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    expect(b.origin).toBe("main");
+    expect(b.upstream).toBe("main");
+  });
+
+  test("detectDefaultBranchesAuthoritative: ls-remote without `ref:` line falls through", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
+      // exit 0 but stdout lacks "ref: refs/heads/..." — treat as unknown and fall through.
+      { match: ["ls-remote"], stdout: "0123abc\tHEAD\n", exitCode: 0 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"], stdout: "x\n" },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/master"], stdout: "x\n" },
+    ]);
+    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    expect(b.origin).toBe("master");
+    expect(b.upstream).toBe("master");
+  });
+});
+
+describe("withCheckout", () => {
+  function recordingGit(responder: (args: string[]) => { stdout: string; exitCode: number }): {
+    run: RunGit;
+    calls: string[][];
+  } {
+    const calls: string[][] = [];
+    return {
+      calls,
+      run: (args) => {
+        calls.push(args.slice());
+        return responder(args);
+      },
+    };
+  }
+
+  test("named-branch: checks out target, runs callback, restores prior branch", () => {
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "topic\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const result = withCheckout("/x", "master", run, () => {
+      calls.push(["<callback>"]);
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    const sequence = calls.map((c) => c.join(" "));
+    // Prior branch read, then checkout master, then callback, then checkout topic.
+    expect(sequence[0]).toContain("rev-parse --abbrev-ref");
+    expect(sequence[1]).toBe("checkout master");
+    expect(sequence[2]).toBe("<callback>");
+    expect(sequence[3]).toBe("checkout topic");
+  });
+
+  test("detached HEAD: captures SHA, checks out target, restores with --detach", () => {
+    const SHA = "abcdef0123456789abcdef0123456789abcdef01";
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "HEAD\n", exitCode: 0 };
+      }
+      if (args[0] === "rev-parse" && args[1] === "HEAD") {
+        return { stdout: `${SHA}\n`, exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    withCheckout("/x", "master", run, () => undefined);
+    const last = calls[calls.length - 1]!;
+    expect(last).toEqual(["checkout", "--detach", SHA]);
+  });
+
+  test("already on target: skips checkout and restore, just invokes callback", () => {
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "master\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    let called = false;
+    const r = withCheckout("/x", "master", run, () => {
+      called = true;
+      return 42;
+    });
+    expect(r).toBe(42);
+    expect(called).toBe(true);
+    expect(calls.some((c) => c[0] === "checkout")).toBe(false);
+  });
+
+  test("callback exception still triggers restore", () => {
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "topic\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    expect(() =>
+      withCheckout("/x", "master", run, () => {
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    const last = calls[calls.length - 1]!;
+    expect(last).toEqual(["checkout", "topic"]);
+  });
+
+  test("checkout failure throws and does not invoke callback", () => {
+    const { run, calls } = recordingGit((args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "topic\n", exitCode: 0 };
+      }
+      if (args[0] === "checkout") {
+        return { stdout: "error: the following untracked files\n", exitCode: 1 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    let invoked = false;
+    expect(() =>
+      withCheckout("/x", "master", run, () => {
+        invoked = true;
+      }),
+    ).toThrow(/checkout master failed/);
+    expect(invoked).toBe(false);
+    // No restore call recorded, because we never swapped away.
+    expect(calls.filter((c) => c[0] === "checkout")).toHaveLength(1);
+  });
+});

--- a/src/git-runner.ts
+++ b/src/git-runner.ts
@@ -115,6 +115,11 @@ export function detectDefaultBranchesAuthoritative(
   return { origin: read("origin"), upstream: read("upstream") };
 }
 
+function isThenable(x: unknown): x is PromiseLike<unknown> {
+  return x !== null && (typeof x === "object" || typeof x === "function")
+    && typeof (x as { then?: unknown }).then === "function";
+}
+
 /**
  * Run `fn` with `targetBranch` checked out, restoring the prior branch (or
  * detached-HEAD SHA) afterwards. If the current branch is already
@@ -127,6 +132,13 @@ export function detectDefaultBranchesAuthoritative(
  * will succeed. A `git merge --ff-only` satisfies this (never dirties the
  * tree); arbitrary callback behaviour does not. The restore is best-effort
  * — callers that need guaranteed restore must keep the tree clean.
+ *
+ * Synchronous only: `fn` must not return a Promise. The finally block runs
+ * as soon as `fn()` returns, so for an async callback the branch restore
+ * would fire before the awaited git work settled — the awaited commands
+ * would then execute on the wrong branch. If you need async, build a
+ * dedicated `withCheckoutAsync` that awaits before restoring. Violations
+ * throw at runtime (detected by inspecting the return value's `.then`).
  */
 export function withCheckout<T>(
   cwd: string,
@@ -142,14 +154,32 @@ export function withCheckout<T>(
     return r.exitCode === 0 ? r.stdout.trim() : null;
   })() : null;
 
-  if (priorBranch === targetBranch) return fn();
+  if (priorBranch === targetBranch) {
+    const result = fn();
+    if (isThenable(result)) {
+      throw new Error(
+        "withCheckout: async callbacks are not supported — the branch restore " +
+        "would fire before the Promise settled. Make `fn` synchronous or " +
+        "introduce a separate async helper that awaits before restoring.",
+      );
+    }
+    return result;
+  }
 
   const co = runGit(["checkout", targetBranch], cwd);
   if (co.exitCode !== 0) {
     throw new Error(`checkout ${targetBranch} failed: ${co.stdout.trim().slice(0, 200)}`);
   }
   try {
-    return fn();
+    const result = fn();
+    if (isThenable(result)) {
+      throw new Error(
+        "withCheckout: async callbacks are not supported — the branch restore " +
+        "would fire before the Promise settled. Make `fn` synchronous or " +
+        "introduce a separate async helper that awaits before restoring.",
+      );
+    }
+    return result;
   } finally {
     if (priorBranch) {
       runGit(["checkout", priorBranch], cwd);

--- a/src/git-runner.ts
+++ b/src/git-runner.ts
@@ -1,0 +1,171 @@
+// Injectable git runner + remote/branch helpers shared across briefing-lag
+// and staging-ff (and any future module that needs to shell out to git). All
+// subprocess calls go through the injected `RunGit` callable so tests can
+// inject a fake; the production `defaultRunGit` routes through
+// `safeSyncOutput` per the spawn.ts policy.
+
+import { join } from "path";
+import { safeSyncOutput } from "./spawn.ts";
+
+export interface RunGitResult {
+  stdout: string;
+  exitCode: number;
+}
+
+/** A minimal git runner: takes argv and a cwd, returns stdout + exit code. */
+export type RunGit = (args: string[], cwd: string) => RunGitResult;
+
+export interface DetectedBranches {
+  origin: string | null;
+  upstream: string | null;
+}
+
+export function expandHome(path: string): string {
+  if (path.startsWith("~/")) return join(process.env.HOME ?? "~", path.slice(2));
+  return path;
+}
+
+export function hasRemote(cwd: string, name: string, runGit: RunGit): boolean {
+  const r = runGit(["remote"], cwd);
+  if (r.exitCode !== 0) return false;
+  return r.stdout.split(/\r?\n/).map((s) => s.trim()).includes(name);
+}
+
+/**
+ * Detect the default branch name for each of origin and upstream.
+ *
+ * Local-only: no network round-trip. Used by the briefing path where any
+ * added latency would compound on every tick.
+ *
+ * Primary path: `git symbolic-ref refs/remotes/<remote>/HEAD`. This ref
+ * exists when the repo was cloned (git creates it automatically) or when
+ * the user has explicitly run `git remote set-head <remote> -a`.
+ *
+ * Fallback: for manually-added remotes (`git remote add upstream … && git
+ * fetch upstream`), git does NOT create `refs/remotes/upstream/HEAD`, so
+ * the primary path returns null. Probe the two overwhelmingly common
+ * default branches — `main` then `master` — via `git rev-parse --verify`.
+ *
+ * If neither the symbolic ref nor a `main`/`master` ref is present, return
+ * null.
+ */
+export function detectDefaultBranches(cwd: string, runGit: RunGit): DetectedBranches {
+  const read = (remote: string): string | null => {
+    const primary = runGit(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
+    if (primary.exitCode === 0) {
+      const line = primary.stdout.trim();
+      const prefix = `refs/remotes/${remote}/`;
+      if (line.startsWith(prefix)) {
+        const name = line.slice(prefix.length);
+        if (name) return name;
+      }
+    }
+    for (const candidate of ["main", "master"]) {
+      const verify = runGit(
+        ["rev-parse", "--verify", "--quiet", `refs/remotes/${remote}/${candidate}`],
+        cwd,
+      );
+      if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
+    }
+    return null;
+  };
+  return { origin: read("origin"), upstream: read("upstream") };
+}
+
+/**
+ * Detect the default branch name with an authoritative `ls-remote --symref`
+ * tier that queries the remote directly. Intended for paths that have
+ * already established network connectivity (e.g. `git fetch <remote>` moments
+ * earlier), so the ls-remote round-trip is cheap.
+ *
+ * Tier ordering per remote: symbolic-ref (local) → ls-remote --symref
+ * (network) → main/master probe (local) → null. Each tier short-circuits
+ * on success.
+ */
+export function detectDefaultBranchesAuthoritative(
+  cwd: string,
+  runGit: RunGit,
+): DetectedBranches {
+  const read = (remote: string): string | null => {
+    const primary = runGit(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
+    if (primary.exitCode === 0) {
+      const line = primary.stdout.trim();
+      const prefix = `refs/remotes/${remote}/`;
+      if (line.startsWith(prefix)) {
+        const name = line.slice(prefix.length);
+        if (name) return name;
+      }
+    }
+    const symref = runGit(["ls-remote", "--symref", remote, "HEAD"], cwd);
+    if (symref.exitCode === 0) {
+      // Expected line: `ref: refs/heads/<branch>\tHEAD` (whitespace may be
+      // a tab or spaces depending on git version).
+      const m = symref.stdout.match(/^ref:\s+refs\/heads\/(.+?)\s+HEAD\b/m);
+      if (m && m[1]) return m[1];
+    }
+    for (const candidate of ["main", "master"]) {
+      const verify = runGit(
+        ["rev-parse", "--verify", "--quiet", `refs/remotes/${remote}/${candidate}`],
+        cwd,
+      );
+      if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
+    }
+    return null;
+  };
+  return { origin: read("origin"), upstream: read("upstream") };
+}
+
+/**
+ * Run `fn` with `targetBranch` checked out, restoring the prior branch (or
+ * detached-HEAD SHA) afterwards. If the current branch is already
+ * `targetBranch`, the checkout and the restore are both skipped.
+ *
+ * On checkout failure (entering), throws with the git error message. The
+ * callback's exceptions propagate after the restore runs in `finally`.
+ *
+ * Contract: `fn` must leave the worktree in a state where checkout-back
+ * will succeed. A `git merge --ff-only` satisfies this (never dirties the
+ * tree); arbitrary callback behaviour does not. The restore is best-effort
+ * — callers that need guaranteed restore must keep the tree clean.
+ */
+export function withCheckout<T>(
+  cwd: string,
+  targetBranch: string,
+  runGit: RunGit,
+  fn: () => T,
+): T {
+  const abbrev = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const rawName = abbrev.exitCode === 0 ? abbrev.stdout.trim() : "";
+  const priorBranch = rawName && rawName !== "HEAD" ? rawName : null;
+  const priorHeadSha = priorBranch === null ? (() => {
+    const r = runGit(["rev-parse", "HEAD"], cwd);
+    return r.exitCode === 0 ? r.stdout.trim() : null;
+  })() : null;
+
+  if (priorBranch === targetBranch) return fn();
+
+  const co = runGit(["checkout", targetBranch], cwd);
+  if (co.exitCode !== 0) {
+    throw new Error(`checkout ${targetBranch} failed: ${co.stdout.trim().slice(0, 200)}`);
+  }
+  try {
+    return fn();
+  } finally {
+    if (priorBranch) {
+      runGit(["checkout", priorBranch], cwd);
+    } else if (priorHeadSha) {
+      runGit(["checkout", "--detach", priorHeadSha], cwd);
+    }
+  }
+}
+
+/**
+ * Production git runner — wraps Bun.spawnSync via safeSyncOutput so this
+ * call path complies with spawn.ts's policy. Preserves the historic
+ * RunGitResult shape: untrimmed stdout + exit code (so callers that
+ * fingerprint output with their own trim/regex logic keep working).
+ */
+export const defaultRunGit: RunGit = (args, cwd) => {
+  const res = safeSyncOutput(["git", "-C", cwd, ...args], { trim: false });
+  return { stdout: res.stdout, exitCode: res.exitCode };
+};

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3,7 +3,8 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { join } from "path";
 import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, stateRepoDir, effectivePriorityValue, milestonesEnabledProjects, milestoneKey, resolveProjectPath, postponedProjectSet, findProjectConfigByName, type LudicsFullConfig } from "./config.ts";
-import { formatUpstreamLagSection, defaultRunGit, type RunGit } from "./briefing-lag.ts";
+import { formatUpstreamLagSection } from "./briefing-lag.ts";
+import { defaultRunGit, type RunGit } from "./git-runner.ts";
 import { maybeFastForwardStagingFromUpstream } from "./staging-ff.ts";
 import { atomicWriteFileSync, isPlainObject } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -6,7 +6,7 @@ import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, stateRep
 import { formatUpstreamLagSection } from "./briefing-lag.ts";
 import { defaultRunGit, type RunGit } from "./git-runner.ts";
 import { clearSentinel, readSentinelEpoch, sentinelExists, sentinelFresh, touchSentinel } from "./sentinel.ts";
-import { maybeFastForwardStagingFromUpstream } from "./staging-ff.ts";
+import { syncStagingMainWithUpstream } from "./staging-ff.ts";
 import { atomicWriteFileSync, isPlainObject } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
@@ -1526,7 +1526,7 @@ async function cleanupDoneTaskThreads(): Promise<void> {
  * appears in log messages to aid debugging.
  */
 /**
- * Wrapper around maybeFastForwardStagingFromUpstream that wires up config,
+ * Wrapper around syncStagingMainWithUpstream that wires up config,
  * sentinel directory, and event emission. Guarded by clusterIsController so
  * only one machine runs git operations. Sentinel files throttle to once per
  * 24 hours per project. See src/staging-ff.ts for the core logic.
@@ -1540,7 +1540,7 @@ function runStagingFastForwardTick(): void {
     if (projects.every((p) => !p.upstream_repo)) return;
     const sentinelDir = join(harnessDir(), "mag");
     mkdirSync(sentinelDir, { recursive: true });
-    const results = maybeFastForwardStagingFromUpstream(projects, {
+    const results = syncStagingMainWithUpstream(projects, {
       now: new Date(),
       runGit: defaultRunGit,
       sentinelDir,

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, stateRepoDir, effectivePriorityValue, milestonesEnabledProjects, milestoneKey, resolveProjectPath, postponedProjectSet, findProjectConfigByName, type LudicsFullConfig } from "./config.ts";
 import { formatUpstreamLagSection } from "./briefing-lag.ts";
 import { defaultRunGit, type RunGit } from "./git-runner.ts";
+import { clearSentinel, readSentinelEpoch, sentinelExists, sentinelFresh, touchSentinel } from "./sentinel.ts";
 import { maybeFastForwardStagingFromUpstream } from "./staging-ff.ts";
 import { atomicWriteFileSync, isPlainObject } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";
@@ -125,16 +126,6 @@ function startupWatchdogEpochFile(): string {
   return join(magStateDir(), "startup-watchdog.epoch");
 }
 
-function readEpochFile(file: string): number | null {
-  if (!existsSync(file)) return null;
-  try {
-    const epoch = parseInt(readFileSync(file, "utf-8").trim(), 10);
-    return Number.isFinite(epoch) && epoch > 0 ? epoch : null;
-  } catch {
-    return null;
-  }
-}
-
 // --- Settled state helpers ---
 
 function settledSentinelFile(): string {
@@ -142,16 +133,15 @@ function settledSentinelFile(): string {
 }
 
 function markMagSettled(): void {
-  mkdirSync(magStateDir(), { recursive: true });
-  writeFileSync(settledSentinelFile(), String(Math.floor(Date.now() / 1000)));
+  touchSentinel(settledSentinelFile());
 }
 
 function clearMagSettled(): void {
-  try { unlinkSync(settledSentinelFile()); } catch {}
+  clearSentinel(settledSentinelFile());
 }
 
 function isMagSettled(): boolean {
-  return existsSync(settledSentinelFile());
+  return sentinelExists(settledSentinelFile());
 }
 
 /**
@@ -195,7 +185,7 @@ function isMagReady(): boolean {
 function clearStaleSettled(): void {
   if (!isMagSettled()) return;
 
-  const settledEpoch = readEpochFile(settledSentinelFile());
+  const settledEpoch = readSentinelEpoch(settledSentinelFile());
   if (settledEpoch !== null) {
     const ageMs = Date.now() - settledEpoch * 1000;
     if (ageMs < keepaliveIntervalMs() * 1.5) return;
@@ -263,28 +253,28 @@ function writePaneHash(hash: string): void {
 }
 
 function readPaneChangeEpoch(): number {
-  const epoch = readEpochFile(paneChangeEpochFile());
+  const epoch = readSentinelEpoch(paneChangeEpochFile());
   return epoch ? epoch * 1000 : Date.now();
 }
 
 function writePaneChangeEpoch(): void {
-  writeFileSync(paneChangeEpochFile(), String(Math.floor(Date.now() / 1000)));
+  touchSentinel(paneChangeEpochFile());
 }
 
 function stallNudgeCoolingDown(): boolean {
-  const lastNudge = readEpochFile(stallNudgeEpochFile());
+  const lastNudge = readSentinelEpoch(stallNudgeEpochFile());
   if (lastNudge === null) return false;
   return (Date.now() - lastNudge * 1000) < stallNudgeCooldownMs();
 }
 
 function writeStallNudgeEpoch(): void {
-  writeFileSync(stallNudgeEpochFile(), String(Math.floor(Date.now() / 1000)));
+  touchSentinel(stallNudgeEpochFile());
 }
 
 function clearStallState(): void {
   try { unlinkSync(paneHashFile()); } catch {}
-  try { unlinkSync(paneChangeEpochFile()); } catch {}
-  try { unlinkSync(stallNudgeEpochFile()); } catch {}
+  clearSentinel(paneChangeEpochFile());
+  clearSentinel(stallNudgeEpochFile());
 }
 
 // --- Queue feed and stall nudge helpers ---
@@ -397,8 +387,7 @@ function maybeNudgeStalledMag(): void {
 }
 
 function writeStopHookTimestamp(): void {
-  mkdirSync(magStateDir(), { recursive: true });
-  writeFileSync(stopHookTimestampFile(), String(Math.floor(Date.now() / 1000)));
+  touchSentinel(stopHookTimestampFile());
 }
 
 function startupWatchdogSeconds(): number {
@@ -436,18 +425,11 @@ function startupHelperStuckSeconds(): number {
 }
 
 function writeStartupWatchdogEpoch(): void {
-  mkdirSync(magStateDir(), { recursive: true });
-  writeFileSync(startupWatchdogEpochFile(), String(Math.floor(Date.now() / 1000)));
+  touchSentinel(startupWatchdogEpochFile());
 }
 
 function clearStartupWatchdogEpoch(): void {
-  const file = startupWatchdogEpochFile();
-  if (!existsSync(file)) return;
-  try {
-    unlinkSync(file);
-  } catch {
-    // Best-effort
-  }
+  clearSentinel(startupWatchdogEpochFile());
 }
 
 function startupAlertStateFile(): string {
@@ -600,10 +582,10 @@ function restartClaudeInMag(reason: string): boolean {
 }
 
 function maybeRecoverStuckStartup(): void {
-  const startupEpoch = readEpochFile(startupWatchdogEpochFile());
+  const startupEpoch = readSentinelEpoch(startupWatchdogEpochFile());
   if (!startupEpoch) return;
 
-  const lastStopHook = readEpochFile(stopHookTimestampFile());
+  const lastStopHook = readSentinelEpoch(stopHookTimestampFile());
   if (lastStopHook && lastStopHook >= startupEpoch) {
     clearStartupAlertsForEpoch(startupEpoch);
     clearStartupWatchdogEpoch();
@@ -2086,20 +2068,11 @@ function autoProposalDebounceFile(taskId: string): string {
 }
 
 function autoProposalDebounced(taskId: string): boolean {
-  const file = autoProposalDebounceFile(taskId);
-  if (!existsSync(file)) return false;
-  try {
-    const lastEpoch = parseInt(readFileSync(file, "utf-8").trim(), 10);
-    return (Math.floor(Date.now() / 1000) - lastEpoch) < AUTO_PROPOSAL_DEBOUNCE_SECONDS;
-  } catch {
-    return false;
-  }
+  return sentinelFresh(autoProposalDebounceFile(taskId), new Date(), AUTO_PROPOSAL_DEBOUNCE_SECONDS);
 }
 
 function markAutoProposalQueued(taskId: string): void {
-  const file = autoProposalDebounceFile(taskId);
-  mkdirSync(join(magStateDir(), "auto-proposal-debounce"), { recursive: true });
-  writeFileSync(file, String(Math.floor(Date.now() / 1000)));
+  touchSentinel(autoProposalDebounceFile(taskId));
 }
 
 /** Auto-start slots that have proposals but no active session. */

--- a/src/sentinel.test.ts
+++ b/src/sentinel.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, existsSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  sentinelFresh,
+  readSentinelEpoch,
+  touchSentinel,
+  clearSentinel,
+  sentinelExists,
+} from "./sentinel.ts";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "ludics-sentinel-"));
+}
+
+describe("sentinel", () => {
+  test("sentinelFresh: true when mtime is within window", () => {
+    const dir = tmp();
+    const file = join(dir, "x.epoch");
+    writeFileSync(file, "0");
+    const now = new Date();
+    expect(sentinelFresh(file, now, 3600)).toBe(true);
+  });
+
+  test("sentinelFresh: false when mtime is past window", () => {
+    const dir = tmp();
+    const file = join(dir, "x.epoch");
+    writeFileSync(file, "0");
+    const old = new Date(Date.now() - 2 * 3600 * 1000);
+    utimesSync(file, old, old);
+    expect(sentinelFresh(file, new Date(), 3600)).toBe(false);
+  });
+
+  test("sentinelFresh: false when file is missing", () => {
+    const dir = tmp();
+    expect(sentinelFresh(join(dir, "missing.epoch"), new Date(), 3600)).toBe(false);
+  });
+
+  test("readSentinelEpoch: returns stored integer", () => {
+    const dir = tmp();
+    const file = join(dir, "x.epoch");
+    writeFileSync(file, "1700000000\n");
+    expect(readSentinelEpoch(file)).toBe(1700000000);
+  });
+
+  test("readSentinelEpoch: returns null for missing file", () => {
+    expect(readSentinelEpoch(join(tmp(), "missing.epoch"))).toBeNull();
+  });
+
+  test("readSentinelEpoch: returns null for non-positive epoch (conservative policy)", () => {
+    const dir = tmp();
+    const zero = join(dir, "zero.epoch");
+    writeFileSync(zero, "0");
+    expect(readSentinelEpoch(zero)).toBeNull();
+    const negative = join(dir, "neg.epoch");
+    writeFileSync(negative, "-1");
+    expect(readSentinelEpoch(negative)).toBeNull();
+    const garbage = join(dir, "garbage.epoch");
+    writeFileSync(garbage, "not-a-number");
+    expect(readSentinelEpoch(garbage)).toBeNull();
+  });
+
+  test("touchSentinel: creates parent dir and writes epoch", () => {
+    const dir = tmp();
+    const file = join(dir, "nested", "deep", "x.epoch");
+    const when = new Date(1700000000 * 1000);
+    touchSentinel(file, when);
+    expect(existsSync(file)).toBe(true);
+    expect(readSentinelEpoch(file)).toBe(1700000000);
+  });
+
+  test("touchSentinel: defaults `now` to current time when omitted", () => {
+    const dir = tmp();
+    const file = join(dir, "x.epoch");
+    const before = Math.floor(Date.now() / 1000);
+    touchSentinel(file);
+    const epoch = readSentinelEpoch(file);
+    expect(epoch).not.toBeNull();
+    expect(epoch!).toBeGreaterThanOrEqual(before);
+  });
+
+  test("clearSentinel: removes existing file", () => {
+    const dir = tmp();
+    const file = join(dir, "x.epoch");
+    touchSentinel(file, new Date());
+    expect(existsSync(file)).toBe(true);
+    clearSentinel(file);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  test("clearSentinel: swallows errors when file is absent", () => {
+    const dir = tmp();
+    expect(() => clearSentinel(join(dir, "never-existed.epoch"))).not.toThrow();
+  });
+
+  test("sentinelExists: boolean presence check (no freshness)", () => {
+    const dir = tmp();
+    const file = join(dir, "settled");
+    expect(sentinelExists(file)).toBe(false);
+    writeFileSync(file, "");
+    expect(sentinelExists(file)).toBe(true);
+  });
+
+  test("round-trip: touch → readSentinelEpoch yields the written epoch (stable under serialize/deserialize)", () => {
+    const dir = tmp();
+    const file = join(dir, "round-trip.epoch");
+    const when = new Date(1_700_000_042 * 1000);
+    touchSentinel(file, when);
+    expect(readSentinelEpoch(file)).toBe(1_700_000_042);
+    expect(sentinelFresh(file, when, 10)).toBe(true);
+  });
+});

--- a/src/sentinel.ts
+++ b/src/sentinel.ts
@@ -1,0 +1,73 @@
+// Unified sentinel-file primitives used across mag.ts + staging-ff.ts for
+// freshness-windowed throttles (epoch text files) and boolean presence
+// markers. All writes are best-effort: a failed sentinel write just means
+// the next tick may run again.
+
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, utimesSync, writeFileSync } from "fs";
+import { dirname } from "path";
+
+/**
+ * True iff the sentinel file exists and its mtime is within `windowSec`
+ * seconds of `now`. Missing / unreadable files return false (fail-open:
+ * caller proceeds as if no throttle is active).
+ */
+export function sentinelFresh(path: string, now: Date, windowSec: number): boolean {
+  if (!existsSync(path)) return false;
+  try {
+    const mtime = statSync(path).mtimeMs;
+    const ageSec = (now.getTime() - mtime) / 1000;
+    return ageSec < windowSec;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the epoch stored in a sentinel file. Returns null when the file is
+ * missing, unreadable, or contains a non-positive / non-finite integer
+ * (the conservative policy that matches the former readEpochFile site).
+ */
+export function readSentinelEpoch(path: string): number | null {
+  if (!existsSync(path)) return null;
+  try {
+    const epoch = parseInt(readFileSync(path, "utf-8").trim(), 10);
+    return Number.isFinite(epoch) && epoch > 0 ? epoch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the current epoch into `path`, creating parent directories as
+ * needed. `now` defaults to new Date() for callers that don't already have
+ * a Date value in hand. Failures are swallowed — sentinel writes are
+ * best-effort.
+ */
+export function touchSentinel(path: string, now?: Date): void {
+  const when = now ?? new Date();
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+  } catch {
+    // Parent dir may already exist; that's fine.
+  }
+  try {
+    writeFileSync(path, String(Math.floor(when.getTime() / 1000)));
+    utimesSync(path, when, when);
+  } catch {
+    // Best-effort; a missed write means the next tick may run again.
+  }
+}
+
+/** Unlink the sentinel if present; swallow errors. */
+export function clearSentinel(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // Absent-or-unremovable: either way, there's nothing more we can do.
+  }
+}
+
+/** Presence-only check for boolean sentinels (e.g. mag/settled). */
+export function sentinelExists(path: string): boolean {
+  return existsSync(path);
+}

--- a/src/staging-ff.test.ts
+++ b/src/staging-ff.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, existsSync, utimesSync } from "f
 import { join } from "path";
 import { tmpdir } from "os";
 import {
-  maybeFastForwardStagingFromUpstream,
+  syncStagingMainWithUpstream,
   type FastForwardProjectResult,
 } from "./staging-ff.ts";
 import type { RunGit } from "./briefing-lag.ts";
@@ -50,11 +50,11 @@ function project(name: string, path: string, upstream = "upstream/bar"): Project
   return { name, repo: "o/foo", upstream_repo: upstream, path } as ProjectConfig;
 }
 
-describe("maybeFastForwardStagingFromUpstream", () => {
+describe("syncStagingMainWithUpstream", () => {
   test("skips projects without upstream_repo", () => {
     const sentinelDir = tmp("ff-sentinel-");
     const { run, calls } = recordingGit({});
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [{ name: "plain", repo: "o/r" } as ProjectConfig],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -72,7 +72,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
     const recent = new Date(Date.now() - 10 * 60 * 1000);
     utimesSync(sentinel, recent, recent);
     const { run, calls } = recordingGit({});
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -95,7 +95,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       "rev-list": { stdout: "0\n" },
     };
     const { run, calls } = recordingGit(handlers, defaultSymbolicRef);
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir, "upstream/bar")],
       {
         now: new Date(),
@@ -154,7 +154,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       return { stdout: "", exitCode: 0 };
     };
 
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       {
         now: new Date(),
@@ -195,7 +195,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       merge: { stdout: "Already up to date.\n" },
       "rev-list": { stdout: "0\n" },
     }, defaultSymbolicRef);
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir, emitEvent: (ev) => events.push({ type: ev.type }) },
     );
@@ -215,7 +215,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       fetch: { stdout: "" },
       merge: { stdout: "fatal: Not possible to fast-forward, aborting.\n", exitCode: 128 },
     }, defaultSymbolicRef);
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir, emitEvent: (ev) => events.push({ type: ev.type }) },
     );
@@ -236,7 +236,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       fetch: { stdout: "" },
       status: { stdout: " M path/to/file\n" }, // dirty
     }, defaultSymbolicRef);
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -250,7 +250,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
     const sentinelDir = tmp("ff-sentinel-");
     mkdirSync(dir, { recursive: true });
     const { run, calls } = recordingGit({ remote: { stdout: "origin\n" } });
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -262,7 +262,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
   test("non-existent checkout path is reported, not thrown", () => {
     const sentinelDir = tmp("ff-sentinel-");
     const { run } = recordingGit({});
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ghost", "/does/not/exist/xyz-ludics-test")],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -298,7 +298,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       if (key === "rev-list") return { stdout: "0\n", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     };
-    const res = maybeFastForwardStagingFromUpstream(
+    const res = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir },
     );
@@ -319,7 +319,7 @@ describe("maybeFastForwardStagingFromUpstream", () => {
       remote: { stdout: "origin\nupstream\n" },
       fetch: { stdout: "fatal: unable to reach upstream\n", exitCode: 128 },
     });
-    const res: FastForwardProjectResult[] = maybeFastForwardStagingFromUpstream(
+    const res: FastForwardProjectResult[] = syncStagingMainWithUpstream(
       [project("ocannl", dir)],
       { now: new Date(), runGit: run, sentinelDir },
     );

--- a/src/staging-ff.test.ts
+++ b/src/staging-ff.test.ts
@@ -269,6 +269,48 @@ describe("maybeFastForwardStagingFromUpstream", () => {
     expect(res[0]!.outcome).toBe("skipped-no-path");
   });
 
+  test("default-branch detection uses ls-remote --symref after fetch (authoritative tier)", () => {
+    // Regression for task-b0d4f45b item 3: when symbolic-ref is absent (common
+    // for manually-added remotes), the fast-forward path must consult
+    // `ls-remote --symref` so non-main/master defaults (e.g. `develop`) are
+    // detected correctly. The briefing path still stays local-only.
+    const dir = tmp("ff-checkout-");
+    const sentinelDir = tmp("ff-sentinel-");
+    mkdirSync(dir, { recursive: true });
+    const calls: string[][] = [];
+    const run: RunGit = (args) => {
+      calls.push(args.slice());
+      const key = args[0] ?? "";
+      if (key === "remote") return { stdout: "origin\nupstream\n", exitCode: 0 };
+      if (key === "fetch") return { stdout: "", exitCode: 0 };
+      if (key === "status") return { stdout: "", exitCode: 0 };
+      if (key === "symbolic-ref") return { stdout: "", exitCode: 128 };
+      if (key === "ls-remote" && args[2] === "upstream") {
+        return { stdout: "ref: refs/heads/develop\tHEAD\n0123abc\tHEAD\n", exitCode: 0 };
+      }
+      if (key === "ls-remote" && args[2] === "origin") {
+        return { stdout: "ref: refs/heads/develop\tHEAD\n0123abc\tHEAD\n", exitCode: 0 };
+      }
+      if (key === "rev-parse" && args[1] === "--abbrev-ref") {
+        return { stdout: "develop\n", exitCode: 0 };
+      }
+      if (key === "merge") return { stdout: "Already up to date.\n", exitCode: 0 };
+      if (key === "rev-list") return { stdout: "0\n", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    };
+    const res = maybeFastForwardStagingFromUpstream(
+      [project("ocannl", dir)],
+      { now: new Date(), runGit: run, sentinelDir },
+    );
+    expect(res[0]!.outcome).toBe("already-up-to-date");
+    // ls-remote --symref was consulted (proof of authoritative path engaging).
+    expect(calls.some((c) => c[0] === "ls-remote" && c[1] === "--symref")).toBe(true);
+    // Merge target used the `develop` branch name from ls-remote output.
+    const merge = calls.find((c) => c[0] === "merge");
+    expect(merge).toBeDefined();
+    expect(merge!.includes("upstream/develop")).toBe(true);
+  });
+
   test("fetch failure: records error, touches sentinel, does not attempt merge", () => {
     const dir = tmp("ff-checkout-");
     const sentinelDir = tmp("ff-sentinel-");

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -7,7 +7,7 @@
 // dirty. Throttled per-project via a sentinel file so each project runs at
 // most once every 24 hours.
 
-import { existsSync, statSync, mkdirSync, utimesSync, writeFileSync } from "fs";
+import { existsSync } from "fs";
 import { join } from "path";
 import {
   detectDefaultBranchesAuthoritative,
@@ -16,6 +16,7 @@ import {
   withCheckout,
   type RunGit,
 } from "./git-runner.ts";
+import { sentinelFresh, touchSentinel } from "./sentinel.ts";
 import type { ProjectConfig } from "./config.ts";
 
 export type FastForwardOutcome =
@@ -49,32 +50,6 @@ export interface FastForwardOptions {
 
 function sentinelFile(dir: string, project: string): string {
   return join(dir, `last-fast-forward-${project}.epoch`);
-}
-
-function sentinelFresh(file: string, now: Date, windowSec: number): boolean {
-  if (!existsSync(file)) return false;
-  try {
-    const mtime = statSync(file).mtimeMs;
-    const ageSec = (now.getTime() - mtime) / 1000;
-    return ageSec < windowSec;
-  } catch {
-    return false;
-  }
-}
-
-function touchSentinel(file: string, now: Date): void {
-  try {
-    mkdirSync(join(file, ".."), { recursive: true });
-  } catch {
-    // Parent dir may already exist; that's fine.
-  }
-  try {
-    writeFileSync(file, String(Math.floor(now.getTime() / 1000)));
-    utimesSync(file, now, now);
-  } catch {
-    // Sentinel writes are best-effort; a stale sentinel just means the next
-    // tick may run again. Not worth aborting the tick.
-  }
 }
 
 function worktreeClean(cwd: string, runGit: RunGit): boolean {

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -10,7 +10,7 @@
 import { existsSync, statSync, mkdirSync, utimesSync, writeFileSync } from "fs";
 import { join } from "path";
 import {
-  detectDefaultBranches,
+  detectDefaultBranchesAuthoritative,
   expandHome,
   hasRemote,
   withCheckout,
@@ -135,7 +135,10 @@ export function maybeFastForwardStagingFromUpstream(
       continue;
     }
 
-    const branches = detectDefaultBranches(path, opts.runGit);
+    // After `git fetch upstream` above, network connectivity + credentials
+    // are warm — use the authoritative `ls-remote --symref` tier so non-
+    // main/master defaults (e.g. `develop`, `trunk`) are detected correctly.
+    const branches = detectDefaultBranchesAuthoritative(path, opts.runGit);
     if (!branches.origin || !branches.upstream) {
       out.push({ project, outcome: "skipped-no-default-branch" });
       touchSentinel(sentinel, opts.now);

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -13,6 +13,7 @@ import {
   detectDefaultBranches,
   expandHome,
   hasRemote,
+  withCheckout,
   type RunGit,
 } from "./git-runner.ts";
 import type { ProjectConfig } from "./config.ts";
@@ -80,13 +81,6 @@ function worktreeClean(cwd: string, runGit: RunGit): boolean {
   const r = runGit(["status", "--porcelain"], cwd);
   if (r.exitCode !== 0) return false;
   return r.stdout.trim() === "";
-}
-
-function currentBranch(cwd: string, runGit: RunGit): string | null {
-  const r = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
-  if (r.exitCode !== 0) return null;
-  const name = r.stdout.trim();
-  return name && name !== "HEAD" ? name : null;
 }
 
 function commitCount(cwd: string, range: string, runGit: RunGit): number | null {
@@ -157,74 +151,50 @@ export function maybeFastForwardStagingFromUpstream(
     }
 
     // Always target `branches.origin` for the merge, even on detached HEAD.
-    // currentBranch() returns null for detached HEAD — we must still check out
-    // the default branch, otherwise `git merge --ff-only upstream/<default>`
-    // would advance the detached commit while leaving `origin/<default>`
-    // unchanged, violating the acceptance criterion that the staging default
-    // branch be the thing moved forward.
-    const priorBranch = currentBranch(path, opts.runGit);
-    // Capture prior HEAD SHA so we can restore a detached-HEAD checkout
-    // exactly. On a regular branch, this is only a fallback; the named branch
-    // is preferable for the restore.
-    const priorHeadSha = priorBranch === null ? (() => {
-      const r = opts.runGit(["rev-parse", "HEAD"], path);
-      return r.exitCode === 0 ? r.stdout.trim() : null;
-    })() : null;
-    const needCheckout = priorBranch !== branches.origin;
-    if (needCheckout) {
-      const co = opts.runGit(["checkout", branches.origin], path);
-      if (co.exitCode !== 0) {
-        out.push({ project, outcome: "error", detail: `checkout failed: ${co.stdout.trim().slice(0, 200)}` });
-        touchSentinel(sentinel, opts.now);
-        continue;
-      }
-    }
-
+    // withCheckout() handles the prior-branch / detached-HEAD-SHA capture and
+    // restore; it throws on checkout failure, which we classify as `error`.
     try {
-      const merge = opts.runGit(
-        ["merge", "--ff-only", `upstream/${branches.upstream}`],
-        path,
-      );
-      if (merge.exitCode === 0) {
-        // Count commits the branch advanced by (may be 0 if already up-to-date).
-        const advancedBy = commitCount(
+      withCheckout(path, branches.origin, opts.runGit, () => {
+        const merge = opts.runGit(
+          ["merge", "--ff-only", `upstream/${branches.upstream}`],
           path,
-          `origin/${branches.origin}..upstream/${branches.upstream}`,
-          opts.runGit,
-        ) ?? 0;
-        // `origin/<default>..upstream/<default>` after FF is always 0. Instead
-        // measure progress via `HEAD@{1}..HEAD` would require reflog; for the
-        // sake of simplicity and test-friendliness, infer from the "Already up
-        // to date." vs advancing output of the merge subprocess.
-        const up2date = /up[- ]to[- ]date/i.test(merge.stdout);
-        const outcome: FastForwardOutcome = up2date ? "already-up-to-date" : "fast-forwarded";
-        out.push({ project, outcome, advancedBy });
-        touchSentinel(sentinel, opts.now);
-        if (outcome === "fast-forwarded") {
+        );
+        if (merge.exitCode === 0) {
+          // Count commits the branch advanced by (may be 0 if already up-to-date).
+          const advancedBy = commitCount(
+            path,
+            `origin/${branches.origin}..upstream/${branches.upstream}`,
+            opts.runGit,
+          ) ?? 0;
+          // `origin/<default>..upstream/<default>` after FF is always 0. Instead
+          // measure progress via `HEAD@{1}..HEAD` would require reflog; for the
+          // sake of simplicity and test-friendliness, infer from the "Already up
+          // to date." vs advancing output of the merge subprocess.
+          const up2date = /up[- ]to[- ]date/i.test(merge.stdout);
+          const outcome: FastForwardOutcome = up2date ? "already-up-to-date" : "fast-forwarded";
+          out.push({ project, outcome, advancedBy });
+          touchSentinel(sentinel, opts.now);
+          if (outcome === "fast-forwarded") {
+            opts.emitEvent?.({
+              type: "staging_fast_forwarded",
+              project,
+              message: `${project}: staging fast-forwarded from upstream/${branches.upstream}`,
+            });
+          }
+        } else {
+          out.push({ project, outcome: "diverged", detail: merge.stdout.trim().slice(0, 200) });
           opts.emitEvent?.({
-            type: "staging_fast_forwarded",
+            type: "staging_fast_forward_diverged",
             project,
-            message: `${project}: staging fast-forwarded from upstream/${branches.upstream}`,
+            message: `${project}: staging and upstream have diverged — manual reconciliation needed`,
           });
+          touchSentinel(sentinel, opts.now);
         }
-      } else {
-        out.push({ project, outcome: "diverged", detail: merge.stdout.trim().slice(0, 200) });
-        opts.emitEvent?.({
-          type: "staging_fast_forward_diverged",
-          project,
-          message: `${project}: staging and upstream have diverged — manual reconciliation needed`,
-        });
-        touchSentinel(sentinel, opts.now);
-      }
-    } finally {
-      if (needCheckout) {
-        if (priorBranch) {
-          opts.runGit(["checkout", priorBranch], path);
-        } else if (priorHeadSha) {
-          // Restore detached-HEAD state at the exact prior commit.
-          opts.runGit(["checkout", "--detach", priorHeadSha], path);
-        }
-      }
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      out.push({ project, outcome: "error", detail: detail.slice(0, 200) });
+      touchSentinel(sentinel, opts.now);
     }
   }
   return out;

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -9,7 +9,12 @@
 
 import { existsSync, statSync, mkdirSync, utimesSync, writeFileSync } from "fs";
 import { join } from "path";
-import { detectDefaultBranches, type RunGit } from "./briefing-lag.ts";
+import {
+  detectDefaultBranches,
+  expandHome,
+  hasRemote,
+  type RunGit,
+} from "./git-runner.ts";
 import type { ProjectConfig } from "./config.ts";
 
 export type FastForwardOutcome =
@@ -41,11 +46,6 @@ export interface FastForwardOptions {
   emitEvent?: (ev: { type: string; project: string; message: string }) => void;
 }
 
-function expandHome(path: string): string {
-  if (path.startsWith("~/")) return join(process.env.HOME ?? "~", path.slice(2));
-  return path;
-}
-
 function sentinelFile(dir: string, project: string): string {
   return join(dir, `last-fast-forward-${project}.epoch`);
 }
@@ -74,12 +74,6 @@ function touchSentinel(file: string, now: Date): void {
     // Sentinel writes are best-effort; a stale sentinel just means the next
     // tick may run again. Not worth aborting the tick.
   }
-}
-
-function hasRemote(cwd: string, name: string, runGit: RunGit): boolean {
-  const r = runGit(["remote"], cwd);
-  if (r.exitCode !== 0) return false;
-  return r.stdout.split(/\r?\n/).map((s) => s.trim()).includes(name);
 }
 
 function worktreeClean(cwd: string, runGit: RunGit): boolean {

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -70,7 +70,7 @@ function commitCount(cwd: string, range: string, runGit: RunGit): number | null 
  * Returns an outcome describing what happened; callers can treat everything
  * except `fast-forwarded` / `already-up-to-date` / `throttled` as diagnostic.
  */
-export function maybeFastForwardStagingFromUpstream(
+export function syncStagingMainWithUpstream(
   projects: ProjectConfig[],
   opts: FastForwardOptions,
 ): FastForwardProjectResult[] {


### PR DESCRIPTION
## Summary

Five related code-shape consolidations from the retrospective of task-d1932b8f, delivered as five commits in one PR:

1. **src/git-runner.ts** — extract `RunGit` + `RunGitResult` + `defaultRunGit` (now routed through `safeSyncOutput` per the spawn.ts policy) + `expandHome` + `hasRemote` + `detectDefaultBranches` from briefing-lag/staging-ff. briefing-lag re-exports for API compatibility; staging-ff drops its duplicate `expandHome` + `hasRemote`; mag.ts imports `defaultRunGit` + `RunGit` from the new module.
2. **`withCheckout<T>`** — abstraction in git-runner.ts that owns the prior-branch / detached-HEAD-SHA capture + restore. `syncStagingMainWithUpstream` collapses its ~50-line inline dance into a single `withCheckout(...)` call; checkout failure surfaces as an `error` outcome via try/catch.
3. **`detectDefaultBranchesAuthoritative`** — adds an `ls-remote --symref` tier (between symbolic-ref and main/master probe) for the fast-forward path, so non-main/master defaults (`develop`, `trunk`) are detected correctly. Briefing path stays local-only.
4. **src/sentinel.ts** — unified sentinel-file primitives (`sentinelFresh`, `readSentinelEpoch`, `touchSentinel`, `clearSentinel`, `sentinelExists`). 7 migration sites across staging-ff.ts + mag.ts. `mag/settled` stays a boolean sentinel (not freshness-windowed).
5. **Rename** — `maybeFastForwardStagingFromUpstream` → `syncStagingMainWithUpstream` (direction-unambiguous, callers already have `runStagingFastForwardTick` as the outer wrapper name).

### gh-ludics-336 coordination

This PR folds in gh-ludics-336's code-extraction residual (the `RunGit` + `defaultRunGit` + `safeSyncOutput` routing). gh-ludics-336 narrows to docs-only: a `docs/testing-patterns.md` entry citing `src/git-runner.ts` as the worked example for the "Injectable Subprocess Runners" pattern. Closing / updating that task is orchestrator follow-up.

### Verification

- `bun run typecheck`: clean.
- `bun run build`: compiles to `bin/ludics`.
- `bun test`: 1232 pass / 0 fail across 65 files.
- New tests: `src/git-runner.test.ts` (17 cases covering all six extracted symbols + authoritative ls-remote tier + withCheckout 5 cases), `src/sentinel.test.ts` (12 cases incl. round-trip fidelity), and a new ls-remote-engages-end-to-end regression in `src/staging-ff.test.ts`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test` (full suite, 1232 pass)
- [x] Verify briefing path still uses local-only `detectDefaultBranches`
- [x] Verify mag/settled read stays `existsSync`-based (boolean sentinel preserved)
- [x] Confirm `git log --grep=maybeFastForwardStagingFromUpstream` still finds the rename commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)