### PR TITLE
refactor: rename sleep to sleepMs and consolidate definitions

### DIFF
--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -14,7 +14,7 @@ import {
   persistState, readOrchestrationState,
   type AgentConfig, type OrchestrationState,
 } from "./state.ts";
-import { isoNow, makeId, nowEpoch, sleep } from "./util.ts";
+import { isoNow, makeId, nowEpoch, sleepMs } from "./util.ts";
 import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, validateAndFixPrFile, type PrVerification } from "./github.ts";
 import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
 import { findProjectConfig, globalAdapter, harnessDir, ludicsRoot } from "../config.ts";
@@ -1251,7 +1251,7 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
 
       // Sleep with early wakeup from transport events.
       await Promise.race([
-        sleep(interval),
+        sleepMs(interval),
         new Promise<void>((resolve) => { wakeResolve = resolve; }),
       ]);
       wakeResolve = null;
@@ -1545,7 +1545,7 @@ export async function runOrchestration(
       if (!sibling) {
         if (Date.now() - runnerStartMs < startupGraceMs) {
           // Parent adapter hasn't written sibling state yet — re-check.
-          await sleep(200);
+          await sleepMs(200);
           continue;
         }
         console.error(
@@ -1599,7 +1599,7 @@ export async function runOrchestration(
 
     if (gateDecision === "redispatch" || gateDecision === "hold") {
       persistState(state);
-      await sleep(state.config.pollInterval * 1000);
+      await sleepMs(state.config.pollInterval * 1000);
       continue; // re-enter loop: redispatch runs enterPhase, hold waits for timeout/human
     }
     // gateDecision === "advance" or "skip" → proceed to evaluateTransition normally
@@ -1609,7 +1609,7 @@ export async function runOrchestration(
 
     if (!next) {
       persistState(state);
-      await sleep(state.config.pollInterval * 1000);
+      await sleepMs(state.config.pollInterval * 1000);
       continue;
     }
 

--- a/src/orchestration/util.test.ts
+++ b/src/orchestration/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { setsidWrap } from "./util.ts";
+import { setsidWrap, sleepMs } from "./util.ts";
 
 describe("setsidWrap", () => {
   const cmd = ["ludics", "orch", "run-internal", "1"];
@@ -28,5 +28,20 @@ describe("setsidWrap", () => {
     expect(wrapped.length).toBeGreaterThan(cmd.length);
     // Original command args always appear at the tail
     expect(wrapped.slice(-cmd.length)).toEqual(cmd);
+  });
+});
+
+describe("sleepMs", () => {
+  test("resolves after at least the requested number of milliseconds", async () => {
+    const start = Date.now();
+    await sleepMs(25);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(20);
+  });
+
+  test("returns a Promise that resolves to undefined", async () => {
+    const result = sleepMs(1);
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
   });
 });

--- a/src/orchestration/util.ts
+++ b/src/orchestration/util.ts
@@ -36,7 +36,7 @@ export function ludicsSelfCommand(args: string[]): string[] {
   return [process.execPath, ...args];
 }
 
-export function sleep(ms: number): Promise<void> {
+export function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/t3code/client.ts
+++ b/src/t3code/client.ts
@@ -9,16 +9,9 @@ import {
   type T3WsPush,
   type T3WsResponse,
 } from "./types.ts";
+import { sleepMs } from "../orchestration/util.ts";
 
 export { threadModel, projectModel } from "./types.ts";
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 type PushListener = (data: unknown) => void;
 
@@ -320,7 +313,7 @@ export async function waitForNewTurn(
   const deadline = Date.now() + options.maxWaitMs;
 
   while (Date.now() < deadline) {
-    await sleep(options.pollIntervalMs);
+    await sleepMs(options.pollIntervalMs);
     try {
       const snap = await getSnapshot();
       if (!snap) continue;

--- a/src/t3code/server.ts
+++ b/src/t3code/server.ts
@@ -2,7 +2,7 @@ import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readF
 import { createServer } from "node:net";
 import { join, resolve } from "path";
 import { Database } from "bun:sqlite";
-import { setsidWrap } from "../orchestration/util.ts";
+import { setsidWrap, sleepMs } from "../orchestration/util.ts";
 import { readJsonFile, writeJsonFile } from "../json.ts";
 
 /**
@@ -228,7 +228,7 @@ export async function ensureServer(
       }
       break;
     }
-    await sleep(1_000);
+    await sleepMs(1_000);
     // Re-check: the other process may have finished starting.
     const recheck = await serverStatus({ harnessDir });
     if (recheck.running && recheck.record) {
@@ -252,7 +252,7 @@ export async function ensureServer(
         if (remainingGrace > 0) {
           const graceDeadline = Date.now() + remainingGrace;
           while (Date.now() < graceDeadline) {
-            await sleep(1_000);
+            await sleepMs(1_000);
             const graceCheck = await serverStatus({ harnessDir });
             if (graceCheck.running && graceCheck.record) return graceCheck.record;
           }
@@ -449,7 +449,7 @@ async function terminateProcess(pid: number): Promise<boolean> {
   const deadline = Date.now() + STOP_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (!processAlive(pid)) return true;
-    await sleep(100);
+    await sleepMs(100);
   }
 
   if (processAlive(pid)) {
@@ -483,7 +483,7 @@ async function waitForReady(record: T3CodeServerRecord, timeoutMs: number): Prom
       return;
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
-      await sleep(200);
+      await sleepMs(200);
     } finally {
       client.close();
     }
@@ -948,10 +948,6 @@ function checkAndRecoverDb(dbPath: string): boolean {
 
   console.error("t3code: no usable backup — starting with corrupt DB (may fail)");
   return false;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function isoNow(): string {


### PR DESCRIPTION
## Summary

- Rename the project's `sleep(ms)` helper to `sleepMs` at `src/orchestration/util.ts` so every call site reads as unambiguously millisecond-scaled — `sleepMs(0.2)` makes the 200µs-busy-spin bug visible at the point of use (context: near-miss caught in task-72a318c3).
- Remove the two file-private `sleep` duplicates in `src/t3code/client.ts` and `src/t3code/server.ts`; both now import `sleepMs` from `../orchestration/util.ts`.
- Rename all 9 project-`sleep` call sites (4 in `runner.ts`, 1 in `client.ts`, 4 in `server.ts`). Signature `(ms: number): Promise<void>` and body unchanged; `Bun.sleep` and shell `sleep` invocations intentionally untouched.
- Add a regression contract test for `sleepMs` in `src/orchestration/util.test.ts` covering ms-scale timing and the `Promise<void>` resolution.

Refs task-d1ab1125, proposal at `docs/proposals/rename-sleep-to-sleepms.md`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` compiles `bin/ludics` (164 modules)
- [x] `bun run lint` clean (0 warnings)
- [x] `bun test` — 1353 pass, 0 fail
- [x] Grep verification: `\bsleep\b` (excluding `Bun.sleep`, shell literals, `sleepSync`) returns no remaining project-`sleep` references