### PR TITLE
skills: add <!-- section:NAME --> anchors and replace step-number cross-refs (gh-ludics-315)

### DIFF
--- a/skills/ludics-adopt-sessions.md
+++ b/skills/ludics-adopt-sessions.md
@@ -8,20 +8,24 @@ queue-action: adopt-sessions
 
 Match discovered agent sessions to projects and assign them to available slots.
 
+<!-- section:trigger -->
 ## Trigger
 
 This skill is invoked when:
 - Periodic trigger runs `ludics mag adopt-sessions` (every 5 min via launchd/systemd)
 - Health-check detects orphaned sessions and queues this action
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - **Pre-computed context**: `$LUDICS_STATE_PATH/mag/adopt-sessions-context.md`
 - **Request ID**: Read from `$LUDICS_STATE_PATH/mag/current-request-id`
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-context -->
 1. **Read context**:
    ```bash
    cat "$LUDICS_STATE_PATH/mag/adopt-sessions-context.md"
@@ -29,11 +33,13 @@ This skill is invoked when:
    If the context says "(stale or missing session data)" or "(no unclassified sessions)",
    write a no-op result and exit.
 
+<!-- section:read-slots -->
 2. **Read current slots** for confirmation:
    ```bash
    ludics slots
    ```
 
+<!-- section:adopt-matched -->
 3. **For each matched, non-stale session** (from `## Session-Project Matches`):
 
    Adapter selection — use the `**Recommended adapter:**` from the context.
@@ -110,10 +116,12 @@ This skill is invoked when:
    ludics slot N preempt <task-id> -a <adapter> -s <session-id> -p <session-cwd>
    ```
 
+<!-- section:handle-unmatched -->
 4. **Handle unmatched sessions**:
    Note them in the report. These may be scratch/experimental sessions or projects
    the user hasn't added to config yet. Do not attempt to assign them.
 
+<!-- section:autonomy-check -->
 5. **Autonomy check**:
    ```bash
    yq eval '.mag.autonomy_level.assign_to_slots' "$LUDICS_STATE_PATH/config.yaml"
@@ -122,12 +130,14 @@ This skill is invoked when:
    - **suggest**: Include ready-to-run commands in the report
    - **manual**: Include observations and recommendations only
 
+<!-- section:queue-draft-proposal -->
 6. **Queue draft-proposal** for each newly assigned task (so user gets launch buttons):
    ```bash
    ludics mag draft-proposal <task-id>
    ```
    Skip this for sessions assigned without a task (Case C).
 
+<!-- section:write-result -->
 7. **Write result JSON**:
    ```bash
    REQ_ID=$(cat "$LUDICS_STATE_PATH/mag/current-request-id" 2>/dev/null || echo "req-unknown")
@@ -144,11 +154,13 @@ This skill is invoked when:
    }
    ```
 
+<!-- section:commit-state -->
 8. **Commit state**:
    ```bash
    ludics sync
    ```
 
+<!-- section:output-format -->
 ## Output Format
 
 Brief report:
@@ -159,6 +171,7 @@ Adopted 2 sessions:
 Skipped: 1 stale, 1 unmatched (scratch), 1 project already in slot 3
 ```
 
+<!-- section:delegation-strategy -->
 ## Delegation Strategy
 
 - Pre-computed data lives in `adopt-sessions-context.md` — no discovery or
@@ -167,6 +180,7 @@ Skipped: 1 stale, 1 unmatched (scratch), 1 project already in slot 3
 - Direct judgment for prioritization, preemption trade-offs, and ambiguous cases.
 - Execute commands directly; don't spawn sub-agents.
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Context file missing: Write result with `"status": "error"`, message: "No context file"

--- a/skills/ludics-briefing.md
+++ b/skills/ludics-briefing.md
@@ -8,18 +8,21 @@ queue-action: briefing
 
 Generate a comprehensive strategic briefing for the user.
 
+<!-- section:trigger -->
 ## Trigger
 
 This skill is invoked by the ludics automation when:
 - The user runs `ludics briefing` or `ludics mag briefing`
 - A morning trigger fires (e.g., 08:00 via launchd)
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - `$LUDICS_RESULTS_DIR`: Directory for writing result JSON (environment variable)
 - **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id` — use as `LUDICS_REQUEST_ID` in result JSON
 
