### PR TITLE
feat(escalate): bail-out: escalate — agent-initiated resumable halt

### DIFF
--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -279,6 +279,32 @@ If the reviewer disagrees, they write `REQUEST_CHANGES` in the review file and e
 
 **When to bail vs finish normally.** Bail-out is for tasks where there is genuinely nothing to do — the fix landed elsewhere, the feature was superseded, the bug no longer reproduces. A partially-done task still finishes normally.
 
+### Escalation contract
+
+**Principle.** When an agent believes it's stuck in a contradictory or looping situation that ordinary progress can't escape — the reviewer keeps reversing on unchanged work, a parser misread keeps inverting the verdict, contradictory instructions in the spec can't be reconciled — it raises its hand with `bail-out: escalate`. The runner halts at the current phase without discarding work, flags the slot, and notifies Mag/the user. The human inspects the situation, applies a manual fix, and resumes via `ludics slot N resume` — the same command that recovers an interrupted slot.
+
+**Why.** Round-count loop-detection is brittle (legitimate merge-round churn, plan-merge iterations, genuine disagreement-driven work cycles all trip a threshold) and fires late — N rounds of wasted agent time before the guardrail notices. Agents see the content (identical reviews, same coder output, contradictory reviewer guidance) and can detect the trap faster than any external counter. See task-4cd94043 and gh-ludics-310 (the 9-round loop that motivated this).
+
+**Distinction from bail-out.** `bail-out` means *done, no work needed* — the phase advances to done. `escalate` means *not done, need a human* — the phase does NOT advance. Both are resumable; bail-out resumes as "next task," escalate resumes as "pick up where the agent raised its hand."
+
+**Distinction from `interrupted`.** `interrupted` is a framework failure (setup error, orchestrator crash) — a passive signal. `escalated` is an agent-initiated collaborative ask — active signal. Both are cleared by the same `ludics slot N resume` command, but they preserve different provenance for retrospectives.
+
+**Shell block (coder, reviewer, or solo coder — unilateral; no handshake needed).**
+
+```sh
+printf 'escalate|%s|<one-sentence reason>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+**Reason field.** Non-empty is strongly encouraged but not required. An empty reason is accepted (to avoid blocking the very escape hatch the action is meant to enable); the notification reads "(no reason provided)" and a warning is logged.
+
+**What the runner does.** For each agent whose `.status` starts with `escalate`, emit an `escalation_requested` event with `{slot, task, phase, agent, reason}`. Fire a priority-5 `ludics notify outgoing` summarizing all raisers. Flip the slot's `liveness` to `"escalated"`. Persist state before and after the slot-json flip so a mid-halt crash leaves a consistent record. Return cleanly from `runOrchestration` — do **not** break (the outer loop would advance phase).
+
+**What Mag does.** Nothing. Mag's auto-start / auto-unstick paths skip slots with `liveness === "escalated"` the same way they skip `"interrupted"`. Only explicit user action clears the marker.
+
+**Resolution.** User reads the notification + peer-sync artifacts + PR state, applies whatever fix is needed (edit a review file, patch the code, `ludics orch skip`, etc.), then runs `ludics slot N resume`. Resume clears liveness back to `null` and re-enters the orchestrator at the preserved phase/round.
+
+**When to use.** Primary triggers are (a) "I've had nothing meaningful to do for 2–3 rounds on unchanged input" (coder observing a no-op loop), (b) "the review content hasn't meaningfully changed across rounds on unchanged coder output" (reviewer observing the same loop from the other side), (c) "the instructions or environment contradict themselves and I can't pick a path." Do **not** use it for: recoverable review/work disagreement (use normal review/work-round channels), tasks that are genuinely done (use bail-out), legitimate multi-round churn (the point of multi-round is iteration).
+
 ### Injectable subprocess runners
 
 **Principle.** When code reaches for `Bun.spawnSync` / `child_process`, accept an injectable runner type — `type RunGit = (args: string[], cwd: string) => RunGitResult` — with a production shim (`defaultRunGit`) and a test-side fake.

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -58,6 +58,12 @@ printf 'bail-out|%s|<describe why task is obsolete>\n' "$(date +%s)" > "{{STATUS
 
 Use bail-out only when there's genuinely nothing to do. Partially-done tasks still finish normally.
 
+If you believe you're stuck in a contradictory or looping situation that ordinary progress can't escape — e.g., the reviewer keeps flipping verdict on identical work, or you've done nothing meaningful for several rounds on unchanged input — raise your hand with `bail-out: escalate`. The runner halts at the current phase (no discarded work, no phase advance), flags the slot, and notifies the user. See [escalation contract](../../docs/orchestration-patterns.md#escalation-contract) for when to use it.
+
+```sh
+printf 'escalate|%s|<one-sentence reason>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
 ```sh
 printf '%s|%s|coder work complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/skills/orchestration/pair-reviewer-review.md
+++ b/skills/orchestration/pair-reviewer-review.md
@@ -38,6 +38,12 @@ printf 'bail-out-confirmed|%s|<describe why you agree task is obsolete>\n' "$(da
 
 If you disagree with the bail-out, write `REQUEST_CHANGES` in the review file and explain what's still needed.
 
+If you believe the pair is stuck in a contradictory or looping situation that ordinary feedback can't break — e.g., the coder keeps reproducing a misread of your review, or the review contents haven't meaningfully changed across rounds on unchanged coder output — raise your hand with `bail-out: escalate`. Reviewer-side escalation is unilateral: the runner halts immediately without waiting for the coder to confirm. See [escalation contract](../../docs/orchestration-patterns.md#escalation-contract) for when to use it.
+
+```sh
+printf 'escalate|%s|<one-sentence reason>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
 ```sh
 printf '%s|%s|reviewer work review complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/skills/orchestration/solo-work.md
+++ b/skills/orchestration/solo-work.md
@@ -28,6 +28,12 @@ printf 'bail-out|%s|<describe why task is obsolete>\n' "$(date +%s)" > "{{STATUS
 
 Solo bail-out is terminal — the runner transitions straight to `done` with no reviewer confirmation. Use bail-out only when there's genuinely nothing to do. Partially-done tasks still finish normally.
 
+If you believe you're stuck in a contradictory or looping situation that ordinary progress can't escape — e.g., contradictory instructions in the proposal you can't reconcile, or an environment problem no retry has fixed — raise your hand with `bail-out: escalate`. The runner halts at the current phase (no discarded work, no phase advance) and notifies the user. See [escalation contract](../../docs/orchestration-patterns.md#escalation-contract) for when to use it.
+
+```sh
+printf 'escalate|%s|<one-sentence reason>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
 ```sh
 printf '%s|%s|coder work complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -8,7 +8,7 @@ import { writeJsonFile, writeJsonFileCompact } from "./json.ts";
 import { join } from "path";
 import { harnessDir, loadConfigSync, slotsCount, stateRepoDir } from "./config.ts";
 import { readSlotJson, writeSlotJson, readAllSlotJson, slotDataToMarkdown } from "./slots/json.ts";
-import type { SlotData } from "./slots/types.ts";
+import { parseSlotLiveness, type SlotData } from "./slots/types.ts";
 import { slotClear } from "./slots/index.ts";
 import { emitEvent } from "./events.ts";
 import { journalAppend } from "./journal.ts";
@@ -650,7 +650,7 @@ function handlePostSlotUpdate(body: Record<string, unknown>): Response {
 
   // Merge runtime fields + adapter args (for worker auto-fill)
   if (body.sessionStarted !== undefined) data.sessionStarted = String(body.sessionStarted);
-  if (body.liveness !== undefined) data.liveness = String(body.liveness);
+  if (body.liveness !== undefined) data.liveness = parseSlotLiveness(body.liveness);
   if (body.adapterArgs !== undefined) data.adapterArgs = String(body.adapterArgs);
 
   // Merge sections (Terminals, Runtime, Git)

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -134,6 +134,25 @@ describe("computeSlotLiveness", () => {
     expect(computeSlotLiveness({ slotNum: 1, mode: null, slotData })).toBe("interrupted");
   });
 
+  test("explicit Liveness field 'escalated' in slot data returns 'escalated'", async () => {
+    const { computeSlotLiveness } = await import("./dashboard.ts");
+    const { emptySlotData } = await import("./slots/json.ts");
+    const slotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
+    expect(computeSlotLiveness({ slotNum: 1, mode: null, slotData })).toBe("escalated");
+  });
+
+  test("escalated wins over an alive PID — user-initiated halt is sticky", async () => {
+    const { computeSlotLiveness } = await import("./dashboard.ts");
+    const { emptySlotData } = await import("./slots/json.ts");
+    writeT3codeSlotState(1, {
+      slot: 1,
+      threads: [],
+      orchestration: { stateFile: "orch.json", mode: "pair", pid: process.pid },
+    });
+    const slotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
+    expect(computeSlotLiveness({ slotNum: 1, mode: "t3code", slotData })).toBe("escalated");
+  });
+
   test("explicit Liveness field null in slot data falls through to PID check", async () => {
     const { computeSlotLiveness } = await import("./dashboard.ts");
     const { emptySlotData } = await import("./slots/json.ts");

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import type { SlotData } from "./slots/types.ts";
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
@@ -130,14 +131,14 @@ describe("computeSlotLiveness", () => {
   test("explicit Liveness field 'interrupted' in slot data returns 'interrupted'", async () => {
     const { computeSlotLiveness } = await import("./dashboard.ts");
     const { emptySlotData } = await import("./slots/json.ts");
-    const slotData = { ...emptySlotData(1), process: "test", liveness: "interrupted" };
+    const slotData: SlotData = { ...emptySlotData(1), process: "test", liveness: "interrupted" };
     expect(computeSlotLiveness({ slotNum: 1, mode: null, slotData })).toBe("interrupted");
   });
 
   test("explicit Liveness field 'escalated' in slot data returns 'escalated'", async () => {
     const { computeSlotLiveness } = await import("./dashboard.ts");
     const { emptySlotData } = await import("./slots/json.ts");
-    const slotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
+    const slotData: SlotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
     expect(computeSlotLiveness({ slotNum: 1, mode: null, slotData })).toBe("escalated");
   });
 
@@ -149,7 +150,7 @@ describe("computeSlotLiveness", () => {
       threads: [],
       orchestration: { stateFile: "orch.json", mode: "pair", pid: process.pid },
     });
-    const slotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
+    const slotData: SlotData = { ...emptySlotData(1), process: "test", liveness: "escalated" };
     expect(computeSlotLiveness({ slotNum: 1, mode: "t3code", slotData })).toBe("escalated");
   });
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -64,7 +64,7 @@ interface SlotJson {
   githubUrl: string | null;
   terminalLinks: Record<string, string> | null;
   effort: string | null;
-  liveness: "alive" | "interrupted" | null;
+  liveness: "alive" | "interrupted" | "escalated" | null;
   machine: string | null;
   /** Pending controller action for remote slots, derived from intent files. */
   pendingAction: "starting" | "stopping" | "resuming" | null;
@@ -78,11 +78,13 @@ export interface SlotLivenessContext {
   slotData?: SlotData;
 }
 
-export function computeSlotLiveness(ctx: SlotLivenessContext): "alive" | "interrupted" | null {
+export function computeSlotLiveness(ctx: SlotLivenessContext): "alive" | "interrupted" | "escalated" | null {
   const { slotNum, mode, slotData } = ctx;
-  // Check explicit Liveness field from slot data (set by markSlotSetupFailed)
+  // Check explicit Liveness field from slot data (set by markSlotSetupFailed
+  // or the runner's escalation halt).
   if (slotData) {
     const explicit = (slotData.liveness ?? "").trim();
+    if (explicit === "escalated") return "escalated";
     if (explicit === "interrupted") return "interrupted";
   }
   if (!mode) return null;
@@ -260,13 +262,19 @@ function generateSlots(): SlotJson[] {
     const sessionStarted = rawSessionStarted ? rawSessionStarted : null;
 
     // Compute liveness — for local slots use PID check, for remote slots use heartbeat.
-    let liveness: "alive" | "interrupted" | null = null;
+    let liveness: "alive" | "interrupted" | "escalated" | null = null;
     if (!empty) {
       const explicitLiveness = (data.liveness ?? "").trim();
-      const shouldCheck = (phase && phase !== "done") || explicitLiveness === "interrupted";
+      const shouldCheck = (phase && phase !== "done")
+        || explicitLiveness === "interrupted"
+        || explicitLiveness === "escalated";
       if (shouldCheck) {
         if (!machineName || !isRemoteMachine(machineName)) {
           liveness = computeSlotLiveness({ slotNum: num, mode: (data.mode ?? "") || null, slotData: data });
+        } else if (explicitLiveness === "escalated") {
+          // Remote escalation marker propagates via git-sync of the slot json;
+          // the user's resume on the owning node is the only clearing path.
+          liveness = "escalated";
         } else {
           // Remote slot: use heartbeat freshness as liveness proxy
           liveness = heartbeatIsFresh(machineName) ? "alive" : "interrupted";

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2023,9 +2023,12 @@ async function maybeAutoStartSlots(): Promise<void> {
     const taskId = data.task ?? "";
     if (!taskId) continue;
 
-    // Skip slots already marked as interrupted (setup failure) — needs manual resume
+    // Skip slots already marked as interrupted (setup failure) or escalated
+    // (agent-initiated halt per task-4cd94043) — both require manual resume.
+    // Mag must not silently restart an escalation; only explicit user action
+    // (`ludics slot N resume`) clears the marker.
     const slotLiveness = data.liveness ?? "";
-    if (slotLiveness === "interrupted") continue;
+    if (slotLiveness === "interrupted" || slotLiveness === "escalated") continue;
 
     // Skip if the slot has an active session for the CURRENT task
     const orchState = readOrchestrationState(slotNum);
@@ -2093,9 +2096,10 @@ function maybeUnstickAssignedSlots(): void {
     const taskId = data.task ?? "";
     if (!taskId) continue;
 
-    // Skip slots marked as interrupted — needs manual resume
+    // Skip slots marked as interrupted or escalated — both need explicit
+    // `ludics slot N resume` (no automatic unstick).
     const slotLiveness = data.liveness ?? "";
-    if (slotLiveness === "interrupted") continue;
+    if (slotLiveness === "interrupted" || slotLiveness === "escalated") continue;
 
     // Skip if session is active
     const sessionStarted = data.sessionStarted ?? "";

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, isPairBailedOut, isSoloBailedOut, PHASE_CATEGORIES, phaseTimeoutExpired } from "./phases.ts";
+import { agentParticipatesInPhase, DONE_STATUSES, escalatingAgents, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, isEscalated, isPairBailedOut, isSoloBailedOut, PHASE_CATEGORIES, phaseTimeoutExpired } from "./phases.ts";
 import { statusFileFingerprint } from "./peer-sync.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
 import { applyPhaseSideEffects } from "./runner.ts";
@@ -1212,6 +1212,60 @@ describe("isSoloBailedOut / isBailedOut", () => {
     state.agentStates.coder.status = "bail-out";
     state.agentStates.reviewer.status = "done";
     expect(isBailedOut(state)).toBe(false);
+  });
+});
+
+describe("isEscalated / escalatingAgents", () => {
+  test("false when no agent has the escalate status", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "done";
+    state.agentStates.reviewer.status = "review-done";
+    expect(isEscalated(state)).toBe(false);
+    expect(escalatingAgents(state)).toEqual([]);
+  });
+
+  test("true when the coder escalates (pair mode)", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "escalate";
+    expect(isEscalated(state)).toBe(true);
+    expect(escalatingAgents(state).map((a) => a.name)).toEqual(["coder"]);
+  });
+
+  test("true when the reviewer escalates unilaterally (pair mode)", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "done";
+    state.agentStates.reviewer.status = "escalate";
+    expect(isEscalated(state)).toBe(true);
+    expect(escalatingAgents(state).map((a) => a.name)).toEqual(["reviewer"]);
+  });
+
+  test("true when both agents escalate simultaneously; both surface", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "escalate";
+    state.agentStates.reviewer.status = "escalate";
+    expect(isEscalated(state)).toBe(true);
+    expect(escalatingAgents(state).map((a) => a.name).sort()).toEqual(["coder", "reviewer"]);
+  });
+
+  test("true when a solo coder escalates", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.status = "escalate";
+    expect(isEscalated(state)).toBe(true);
+    expect(escalatingAgents(state).map((a) => a.name)).toEqual(["coder"]);
+  });
+
+  test("escalate status is NOT a done status — stays out of DONE_STATUSES", () => {
+    expect(DONE_STATUSES.has("escalate")).toBe(false);
+  });
+
+  test("escalate does not route through isBailedOut", () => {
+    const state = makeState();
+    state.agentStates.coder.status = "escalate";
+    state.agentStates.reviewer.status = "escalate";
+    expect(isBailedOut(state)).toBe(false);
+    const solo = makeSoloState();
+    solo.agentStates.coder.status = "escalate";
+    expect(isBailedOut(solo)).toBe(false);
   });
 });
 

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -357,6 +357,21 @@ export function isBailedOut(state: OrchestrationState): boolean {
   return isPairBailedOut(state) || isSoloBailedOut(state);
 }
 
+/** Agents that have raised the `escalate` hand. Returned in declaration order
+ * so callers that surface names/reasons (notification, event log) produce a
+ * stable ordering. */
+export function escalatingAgents(state: OrchestrationState): AgentConfig[] {
+  return state.agents.filter((a) => (state.agentStates[a.name]?.status ?? "") === "escalate");
+}
+
+/** True when any agent has written `escalate` to its status file. Unlike
+ * `isBailedOut`, this is a disjunction — a single agent's hand-raise suffices.
+ * `escalate` is intentionally NOT in DONE_STATUSES: escalation is not "done",
+ * it is a resumable halt. */
+export function isEscalated(state: OrchestrationState): boolean {
+  return escalatingAgents(state).length > 0;
+}
+
 function hasAnyPr(state: OrchestrationState): boolean {
   return state.agents.some((agent) => {
     const url = state.agentStates[agent.name]?.prUrl;

--- a/src/orchestration/runner.escalation.test.ts
+++ b/src/orchestration/runner.escalation.test.ts
@@ -1,0 +1,316 @@
+// Regression tests for `bail-out: escalate` — the agent-initiated resumable
+// halt. See task-4cd94043 and docs/orchestration-patterns.md#escalation-contract.
+//
+// Tests drive runOrchestration with a stub transport and a pre-seeded
+// `escalate` status file. The runner should: (a) emit one
+// `escalation_requested` event per raising agent, (b) fire a priority-5
+// notifyOutgoing, (c) flip slot-json liveness to "escalated", (d) NOT advance
+// phase, and (e) return cleanly from runOrchestration.
+
+import { describe, expect, test, beforeEach, afterEach, spyOn, setDefaultTimeout } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { handleEscalation, runOrchestration } from "./runner.ts";
+import * as events from "../events.ts";
+import * as notify from "../notify.ts";
+import type { OrchestrationTransport } from "./transport.ts";
+import {
+  makeTmpDir,
+  makeLifecycle,
+  makeState,
+} from "./runner.test-helpers.ts";
+
+setDefaultTimeout(15_000);
+
+function stubTransport(): OrchestrationTransport {
+  return {
+    async sendTurn() { return "cmd-escalation-test"; },
+    async sendEnter() {},
+    async refreshAgentTransportState() {},
+    async interruptAgent() {},
+  };
+}
+
+function seedHarness(slot: number, backend: "tmux" | "t3code" = "tmux"): {
+  harness: string;
+  peerSyncDir: string;
+} {
+  const tmpDir = makeTmpDir();
+  const harness = join(tmpDir, "harness");
+  const peerSyncDir = join(tmpDir, "peer-sync");
+  mkdirSync(join(harness, "orchestration"), { recursive: true });
+  mkdirSync(join(harness, "slots"), { recursive: true });
+  mkdirSync(join(harness, "t3code"), { recursive: true });
+  mkdirSync(join(harness, "journal"), { recursive: true });
+  mkdirSync(join(peerSyncDir, "plans"), { recursive: true });
+  mkdirSync(join(peerSyncDir, "reviews"), { recursive: true });
+
+  // Sibling adapter state with our own PID so the self-guard passes.
+  if (backend === "tmux") {
+    writeFileSync(
+      join(harness, "orchestration", `tmux-slot-${slot}.json`),
+      JSON.stringify({
+        orchestration: { pid: process.pid, stateFile: "x", mode: "pair" },
+        sessionNames: { coder: "c", reviewer: "r" },
+        ttydPids: {},
+      }),
+    );
+  } else {
+    writeFileSync(
+      join(harness, "t3code", `slot-${slot}.json`),
+      JSON.stringify({
+        orchestration: { pid: process.pid, stateFile: "x", mode: "pair" },
+        threads: [],
+      }),
+    );
+  }
+
+  // Pre-existing slot json so writeSlotJson has a file to flip.
+  writeFileSync(
+    join(harness, "slots", `slot-${slot}.json`),
+    JSON.stringify({
+      slot,
+      process: "test-process",
+      task: "feat",
+      mode: backend,
+      session: null,
+      path: null,
+      started: null,
+      adapterArgs: null,
+      machine: null,
+      sessionStarted: null,
+      liveness: null,
+      terminals: "",
+      runtime: "",
+      git: "",
+    }, null, 2),
+  );
+
+  return { harness, peerSyncDir };
+}
+
+function writeStatus(peerSyncDir: string, agent: string, status: string, reason: string): void {
+  writeFileSync(
+    join(peerSyncDir, `${agent}.status`),
+    `${status}|${Math.floor(Date.now() / 1000)}|${reason}\n`,
+  );
+}
+
+describe("runner escalation halt — runOrchestration end-to-end", () => {
+  let origHarnessDir: string | undefined;
+  let origStartupGrace: string | undefined;
+
+  beforeEach(() => {
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+    origStartupGrace = process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+    process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "0";
+  });
+
+  afterEach(() => {
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+    if (origStartupGrace !== undefined) process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = origStartupGrace;
+    else delete process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+  });
+
+  test("coder escalation halts: event emitted, notification sent, liveness flipped, phase unchanged", async () => {
+    const slot = 11;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    writeStatus(peerSyncDir, "coder", "escalate", "reviewer keeps reversing my fix");
+    writeStatus(peerSyncDir, "reviewer", "idle", "awaiting-reviewer");
+
+    const state = makeState({
+      slot,
+      backend: "tmux",
+      phase: "review",
+      round: 2,
+      // phaseDispatched + currentPhaseToken skip re-entry into enterPhase's
+      // dispatch loop while still exercising the real pollUntilDone path.
+      phaseDispatched: true,
+      currentPhaseToken: "phase-existing",
+      agentStates: {
+        coder: { status: "working", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+        reviewer: { status: "idle", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+      },
+    }, peerSyncDir);
+
+    const eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+
+    try {
+      await runOrchestration(state, stubTransport());
+
+      const escalationEvents = eventSpy.mock.calls
+        .map((c) => c[0] as { event_type: string; agent?: string; phase?: string; reason?: string; slot?: number; task?: string })
+        .filter((e) => e.event_type === "escalation_requested");
+      expect(escalationEvents).toHaveLength(1);
+      expect(escalationEvents[0]!.agent).toBe("coder");
+      expect(escalationEvents[0]!.phase).toBe("review");
+      expect(escalationEvents[0]!.reason).toBe("reviewer keeps reversing my fix");
+      expect(escalationEvents[0]!.slot).toBe(slot);
+      expect(escalationEvents[0]!.task).toBe(state.taskId);
+
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      const [msg, priority, title] = notifySpy.mock.calls[0] as [string, number, string];
+      expect(priority).toBe(5);
+      expect(title).toContain(`slot ${slot}`);
+      expect(msg).toContain(`Slot ${slot}`);
+      expect(msg).toContain("coder escalated");
+      expect(msg).toContain("review");
+      expect(msg).toContain("reviewer keeps reversing my fix");
+
+      const slotData = JSON.parse(readFileSync(join(harness, "slots", `slot-${slot}.json`), "utf-8"));
+      expect(slotData.liveness).toBe("escalated");
+      // Phase must not advance — resume should pick up exactly where we left off.
+      expect(state.phase).toBe("review");
+    } finally {
+      eventSpy.mockRestore();
+      notifySpy.mockRestore();
+    }
+  });
+
+  test("empty-reason escalation logs a warning and uses '(no reason provided)'", async () => {
+    const slot = 12;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    writeStatus(peerSyncDir, "coder", "escalate", "");
+    writeStatus(peerSyncDir, "reviewer", "idle", "");
+
+    const state = makeState({
+      slot,
+      backend: "tmux",
+      phase: "work",
+      phaseDispatched: true,
+      currentPhaseToken: "phase-existing",
+      agentStates: {
+        coder: { status: "working", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+        reviewer: { status: "idle", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+      },
+    }, peerSyncDir);
+
+    const eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await runOrchestration(state, stubTransport());
+
+      const escalationEvents = eventSpy.mock.calls
+        .map((c) => c[0] as { event_type: string; reason?: string; reason_provided?: boolean })
+        .filter((e) => e.event_type === "escalation_requested");
+      expect(escalationEvents).toHaveLength(1);
+      expect(escalationEvents[0]!.reason).toBe("(no reason provided)");
+      expect(escalationEvents[0]!.reason_provided).toBe(false);
+
+      const [msg] = notifySpy.mock.calls[0] as [string, number, string];
+      expect(msg).toContain("(no reason provided)");
+
+      const warnings = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(warnings.some((m) => m.includes("empty reason"))).toBe(true);
+    } finally {
+      eventSpy.mockRestore();
+      notifySpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  test("both agents escalating in the same tick surface both, halt fires once", async () => {
+    const slot = 13;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    writeStatus(peerSyncDir, "coder", "escalate", "coder reason");
+    writeStatus(peerSyncDir, "reviewer", "escalate", "reviewer reason");
+
+    const state = makeState({
+      slot,
+      backend: "tmux",
+      phase: "review",
+      phaseDispatched: true,
+      currentPhaseToken: "phase-existing",
+      agentStates: {
+        coder: { status: "working", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+        reviewer: { status: "idle", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+      },
+    }, peerSyncDir);
+
+    const eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+
+    try {
+      await runOrchestration(state, stubTransport());
+
+      const escalationEvents = eventSpy.mock.calls
+        .map((c) => c[0] as { event_type: string; agent?: string; reason?: string })
+        .filter((e) => e.event_type === "escalation_requested");
+      expect(escalationEvents).toHaveLength(2);
+      const byAgent = Object.fromEntries(escalationEvents.map((e) => [e.agent, e.reason]));
+      expect(byAgent.coder).toBe("coder reason");
+      expect(byAgent.reviewer).toBe("reviewer reason");
+
+      // Single notification summarizing both.
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      const [msg, priority] = notifySpy.mock.calls[0] as [string, number, string];
+      expect(priority).toBe(5);
+      expect(msg).toContain("coder");
+      expect(msg).toContain("reviewer");
+      expect(msg).toContain("coder reason");
+      expect(msg).toContain("reviewer reason");
+
+      const slotData = JSON.parse(readFileSync(join(harness, "slots", `slot-${slot}.json`), "utf-8"));
+      expect(slotData.liveness).toBe("escalated");
+    } finally {
+      eventSpy.mockRestore();
+      notifySpy.mockRestore();
+    }
+  });
+});
+
+describe("handleEscalation — isolated halt helper", () => {
+  let origHarnessDir: string | undefined;
+
+  beforeEach(() => {
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+  });
+
+  afterEach(() => {
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+  });
+
+  test("no-op when no agent has the escalate status", () => {
+    const slot = 20;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    const state = makeState({
+      slot,
+      phase: "work",
+      agentStates: {
+        coder: { status: "done", statusEpoch: 0, statusMessage: "ok", prUrl: null, interrupted: false },
+        reviewer: { status: "review-done", statusEpoch: 0, statusMessage: "ok", prUrl: null, interrupted: false },
+      },
+    }, peerSyncDir);
+
+    const eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+
+    try {
+      handleEscalation(state);
+      const escalationEvents = eventSpy.mock.calls
+        .map((c) => (c[0] as { event_type: string }).event_type)
+        .filter((t) => t === "escalation_requested");
+      expect(escalationEvents).toHaveLength(0);
+      expect(notifySpy).not.toHaveBeenCalled();
+
+      const slotData = JSON.parse(readFileSync(join(harness, "slots", `slot-${slot}.json`), "utf-8"));
+      expect(slotData.liveness).toBeNull();
+    } finally {
+      eventSpy.mockRestore();
+      notifySpy.mockRestore();
+    }
+  });
+});

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -2,7 +2,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { join } from "path";
 import { emitEvent } from "../events.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
-import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
+import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, escalatingAgents, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, isEscalated, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
 import {
   clearInterrupt, readAgentStatus, readMarker, readPhaseToken, readPrUrl,
   statusFileFingerprint, touchStatusFile, writeInterrupt, writePeerSync,
@@ -18,7 +18,8 @@ import { isoNow, makeId, nowEpoch, sleepMs } from "./util.ts";
 import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, validateAndFixPrFile, type PrVerification } from "./github.ts";
 import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
 import { findProjectConfig, globalAdapter, harnessDir, ludicsRoot } from "../config.ts";
-import { notifyAgents } from "../notify.ts";
+import { notifyAgents, notifyOutgoing } from "../notify.ts";
+import { readSlotJson, writeSlotJson } from "../slots/json.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, defaultMainBranch, pushBranch } from "./worktrees.ts";
@@ -1170,6 +1171,15 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
     while (true) {
       await refreshAgentStatuses(state, transport);
 
+      // Agent-initiated resumable halt — exit the poll loop immediately so
+      // runOrchestration's caller-side handler can persist state, emit the
+      // event + priority-5 notification, and flip slot liveness without any
+      // intervening phase-advance work (nudge, auto-commit, verification gate).
+      if (isEscalated(state)) {
+        persistState(state);
+        return;
+      }
+
       // Detect hung agents (static terminal) and send nudges / force-settle.
       await detectAndNudgeHungAgents(state, transport);
 
@@ -1483,6 +1493,74 @@ export function triggerCoderBailOut(
  * ahead of the base branch, skip PR creation and transition directly to done.
  * Returns true if bail-out was triggered (caller should break the loop).
  */
+/**
+ * Agent-initiated resumable halt.  Called when `isEscalated(state)` is true
+ * after a status refresh.  Emits one `escalation_requested` event per raising
+ * agent, fires a priority-5 `ludics notify outgoing` summarizing all raises,
+ * flips slot liveness to "escalated", and persists state twice (before and
+ * after the slot-json flip) so a mid-halt crash leaves a consistent record.
+ *
+ * Does NOT advance phase — the runner's outer loop must `return` after this
+ * runs, not `break` (breaking would fall through to persistState with an
+ * unchanged non-"done" phase).  This is the runtime analogue of a user-asked
+ * pause: resumption is via `ludics slot N resume`.
+ */
+export function handleEscalation(state: OrchestrationState): void {
+  const raisers = escalatingAgents(state);
+  if (raisers.length === 0) return; // defensive: caller should have gated
+
+  persistState(state);
+
+  const reasonFor = (name: string): { reason: string; warned: boolean } => {
+    const raw = (state.agentStates[name]?.statusMessage ?? "").trim();
+    if (raw === "") return { reason: "(no reason provided)", warned: true };
+    return { reason: raw, warned: false };
+  };
+
+  const parts: string[] = [];
+  for (const agent of raisers) {
+    const { reason, warned } = reasonFor(agent.name);
+    emitEvent({
+      event_type: "escalation_requested",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.taskId,
+      phase: state.phase,
+      agent: agent.name,
+      reason,
+      reason_provided: !warned,
+      message: `${agent.name} escalated at phase ${state.phase}: ${reason}`,
+    });
+    if (warned) {
+      console.error(`ludics: slot ${state.slot} ${agent.name}: escalate status written with empty reason`);
+    }
+    parts.push(`${agent.name}: ${reason}`);
+  }
+
+  const message = raisers.length === 1
+    ? `Slot ${state.slot} agent ${raisers[0]!.name} escalated on task ${state.taskId} at phase ${state.phase}: ${reasonFor(raisers[0]!.name).reason}`
+    : `Slot ${state.slot} agents escalated on task ${state.taskId} at phase ${state.phase} — ${parts.join(" | ")}`;
+  const title = `slot ${state.slot} escalation`;
+  try {
+    notifyOutgoing(message, 5, title);
+  } catch (err) {
+    // notify is best-effort; still halt the runner even if the notification
+    // pipe is broken. The event log is the authoritative record.
+    console.error(`ludics: notifyOutgoing failed for slot ${state.slot} escalation: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    const data = readSlotJson(state.slot);
+    data.liveness = "escalated";
+    writeSlotJson(state.slot, data);
+  } catch (err) {
+    console.error(`ludics: failed to set slot ${state.slot} liveness=escalated: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  persistState(state);
+}
+
 export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean {
   if (state.phase !== "pr-create") return false;
   const coder = state.agents.find(a => a.role === "coder");
@@ -1565,6 +1643,17 @@ export async function runOrchestration(
     persistState(state);
 
     await pollUntilDone(state, transport);
+
+    // Escalation halt — checked before any phase-advance work so we don't
+    // auto-commit, verify, or transition while the human is being flagged in.
+    // handleEscalation persists state, flips slot liveness, and emits the
+    // event + priority-5 notification. We return (not break) to preserve the
+    // non-"done" phase so `ludics slot N resume` can pick up exactly where
+    // the agent raised its hand.
+    if (isEscalated(state)) {
+      handleEscalation(state);
+      return;
+    }
 
     // Auto-commit any uncommitted work after agents finish their turn.
     // Push=false here; push happens before PR-related phases below.

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -781,9 +781,11 @@ describe("slotResume — escalated slot handling (task-4cd94043)", () => {
 
   test("escalated slot with intact orch state proceeds through normal resume and clears liveness", async () => {
     // Realistic path: handleEscalation flipped liveness to "escalated" but
-    // left OrchestrationState on disk. slotResume should NOT throw, should
-    // proceed through the normal resume flow, and should clear liveness back
-    // to null at the end (mirroring the existing interrupted-resume contract).
+    // left OrchestrationState on disk. slotResume should NOT throw on the
+    // escalated marker (no "use 'slot start'" rejection) and the resume flow
+    // should reach the final data.liveness = null write. We assert that the
+    // startOrchestrationProcess call was reached (proving we advanced past
+    // the marker) rather than relying on catch-then-pass semantics.
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");
     const orchDir = join(harness, "orchestration");
@@ -822,19 +824,111 @@ describe("slotResume — escalated slot handling (task-4cd94043)", () => {
     };
     persistState(orchState, harness);
 
+    // Stub the expensive spawn so the test observes liveness flipped to null.
+    // spyOn against the module export replaces the call site's live binding.
+    const orchProcess = await import("../orchestration/process.ts");
+    const startSpy = spyOn(orchProcess, "startOrchestrationProcess")
+      .mockImplementation(async () => 99_998); // dead-but-recorded pid
+
     createdTmuxSessions.push(
       "s1_coder_task-escalate-intact", "s1_reviewer_task-escalate-intact",
     );
     try {
       await slotResume(1, { startTtyd: false });
-    } catch (err) {
-      // The tmux-adapter's real work may fail under the test harness; that's
-      // not the contract we're asserting. What matters: slotResume did not
-      // reject the escalated-liveness marker and did not throw the
-      // missing-state / recoverable-state errors.
-      const msg = err instanceof Error ? err.message : String(err);
-      expect(msg).not.toContain("no persisted orchestration state");
-      expect(msg).not.toContain("has recoverable orchestration state");
+      // The resume reached the final data.liveness = null write. Without the
+      // escalated-liveness acceptance branch, the resume would have thrown
+      // earlier and this assertion would never run.
+      expect(readSlotJson(1, harness).liveness).toBeNull();
+      expect(startSpy).toHaveBeenCalled();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  test("second slotResume on an already-resumed slot is a no-op (AC5 idempotence)", async () => {
+    // Contract: after a resume has cleared the liveness marker and started a
+    // fresh orchestrator, a redundant `ludics slot N resume` must NOT kill
+    // and restart that orchestrator — doing so churns state and races the
+    // runner's self-guard. We seed a slot whose orchestrator pid is our own
+    // (alive) PID and whose liveness is null, then call slotResume and assert:
+    //   (1) it returns cleanly
+    //   (2) it does NOT invoke startOrchestrationProcess
+    //   (3) the recorded orchestrator pid is unchanged (no terminate+restart)
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const orchDir = join(harness, "orchestration");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(orchDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-resume-idempotent", "Idempotent resume");
+
+    void slotAssign(1, "task-resume-idempotent", "tmux", "", "", "--pair --coder claude --reviewer claude");
+
+    // Seed tmux-slot-1.json with our own (alive) PID. The idempotence guard
+    // checks this via process.kill(pid, 0), so using process.pid is both
+    // simple and portable across platforms.
+    writeFileSync(
+      join(orchDir, "tmux-slot-1.json"),
+      JSON.stringify({
+        orchestration: { pid: process.pid, stateFile: "orch-1.json", mode: "pair" },
+        sessionNames: { coder: "s1_coder_task-resume-idempotent", reviewer: "s1_reviewer_task-resume-idempotent" },
+        ttydPids: {},
+      }),
+    );
+
+    const orchState: OrchestrationState = {
+      slot: 1,
+      taskId: "task-resume-idempotent",
+      mode: "pair",
+      phase: "work",
+      round: 1,
+      mergeRound: 0,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "sonnet", branch: "test-coder", worktreePath: "/tmp/wt-coder" },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "sonnet", branch: "test-reviewer", worktreePath: "/tmp/wt-reviewer" },
+      ],
+      agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+      config: defaultOrchestrationConfig({}),
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+      startedAt: new Date().toISOString(),
+      projectDir: "/tmp/fake-project",
+      rootWorktree: "/tmp/fake-root",
+      peerSyncDir: "/tmp/fake-peersync",
+      threadIds: {},
+      backend: "tmux",
+      slotTitle: "test",
+    };
+    persistState(orchState, harness);
+
+    const orchProcess = await import("../orchestration/process.ts");
+    const startSpy = spyOn(orchProcess, "startOrchestrationProcess")
+      .mockImplementation(async () => { throw new Error("should not have been called"); });
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      // First resume on an already-null/alive slot — must short-circuit.
+      await slotResume(1, { startTtyd: false });
+      expect(startSpy).not.toHaveBeenCalled();
+      const logged = logSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(logged.some((m) => m.includes("already running"))).toBe(true);
+
+      // Orchestrator pid must be unchanged — we did NOT terminate and restart.
+      const state = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
+      expect(state.orchestration.pid).toBe(process.pid);
+
+      // And the liveness must stay null (no stray writes into the slot json).
+      expect(readSlotJson(1, harness).liveness).toBeNull();
+
+      // Second call: still a no-op — proves true idempotence, not just
+      // first-call serendipity.
+      await slotResume(1, { startTtyd: false });
+      expect(startSpy).not.toHaveBeenCalled();
+      const state2 = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
+      expect(state2.orchestration.pid).toBe(process.pid);
+    } finally {
+      startSpy.mockRestore();
+      logSpy.mockRestore();
     }
   });
 });

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -734,6 +734,111 @@ describe("slotResume — interrupted fallback to fresh start", () => {
   });
 });
 
+describe("slotResume — escalated slot handling (task-4cd94043)", () => {
+  // Track tmux sessions created during tests so we can clean them up.
+  const createdTmuxSessions: string[] = [];
+  afterEach(() => {
+    for (const session of createdTmuxSessions) {
+      try { if (tmuxHasSession(session)) tmuxKillSession(session); } catch { /* ignore */ }
+    }
+    createdTmuxSessions.length = 0;
+  });
+
+  test("falls back to slotStart when escalated slot has no orchestration state", async () => {
+    // Symmetric to the interrupted-fallback test: an escalated slot with
+    // missing state should fresh-start rather than throw "no persisted
+    // orchestration state". Normal escalations preserve state and never hit
+    // this branch, but we support the missing-state path for robustness
+    // (mirrors interrupted). After the fallback/resume, liveness must have
+    // been cleared from "escalated" — we can't observe the intermediate path
+    // in-process because slotStart will fail under test tmux, but we verify
+    // the fallback was taken (no "no persisted orchestration state" error).
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-escalate-fallback", "Resume from escalated");
+
+    void slotAssign(1, "task-escalate-fallback", "tmux", "", "", "--pair --coder claude --reviewer claude");
+    // Simulate agent-initiated escalation: runner flipped liveness + left
+    // orchestration state intact (in the realistic path). For this missing-
+    // state variant, clear state explicitly and set liveness to "escalated".
+    const data = readSlotJson(1, harness);
+    data.liveness = "escalated";
+    writeSlotJson(1, data, harness);
+
+    createdTmuxSessions.push(
+      "s1_coder_task-escalate-fallback", "s1_reviewer_task-escalate-fallback",
+    );
+    try {
+      await slotResume(1, { startTtyd: false });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).not.toContain("no persisted orchestration state");
+    }
+  });
+
+  test("escalated slot with intact orch state proceeds through normal resume and clears liveness", async () => {
+    // Realistic path: handleEscalation flipped liveness to "escalated" but
+    // left OrchestrationState on disk. slotResume should NOT throw, should
+    // proceed through the normal resume flow, and should clear liveness back
+    // to null at the end (mirroring the existing interrupted-resume contract).
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const orchDir = join(harness, "orchestration");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(orchDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-escalate-intact", "Resume escalated intact");
+
+    void slotAssign(1, "task-escalate-intact", "tmux", "", "", "--pair --coder claude --reviewer claude");
+    const data = readSlotJson(1, harness);
+    data.liveness = "escalated";
+    writeSlotJson(1, data, harness);
+
+    const orchState: OrchestrationState = {
+      slot: 1,
+      taskId: "task-escalate-intact",
+      mode: "pair",
+      phase: "review",
+      round: 2,
+      mergeRound: 0,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "sonnet", branch: "test-coder", worktreePath: "/tmp/wt-coder" },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "sonnet", branch: "test-reviewer", worktreePath: "/tmp/wt-reviewer" },
+      ],
+      agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+      config: defaultOrchestrationConfig({}),
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+      startedAt: new Date().toISOString(),
+      projectDir: "/tmp/fake-project",
+      rootWorktree: "/tmp/fake-root",
+      peerSyncDir: "/tmp/fake-peersync",
+      threadIds: {},
+      backend: "tmux",
+      slotTitle: "test",
+    };
+    persistState(orchState, harness);
+
+    createdTmuxSessions.push(
+      "s1_coder_task-escalate-intact", "s1_reviewer_task-escalate-intact",
+    );
+    try {
+      await slotResume(1, { startTtyd: false });
+    } catch (err) {
+      // The tmux-adapter's real work may fail under the test harness; that's
+      // not the contract we're asserting. What matters: slotResume did not
+      // reject the escalated-liveness marker and did not throw the
+      // missing-state / recoverable-state errors.
+      const msg = err instanceof Error ? err.message : String(err);
+      expect(msg).not.toContain("no persisted orchestration state");
+      expect(msg).not.toContain("has recoverable orchestration state");
+    }
+  });
+});
+
 describe("slotSetMode — preserve state on mode toggle", () => {
   function makeOrchState(harness: string, slot: number, taskId: string): OrchestrationState {
     const orchDir = join(harness, "orchestration");

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -946,11 +946,18 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
     cancelDeferredCleanup(ctx.taskId, slotNum);
   } catch { /* non-critical */ }
 
+  // Recoverable-from-fresh-start fallback: triggered when the slot was flagged
+  // interrupted (setup failure) or escalated (agent hand-raise) AND persisted
+  // state has gone missing. Normal escalations leave state intact and flow
+  // through the regular resume path; the liveness marker gets cleared to null
+  // at the end of this function just like a normal interrupted-resume.
+  const needsFreshFallback = data.liveness === "interrupted" || data.liveness === "escalated";
+
   // --- t3code-specific: Require persisted slot state ---
   if (ctx.mode === "t3code") {
     const slotState = readSlotState(slotNum, ctx.harnessDir);
     if (!slotState || slotState.threads.length === 0) {
-      if (data.liveness === "interrupted") {
+      if (needsFreshFallback) {
         console.error(`ludics: slot ${slotNum}: no recoverable t3code state — falling back to fresh start`);
         try { removeOrchestrationState(slotNum, ctx.harnessDir); } catch { /* ignore */ }
         await slotStart(slotNum, { startTtyd: shouldStartTtyd });
@@ -965,7 +972,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
   // Require persisted orchestration state (orchestrated sessions only)
   const orchState = readOrchestrationState(slotNum);
   if (!orchState) {
-    if (data.liveness === "interrupted") {
+    if (needsFreshFallback) {
       console.error(`ludics: slot ${slotNum}: no recoverable orchestration state — falling back to fresh start`);
       await slotStart(slotNum, { startTtyd: shouldStartTtyd });
       return;

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -18,6 +18,7 @@ import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
 import { readSlotState, writeSlotState } from "../t3code/server.ts";
+import { readTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { selectOrchestrationFlagsForTask } from "../adapters/t3code.ts";
 import { readOrchestrationState, persistState, removeOrchestrationState } from "../orchestration/state.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
@@ -915,6 +916,34 @@ export async function slotStop(slotNum: number, force: boolean = false, preserve
 }
 
 /**
+ * Read the orchestrator PID for a slot from whichever adapter-side state file
+ * owns it (t3code or tmux) and return it only when the process is actually
+ * alive. Returns `null` when no PID is recorded, the PID is stale/dead, or the
+ * adapter state is missing.
+ *
+ * Used by slotResume's idempotence short-circuit (AC5): when the caller
+ * invokes resume on a slot whose orchestrator is already running, we skip the
+ * terminate-and-restart path instead of churning the runner.
+ */
+function readLiveOrchestratorPid(slotNum: number, mode: string, harness: string): number | null {
+  let pid: number | undefined;
+  if (mode === "t3code") {
+    pid = readSlotState(slotNum, harness)?.orchestration?.pid;
+  } else if (mode === "tmux") {
+    pid = readTmuxSlotState(slotNum, harness)?.orchestration?.pid;
+  } else {
+    return null;
+  }
+  if (pid === undefined || pid <= 0) return null;
+  try {
+    process.kill(pid, 0);
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resume a crashed orchestrated session from persisted state.
  */
 export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd = true }: { startTtyd?: boolean } = {}): Promise<void> {
@@ -994,6 +1023,22 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
   if (orchState.phase === "done") {
     console.log(`Orchestration already completed for slot ${slotNum} (task ${ctx.taskId}).`);
     return;
+  }
+
+  // Idempotence (AC5): if the orchestrator is already live and no liveness
+  // marker needs clearing, a second `ludics slot N resume` is a no-op. Without
+  // this short-circuit we would kill the running runner and start a fresh one
+  // on every redundant invocation — which also races the self-guard and can
+  // leave the slot in a transiently inconsistent state. `liveness === null`
+  // gates the check: if the caller wants to clear "interrupted" or
+  // "escalated", they fall through to the normal terminate-and-restart path
+  // that flips the marker back to null at the end.
+  if (data.liveness === null) {
+    const livePid = readLiveOrchestratorPid(slotNum, ctx.mode, ctx.harnessDir);
+    if (livePid !== null) {
+      console.log(`Slot ${slotNum} orchestrator already running (pid ${livePid}); nothing to resume.`);
+      return;
+    }
   }
 
   // --- t3code-specific: validate server and threads ---

--- a/src/slots/json.test.ts
+++ b/src/slots/json.test.ts
@@ -143,6 +143,55 @@ describe("slotDataToMarkdown round-trip fidelity", () => {
     }
   });
 
+  test("round-trip preserves 'escalated' liveness through markdown migration", () => {
+    // Regression: the SlotLiveness enum narrowing (task-4cd94043) must not
+    // silently collapse "escalated" to null on legacy markdown migration.
+    const original: SlotData = {
+      slot: 1,
+      process: "running",
+      task: "task-xyz",
+      mode: "tmux",
+      session: null,
+      path: null,
+      started: null,
+      adapterArgs: null,
+      machine: null,
+      sessionStarted: null,
+      liveness: "escalated",
+      terminals: "",
+      runtime: "",
+      git: "",
+    };
+
+    const tmp = mkdtempSync(join(tmpdir(), "ludics-rt-esc-"));
+    try {
+      const md = slotDataToMarkdown(original);
+      expect(md).toContain("**Liveness:** escalated");
+      const slotsFile = join(tmp, "slots.md");
+      writeFileSync(slotsFile, md);
+      const parsed = migrateMarkdownToSlotData(slotsFile, 1);
+      expect(parsed.get(1)!.liveness).toBe("escalated");
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  test("migration coerces unknown liveness string to null (forward-compat guard)", async () => {
+    // parseSlotLiveness is the validation boundary: a future release writing
+    // an unknown token (or a hand-edited slots.md) should degrade gracefully
+    // to null rather than land an invalid enum value in runtime state.
+    const { parseSlotLiveness } = await import("./types.ts");
+    expect(parseSlotLiveness("alive")).toBe("alive");
+    expect(parseSlotLiveness("interrupted")).toBe("interrupted");
+    expect(parseSlotLiveness("escalated")).toBe("escalated");
+    expect(parseSlotLiveness("  escalated  ")).toBe("escalated");
+    expect(parseSlotLiveness(null)).toBeNull();
+    expect(parseSlotLiveness(undefined)).toBeNull();
+    expect(parseSlotLiveness("")).toBeNull();
+    expect(parseSlotLiveness("bogus")).toBeNull();
+    expect(parseSlotLiveness(42)).toBeNull();
+  });
+
   test("round-trip preserves trailing spaces in section content", () => {
     const original: SlotData = {
       slot: 1,
@@ -191,7 +240,9 @@ describe("slotDataToMarkdown round-trip fidelity", () => {
       adapterArgs: "ADAPTER_SENTINEL",
       machine: "MACHINE_SENTINEL",
       sessionStarted: "SESSSTART_SENTINEL",
-      liveness: "LIVE_SENTINEL",
+      // `liveness` is a narrow enum (SlotLiveness) — use the real "alive" value
+      // rather than a made-up sentinel so the type still covers this key.
+      liveness: "alive",
       terminals: "TERM_SENTINEL",
       runtime: "RT_SENTINEL",
       git: "GIT_SENTINEL",

--- a/src/slots/migration.ts
+++ b/src/slots/migration.ts
@@ -1,7 +1,7 @@
 // One-time slots.md → JSON migration helper
 
 import { readFileSync } from "fs";
-import type { SlotData } from "./types.ts";
+import { parseSlotLiveness, type SlotData } from "./types.ts";
 import { emptySlotData } from "./json.ts";
 
 function parseSlotBlocks(content: string): Map<number, string> {
@@ -78,7 +78,7 @@ function blockToSlotData(slot: number, block: string): SlotData {
   base.adapterArgs = nullIfEmpty(getField(block, "Adapter Args"));
   base.machine = nullIfEmpty(getField(block, "Machine"));
   base.sessionStarted = nullIfEmpty(getField(block, "Session Started"));
-  base.liveness = nullIfEmpty(getField(block, "Liveness"));
+  base.liveness = parseSlotLiveness(nullIfEmpty(getField(block, "Liveness")));
   base.terminals = extractSection(block, "Terminals");
   base.runtime = extractSection(block, "Runtime");
   base.git = extractSection(block, "Git");

--- a/src/slots/types.ts
+++ b/src/slots/types.ts
@@ -1,5 +1,23 @@
 // Slot data types
 
+/** Canonical slot-liveness enum.
+ *  - `"alive"`:       orchestrator running normally (set from runtime PID checks; rarely persisted).
+ *  - `"interrupted"`: orchestration setup failed, or runtime exited abnormally — needs `slot N resume`.
+ *  - `"escalated"`:   agent wrote `escalate` to its status file (task-4cd94043); user-resumed via `slot N resume`.
+ *  - `null`:          no explicit liveness marker (default, empty, or just-resumed slot). */
+export type SlotLiveness = "alive" | "interrupted" | "escalated" | null;
+
+/** Narrow an untrusted string (legacy markdown migration, HTTP body, etc.)
+ *  to a valid {@link SlotLiveness}. Unknown or empty values collapse to `null`
+ *  — the safest default, since `null` means "no explicit marker" and callers
+ *  that need a stronger signal will re-derive it from runtime state. */
+export function parseSlotLiveness(raw: unknown): SlotLiveness {
+  if (raw === null || raw === undefined) return null;
+  const s = typeof raw === "string" ? raw.trim() : String(raw).trim();
+  if (s === "alive" || s === "interrupted" || s === "escalated") return s;
+  return null;
+}
+
 export interface SlotData {
   slot: number;
   process: string;
@@ -11,7 +29,7 @@ export interface SlotData {
   adapterArgs: string | null;
   machine: string | null;
   sessionStarted: string | null;
-  liveness: string | null;
+  liveness: SlotLiveness;
   terminals: string;
   runtime: string;
   git: string;

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -161,6 +161,14 @@ function renderSlots(slots) {
                     + '<button class="slot-action-btn slot-abandon-btn" onclick="slotActionAbandon(' + i + ')" title="Abandon" aria-label="Abandon">✕</button>'
                     + '<button class="slot-action-btn slot-postpone-btn" onclick="slotActionPostpone(' + i + ')" title="Postpone (decrease priority)" aria-label="Postpone">↓</button>'
                     + '</span>';
+            } else if (slot.liveness === 'escalated') {
+                statusDiv.className = 'slot-status escalated';
+                statusText.innerHTML = 'Escalated <button class="start-slot-btn" onclick="resumeSlot(' + i + ')" title="Resume session">resume</button>'
+                    + ' <span class="slot-action-btns">'
+                    + '<button class="slot-action-btn slot-done-btn" onclick="slotActionDone(' + i + ')" title="Mark done" aria-label="Mark done">✓</button>'
+                    + '<button class="slot-action-btn slot-abandon-btn" onclick="slotActionAbandon(' + i + ')" title="Abandon" aria-label="Abandon">✕</button>'
+                    + '<button class="slot-action-btn slot-postpone-btn" onclick="slotActionPostpone(' + i + ')" title="Postpone (decrease priority)" aria-label="Postpone">↓</button>'
+                    + '</span>';
             } else if (slot.liveness === 'interrupted') {
                 statusDiv.className = 'slot-status interrupted';
                 statusText.innerHTML = 'Interrupted <button class="start-slot-btn" onclick="resumeSlot(' + i + ')" title="Resume session">resume</button>'

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -36,6 +36,7 @@
 
     --empty: #6b6560;
     --interrupted: #f87171;
+    --escalated: #fb923c;
 
     --border: #3a3835;
     --border-hover: #504d4a;
@@ -86,6 +87,7 @@
 
     --empty: #a8a29e;
     --interrupted: #ef4444;
+    --escalated: #ea580c;
 
     --border: #d6d3d1;
     --border-hover: #a8a29e;
@@ -125,6 +127,7 @@
 
     --empty: #606060;
     --interrupted: #ff5555;
+    --escalated: #ff8800;
 
     --border: #1e1e1e;
     --border-hover: #3a3a3a;
@@ -372,6 +375,11 @@ main {
     border-left-color: var(--interrupted);
 }
 
+.slot-tile:has(.slot-status.escalated) {
+    border-left-color: var(--escalated);
+    box-shadow: var(--shadow-md), 0 0 18px rgba(251, 146, 60, 0.35);
+}
+
 .slot-tile:has(.slot-status.assigned) {
     border-left-color: var(--warning);
 }
@@ -478,6 +486,30 @@ main {
 
 .slot-status.interrupted .start-slot-btn:hover {
     background: var(--interrupted);
+    color: var(--bg-primary);
+}
+
+.slot-status.escalated .status-indicator {
+    background-color: var(--escalated);
+    box-shadow: 0 0 8px var(--escalated);
+    animation: pulse-active 1.5s ease-in-out infinite;
+}
+
+.slot-status.escalated .status-text {
+    color: var(--escalated);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+}
+
+.slot-status.escalated .start-slot-btn {
+    border-color: var(--escalated);
+    color: var(--escalated);
+}
+
+.slot-status.escalated .start-slot-btn:hover {
+    background: var(--escalated);
     color: var(--bg-primary);
 }
 
@@ -2298,6 +2330,7 @@ textarea:focus-visible {
         --priority-d: #d6d3d1;
         --empty: #a8a29e;
         --interrupted: #ef4444;
+        --escalated: #ea580c;
         --border: #d6d3d1;
         --border-hover: #a8a29e;
         --border-active: var(--accent);


### PR DESCRIPTION
## Summary

Introduces `bail-out: escalate` — a new agent status token that halts orchestration at the current phase (no discarded work, no phase advance), flags the slot, and notifies Mag/the user via priority-5 `ludics notify outgoing`. Resolution is the existing `ludics slot N resume` command, extended to clear a new `"escalated"` liveness marker the same way it clears `"interrupted"`.

Motivated by gh-ludics-310 (9-round review/work loop before manual stop). Deliberately agent-initiated rather than a round-count guardrail — agents see the content (identical reviews, unchanged coder output, contradictory instructions) faster than any external counter.

## Changes

- `src/orchestration/phases.ts` — new `escalatingAgents()` / `isEscalated()` predicates; `"escalate"` deliberately NOT added to `DONE_STATUSES`.
- `src/orchestration/runner.ts` — `handleEscalation()` helper; `pollUntilDone` short-circuits on `isEscalated`; `runOrchestration` halts with event + priority-5 notification + slot-json flip; returns (not breaks) to preserve phase.
- `src/dashboard.ts` + dashboard.js/css — liveness enum widened to `"alive" | "interrupted" | "escalated" | null`; new tile rendering + CSS theming across three themes.
- `src/slots/index.ts` — `slotResume` accepts `"escalated"` in the fresh-start fallback; intact state flows through normal resume and clears liveness to null.
- `src/mag.ts` — auto-start / auto-unstick skip sets now skip `"escalated"` as well as `"interrupted"`.
- `skills/orchestration/pair-coder-work.md`, `pair-reviewer-review.md`, `solo-work.md` — one-paragraph mention + printf form, cross-linking the pattern doc.
- `docs/orchestration-patterns.md` — new `### Escalation contract` section sibling to `### Bail-out contract`.
- Tests: +6 in `phases.test.ts`, new `runner.escalation.test.ts` (4), +2 in `slots/index.test.ts`, +2 in `dashboard.test.ts`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun test` — 1366 pass / 0 fail
- [ ] Manual: write `escalate|<epoch>|test` to `<agent>.status` on a running slot and verify halt + notification + resume flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)