### PR TITLE
feat(dashboard): promote and edit/cancel buttons on pending Mag queue items

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ ludics mag analyze <issue>   # Analyze GitHub issue
 ludics mag elaborate <id>    # Elaborate task into detailed spec
 ludics mag health-check      # Check for deadlines, issues
 ludics mag queue             # Show pending requests
+ludics mag queue pop one     # Atomic dequeue of one request
+ludics mag queue pop all     # Atomic dequeue of all requests
+ludics mag queue promote <id> # Move a pending request to the head of the queue
+ludics mag queue cancel <id>  # Remove a pending request (prints the JSON line)
 ```
 
 ### Using skills directly

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1152,6 +1152,8 @@ ludics mag message "text"      # Send async message to Mag
 ludics mag queue               # Show pending queue requests
 ludics mag queue pop one       # Atomic dequeue of one request
 ludics mag queue pop all       # Atomic dequeue of all requests
+ludics mag queue promote <id>  # Move pending request to head of queue
+ludics mag queue cancel <id>   # Remove pending request (prints the JSON line)
 ludics mag context             # Pre-compute briefing context file
 ludics auto-start-evaluate <id> [confidence] [rationale...]  # Evaluate auto-start decision
 

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -14,7 +14,7 @@ import { updateFrontmatterField, addFrontmatterField, readFrontmatterField, TASK
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
 import { setQueueHold, maybeFeedMagQueue } from "./mag.ts";
-import { queueList, queueRequest, recentResults } from "./queue.ts";
+import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
 import { handleClusterRequest } from "./cluster-http.ts";
 
 const MIME_TYPES: Record<string, string> = {
@@ -28,11 +28,13 @@ const MIME_TYPES: Record<string, string> = {
   ".ico": "image/x-icon",
 };
 
+const QUEUE_ID_RE = /^req-\d+-\d+$/;
+
 export function startDashboardServer(
   port: number,
   dashboardDir: string,
   ttlSeconds: number,
-): void {
+): ReturnType<typeof Bun.serve> {
   // Normalize to absolute path with trailing separator for safe startsWith checks
   const resolvedRoot = resolve(dashboardDir) + "/";
   const tasksRoot = resolve(dashboardDir, "..", "tasks") + "/";
@@ -456,6 +458,51 @@ export function startDashboardServer(
         }
       }
 
+      // API: promote a pending queue item to the head
+      if (pathname === "/api/queue-promote" && req.method === "POST") {
+        const idParam = url.searchParams.get("id");
+        if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+          return new Response("Bad Request: invalid queue id", { status: 400 });
+        }
+        try {
+          const status = queuePromoteToTop(idParam);
+          lastGenerated = 0;
+          return new Response(JSON.stringify({ status }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        } catch (e) {
+          return new Response(String(e), { status: 500 });
+        }
+      }
+
+      // API: cancel (remove) a pending queue item; return its payload for composer hydration
+      if (pathname === "/api/queue-cancel" && req.method === "POST") {
+        const idParam = url.searchParams.get("id");
+        if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+          return new Response("Bad Request: invalid queue id", { status: 400 });
+        }
+        try {
+          const result = queueCancel(idParam);
+          lastGenerated = 0;
+          if (result.status === "not-found") {
+            return new Response(JSON.stringify({ status: "not-found" }), {
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          const request = result.request;
+          const content = typeof request.content === "string" ? request.content : null;
+          const action = typeof request.action === "string" ? request.action : "unknown";
+          const task = typeof request.task === "string" ? request.task : undefined;
+          const body: Record<string, unknown> = { status: "cancelled", content, action };
+          if (task !== undefined) body.task = task;
+          return new Response(JSON.stringify(body), {
+            headers: { "Content-Type": "application/json" },
+          });
+        } catch (e) {
+          return new Response(String(e), { status: 500 });
+        }
+      }
+
       // API: list queue items and recent results
       if (pathname === "/api/queue") {
         try {
@@ -614,4 +661,5 @@ export function startDashboardServer(
   console.error(`ludics: dashboard server listening on http://localhost:${server.port}`);
   console.error(`ludics: data regenerates lazily (TTL: ${ttlSeconds}s)`);
   console.error("ludics: press Ctrl+C to stop");