+<!-- section:pre-computed-context -->
 ## Pre-computed Context
 
 All data gathering (slots refresh, session discovery, flow computations, recent incoming,
@@ -49,10 +52,13 @@ The context file contains these sections:
 
 Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-context -->
 1. **Read context**: Read `$LUDICS_STATE_PATH/mag/briefing-context.md`
 
+<!-- section:check-same-day -->
 2. **Check same-day status** via the `## Same-Day Status` section.
    - `Status: amend` — light-touch update only:
      - Figure out what actually changed since the last briefing:
@@ -66,19 +72,22 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      - Do a lightweight slot reassignment (newly-empty slots or newly-ready
        high-priority tasks only).
      - Don't re-elaborate tasks or redo the full analysis.
-     - Still run step 7 (nudge stalled slotted tasks), then skip to step 9.
+     - Still run the nudge-stalled section, then skip to the write-result section.
    - `Status: new` — proceed with the full process below.
 
+<!-- section:elaborate-tasks -->
 3. **Elaborate unprocessed tasks**:
    - Check the `## Tasks Needing Elaboration` section
    - For tasks that appear in the ready queue or are high-priority:
      - Use the Task tool to invoke `/ludics-elaborate <task-id>` (parallel)
 
+<!-- section:scan-needs-confirmation -->
 4. **Scan for needs-confirmation tasks**:
    - Check task files for `status: needs-confirmation`
    - For each, note the task ID, title, priority, and `relates_to` source task
    - These will be included in a dedicated "Needs Confirmation" section
 
+<!-- section:analyze-work -->
 5. **Analyze, merge, and split work**:
    - Identify high-priority ready tasks, approaching deadlines (7 days),
      slot utilization
@@ -94,6 +103,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      - Sub-tasks: `ludics tasks create "<title>" <project> <priority>` or
        `/ludics-elaborate <task-id>` to break into children
 
+<!-- section:assign-slots -->
 6. **(Re)Assign slots**:
 
    Slot states: **Empty** (available), **Project-reserved** (path+mode, no task),
@@ -129,6 +139,7 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
    - **suggest**: include ready-to-run commands in the briefing
    - **manual**: include observations only
 
+<!-- section:nudge-stalled -->
 7. **Nudge stalled slotted tasks**:
    - Read the `## Active Unconcluded Slots` section first.
      - Treat listed slots as **Case A** (active, unconcluded): do **not** re-send
@@ -143,10 +154,11 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
        ```
      - Note the nudge in the briefing under Slot Assignments (e.g.,
        "Slot 3: re-sent launch buttons for task-101 (no active session)")
-   - Skip tasks whose slot was just assigned in step 6 (fresh assignments will
+   - Skip tasks whose slot was just assigned in the assign-slots section (fresh assignments will
      get their own proposal via the normal draft-proposal flow)
    - Skip if `start_sessions` autonomy is `manual`
 
+<!-- section:surface-ambiguities -->
 8. **Surface ambiguities**:
    - Review the full briefing for information gaps that would change your next
      autonomous actions (conflicting priorities, unclear task scope, suspiciously elaborated tasks,
@@ -154,11 +166,13 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
    - Formulate 1-5 specific questions (see Questions Guidelines in the output format)
    - If no genuine ambiguities exist, note "No blocking ambiguities."
 
+<!-- section:write-result -->
 9. **Write result**:
    - Write briefing to `$LUDICS_STATE_PATH/briefing.md`
    - Read request ID: `REQ_ID=$(cat "$LUDICS_STATE_PATH/mag/current-request-id")`
    - Write result JSON to `$LUDICS_RESULTS_DIR/$REQ_ID.json`
 
+<!-- section:send-questions -->
 10. **Send questions notification**:
    - Extract the `## Questions` section from the briefing you just wrote
    - If there are questions (not just "No blocking ambiguities"), send them:
@@ -168,11 +182,14 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      Use the briefing date as the title, e.g., "Briefing questions — 2026-02-27"
    - Keep the message concise: just the numbered questions, no preamble
 
+<!-- section:commit-push -->
 11. **Commit and push state**:
     - Run `ludics sync` to commit and push to remote
 
+<!-- section:output-format -->
 ## Output Format
 
+<!-- section:briefing-md-output -->
 ### briefing.md
 
 ```markdown
@@ -223,6 +240,7 @@ project in the config has `upstream_repo` set.]
 2. [...]
 ```
 
+<!-- section:questions-guidelines -->
 ### Questions Guidelines
 
 End every briefing with 1-5 questions that surface information you can't
@@ -235,6 +253,7 @@ good idea is the right default; worst case, the user discards the results.
 When answers arrive, update the relevant files or take the relevant actions
 so the answers become discoverable.
 
+<!-- section:result-json-output -->
 ### Result JSON
 
 ```json
@@ -246,6 +265,7 @@ so the answers become discoverable.
 }
 ```
 
+<!-- section:delegation-strategy -->
 ## Delegation Strategy
 
 - Pre-computed data lives in `briefing-context.md` — no CLI commands needed
@@ -258,6 +278,7 @@ so the answers become discoverable.
 - Direct analysis for strategic reasoning, slot-assignment trade-offs,
   suggestions.
 
+<!-- section:error-handling -->
 ## Error Handling
 
 If state files are missing or malformed:

--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -14,6 +14,7 @@ Your job: explore a project's codebase, assess the task, and write a proposal do
 
 Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
+<!-- section:arguments -->
 ## Arguments
 
 `$ARGUMENTS` format: `<task_id> <project_path> <proposals_path> [<context_brief>]`
@@ -23,8 +24,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 - `<proposals_path>`: Absolute path to the proposals directory (pre-resolved by orchestrator)
 - `<context_brief>`: Optional free-form context from the orchestrator (see worker-conventions.md § Broader Context)
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-task -->
 1. **Read task file**:
    Parse `$ARGUMENTS` to extract the task ID (first word), project path (second word), and
    proposals path (third word). Any remaining text after the third word is the context brief.
@@ -34,9 +37,11 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    Extract: title, project, dependencies, context, any linked GitHub issue,
    acceptance criteria, elaboration content.
 
+<!-- section:resolve-project-path -->
 2. **Resolve project path**: Use the project path from `$ARGUMENTS`. If the
    `personal` project, use `$LUDICS_STATE_PATH/..` (the state repository root).
 
+<!-- section:check-preconditions -->
 3. **Check preconditions**:
    - If `has_questions` is set in frontmatter, the task has unanswered
      questions from elaboration — report `status: "error"` with "task has
@@ -47,17 +52,20 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
      separable features that could merge to main independently), report
      `status: "split-needed"` and stop.
 
