### PR TITLE
refactor(queue): dedupe JSON shape guard in recentResults

### DIFF
--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -285,7 +285,7 @@ describe("recentResults", () => {
     const { recentResults } = await loadQueue();
     const results = recentResults();
     expect(results).toHaveLength(1);
-    expect(results[0]!.data.error).toBe("parse error");
+    expect(results[0]!.data.error).toBe("invalid result JSON");
   });
 
   test("ignores non-json files", async () => {
@@ -325,12 +325,25 @@ describe("recentResults", () => {
     const results = recentResults();
     expect(results).toHaveLength(3);
     for (const r of results) {
-      expect(r.data.error).toBe("non-object result");
+      expect(r.data.error).toBe("invalid result JSON");
     }
+  });
+
+  test("returns read-error sentinel when file vanishes between stat and read", async () => {
+    const resultsDir = join(tmpDir, "mag", "results");
+    mkdirSync(resultsDir, { recursive: true });
+
+    writeFileSync(join(resultsDir, "req-keep.json"), JSON.stringify({ id: "keep", status: "ok" }));
+    // A directory-as-file: statSync succeeds (it's a valid inode), readFileSync fails with EISDIR.
+    // This simulates the race where a file disappears or changes type between stat and read.
+    mkdirSync(join(resultsDir, "req-dir.json"), { recursive: true });
+
+    const { recentResults } = await loadQueue();
+    const results = recentResults();
+    expect(results).toHaveLength(2);
     const byFile = Object.fromEntries(results.map(r => [r.file.split("/").pop(), r.data]));
-    expect(byFile["req-null.json"]!.raw).toBe("object");  // typeof null === "object"
-    expect(byFile["req-num.json"]!.raw).toBe("number");
-    expect(byFile["req-arr.json"]!.raw).toBe("object");    // typeof [] === "object"
+    expect(byFile["req-keep.json"]!.id).toBe("keep");
+    expect(byFile["req-dir.json"]!.error).toBe("read error");
   });
 
   test("round-trip: writeResult then recentResults preserves key fields", async () => {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -317,13 +317,11 @@ export function recentResults(limit: number = 20): { file: string; data: Record<
     .slice(0, limit);
   return files.map(({ file, mtimeMs }) => {
     try {
-      const parsed: unknown = JSON.parse(readFileSync(file, "utf-8"));
-      const data = parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : ({ error: "non-object result", raw: typeof parsed } as Record<string, unknown>);
+      const parsed = parseJsonRecord(readFileSync(file, "utf-8"));
+      const data = parsed ?? ({ error: "invalid result JSON" } as Record<string, unknown>);
       return { file, data, mtimeMs };
     } catch {
-      return { file, data: { error: "parse error" } as Record<string, unknown>, mtimeMs };
+      return { file, data: { error: "read error" } as Record<string, unknown>, mtimeMs };
     }
   });
 }


### PR DESCRIPTION
## Summary

- Collapse the inline `JSON.parse` + `typeof === "object" && !Array.isArray(...)` check inside `recentResults()` (`src/queue.ts`) through the already-colocated `parseJsonRecord()` helper — the shape check now lives in one place (`parseJsonRecord` / `isPlainObject`).
- Unify the two legacy error sentinels (`{ error: "parse error" }` and `{ error: "non-object result", raw: typeof parsed }`) into two category sentinels: `{ error: "invalid result JSON" }` for parse/shape failures and `{ error: "read error" }` for fs failures. The sole caller (`magLogs()` in `src/mag.ts`) only `JSON.stringify`s the data for display and does not branch on sentinel shape.
- Update `src/queue.test.ts` assertions for the new sentinels and add a read-time race regression test (directory-as-file passes `statSync` but fails `readFileSync` with `EISDIR`), covering the race class one step past the existing dangling-symlink/`statSync` test.

Follow-up to task-b1e8641b (which introduced the inline guard) and task-a61eea42 (which co-located `recentResults` with `parseJsonRecord` in `queue.ts`). Net diff: 2 files, +21/-10.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test src/queue.test.ts` — 57 pass (includes the new directory-as-file race test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)