### PR TITLE
Add writeJsonFileCompact helper and migrate ad-hoc JSON writers

### DIFF
--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -3,7 +3,7 @@
 
 import { existsSync, mkdirSync, readFileSync, unlinkSync } from "fs";
 import { join, resolve } from "path";
-import { atomicWriteFileSync } from "../json.ts";
+import { writeJsonFile } from "../json.ts";
 import { getMainRepoFromWorktree, latestMtime, resolveProjectDir, slotSessionName } from "./base.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import { MarkdownBuilder } from "./markdown.ts";
@@ -76,7 +76,7 @@ function writeTmuxSlotState(state: TmuxSlotState, harnessDir: string): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  atomicWriteFileSync(path, JSON.stringify(state, null, 2));
+  writeJsonFile(path, state);
 }
 
 function removeTmuxSlotState(slot: number, harnessDir: string): void {

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -4,7 +4,7 @@
 // Client helper is used by slots, cluster, and worker-signal modules.
 
 import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync, appendFileSync } from "fs";
-import { atomicWriteFileSync, writeJsonFile } from "./json.ts";
+import { writeJsonFile, writeJsonFileCompact } from "./json.ts";
 import { join } from "path";
 import { harnessDir, loadConfigSync, slotsCount, stateRepoDir } from "./config.ts";
 import { readSlotJson, writeSlotJson, readAllSlotJson, slotDataToMarkdown } from "./slots/json.ts";