+<!-- section:explore-codebase -->
 4. **Explore project codebase**:
    - Read relevant source files mentioned in the task elaboration
    - Understand existing patterns, architecture, related code
    - Use code pointers from the Tentative Design section as starting points
 
+<!-- section:proposals-path -->
 6. **Use provided proposals path**:
    Create the directory if it doesn't exist:
    ```bash
    mkdir -p "<proposals_path>"
    ```
 
+<!-- section:write-proposal -->
 7. **Write proposal** to `<proposals_path>/<feature-name>.md`:
 
    ```markdown
@@ -94,6 +102,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    Stay on goal/what, not how — no implementation plan, no effort estimates,
    no micro-managed steps. Coding agents handle the how during their plan phase.
 
+<!-- section:commit-push -->
 8. **Commit and push**:
    Strip the `<project_path>/` prefix from `<proposals_path>` to get the repo-relative path:
    ```bash
@@ -103,15 +112,18 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    git push
    ```
 
+<!-- section:update-frontmatter -->
 9. **Update task frontmatter**: Set `proposal: <proposals_path_relative>/<feature-name>.md`
    (e.g., `proposal: docs/proposals/add-filter.md`) in the task file.
    Add the field before the closing `---` in the YAML frontmatter.
 
+<!-- section:final-response -->
 ## Final Response
 
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+<!-- section:response-contract -->
 ### Response Contract
 
 1. `status` — string, required. Values: `"completed"`, `"stale"`, `"split-needed"`, `"already-exists"`, `"error"`.
@@ -163,6 +175,7 @@ Picking `skip_plan`:
   confidence but complex to implement (`skip_plan=false`), or trivial to
   implement with uncertain scope (`skip_plan=true, start_confidence=low`).
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Task not found: report `status: "error"` with an explanation.

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -10,6 +10,7 @@ queue-args: [task]
 Thin orchestrator that reads the task, delegates codebase exploration to an
 isolated worker, then handles notifications and result reporting.
 
+<!-- section:trigger -->
 ## Trigger
 
 This skill is invoked when:
@@ -17,15 +18,18 @@ This skill is invoked when:
 - Auto-queued during keepalive for top ready queue tasks that are elaborated,
   have no unanswered questions (`has_questions` not set), and have no proposal yet
 
+<!-- section:arguments -->
 ## Arguments
 
 - `$ARGUMENTS`: `<task_id>` — Task identifier (e.g., `task-042`)
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id`
 
+<!-- section:common-steps -->
 ## Common Steps
 
 Follow [orchestrator-conventions.md](orchestrator-conventions.md):
@@ -37,6 +41,7 @@ Follow [orchestrator-conventions.md](orchestrator-conventions.md):
 - **E** (Result JSON): write the result with the request ID.
 - **F** (Error Handling): standard patterns.
 
+<!-- section:proposals-path-resolution -->
 ### Proposals Path Resolution (extends Section B)
 
 After resolving the project path, check the project's `proposals_path` in
@@ -53,6 +58,7 @@ The worker creates the directory; this step just resolves the path.
 
 Worker: `/ludics-draft-proposal-worker <task_id> <project_path> <proposals_path> <context_brief>`
 
+<!-- section:precondition-check -->
 ## Precondition check
 
 If the task frontmatter has `has_questions: true`, there are unanswered
@@ -60,6 +66,7 @@ questions from elaboration — skip the proposal:
 - Write result JSON with `"status": "blocked"` and `"unanswered questions"`.
 - Don't delegate to the worker; Mag's nag loop reminds the user to answer.
 
+<!-- section:status-routing -->
 ## Status routing
 
 Extract the final ` ```json ` block from the worker's response. Fields:
@@ -92,6 +99,7 @@ Routing by status:
 - **error** — write result JSON with `"status": "error"` and stop.
 - **already-exists** — check whether re-generation is wanted, or skip.
 
+<!-- section:auto-start-evaluation -->
 ## Auto-start evaluation
 
 After `status: "completed"`, decide whether to auto-start the slot or defer:
@@ -124,6 +132,7 @@ The `skip_plan` frontmatter field (if the worker sets it) is consumed later by
 with `skip_plan: true` skip the plan phase. It isn't used by
 `auto-start-evaluate`.
 
+<!-- section:auto-start-slot -->
 ## Auto-start slot
 
 For `decision = "auto-start"`, start the slot directly and send a lighter
@@ -136,6 +145,7 @@ ludics notify outgoing "Started slot <N> for <task_id>: <title>"
 
 Skip the launch-button notification; move on to questions and result JSON.
 
+<!-- section:proposal-notification -->
 ## Proposal notification (defer-to-user)
 
 For `decision = "defer-to-user"`, use the worker's `proposal_path`:
@@ -144,6 +154,7 @@ For `decision = "defer-to-user"`, use the worker's `proposal_path`:
 ludics notify proposal "<task_id>" "<title>" "<summary>" "<project_path>/<proposal_path>"
 ```
 
+<!-- section:questions-notification -->
 ## Questions notification
 
 If `ambiguities` is non-empty (and not `"none"`), send them as a numbered