+  return server;
 }

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -604,3 +604,149 @@ describe("slots.json field shape", () => {
 // Note: /api/slot-resume follows the exact same pattern as /api/slot-start
 // (validate slot 1-6, spawnSync `ludics slot N resume`, return OK/error).
 // slotResume() itself is already tested in src/slots/index.test.ts.
+
+describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
+  async function startServer(): Promise<{ baseUrl: string; stop: () => void }> {
+    const { startDashboardServer } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    // Silence boot logging + lazy-regeneration complaints
+    const origErr = console.error;
+    console.error = () => {};
+    let server: ReturnType<typeof startDashboardServer>;
+    try {
+      server = startDashboardServer(0, dashboardDir, 3600);
+    } finally {
+      console.error = origErr;
+    }
+    return {
+      baseUrl: `http://localhost:${server.port}`,
+      stop: () => { void server.stop(true); },
+    };
+  }
+
+  test("POST /api/queue-promote moves target to head and returns 'promoted'", async () => {
+    const { queueRequest, queueList } = await import("./queue.ts");
+    const idA = queueRequest({ action: "briefing" });
+    const idB = queueRequest({ action: "briefing" });
+    const idC = queueRequest({ action: "briefing" });
+    expect(queueList().map(i => i.id)).toEqual([idA, idB, idC]);
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-promote?id=${encodeURIComponent(idC)}`, { method: "POST" });
+      expect(resp.status).toBe(200);
+      expect(resp.headers.get("content-type")).toContain("application/json");
+      const body = await resp.json() as { status: string };
+      expect(body.status).toBe("promoted");
+    } finally {
+      stop();
+    }
+    expect(queueList().map(i => i.id)).toEqual([idC, idA, idB]);
+  });
+
+  test("POST /api/queue-promote returns 'already-head' without mutating", async () => {
+    const { queueRequest, queueList } = await import("./queue.ts");
+    const idA = queueRequest({ action: "briefing" });
+    const idB = queueRequest({ action: "briefing" });
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-promote?id=${encodeURIComponent(idA)}`, { method: "POST" });
+      const body = await resp.json() as { status: string };
+      expect(body.status).toBe("already-head");
+    } finally {
+      stop();
+    }
+    expect(queueList().map(i => i.id)).toEqual([idA, idB]);
+  });
+
+  test("POST /api/queue-promote returns 'not-found' for unknown id", async () => {
+    const { queueRequest } = await import("./queue.ts");
+    queueRequest({ action: "briefing" });
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-promote?id=req-0-0`, { method: "POST" });
+      expect(resp.status).toBe(200);
+      const body = await resp.json() as { status: string };
+      expect(body.status).toBe("not-found");
+    } finally {
+      stop();
+    }
+  });
+
+  test("POST /api/queue-promote rejects malformed id with 400", async () => {
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-promote?id=not-a-queue-id`, { method: "POST" });
+      expect(resp.status).toBe(400);
+    } finally {
+      stop();
+    }
+  });
+
+  test("POST /api/queue-cancel removes item and returns content for message actions", async () => {
+    const { queueRequest, queueList } = await import("./queue.ts");
+    const idA = queueRequest({ action: "message", content: "please recycle me" });
+    const idB = queueRequest({ action: "briefing" });
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
+      expect(resp.status).toBe(200);
+      const body = await resp.json() as { status: string; content: string | null; action: string; task?: string };
+      expect(body.status).toBe("cancelled");
+      expect(body.content).toBe("please recycle me");
+      expect(body.action).toBe("message");
+      expect(body.task).toBeUndefined();
+    } finally {
+      stop();
+    }
+    expect(queueList().map(i => i.id)).toEqual([idB]);
+  });
+
+  test("POST /api/queue-cancel returns null content for non-message actions and includes task field", async () => {
+    const { queueRequest } = await import("./queue.ts");
+    const idA = queueRequest({ action: "elaborate", task: "task-abc" });
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
+      const body = await resp.json() as { status: string; content: string | null; action: string; task?: string };
+      expect(body.status).toBe("cancelled");
+      expect(body.content).toBeNull();
+      expect(body.action).toBe("elaborate");
+      expect(body.task).toBe("task-abc");
+    } finally {
+      stop();
+    }
+  });
+
+  test("POST /api/queue-cancel returns 'not-found' for unknown id without mutating queue", async () => {
+    const { queueRequest, queueList } = await import("./queue.ts");
+    const idA = queueRequest({ action: "briefing" });
+
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=req-0-0`, { method: "POST" });
+      expect(resp.status).toBe(200);
+      const body = await resp.json() as { status: string };
+      expect(body.status).toBe("not-found");
+    } finally {
+      stop();
+    }
+    expect(queueList().map(i => i.id)).toEqual([idA]);
+  });
+
+  test("POST /api/queue-cancel rejects malformed id with 400", async () => {
+    const { baseUrl, stop } = await startServer();
+    try {
+      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=`, { method: "POST" });
+      expect(resp.status).toBe(400);
+    } finally {
+      stop();
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,8 @@ Commands:
   mag queue                    Show pending queue requests
   mag queue pop one            Pop and print first queue item (JSONL)
   mag queue pop all            Pop and print all queue items (JSONL)
+  mag queue promote <id>       Move a pending queue item to the head
+  mag queue cancel <id>        Remove a pending queue item (prints the JSON line)
   mag context                  Pre-compute briefing context file
 
   notify outgoing <msg>        Send notification to user

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3420,11 +3420,35 @@ export async function runMag(args: string[]): Promise<void> {
         } else {
           throw new Error(`unknown queue pop mode: ${mode ?? "(missing)"} (use: one, all)`);
         }
+      } else if (sub2 === "promote") {
+        const id = args[2];
+        if (!id) throw new Error("id required (usage: mag queue promote <id>)");
+        if (args.length > 3) {
+          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue promote <id>)`);
+        }
+        const { queuePromoteToTop } = await import("./queue.ts");
+        const result = queuePromoteToTop(id);
+        if (result === "not-found") process.exitCode = 1;
+        console.log(result);
+      } else if (sub2 === "cancel") {
+        const id = args[2];
+        if (!id) throw new Error("id required (usage: mag queue cancel <id>)");
+        if (args.length > 3) {
+          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue cancel <id>)`);
+        }
+        const { queueCancel } = await import("./queue.ts");
+        const result = queueCancel(id);
+        if (result.status === "not-found") {
+          process.exitCode = 1;
+          console.log("not-found");
+        } else {
+          console.log(result.line);
+        }
       } else if (!sub2) {
         const { queueShow } = await import("./queue.ts");
         queueShow();
       } else {
-        throw new Error(`unknown queue subcommand: ${sub2} (use: pop one, pop all)`);
+        throw new Error(`unknown queue subcommand: ${sub2} (use: pop one, pop all, promote <id>, cancel <id>)`);
       }
       break;
     }

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -606,6 +606,123 @@ describe("queueRequest holds the queue lock", () => {
   });
 });
 