@@ -157,7 +157,7 @@ function intentFilePath(slot: number): string {
 export function recordIntent(slot: number, intent: PendingIntent): void {
   const dir = intentsDir();
   mkdirSync(dir, { recursive: true });
-  atomicWriteFileSync(intentFilePath(slot), JSON.stringify(intent) + "\n");
+  writeJsonFileCompact(intentFilePath(slot), intent);
 }
 
 export function clearIntent(slot: number): void {

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -192,8 +192,8 @@ describe("saveTestHealthState atomic write", () => {
       expect(mod.loadTestHealthState()).toEqual(state);
       const path = mod.testHealthStatePath();
       expect(existsSync(path + ".tmp")).toBe(false);
-      // Byte-exactness: no added trailing newline
-      expect(readFileSync(path, "utf-8")).toBe(JSON.stringify(state, null, 2));
+      // Byte-exactness: pretty-printed with one trailing newline (writeJsonFile shape)
+      expect(readFileSync(path, "utf-8")).toBe(JSON.stringify(state, null, 2) + "\n");
     } finally {
       if (ORIGINAL === undefined) delete process.env.LUDICS_HARNESS_DIR;
       else process.env.LUDICS_HARNESS_DIR = ORIGINAL;

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, mkdirSync } from "fs";
-import { atomicWriteFileSync } from "./json.ts";
+import { writeJsonFile } from "./json.ts";
 import { join } from "path";
 import { type ProjectConfig, loadConfigSync, harnessDir, resolveProjectPath } from "./config.ts";
 import { tasksCreate } from "./tasks/index.ts";
@@ -87,7 +87,7 @@ export function loadTestHealthState(): TestHealthState {
 export function saveTestHealthState(state: TestHealthState): void {
   const dir = join(harnessDir(), "mag");
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  atomicWriteFileSync(testHealthStatePath(), JSON.stringify(state, null, 2));
+  writeJsonFile(testHealthStatePath(), state);
 }
 
 // --- Execution ---

--- a/src/json.test.ts
+++ b/src/json.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { atomicWriteFileSync, readJsonFile, writeJsonFile } from "./json.ts";
+import { atomicWriteFileSync, readJsonFile, writeJsonFile, writeJsonFileCompact } from "./json.ts";
 
 describe("readJsonFile", () => {
   function withTmpFile(content: string): string {
@@ -107,6 +107,36 @@ describe("writeJsonFile", () => {
     const value = { key: "value", num: 42 };
     writeJsonFile(file, value);
     expect(readJsonFile<typeof value>(file)).toEqual(value);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("writeJsonFileCompact", () => {
+  test("produces JSON.stringify(x) + trailing newline (no indentation)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "write-json-compact-"));
+    const file = join(dir, "out.json");
+    const value = { a: 1, b: "two" };
+    writeJsonFileCompact(file, value);
+    expect(readFileSync(file, "utf-8")).toBe(JSON.stringify(value) + "\n");
+    expect(existsSync(`${file}.tmp`)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("round-trips through readJsonFile", () => {
+    const dir = mkdtempSync(join(tmpdir(), "write-json-compact-"));
+    const file = join(dir, "out.json");
+    const value = { key: "value", num: 42 };
+    writeJsonFileCompact(file, value);
+    expect(readJsonFile<typeof value>(file)).toEqual(value);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("auto-creates a missing parent directory", () => {
+    const dir = mkdtempSync(join(tmpdir(), "write-json-compact-"));
+    const file = join(dir, "nested", "deeper", "out.json");
+    const value = { deep: true };
+    writeJsonFileCompact(file, value);
+    expect(readFileSync(file, "utf-8")).toBe(JSON.stringify(value) + "\n");
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/json.ts
+++ b/src/json.ts
@@ -45,3 +45,7 @@ export function atomicWriteFileSync(path: string, content: string): void {
 export function writeJsonFile(path: string, value: unknown): void {
   atomicWriteFileSync(path, JSON.stringify(value, null, 2) + "\n");
 }
+
+export function writeJsonFileCompact(path: string, value: unknown): void {
+  atomicWriteFileSync(path, JSON.stringify(value) + "\n");
+}

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, appendFileSync, writeFileSync, mkdirSync, statSync, readdirSync, unlinkSync } from "fs";
 import { basename, join, resolve } from "path";
 import { loadConfigSync, harnessDir, slotsCount } from "./config.ts";
-import { atomicWriteFileSync, isPlainObject, writeJsonFile } from "./json.ts";
+import { isPlainObject, writeJsonFile, writeJsonFileCompact } from "./json.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { queueRequest } from "./queue.ts";
 import { emitEvent } from "./events.ts";
@@ -659,7 +659,7 @@ export function saveSubscriberState(lastId: string): void {
   const file = subscriberStateFile();
   mkdirSync(join(harnessDir(), "mag"), { recursive: true });
   const state = { last_id: lastId, last_time: new Date().toISOString().replace(/\.\d{3}Z$/, "Z") };
-  atomicWriteFileSync(file, JSON.stringify(state) + "\n");
+  writeJsonFileCompact(file, state);
 }
 
 // --- Pending-revise mode ---
@@ -691,7 +691,7 @@ export function setPendingFollowupRevise(taskId: string, adapter: string): void 
     adapter,
     created: Math.floor(Date.now() / 1000),
   };
-  atomicWriteFileSync(file, JSON.stringify(payload) + "\n");
+  writeJsonFileCompact(file, payload);
   console.log(`ludics: armed followup revise mode for ${taskId} (${adapter}) — waiting for feedback message`);
 }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync, rea
 import { join, dirname } from "path";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
-import { atomicWriteFileSync, isPlainObject } from "./json.ts";
+import { atomicWriteFileSync, isPlainObject, writeJsonFileCompact } from "./json.ts";
 
 function queueFile(): string {
   return join(harnessDir(), "mag", "queue.jsonl");
@@ -337,6 +337,6 @@ export function writeResult(requestId: string, status: string, outputFile?: stri
   if (outputFile && existsSync(outputFile)) {
     result.output = readFileSync(outputFile, "utf-8");
   }
-  atomicWriteFileSync(resultFile, JSON.stringify(result) + "\n");
+  writeJsonFileCompact(resultFile, result);
   emitEvent({ event_type: "queue_result", source: "mag", scope: "queue", status, message: requestId });
 }

--- a/src/retrospective.test.ts
+++ b/src/retrospective.test.ts
@@ -188,8 +188,8 @@ describe("writeRetrospective atomic write", () => {
       const parsed = JSON.parse(readFileSync(file, "utf-8"));
       expect(parsed.taskId).toBe("task-atomic-retro");
       expect(parsed.phases).toEqual(["setup", "plan", "implement"]);
-      // Byte-exactness: no added trailing newline
-      expect(readFileSync(file, "utf-8")).toBe(JSON.stringify(data, null, 2));
+      // Byte-exactness: pretty-printed with one trailing newline (writeJsonFile shape)
+      expect(readFileSync(file, "utf-8")).toBe(JSON.stringify(data, null, 2) + "\n");
     } finally {
       if (ORIGINAL === undefined) delete process.env.LUDICS_HARNESS_DIR;
       else process.env.LUDICS_HARNESS_DIR = ORIGINAL;

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -2,7 +2,7 @@
 // threads at task completion, write to retrospectives/<task-id>.json.
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from "fs";
-import { atomicWriteFileSync } from "./json.ts";
+import { writeJsonFile } from "./json.ts";
 import { join } from "path";
 import YAML from "yaml";
 import { harnessDir } from "./config.ts";
@@ -410,7 +410,7 @@ function readTaskFrontmatter(taskId: string): TaskFrontmatter | null {
 export function writeRetrospective(data: RetrospectiveData): void {
   const dir = join(harnessDir(), "retrospectives");
   mkdirSync(dir, { recursive: true });
-  atomicWriteFileSync(join(dir, `${data.taskId}.json`), JSON.stringify(data, null, 2));
+  writeJsonFile(join(dir, `${data.taskId}.json`), data);
 
   emitEvent({
     event_type: "retrospective_written",


### PR DESCRIPTION
## Summary

Follow-up from gh-ludics-303 retrospective (coder's `suggestRefactorSummary` item 3): ship `writeJsonFileCompact(path, value)` alongside the existing `writeJsonFile` in `src/json.ts` so callers pick pretty-vs-compact explicitly rather than using `atomicWriteFileSync(path, JSON.stringify(...) + "\n")` ad-hoc. Migrates the seven call sites currently bypassing the named helpers (four compact, three pretty) to the canonical helpers, eliminating the "three-shape" anomaly.

- `writeJsonFileCompact(path, value)` in `src/json.ts` — emits `JSON.stringify(value) + "\n"` via `atomicWriteFileSync`; mirrors `writeJsonFile` with compact instead of pretty output.
- 4 compact-with-newline sites migrated byte-identically: `saveSubscriberState` + `setPendingFollowupRevise` (notify.ts), `writeResult` (queue.ts), `recordIntent` (cluster-http.ts).
- 3 pretty-without-newline sites migrated to `writeJsonFile`, gaining one trailing newline byte per file: `writeRetrospective` (retrospective.ts), `saveTestHealthState` (health.ts), tmux-slot state writer (adapters/tmux-adapter.ts). All downstream consumers `JSON.parse` these files, so the delta is invisible.
- Two byte-exactness test assertions (`src/health.test.ts:196`, `src/retrospective.test.ts:192`) updated to expect the `+ "\n"` form.

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun test` — 1356 pass / 0 fail across 67 files (includes new `describe("writeJsonFileCompact", ...)` block with exact-bytes, round-trip, and parent-dir auto-creation tests)
- [x] `bun run build && ./bin/ludics init --no-triggers` — completes successfully
- [x] Proposal scope (`docs/proposals/write-json-file-compact.md`) — all 7 target sites migrated; no other `atomicWriteFileSync + JSON.stringify` sites remain outside `src/json.ts` itself

Closes task-d6c774b8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)