@@ -156,12 +167,14 @@ ludics notify outgoing "<formatted ambiguities>"
 Use title: `"Proposal questions — <task_id>: <title>"`. Skip when
 `ambiguities` is `"none"` or empty.
 
+<!-- section:best-effort-desktop -->
 ## Best-effort desktop
 
 ```bash
 code "<project_path>/<proposal_path>" 2>/dev/null || true
 ```
 
+<!-- section:result-fields -->
 ## Result fields
 
 ```json
@@ -173,6 +186,7 @@ code "<project_path>/<proposal_path>" 2>/dev/null || true
 
 Output: `"Proposal written for <task_id>: <title>"`.
 
+<!-- section:delegation-strategy -->
 ## Delegation strategy
 
 - Worker (`/ludics-draft-proposal-worker`) runs in isolated context: codebase

--- a/skills/ludics-elaborate-worker.md
+++ b/skills/ludics-elaborate-worker.md
@@ -15,6 +15,7 @@ detailed elaboration into the task file.
 
 Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
+<!-- section:arguments -->
 ## Arguments
 
 `$ARGUMENTS` format: `<task_id> <project_path> [<context_brief>]`
@@ -23,8 +24,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 - `<project_path>`: Absolute path to the project's local checkout
 - `<context_brief>`: Optional free-form context from the orchestrator (see worker-conventions.md § Broader Context)
 
+<!-- section:process -->
 ## Process
 
+<!-- section:check-duplicates -->
 ### 0. Check for duplicates
 
 - Parse `$ARGUMENTS` to extract the task ID (first word) and project path (second word).
@@ -40,6 +43,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
   - Run `ludics tasks merge <target> <this_task_id>` to merge
   - Report `status: "merged"` and stop
 
+<!-- section:milestone-blocking -->
 ### 0b. Milestone-aware blocking (watch tasks)
 
 For tasks with `source: watch` (README-derived), determine which **milestone
@@ -64,12 +68,14 @@ Steps:
 
 This prevents premature scheduling of tasks whose prerequisites aren't done.
 
+<!-- section:read-task -->
 ### 1. Read task file (if not already read)
 
 ```bash
 cat "$LUDICS_STATE_PATH/tasks/<task_id>.md"
 ```
 
+<!-- section:gather-context -->
 ### 2. Gather context
 
 - Read related task files (dependencies listed in frontmatter)
@@ -77,6 +83,7 @@ cat "$LUDICS_STATE_PATH/tasks/<task_id>.md"
 - Read project-specific memory: `$LUDICS_STATE_PATH/mag/memory/projects/<project>.md`
 - Identify and read relevant code files in the project repository
 
+<!-- section:cross-task-awareness -->
 ### 3. Cross-task awareness
 
 - Check for related tasks (same project, similar scope, overlapping files)
@@ -84,6 +91,7 @@ cat "$LUDICS_STATE_PATH/tasks/<task_id>.md"
 - Note if this task would conflict with or be subsumed by other work
 - Note any project-wide patterns or conventions relevant to this task
 
+<!-- section:explore-codebase -->
 ### 4. Explore codebase for context
 
 Explore the codebase to understand the current state:
@@ -114,6 +122,7 @@ Write findings as a **Tentative Design** section, clearly marked:
 - [potential issues to consider]
 ```
 
+<!-- section:surface-ambiguities -->
 ### 5. Surface ambiguities and questions
 
 Genuine ambiguities look like:
@@ -138,6 +147,7 @@ Skip questions that:
 
 If there are no genuine questions, write `## Questions\n\nNone.`
 
+<!-- section:update-task -->
 ### 6. Update task file
 
 The elaboration does NOT write acceptance criteria — those belong in the
@@ -163,11 +173,13 @@ elaborated: <today's date>
 [numbered questions about genuine ambiguities, or "None."]
 ```
 
+<!-- section:final-response -->
 ## Final Response
 
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+<!-- section:response-contract -->
 ### Response Contract
 
 1. `status` — string, required. Values: `"completed"`, `"merged"`, `"already-elaborated"`, `"error"`.
@@ -190,6 +202,7 @@ as the last code block in your response:
 }
 ```
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Task not found: Report `status: "error"`

--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -9,24 +9,29 @@ queue-action: health-check
 Detect approaching deadlines, check for semantically complete tasks, and flag
 other issues requiring attention.
 