+describe("queuePromoteToTop", () => {
+  test("returns not-found for empty queue", async () => {
+    const { queuePromoteToTop } = await loadQueue();
+    expect(queuePromoteToTop("req-1-1")).toBe("not-found");
+  });
+
+  test("returns not-found for unknown id", async () => {
+    const { queueRequest, queuePromoteToTop } = await loadQueue();
+    queueRequest({ action: "briefing" });
+    expect(queuePromoteToTop("req-never-1")).toBe("not-found");
+  });
+
+  test("returns already-head when target is already at index 0", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"req-1-1","action":"briefing"}\n{"id":"req-2-2","action":"briefing"}\n');
+    const { queuePromoteToTop } = await loadQueue();
+    expect(queuePromoteToTop("req-1-1")).toBe("already-head");
+    expect(readFileSync(qf, "utf-8")).toBe('{"id":"req-1-1","action":"briefing"}\n{"id":"req-2-2","action":"briefing"}\n');
+  });
+
+  test("promotes middle item to head, preserves relative order", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf,
+      '{"id":"req-a","action":"briefing"}\n' +
+      '{"id":"req-b","action":"briefing"}\n' +
+      '{"id":"req-c","action":"briefing"}\n',
+    );
+    const { queuePromoteToTop, queueList } = await loadQueue();
+    expect(queuePromoteToTop("req-b")).toBe("promoted");
+    const items = queueList();
+    expect(items.map(i => i.id)).toEqual(["req-b", "req-a", "req-c"]);
+  });
+
+  test("promotes tail item to head", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf,
+      '{"id":"req-a","action":"briefing"}\n' +
+      '{"id":"req-b","action":"briefing"}\n' +
+      '{"id":"req-c","action":"briefing"}\n',
+    );
+    const { queuePromoteToTop, queueList } = await loadQueue();
+    expect(queuePromoteToTop("req-c")).toBe("promoted");
+    const items = queueList();
+    expect(items.map(i => i.id)).toEqual(["req-c", "req-a", "req-b"]);
+  });
+
+  test("releases lock after mutation", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"req-a"}\n{"id":"req-b"}\n');
+    const { queuePromoteToTop } = await loadQueue();
+    queuePromoteToTop("req-b");
+    expect(existsSync(qf + ".lock")).toBe(false);
+  });
+});
+
+describe("queueCancel", () => {
+  test("returns not-found for empty queue", async () => {
+    const { queueCancel } = await loadQueue();
+    expect(queueCancel("req-1-1")).toEqual({ status: "not-found" });
+  });
+
+  test("returns not-found for unknown id", async () => {
+    const { queueRequest, queueCancel } = await loadQueue();
+    queueRequest({ action: "briefing" });
+    expect(queueCancel("req-never-1")).toEqual({ status: "not-found" });
+  });
+
+  test("removes targeted item and returns its parsed record + raw line", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf,
+      '{"id":"req-a","action":"message","content":"hello"}\n' +
+      '{"id":"req-b","action":"briefing"}\n',
+    );
+    const { queueCancel, queueList } = await loadQueue();
+    const res = queueCancel("req-a");
+    expect(res.status).toBe("cancelled");
+    if (res.status === "cancelled") {
+      expect(res.line).toBe('{"id":"req-a","action":"message","content":"hello"}');
+      expect(res.request).toEqual({ id: "req-a", action: "message", content: "hello" });
+    }
+    const items = queueList();
+    expect(items.map(i => i.id)).toEqual(["req-b"]);
+  });
+
+  test("removes last item leaving empty queue file", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"req-a","action":"briefing"}\n');
+    const { queueCancel } = await loadQueue();
+    expect(queueCancel("req-a").status).toBe("cancelled");
+    expect(readFileSync(qf, "utf-8")).toBe("");
+  });
+
+  test("releases lock after mutation", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf, '{"id":"req-a"}\n{"id":"req-b"}\n');
+    const { queueCancel } = await loadQueue();
+    queueCancel("req-a");
+    expect(existsSync(qf + ".lock")).toBe(false);
+  });
+
+  test("round-trip: cancelled line can be reinserted via queueReinsertHead", async () => {
+    const qf = join(tmpDir, "mag", "queue.jsonl");
+    writeFileSync(qf,
+      '{"id":"req-a","action":"message","content":"recycle me"}\n' +
+      '{"id":"req-b","action":"briefing"}\n',
+    );
+    const { queueCancel, queueReinsertHead, queueList } = await loadQueue();
+    const res = queueCancel("req-a");
+    expect(res.status).toBe("cancelled");
+    if (res.status !== "cancelled") throw new Error("expected cancelled");
+    queueReinsertHead(res.line);
+    const items = queueList();
+    expect(items.map(i => i.id)).toEqual(["req-a", "req-b"]);
+    expect(items[0]!.content).toBe("recycle me");
+  });
+});
+
 describe("queuePopExpected", () => {
   test("returns empty for missing queue file", async () => {
     const { queuePopExpected } = await loadQueue();

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -203,6 +203,52 @@ export function queuePopAll(): string[] {
   return lines;
 }
 
+export type QueuePromoteResult = "promoted" | "already-head" | "not-found";
+
+function findLineIndexById(lines: string[], id: string): number {
+  return lines.findIndex(line => {
+    const rec = parseJsonRecord(line);
+    return rec !== null && rec.id === id;
+  });
+}
+
+export function queuePromoteToTop(id: string): QueuePromoteResult {
+  const result = withQueueLock<QueuePromoteResult>(() => {
+    const lines = readQueueLines();
+    const idx = findLineIndexById(lines, id);
+    if (idx < 0) return "not-found";
+    if (idx === 0) return "already-head";
+    const [promoted] = lines.splice(idx, 1);
+    writeQueueLines([promoted!, ...lines]);
+    return "promoted";
+  });
+  if (result === "promoted") {
+    emitEvent({ event_type: "queue_mutate", source: "cli", scope: "queue", action: "promote", message: id });
+  }
+  return result;
+}
+
+export type QueueCancelResult =
+  | { status: "cancelled"; line: string; request: Record<string, unknown> }
+  | { status: "not-found" };
+
+export function queueCancel(id: string): QueueCancelResult {
+  const result = withQueueLock<QueueCancelResult>(() => {
+    const lines = readQueueLines();
+    const idx = findLineIndexById(lines, id);
+    if (idx < 0) return { status: "not-found" };
+    const [removed] = lines.splice(idx, 1);
+    const request = parseJsonRecord(removed!);
+    writeQueueLines(lines);
+    // parseJsonRecord returned non-null above (findLineIndexById matched on rec.id)
+    return { status: "cancelled", line: removed!, request: request! };
+  });
+  if (result.status === "cancelled") {
+    emitEvent({ event_type: "queue_mutate", source: "cli", scope: "queue", action: "cancel", message: id });
+  }
+  return result;
+}
+
 export type QueueDequeueResult =
   | { status: "empty" }
   | { status: "mismatch" }

--- a/templates/dashboard/mag.html
+++ b/templates/dashboard/mag.html
@@ -128,7 +128,12 @@
                     const task = item.task ? ` <span>${escapeHtml(String(item.task))}</span>` : '';
                     const content = item.content ? `<div>${escapeHtml(String(item.content).slice(0, 120))}</div>` : '';
                     const ts = item.timestamp ? `<div class="timestamp">${escapeHtml(String(item.timestamp))}</div>` : '';
-                    html += `<div class="mag-queue-item"><span class="action">[${action}]</span>${task}${content}${ts}</div>`;
+                    const id = item.id ? escapeHtml(String(item.id)) : '';
+                    const actions = id ? `<div class="mag-queue-actions">` +
+                        `<button type="button" class="mag-queue-action promote" title="Move to top" data-queue-id="${id}" onclick="promoteQueueItem('${id}')">↑</button>` +
+                        `<button type="button" class="mag-queue-action edit-cancel" title="Edit / cancel" data-queue-id="${id}" onclick="editCancelQueueItem('${id}')">✎✖</button>` +
+                        `</div>` : '';
+                    html += `<div class="mag-queue-item"><span class="action">[${action}]</span>${task}${content}${ts}${actions}</div>`;
                 }
             }
 
@@ -169,6 +174,36 @@
             }
 
             list.innerHTML = html;
+        }
+
+        async function promoteQueueItem(id) {
+            try {
+                await fetch('/api/queue-promote?id=' + encodeURIComponent(id), { method: 'POST' });
+            } catch {
+                // Silently skip — next poll will reconverge
+            }
+            fetchQueue();
+        }
+
+        async function editCancelQueueItem(id) {
+            try {
+                const response = await fetch('/api/queue-cancel?id=' + encodeURIComponent(id), { method: 'POST' });
+                if (response.ok) {
+                    const body = await response.json();
+                    if (body.status === 'cancelled' && typeof body.content === 'string' && body.content.length > 0) {
+                        const ta = document.getElementById('queue-message');
+                        if (ta) {
+                            const existing = ta.value;
+                            const sep = existing && existing.trim() ? '\n\n' : '';
+                            ta.value = existing + sep + body.content;
+                            ta.focus();
+                        }
+                    }
+                }
+            } catch {
+                // Silently skip — next poll will reconverge
+            }
+            fetchQueue();
         }
 
         async function sendMessage() {

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -2134,6 +2134,33 @@ footer a:hover {
 .mag-queue-item .action { font-weight: 600; }
 .mag-queue-item .timestamp { color: var(--text-muted); font-size: 0.72rem; }
 
+.mag-queue-actions {
+    display: inline-flex;
+    gap: 4px;
+    margin-left: 6px;
+    vertical-align: middle;
+}
+
+.mag-queue-action {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    line-height: 1;
+    padding: 2px 6px;
+    background: var(--bg-input);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.mag-queue-action:hover {
+    background: var(--accent-dim);
+    border-color: var(--accent);
+}
+
+.mag-queue-action:disabled { opacity: 0.5; cursor: not-allowed; }
+
 .mag-queue-empty {
     color: var(--text-muted);
     font-style: italic;


### PR DESCRIPTION
## Summary

- Adds `↑` (promote-to-top) and `✎✖` (edit/cancel) buttons to each pending row in the Mag tab's queue list. Cancel dequeues the item and appends its content to the composer textarea (blank-line separator only when both sides are non-empty; non-message actions leave the textarea unchanged).
- New library helpers `queuePromoteToTop(id)` and `queueCancel(id)` in `src/queue.ts`, both wrapping their read-modify-write in `withQueueLock` so they race safely with the stop-hook pop path.
- New endpoints `POST /api/queue-promote?id=<req-id>` and `POST /api/queue-cancel?id=<req-id>` mirroring the existing task-action endpoint shape (validated with `QUEUE_ID_RE`, 400 on bad id, `lastGenerated = 0` bump).
- CLI parity: `ludics mag queue promote <id>` / `ludics mag queue cancel <id>` — `cancel` prints the removed JSON line (or `not-found` with `process.exitCode = 1`).
- `startDashboardServer` now returns the `Bun.serve` instance so integration tests can stop it cleanly.

Task: task-cf3ef9f1 — proposal at `docs/proposals/mag-queue-promote-and-edit-cancel.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 1397 pass / 0 fail
- [x] `bun run build` — standalone binary compiles
- [x] `bun run lint` + `lint:contracts` + `lint:cli-readme` + `lint:config-reference` + `lint:template-safety`
- [ ] Manual smoke-test: open Mag tab, enqueue several requests, promote a middle item, edit/cancel a `message` action (content hydrates composer), edit/cancel an `elaborate` action (textarea unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)