### PR TITLE
fix(flow): use priorityValue() for flowBlocked sort so S sorts before C

### DIFF
--- a/src/flow.test.ts
+++ b/src/flow.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { flowBlocked } from "./flow.ts";
+
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+function harnessDir(): string {
+  return join(TMP, "harness");
+}
+
+function writeTask(id: string, priority: string, blockedBy: string[]): void {
+  const tasksDir = join(harnessDir(), "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  const fm = `---
+id: ${id}
+title: "${id}"
+status: ready
+priority: ${priority}
+deadline: null
+dependencies:
+  blocks: []
+  blocked_by: [${blockedBy.map((b) => `"${b}"`).join(", ")}]
+  relates_to: []
+  subtask_of: null
+project: ludics
+context: ludics
+---
+
+body
+`;
+  writeFileSync(join(tasksDir, `${id}.md`), fm);
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-flow-blocked-"));
+  process.env.LUDICS_HARNESS_DIR = harnessDir();
+  mkdirSync(harnessDir(), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("flowBlocked", () => {
+  test("orders blocked tasks S, A, B, C, D (numeric priority, not lex)", () => {
+    // Insert in non-canonical order so the sort has to do real work.
+    writeTask("task-c1", "C", ["task-blocker"]);
+    writeTask("task-d1", "D", ["task-blocker"]);
+    writeTask("task-s1", "S", ["task-blocker"]);
+    writeTask("task-b1", "B", ["task-blocker"]);
+    writeTask("task-a1", "A", ["task-blocker"]);
+
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (msg?: unknown) => { lines.push(String(msg ?? "")); };
+    try {
+      flowBlocked();
+    } finally {
+      console.log = orig;
+    }
+
+    const ids = lines.map((l) => l.split(" ")[0]);
+    expect(ids).toEqual(["task-s1", "task-a1", "task-b1", "task-c1", "task-d1"]);
+  });
+
+  test("unknown priority sorts after D", () => {
+    writeTask("task-d1", "D", ["task-blocker"]);
+    writeTask("task-x1", "X", ["task-blocker"]);
+    writeTask("task-s1", "S", ["task-blocker"]);
+
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (msg?: unknown) => { lines.push(String(msg ?? "")); };
+    try {
+      flowBlocked();
+    } finally {
+      console.log = orig;
+    }
+
+    const ids = lines.map((l) => l.split(" ")[0]);
+    expect(ids).toEqual(["task-s1", "task-d1", "task-x1"]);
+  });
+});

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -6,6 +6,7 @@ import YAML from "yaml";
 import { harnessDir, slotsCount, effectivePriority, effectivePriorityValue, milestonesEnabledProjects, postponedProjectSet } from "./config.ts";
 import { readAllSlotJson } from "./slots/json.ts";
 import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
+import { priorityValue } from "./tasks/markdown.ts";
 
 interface TaskData {
   id: string;
@@ -218,7 +219,7 @@ export function flowBlocked(): void {
 
   const blocked = tasks
     .filter((t) => t.dependencies.blocked_by && t.dependencies.blocked_by.length > 0)
-    .sort((a, b) => (a.priority ?? "Z").localeCompare(b.priority ?? "Z"));
+    .sort((a, b) => priorityValue(a.priority) - priorityValue(b.priority));
 
   if (blocked.length === 0) {
     console.log("No blocked tasks");


### PR DESCRIPTION
## Summary

`flowBlocked()` in `src/flow.ts` sorted blocked tasks via `localeCompare` with a `"Z"` sentinel, which yielded the lex order `A < B < C < D < S` — so `S`-priority blocked tasks sorted *last* among the named priorities instead of first.

This PR delegates to the canonical numeric comparator `priorityValue()` from `src/tasks/markdown.ts` (already used by `src/dashboard.ts`), restoring the intended `S < A < B < C < D < <unknown>` order.

## Changes

- `src/flow.ts` — import `priorityValue`, replace the `localeCompare`/`"Z"` comparator with `priorityValue(a.priority) - priorityValue(b.priority)`.
- `src/flow.test.ts` — new regression test exercising `flowBlocked()` end-to-end (writes a fixture harness via `LUDICS_HARNESS_DIR`, captures `console.log`, asserts both the canonical S→D order and that an unknown priority sorts after D).

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test src/flow.test.ts` — 2 pass
- [x] `bun test src/tasks/priority-value.test.ts` — 4 pass (sanity)

Closes task-da3cf294. Follow-up to PR #355 (task-9b8ff839) which added `D` as the new priority floor and exposed this latent lex-vs-numeric bug.