+<!-- section:trigger -->
 ## Trigger
 
 This skill is invoked when:
 - The user runs `ludics mag health-check`
 - Periodic automation (every 4h via launchd)
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id` — use as `LUDICS_REQUEST_ID` in result JSON
 
+<!-- section:process -->
 ## Process
 
+<!-- section:check-deadlines -->
 1. **Check approaching deadlines**:
    - Find tasks with `deadline` field
    - Calculate days remaining
    - Flag if <= 7 days (warning) or <= 3 days (critical)
 
+<!-- section:check-slots -->
 2. **Check slot health**:
    - Run `ludics slots status` to get current slot state
    - Identify slots that have been active > 24h without status update
@@ -53,10 +58,12 @@ This skill is invoked when:
      - Build stable issue key: `slot-stall:<slot>:<agent>`
      - Severity: warning if nudgeAttempts < 2, critical if >= 2
 
+<!-- section:check-queue -->
 3. **Check queue health**:
    - Read `mag/queue.jsonl`
    - Flag if requests have been pending > 1h
 
+<!-- section:check-tests -->
 4. **Check test suite health**:
    - Read `$LUDICS_STATE_PATH/mag/test-health.json` for the latest test run
      results (the pre-hook ran the tests before this skill was invoked).
@@ -72,6 +79,7 @@ This skill is invoked when:
      not "new").
    - Don't run tests yourself — the programmatic pre-hook already did.
 
+<!-- section:detect-deltas -->
 5. **Detect deltas since previous health check**:
    - Prefer git diff in state repo for scope awareness:
      `git -C "$LUDICS_STATE_PATH" diff --name-only HEAD~1..HEAD -- tasks/ sessions.md mag/queue.jsonl journal/notifications.jsonl 2>/dev/null || true`
@@ -80,10 +88,12 @@ This skill is invoked when:
    - Read previous snapshot from `$LUDICS_STATE_PATH/mag/health-last.json` if it exists
    - Mark each finding as `new`, `ongoing`, or `resolved`
 
+<!-- section:report-elaboration -->
 6. **Report task elaboration status**:
    - Run `ludics tasks needs-elaboration` to count unprocessed tasks
    - Note: Elaboration queueing is handled automatically by `tasks_queue_elaborations()` in `tasks_sync()` -- no need to enqueue here
 
+<!-- section:queue-verification -->
 7. **Queue completion verification for potentially done tasks**:
    - Run `ludics slots status` to find slots with active in-progress tasks
    - For each slotted in-progress task (where `completed` is null):
@@ -101,23 +111,28 @@ This skill is invoked when:
      c. Note queued verifications in the health report
      d. Build stable issue keys: `completion:<task-id>` for delta tracking
 
+<!-- section:generate-report -->
 8. **Generate report**:
    - Categorize issues by severity
    - Explicitly call out `new` and `resolved` findings since last check
    - Include actionable recommendations
 
+<!-- section:send-notifications -->
 9. **Send notifications** for critical issues:
    - Notify only on `new` critical issues or severity escalation (`warning` -> `critical`)
    ```bash
    ludics notify outgoing "Critical: task-042 deadline in 2 days" 5 "Health Check"
    ```
 
+<!-- section:persist-snapshot -->
 10. **Persist snapshot**:
    - Write current finding keys/severities/timestamp to
      `$LUDICS_STATE_PATH/mag/health-last.json`
 
+<!-- section:output-format -->
 ## Output Format
 
+<!-- section:health-report-output -->
 ### Health Report
 
 ```markdown
@@ -151,6 +166,7 @@ This skill is invoked when:
 2. Slot 3 may need attention - check tmux session
 ```
 
+<!-- section:result-json-output -->
 ### Result JSON
 
 ```json
@@ -164,6 +180,7 @@ This skill is invoked when:
 }
 ```
 
+<!-- section:notification-triggers -->
 ## Notification Triggers
 
 | Condition | Topic | Priority |
@@ -173,6 +190,7 @@ This skill is invoked when:
 | Queue stuck > 1h | agents | 4 (high) |
 | Completion verification queued | (none — notification handled by verify-completion skill) | — |
 
+<!-- section:delegation-strategy -->
 ## Delegation Strategy
 
 - CLI tools for date calculations and file parsing.

--- a/skills/ludics-process-suggestions.md
+++ b/skills/ludics-process-suggestions.md
@@ -11,33 +11,40 @@ queue-required-args: [task]
 Process a completed task's retrospective to create follow-up tasks from
 substantive suggestions. Nitpicky suggestions are skipped with reasoning.
 
+<!-- section:trigger -->
 ## Trigger
 
 Auto-queued after retrospective collection for a completed task.
 Manual: `ludics mag process-suggestions <task-id>`
 
+<!-- section:arguments -->
 ## Arguments
 
 - `$ARGUMENTS`: `<task-id>` -- the completed task whose retrospective to process
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id`
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-request-id -->
 1. Read the request ID:
    ```bash
    LUDICS_REQUEST_ID=$(cat "$LUDICS_STATE_PATH/mag/current-request-id" 2>/dev/null || echo "unknown")
    ```
 
+<!-- section:read-retrospective -->
 2. Read retrospective file:
    ```bash
    cat "$LUDICS_STATE_PATH/retrospectives/$ARGUMENTS.json"
    ```
    If file is missing, write an error result and stop.
 
+<!-- section:parse-retrospective -->
 3. Parse JSON and extract:
    - `suggestRefactorSummary` (string or null)
    - `workflowFeedback` (object keyed by agent name, values are strings)
@@ -50,16 +57,19 @@ Manual: `ludics mag process-suggestions <task-id>`
    a round 1 `request_changes`, meaning the issue was resolved and should
    NOT generate a follow-up task.
 
+<!-- section:short-circuit-empty -->
 4. If all three sources are empty/null — `suggestRefactorSummary` is null,
    `workflowFeedback` has no entries, AND no `request_changes` reviews remain
    after filtering — write an empty result and stop.
 
+<!-- section:read-source-task -->
 5. Read the source task file to recover project name:
    ```bash
    cat "$LUDICS_STATE_PATH/tasks/$ARGUMENTS.md"
    ```
    Extract the `project` field from frontmatter.
 
