### PR TITLE
refactor: drop redundant Record casts after isPlainObject guards

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -126,7 +126,7 @@ function parseYamlFile(path: string): Record<string, unknown> {
   const text = readFileSync(path, "utf-8");
   const parsed: unknown = YAML.parse(text);
   if (!isPlainObject(parsed)) return {};
-  return parsed as Record<string, unknown>;
+  return parsed;
 }
 
 function resolveConfigPath(): string {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -910,9 +910,8 @@ function generateRecentlyCompleted(tasks: DashboardTask[]): RecentlyCompletedTas
           try {
             const parsed: unknown = JSON.parse(line);
             if (!isPlainObject(parsed)) continue;
-            const event = parsed as Record<string, unknown>;
-            if (event.event_type === "pr_merged" && event.task) {
-              mergedTasks.add(String(event.task));
+            if (parsed.event_type === "pr_merged" && parsed.task) {
+              mergedTasks.add(String(parsed.task));
             }
           } catch { /* skip */ }
         }
@@ -927,9 +926,8 @@ function generateRecentlyCompleted(tasks: DashboardTask[]): RecentlyCompletedTas
     try {
       const parsed: unknown = JSON.parse(readFileSync(retroFile, "utf-8"));
       if (!isPlainObject(parsed)) continue;
-      const data = parsed as Record<string, unknown>;
-      if (data.prUrl && typeof data.prUrl === "string") {
-        prUrls.set(t.id, data.prUrl);
+      if (parsed.prUrl && typeof parsed.prUrl === "string") {
+        prUrls.set(t.id, parsed.prUrl);
       }
     } catch { /* skip */ }
   }

--- a/src/events.ts
+++ b/src/events.ts
@@ -106,12 +106,11 @@ function eventsQuery(opts: EventsQueryOptions): void {
     try {
       const parsed: unknown = JSON.parse(line);
       if (!isPlainObject(parsed)) continue;
-      const rec = parsed as Record<string, unknown>;
-      if (typeof rec.ts !== "string") continue;
-      if (typeof rec.epoch !== "number") continue;
-      if (typeof rec.event_type !== "string") continue;
-      if (typeof rec.source !== "string") continue;
-      if (typeof rec.scope !== "string") continue;
+      if (typeof parsed.ts !== "string") continue;
+      if (typeof parsed.epoch !== "number") continue;
+      if (typeof parsed.event_type !== "string") continue;
+      if (typeof parsed.source !== "string") continue;
+      if (typeof parsed.scope !== "string") continue;
       const event = parsed as LudicsEvent;
       if (opts.type && event.event_type !== opts.type) continue;
       if (opts.task && event.task !== opts.task) continue;

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -356,9 +356,8 @@ export function loadSessionConclusionState(): Record<string, string> {
   try {
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as unknown;
     if (!isPlainObject(parsed)) return {};
-    const obj = parsed as Record<string, unknown>;
     const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(obj)) {
+    for (const [k, v] of Object.entries(parsed)) {
       if (typeof v === "string") out[k] = v;
     }
     return out;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -230,7 +230,7 @@ export function queueList(): Record<string, unknown>[] {
         if (!isPlainObject(parsed)) {
           return { raw: line };
         }
-        return parsed as Record<string, unknown>;
+        return parsed;
       } catch { return { raw: line }; }
     });
 }

--- a/src/sessions/sweep-state.ts
+++ b/src/sessions/sweep-state.ts
@@ -80,11 +80,10 @@ export function loadSessionSweepState(): SessionSweepState {
   if (!existsSync(file)) return { version: 1, sessions: {} };
 
   try {
-    const parsedUnknown = JSON.parse(readFileSync(file, "utf-8")) as unknown;
-    if (!isPlainObject(parsedUnknown)) {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf-8"));
+    if (!isPlainObject(parsed)) {
       return { version: 1, sessions: {} };
     }
-    const parsed = parsedUnknown as Record<string, unknown>;
     if (parsed.version !== 1 || typeof parsed.sessions !== "object" || !parsed.sessions || Array.isArray(parsed.sessions)) {
       return { version: 1, sessions: {} };
     }
@@ -93,23 +92,22 @@ export function loadSessionSweepState(): SessionSweepState {
     const sessions: Record<string, KnownSessionRecord> = {};
     for (const [, record] of Object.entries(parsedSessions)) {
       if (!isPlainObject(record)) continue;
-      const recordData = record as Record<string, unknown>;
-      const mode = String(recordData.mode);
+      const mode = String(record.mode);
       if (!SWEEP_TARGET_MODES.has(mode as SweepMode)) continue;
-      const projectDirRaw = String(recordData.projectDir ?? "");
+      const projectDirRaw = String(record.projectDir ?? "");
       const projectDir = normalizeProjectDirForSweep(projectDirRaw);
-      const name = String(recordData.name ?? "");
-      const cleanupCommand = Array.isArray(recordData.cleanupCommand)
-        ? (recordData.cleanupCommand as unknown[]).filter((v) => typeof v === "string").map((v) => String(v))
+      const name = String(record.name ?? "");
+      const cleanupCommand = Array.isArray(record.cleanupCommand)
+        ? (record.cleanupCommand as unknown[]).filter((v) => typeof v === "string").map((v) => String(v))
         : [];
       if (!projectDir || !name || cleanupCommand.length < 2) continue;
 
-      const detachedStreakRaw = Number(recordData.detachedStreak ?? 0);
+      const detachedStreakRaw = Number(record.detachedStreak ?? 0);
       const detachedStreak = Number.isFinite(detachedStreakRaw) && detachedStreakRaw > 0
         ? Math.floor(detachedStreakRaw)
         : 0;
-      const firstSeenAt = String(recordData.firstSeenAt ?? "");
-      const lastSeenAt = String(recordData.lastSeenAt ?? "");
+      const firstSeenAt = String(record.firstSeenAt ?? "");
+      const lastSeenAt = String(record.lastSeenAt ?? "");
 
       const key = buildKnownSessionKey(mode as SweepMode, projectDir, name);
       sessions[key] = {


### PR DESCRIPTION
## Summary

`isPlainObject` in `src/json.ts` is a user-defined type guard
(`v is Record<string, unknown>`), so a follow-up
`as Record<string, unknown>` cast on the same value is a no-op.
Removes the eight such redundant casts enumerated in the task proposal.

- Files: `src/config.ts`, `src/dashboard.ts`, `src/events.ts`,
  `src/notify.ts`, `src/queue.ts`, `src/sessions/sweep-state.ts`.
- Where the cast was only there to build an intermediate local (`rec`,
  `obj`, `event`, `data`, `parsedUnknown`, `recordData`), the local is
  dropped or renamed so the guarded name is used directly.
- Out-of-scope casts listed in the proposal (nested-`unknown` casts
  in `mag.ts`/`config.ts`, `sweep-state.ts`'s `parsed.sessions` cast,
  `queue.ts:322`'s non-guarded cast, `slots/json.ts`'s
  `as unknown as SlotData`) are untouched.

Pure cleanup, no behavior change.

Task: task-76a0beb6. Follow-up from task-15c3100e retrospective.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` — 1351 pass / 0 fail

No new tests required; refactor is a type-level no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)