### PR TITLE
dashboard: remove dead pre-extraction CSS rules from style.css

### DIFF
--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -1275,12 +1275,6 @@ main {
     border-color: rgba(100, 80, 180, 0.25);
 }
 
-/* Day theme fix for alternating table rows in briefing/health pages */
-[data-theme="day"] .briefing-content tr:nth-child(even) td,
-[data-theme="day"] .health-content tr:nth-child(even) td {
-    background-color: rgba(0, 0, 0, 0.03);
-}
-
 /* Day theme fix for task tree nodes */
 [data-theme="day"] .tree-node {
     background-color: rgba(0, 0, 0, 0.02);
@@ -1880,71 +1874,6 @@ footer a:hover {
     margin: 1.5rem 0;
 }
 
-/* Backward compat aliases — pages that still use old class names */
-.briefing-container { max-width: 900px; margin: 0 auto; padding: 1.5rem 2rem; width: 100%; }
-.briefing-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem; }
-.briefing-date { font-size: 0.875rem; color: var(--text-secondary); }
-
-.briefing-content {
-    background-color: var(--bg-panel);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    padding: 2rem;
-    line-height: 1.7;
-    box-shadow: var(--shadow-sm);
-}
-
-.briefing-content h1 { font-family: var(--font-body); font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--border); }
-.briefing-content h2 { font-family: var(--font-body); font-size: 1.125rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: var(--accent); }
-.briefing-content h3 { font-family: var(--font-body); font-size: 1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.5rem; }
-.briefing-content p { margin-bottom: 0.75rem; color: var(--text-primary); }
-.briefing-content ul, .briefing-content ol { margin-bottom: 0.75rem; padding-left: 1.5rem; }
-.briefing-content li { margin-bottom: 0.375rem; color: var(--text-primary); }
-.briefing-content strong { color: var(--text-primary); font-weight: 600; }
-.briefing-content code { font-family: var(--font-mono); background-color: var(--bg-secondary); padding: 0.125rem 0.375rem; border-radius: 3px; font-size: 0.875rem; }
-.briefing-content pre { background-color: var(--bg-secondary); padding: 1rem; border-radius: var(--radius); overflow-x: auto; margin-bottom: 0.75rem; }
-.briefing-content pre code { background-color: transparent; padding: 0; }
-.briefing-content a { color: var(--accent); text-decoration: none; }
-.briefing-content a:hover { text-decoration: underline; }
-.briefing-content table { width: 100%; border-collapse: collapse; margin-bottom: 0.75rem; font-size: 0.875rem; }
-.briefing-content th { background-color: var(--bg-secondary); font-weight: 600; text-align: left; padding: 0.5rem 0.75rem; border: 1px solid var(--border); }
-.briefing-content td { padding: 0.5rem 0.75rem; border: 1px solid var(--border); }
-.briefing-content tr:nth-child(even) td { background-color: rgba(128, 128, 128, 0.05); }
-
-.briefing-placeholder, .health-placeholder {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    min-height: 200px;
-    color: var(--text-secondary);
-}
-
-.briefing-placeholder .icon, .health-placeholder .icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    opacity: 0.5;
-}
-
-.briefing-placeholder .text, .health-placeholder .text {
-    font-size: 1rem;
-    opacity: 0.7;
-}
-
-.briefing-placeholder .hint, .health-placeholder .hint {
-    font-size: 0.875rem;
-    opacity: 0.5;
-    margin-top: 0.5rem;
-}
-
-.briefing-placeholder .hint a {
-    color: var(--accent);
-    text-decoration: none;
-}
-
-/* Health page */
-.health-container { max-width: 900px; margin: 0 auto; padding: 1.5rem 2rem; }
-
 .health-section-title {
     font-family: var(--font-body);
     font-size: 1.125rem;
@@ -1952,31 +1881,6 @@ footer a:hover {
     margin-bottom: 0.75rem;
     color: var(--accent);
 }
-
-.health-content {
-    background-color: var(--bg-panel);
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--border);
-    padding: 2rem;
-    line-height: 1.7;
-    margin-bottom: 1.5rem;
-    box-shadow: var(--shadow-sm);
-}
-
-.health-content h1 { font-family: var(--font-body); font-size: 1.5rem; font-weight: 600; margin-bottom: 1.5rem; padding-bottom: 0.75rem; border-bottom: 1px solid var(--border); }
-.health-content h2 { font-family: var(--font-body); font-size: 1.125rem; font-weight: 600; margin-top: 1.5rem; margin-bottom: 0.75rem; color: var(--accent); }
-.health-content h3 { font-family: var(--font-body); font-size: 1rem; font-weight: 600; margin-top: 1.25rem; margin-bottom: 0.5rem; }
-.health-content p { margin-bottom: 0.75rem; color: var(--text-primary); }
-.health-content ul, .health-content ol { margin-bottom: 0.75rem; padding-left: 1.5rem; }
-.health-content li { margin-bottom: 0.375rem; color: var(--text-primary); }
-.health-content strong { color: var(--text-primary); font-weight: 600; }
-.health-content code { font-family: var(--font-mono); background-color: var(--bg-secondary); padding: 0.125rem 0.375rem; border-radius: 3px; font-size: 0.875rem; }
-.health-content pre { background-color: var(--bg-secondary); padding: 1rem; border-radius: var(--radius); overflow-x: auto; margin-bottom: 0.75rem; }
-.health-content pre code { background-color: transparent; padding: 0; }
-.health-content table { width: 100%; border-collapse: collapse; margin-bottom: 0.75rem; font-size: 0.875rem; }
-.health-content th { background-color: var(--bg-secondary); font-weight: 600; text-align: left; padding: 0.5rem 0.75rem; border: 1px solid var(--border); }
-.health-content td { padding: 0.5rem 0.75rem; border: 1px solid var(--border); }
-.health-content tr:nth-child(even) td { background-color: rgba(128, 128, 128, 0.05); }
 
 .doctor-section {
     background-color: var(--bg-panel);


### PR DESCRIPTION
## Summary

- Removes ~96 lines of dead CSS in `templates/dashboard/style.css` that were superseded by `content.css` during task-c603d177 (which extracted shared dashboard content-rendering rules into `content.css` but intentionally left the old class rules behind as out-of-scope).
- Dropped: the day-theme `[data-theme="day"] .briefing-content / .health-content tr:nth-child(even) td` override, and the "Backward compat aliases" block covering `.briefing-container`, `.briefing-header`, `.briefing-date`, `.briefing-content` + descendants, `.briefing-placeholder` / `.health-placeholder` combined rules, `.health-container`, and `.health-content` + descendants.
- Preserved: `.health-section-title` (still used by `health.html`) and the `.doctor-section` / `.doctor-meta` / `.doctor-section pre` rules that immediately follow the dead block.

Verified no HTML/JS consumers reference the removed class names — the only remaining occurrence of `briefing-content` is an HTML element `id` in `briefing.html`, not a CSS class selector. `content.css` already provides equivalents (`.content-container`, `.rendered-content`, `.content-placeholder`, plus the day-theme table-row override for `.rendered-content`).

Closes task-b4a0d1f9.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run build` produces `bin/ludics`
- [x] Project-wide grep confirms no remaining HTML/JS class-name consumers of the deleted selectors
- [ ] Smoke-check dashboard pages after next `ludics init` sync (briefing, health, proposal, retrospective) render correctly with `content.css` rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)