+<!-- section:normalize-dedupe -->
 6. **Normalize and dedupe**: Split unstructured text into individual suggestion
    items. The `suggestRefactorSummary` may be a single text blob -- split by
    logical suggestion boundaries (numbered items, bullet points, paragraph
@@ -79,6 +89,7 @@ Manual: `ludics mag process-suggestions <task-id>`
    with `suggestRefactorSummary` content since both can originate from the
    same reviewer agent -- dedupe these.
 
+<!-- section:idempotency-guard -->
 7. **Idempotency guard**: Before creating any tasks, scan existing task files
    for follow-ups already created from this source task:
    ```bash
@@ -87,6 +98,7 @@ Manual: `ludics mag process-suggestions <task-id>`
    For each existing follow-up, read its title. Skip any new suggestion that
    substantially overlaps with an existing follow-up title or theme.
 
+<!-- section:classify -->
 8. Classify each distinct suggestion as substantive (create a task) or
    nitpicky (skip with logged reasoning).
 
@@ -96,6 +108,7 @@ Manual: `ludics mag process-suggestions <task-id>`
    lists the constituent suggestions. A single coherent cleanup beats three
    tiny tasks.
 
+<!-- section:create-tasks -->
 9. For substantive suggestions (or groups of related suggestions):
    a. Run: `ludics tasks create "<title>" <project> C`
    b. Check stdout:
@@ -116,8 +129,9 @@ Manual: `ludics mag process-suggestions <task-id>`
         - **From other sources**: "Auto-generated from retrospective of
           `<source-task-id>`. Original suggestion: <brief summary>"
 
+<!-- section:pr-comment -->
 10. **PR comment confirmation**: If any tasks were created, read the `prUrl`
-    field from the retrospective JSON (parsed in step 3). If `prUrl` is
+    field from the retrospective JSON (parsed in the parse-retrospective section). If `prUrl` is
     non-null and non-empty, post a comment on the PR confirming the created
     follow-up tasks:
     ```bash
@@ -136,6 +150,7 @@ Manual: `ludics mag process-suggestions <task-id>`
     If `prUrl` is null or the `gh pr comment` command fails, log a warning
     but do not fail the overall skill — the tasks are already created.
 
+<!-- section:write-result -->
 11. Write result JSON:
     ```bash
     cat > "$LUDICS_RESULTS_DIR/$LUDICS_REQUEST_ID.json" << 'RESULT_EOF'
@@ -151,6 +166,7 @@ Manual: `ludics mag process-suggestions <task-id>`
     RESULT_EOF
     ```
 
+<!-- section:judgment-criteria -->
 ## Judgment Criteria
 
 Substantive (create a task):
@@ -174,6 +190,7 @@ Nitpicky (skip):
 - Suggestions already covered by existing tasks (check `relates_to` overlap).
 - Cosmetic UI tweaks with no functional impact.
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Missing retrospective file: write `{"status": "error", "message": "retrospective not found"}`.
@@ -181,6 +198,7 @@ Nitpicky (skip):
 - Partial failure during batch creation: report partial success in result
   JSON with the tasks created so far and error details.
 
+<!-- section:output -->
 ## Output
 
 Report a summary after processing:

--- a/skills/ludics-revise-proposal-worker.md
+++ b/skills/ludics-revise-proposal-worker.md
@@ -15,6 +15,7 @@ edits — additive notes on the task file, and destructive revision of the propo
 
 Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
+<!-- section:arguments -->
 ## Arguments
 
 `$ARGUMENTS` format: `<task_id> <project_path> [<context_brief>]`
@@ -24,8 +25,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 - `<context_brief>`: Optional free-form context from the orchestrator, often
   including user feedback (see worker-conventions.md § Broader Context)
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-task -->
 1. **Read task file**:
    Parse `$ARGUMENTS` to extract the task ID (first word) and project path
    (second word). Any remaining text after the second word is the context brief.
@@ -35,9 +38,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    Extract: title, project, proposal path, dependencies, acceptance criteria,
    elaboration content, any existing notes.
 
+<!-- section:detect-mode -->
 2. **Detect proposal mode and read existing proposal**:
 
-   Check the `proposal:` frontmatter value extracted in step 1.
+   Check the `proposal:` frontmatter value extracted in the read-task section.
 
    **File-based mode** (`proposal:` is any value other than `inline`):
 
@@ -74,12 +78,14 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    Use the task body as the proposal source. Skip the out-of-tree check — there is no
    separate file.
 
+<!-- section:explore-codebase -->
 3. **Explore relevant codebase**:
    - Re-read source files referenced in the proposal
    - Check if anything has changed since the proposal was written
    - Look for new context that affects the approach
    - Focus exploration on areas where the proposal may be wrong or outdated
 
+<!-- section:edit-task -->
 4. **Edit task file**:
 
    In file-based mode, make additive edits — add a `## Notes` section (or
@@ -89,10 +95,11 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    when they were unclear or incomplete. Preserve existing structure and
    avoid removing content unless it's demonstrably wrong.
 
-   In inline mode, skip step 4 — both proposal revision and notes/criteria
-   updates happen in a single combined pass in step 5 to avoid conflicting
+   In inline mode, skip the edit-task section — both proposal revision and notes/criteria
+   updates happen in a single combined pass in the edit-proposal section to avoid conflicting
    with the destructive rewrite of the same file.
 
+<!-- section:edit-proposal -->
 5. **Edit proposal content**:
 
    In file-based mode, rewrite the proposal file at `$proposal_abs` destructively:
@@ -109,19 +116,20 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
    In inline mode, do one combined edit of the task file: revise the proposal
    sections destructively (same rules as file-based), and fold in any notes
-   or acceptance-criteria corrections that would normally go in step 4.
-   Leave the frontmatter block alone. Step 4 doesn't apply here.
+   or acceptance-criteria corrections that would normally go in the edit-task section.
+   Leave the frontmatter block alone. The edit-task section doesn't apply here.
 
+<!-- section:commit-push -->
 6. **Commit and push**:
 
    **File-based mode**:
    ```bash
    cd <project_path>
-   git add "$proposal_rel"          # repo-relative path computed in step 2
+   git add "$proposal_rel"          # repo-relative path computed in the detect-mode section
    git commit -m "proposal: revise <title>"
    git push
    ```
-   Then commit any task file changes (notes, criteria) written in step 4:
+   Then commit any task file changes (notes, criteria) written in the edit-task section:
    ```bash
    cd "$LUDICS_STATE_PATH"
    git add tasks/<task_id>.md
@@ -138,15 +146,18 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    git push
    ```
 
+<!-- section:assess-changes -->
 7. **Assess changes**:
    If after re-examination the proposal is already solid, report
    `status: "no-changes"` rather than making trivial edits.
 
+<!-- section:final-response -->
 ## Final Response
 
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+<!-- section:response-contract -->
 ### Response Contract
 
 1. `status` — string, required. Values: `"revised"`, `"no-changes"`, `"error"`.
@@ -169,6 +180,7 @@ as the last code block in your response:
 }
 ```
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Task not found: report `status: "error"` with an explanation.

--- a/skills/ludics-sync-learnings.md
+++ b/skills/ludics-sync-learnings.md
@@ -13,6 +13,7 @@ Read scattered learnings from corrections.md and journal files, group by theme,
 update structured memory files, archive processed entries, and file GitHub issues
 for harness improvement patterns.
 
+<!-- section:trigger -->
 ## Trigger
 
 This skill is invoked when:
@@ -20,19 +21,23 @@ This skill is invoked when:
 - Periodically (weekly) via automation
 - When corrections.md grows beyond a threshold
 
+<!-- section:inputs -->
 ## Inputs
 
 - `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable)
 - **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id`
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-corrections -->
 ### 1. Read recent corrections
 
 ```bash
 cat "$LUDICS_STATE_PATH/mag/memory/corrections.md"
 ```
 
+<!-- section:read-journal -->
 ### 2. Read journal friction points
 
 ```bash
@@ -41,23 +46,27 @@ grep -l "friction\|mistake\|learned" "$LUDICS_STATE_PATH/journal/"*.md
 
 Read the matching files for relevant entries.
 
+<!-- section:group-by-theme -->
 ### 3. Group by theme
 
 - Tool-related → `$LUDICS_STATE_PATH/mag/memory/tools.md`
 - Process-related → `$LUDICS_STATE_PATH/mag/memory/workflows.md`
 - Project-specific → `$LUDICS_STATE_PATH/mag/memory/projects/<project>.md`
 
+<!-- section:update-files -->
 ### 4. Update structured files
 
 - Merge similar learnings
 - Remove duplicates
 - Add cross-references
 
+<!-- section:archive-corrections -->
 ### 5. Archive processed corrections
 
 - Move processed entries to `$LUDICS_STATE_PATH/mag/memory/corrections-archive.md`
 - Keep corrections.md for recent items only
 
+<!-- section:file-issues -->
 ### 6. File GitHub issues for harness bugs/improvements
 
 When corrections reveal a pattern about the ludics harness itself:
@@ -91,6 +100,7 @@ When corrections reveal a pattern about the ludics harness itself:
   ```
 - Add comments to existing issues if new corrections add evidence
 
+<!-- section:stage-claude-md -->
 ### 7. Stage CLAUDE.md proposals (if broad patterns detected)
 
 - Append entries to `$LUDICS_STATE_PATH/AGENTS_STAGING.md`
@@ -112,6 +122,7 @@ When corrections reveal a pattern about the ludics harness itself:
   <!-- End entry -->
   ```
 
+<!-- section:write-result -->
 ### 8. Write result JSON
 
 Read the request ID from `$LUDICS_STATE_PATH/mag/current-request-id` and write
@@ -134,12 +145,14 @@ result to `$LUDICS_RESULTS_DIR/$REQ_ID.json`:
 }
 ```
 
+<!-- section:memory-file-structure -->
 ## Memory File Structure
 
 - **tools.md**: CLI tool knowledge organized by tool, with Usage and Gotchas subsections
 - **workflows.md**: Process patterns as numbered steps or checklists
 - **projects/[project].md**: Project-specific knowledge (build system, key modules, common issues)
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Corrections file missing or empty: report `CORRECTIONS_PROCESSED: 0` and

--- a/skills/ludics-verify-completion-worker.md
+++ b/skills/ludics-verify-completion-worker.md
@@ -15,6 +15,7 @@ criteria have been met.
 
 Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
+<!-- section:arguments -->
 ## Arguments
 
 `$ARGUMENTS` format: `<task_id> <project_path> [<context_brief>]`
@@ -23,8 +24,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 - `<project_path>`: Absolute path to the project's local checkout
 - `<context_brief>`: Optional free-form context from the orchestrator (see worker-conventions.md § Broader Context)
 
+<!-- section:process -->
 ## Process
 
+<!-- section:read-task -->
 1. **Read task file**:
    Parse `$ARGUMENTS` to extract the task ID (first word) and project path (second word).
    Any remaining text after the second word is the context brief.
@@ -33,14 +36,16 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    ```
    Extract: title, project, acceptance criteria, proposal path, slot number.
 
+<!-- section:read-proposal -->
 2. **Read proposal** (if available):
    - If `proposal:` points to a file (not `inline`), resolve the path:
      - `~/...` → expand `$HOME/...`; `/...` → use as-is; otherwise join to `<project_path>`.
      Read from the resolved absolute path.
-   - If `proposal: inline`, re-use the task file content already read in step 1 as the
+   - If `proposal: inline`, re-use the task file content already read in the read-task section as the
      proposal source — the proposal body is embedded in the task file.
    - Extract the Proposed Change and Scope sections for verification targets
 
+<!-- section:inspect-codebase -->
 3. **Inspect codebase for completion evidence**:
    - Check git log for recent commits mentioning the task ID or proposal name:
      ```bash
@@ -57,6 +62,7 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
      ```
      Then grep those files for `TODO`, `FIXME`, `HACK`, `XXX`
 
+<!-- section:make-judgment -->
 4. **Make a completion judgment**:
 
    - **complete** — all acceptance criteria appear met with no critical
@@ -70,11 +76,13 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    - **incomplete** — significant acceptance criteria are clearly unmet.
      List what's missing.
 
+<!-- section:final-response -->
 ## Final Response
 
 Use the structured response format from worker-conventions.md. Emit a fenced JSON block
 as the last code block in your response:
 
+<!-- section:response-contract -->
 ### Response Contract
 
 1. `status` — string, required. Always `"completed"` in non-error cases.
@@ -99,6 +107,7 @@ as the last code block in your response:
 }
 ```
 
+<!-- section:error-handling -->
 ## Error Handling
 
 - Task not found: report `status: "error"`.

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -168,6 +168,38 @@ describe("skills", () => {
     expect(text).toContain("review-done");
   });
 
+  test("substituteTemplate: preserves <!-- section:... --> anchors and existing HTML comments", () => {
+    // Anchors inserted by gh-ludics-315 are invisible-in-rendering HTML comments.
+    // substituteTemplate() must pass them through verbatim so future sanitization
+    // refactors don't silently strip the anchors from rendered skill text.
+    const template = [
+      "<!-- section:top -->",
+      "## Process",
+      "",
+      "{{#IF AGENT_NAME}}",
+      "<!-- section:inside-if -->",
+      "step body referencing {{AGENT_NAME}}",
+      "{{/IF}}",
+      "",
+      "{{#IF MISSING_VAR}}",
+      "<!-- section:should-be-dropped -->",
+      "hidden body",
+      "{{/IF}}",
+      "",
+      "<!-- Entry: sync-learnings | 2026-04-24 -->",
+      "entry content",
+      "<!-- End entry -->",
+    ].join("\n");
+    const rendered = substituteTemplate(template, baseCtx());
+    expect(rendered).toContain("<!-- section:top -->");
+    expect(rendered).toContain("<!-- section:inside-if -->");
+    expect(rendered).toContain("step body referencing agent1");
+    expect(rendered).not.toContain("<!-- section:should-be-dropped -->");
+    expect(rendered).not.toContain("hidden body");
+    expect(rendered).toContain("<!-- Entry: sync-learnings | 2026-04-24 -->");
+    expect(rendered).toContain("<!-- End entry -->");
+  });
+
   test("composes a concrete reviewer message", async () => {
     const state = makeState();
     const reviewer = state.agents[1]!;


### PR DESCRIPTION
## Summary

Implements gh-ludics-315: skill markdown files are hard to review in diff form when numbered steps are reordered or inserted, because cross-references target fragile ordinal positions. This PR:

- Adds `<!-- section:NAME -->` HTML comment anchors before every top-level structural heading and numbered process step in 10 skill files.
- Replaces all 9 fragile `"step N"` cross-references in the 4 high-priority skill files with stable named-section references derived from step purpose.
- Locks the invariant that `substituteTemplate()` preserves those anchor comments, via a new test that covers both top-level anchors and comments inside `{{#IF}}` blocks.

Names are purpose-derived (e.g. `nudge-stalled`, `assign-slots`), so future step insertions or reorderings no longer cascade numbering changes through cross-references.

### Proposal drift note

`skills/orchestration/forward-pr.md` — listed as a high-priority file in the proposal — was deleted in commit `8114c32` (`refactor(orchestration): remove forward-pr / upstream-final-merge phases`). That acceptance item is treated as proposal drift; the in-scope high-priority set is 4 files rather than 5. All other files named in the proposal still exist and are covered.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 1213 pass / 0 fail (baseline was 1212; +1 from the new regression test)
- [x] `grep -nE 'step [0-9]+'` on the 4 high-priority files — 0 matches
- [x] `grep -nE '\{\{[^}]*\}\}'` on all 10 touched files — 0 accidental template tokens introduced
- [x] Anchor counts per file match the merged plan (21, 12, 18, 9 + 14, 13, 18, 14, 13, 13)
- [x] Sample-output fenced blocks in `ludics-health-check.md` and `ludics-elaborate-worker.md` are NOT anchored (verified by inspecting anchor line numbers vs. fenced-code boundaries)
- [x] Existing `<!-- Entry: ... -->` / `<!-- End entry -->` markers in `ludics-sync-learnings.md` preserved byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)