### PR TITLE
feat(health-check): gate execution on events.jsonl activity delta

### DIFF
--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -25,6 +25,18 @@ This skill is invoked when:
 <!-- section:process -->
 ## Process
 
+<!-- section:capture-events-baseline -->
+0. **Capture events baseline** (run before step 1):
+   - Record the current line count of `journal/events.jsonl` so the next
+     gate tick can compare against what this run actually saw:
+     ```bash
+     EVENTS_LINES=$(wc -l < "$LUDICS_STATE_PATH/journal/events.jsonl" 2>/dev/null || echo 0)
+     EVENTS_LINES=${EVENTS_LINES// /}
+     ```
+   - Capture this at the *start* of the run, not the end — events this
+     check itself emits must not inflate the anchor.
+   - The value is persisted in step 10 as `eventsJsonlLines`.
+
 <!-- section:check-deadlines -->
 1. **Check approaching deadlines**:
    - Find tasks with `deadline` field
@@ -128,6 +140,17 @@ This skill is invoked when:
 10. **Persist snapshot**:
    - Write current finding keys/severities/timestamp to
      `$LUDICS_STATE_PATH/mag/health-last.json`
+   - Also write `eventsJsonlLines` with the `$EVENTS_LINES` value captured
+     at step 0. This is the gate anchor the next tick reads — skipping it
+     or writing the end-of-run count would break activity-volume gating.
+     Example payload:
+     ```json
+     {
+       "timestamp": "2026-04-24T12:00:00Z",
+       "eventsJsonlLines": 12345,
+       "findings": [ ... ]
+     }
+     ```
 
 <!-- section:output-format -->
 ## Output Format

--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -27,15 +27,24 @@ This skill is invoked when:
 
 <!-- section:capture-events-baseline -->
 0. **Capture events baseline** (run before step 1):
-   - Record the current line count of `journal/events.jsonl` so the next
-     gate tick can compare against what this run actually saw:
+   - Record the current *gate-eligible* line count of `journal/events.jsonl`
+     so the next gate tick can compare against what this run actually saw.
+     Exclude `health_check_skipped` events (emitted by the gate itself) so
+     they cannot inflate the anchor:
      ```bash
-     EVENTS_LINES=$(wc -l < "$LUDICS_STATE_PATH/journal/events.jsonl" 2>/dev/null || echo 0)
+     EVENTS_FILE="$LUDICS_STATE_PATH/journal/events.jsonl"
+     if [ -s "$EVENTS_FILE" ]; then
+       EVENTS_LINES=$(grep -vc '"event_type":"health_check_skipped"' "$EVENTS_FILE" 2>/dev/null || echo 0)
+     else
+       EVENTS_LINES=0
+     fi
      EVENTS_LINES=${EVENTS_LINES// /}
      ```
    - Capture this at the *start* of the run, not the end — events this
      check itself emits must not inflate the anchor.
-   - The value is persisted in step 10 as `eventsJsonlLines`.
+   - The value is persisted in step 10 as `eventsJsonlLines`. Keep the
+     `health_check_skipped` exclusion consistent with the gate in
+     `src/health-gate.ts` (`GATE_INTERNAL_EVENT_MARKERS`).
 
 <!-- section:check-deadlines -->
 1. **Check approaching deadlines**:

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { shouldSkipHealthCheck, HEALTH_GATE_THRESHOLD } from "./health-gate.ts";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `health-gate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(join(dir, "journal"), { recursive: true });
+  mkdirSync(join(dir, "mag"), { recursive: true });
+  return dir;
+}
+
+function writeEvents(dir: string, lines: number): void {
+  const body = Array.from({ length: lines }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+  writeFileSync(join(dir, "journal", "events.jsonl"), body);
+}
+
+function writeSnapshot(dir: string, obj: Record<string, unknown>): void {
+  writeFileSync(join(dir, "mag", "health-last.json"), JSON.stringify(obj));
+}
+
+describe("shouldSkipHealthCheck", () => {
+  test("first run with no health-last.json → skip: false", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 100);
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.priorLines).toBe(0);
+    expect(res.reason).toContain("first run");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("snapshot present but missing eventsJsonlLines → skip: false", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 100);
+    writeSnapshot(dir, { timestamp: "2026-04-24T00:00:00Z", findings: [] });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("eventsJsonlLines");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("delta under threshold → skip: true", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 1030);
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(true);
+    expect(res.currentLines).toBe(1030);
+    expect(res.priorLines).toBe(1000);
+    expect(res.reason).toContain("30");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("delta exactly at threshold (50) → skip: false", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 1050);
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.currentLines - res.priorLines).toBe(HEALTH_GATE_THRESHOLD);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("delta over threshold → skip: false", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 1200);
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.currentLines).toBe(1200);
+    expect(res.priorLines).toBe(1000);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("events.jsonl missing → skip: false (fail open)", () => {
+    const dir = makeTmpDir();
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("fail open");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("events.jsonl empty → skip: false (fail open)", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "journal", "events.jsonl"), "");
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("fail open");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("non-numeric eventsJsonlLines → skip: false", () => {
+    const dir = makeTmpDir();
+    writeEvents(dir, 100);
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: "1000" });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("eventsJsonlLines");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("line count handles file without trailing newline", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "journal", "events.jsonl"), "a\nb\nc");
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.currentLines).toBe(3);
+    rmSync(dir, { recursive: true });
+  });
+});

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -112,4 +112,43 @@ describe("shouldSkipHealthCheck", () => {
     expect(res.currentLines).toBe(3);
     rmSync(dir, { recursive: true });
   });
+
+  test("negative delta (rotated/compacted log) → skip: false (fail open)", () => {
+    const dir = makeTmpDir();
+    // Current file has 200 eligible lines; prior anchor claims 1000.
+    writeEvents(dir, 200);
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("backward");
+    expect(res.reason).toContain("fail open");
+    expect(res.currentLines).toBe(200);
+    expect(res.priorLines).toBe(1000);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("health_check_skipped events are excluded from the gate count", () => {
+    const dir = makeTmpDir();
+    // 40 real events + 20 skip-marker events = 60 physical lines, but only
+    // 40 gate-eligible. Prior 0 → delta 40 < 50 → skip.
+    const realLines = Array.from({ length: 40 }, (_, i) => JSON.stringify({ event_type: "mag_queue_feed", n: i }));
+    const skipLines = Array.from({ length: 20 }, (_, i) => JSON.stringify({ event_type: "health_check_skipped", n: i }));
+    writeFileSync(join(dir, "journal", "events.jsonl"), [...realLines, ...skipLines].join("\n") + "\n");
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.currentLines).toBe(40);
+    expect(res.skip).toBe(true);
+  });
+
+  test("many skip-marker events alone cannot push delta over threshold", () => {
+    const dir = makeTmpDir();
+    // Simulate 100 accumulated skip events and 0 real activity since last run.
+    const skipLines = Array.from({ length: 100 }, (_, i) => JSON.stringify({ event_type: "health_check_skipped", n: i }));
+    writeFileSync(join(dir, "journal", "events.jsonl"), skipLines.join("\n") + "\n");
+    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    expect(res.currentLines).toBe(0);
+    expect(res.skip).toBe(false);
+    expect(res.reason).toContain("empty");
+  });
 });

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -1,0 +1,113 @@
+// Activity-volume gate for the periodic health check.
+//
+// Counts lines appended to journal/events.jsonl since the last executed
+// health check (recorded as eventsJsonlLines in mag/health-last.json). Skips
+// the check when fewer than HEALTH_GATE_THRESHOLD new lines have accumulated.
+
+import { existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { harnessDir } from "./config.ts";
+
+export const HEALTH_GATE_THRESHOLD = 50;
+
+export interface HealthGateDecision {
+  skip: boolean;
+  reason: string;
+  currentLines: number;
+  priorLines: number;
+}
+
+export interface HealthGateOptions {
+  now?: Date;
+  stateDir?: string;
+}
+
+function countLines(path: string): number | null {
+  try {
+    if (!existsSync(path)) return null;
+    const st = statSync(path);
+    if (!st.isFile() || st.size === 0) return 0;
+    const buf = readFileSync(path, "utf8");
+    if (buf.length === 0) return 0;
+    let n = 0;
+    for (let i = 0; i < buf.length; i++) {
+      if (buf.charCodeAt(i) === 10) n++;
+    }
+    if (buf.charCodeAt(buf.length - 1) !== 10) n++;
+    return n;
+  } catch {
+    return null;
+  }
+}
+
+function readPriorLines(stateDir: string): { value: number | null; hadFile: boolean; hadField: boolean } {
+  const snapPath = join(stateDir, "mag", "health-last.json");
+  if (!existsSync(snapPath)) return { value: null, hadFile: false, hadField: false };
+  try {
+    const raw = readFileSync(snapPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return { value: null, hadFile: true, hadField: false };
+    const v = (parsed as Record<string, unknown>).eventsJsonlLines;
+    if (typeof v !== "number" || !Number.isFinite(v)) return { value: null, hadFile: true, hadField: false };
+    return { value: v, hadFile: true, hadField: true };
+  } catch {
+    return { value: null, hadFile: true, hadField: false };
+  }
+}
+
+export function shouldSkipHealthCheck(opts: HealthGateOptions = {}): HealthGateDecision {
+  const stateDir = opts.stateDir ?? harnessDir();
+  const eventsFile = join(stateDir, "journal", "events.jsonl");
+
+  const count = countLines(eventsFile);
+  if (count === null) {
+    return {
+      skip: false,
+      reason: "events.jsonl missing — fail open",
+      currentLines: 0,
+      priorLines: 0,
+    };
+  }
+  if (count === 0) {
+    return {
+      skip: false,
+      reason: "events.jsonl empty — fail open",
+      currentLines: 0,
+      priorLines: 0,
+    };
+  }
+
+  const prior = readPriorLines(stateDir);
+  if (!prior.hadFile) {
+    return {
+      skip: false,
+      reason: "first run — no prior snapshot",
+      currentLines: count,
+      priorLines: 0,
+    };
+  }
+  if (!prior.hadField || prior.value === null) {
+    return {
+      skip: false,
+      reason: "prior snapshot missing eventsJsonlLines field",
+      currentLines: count,
+      priorLines: 0,
+    };
+  }
+
+  const delta = count - prior.value;
+  if (delta < HEALTH_GATE_THRESHOLD) {
+    return {
+      skip: true,
+      reason: `delta ${delta} < ${HEALTH_GATE_THRESHOLD} threshold`,
+      currentLines: count,
+      priorLines: prior.value,
+    };
+  }
+  return {
+    skip: false,
+    reason: `delta ${delta} >= ${HEALTH_GATE_THRESHOLD} threshold`,
+    currentLines: count,
+    priorLines: prior.value,
+  };
+}

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -10,6 +10,13 @@ import { harnessDir } from "./config.ts";
 
 export const HEALTH_GATE_THRESHOLD = 50;
 
+// Event types emitted by the gate itself — excluded from the line-delta
+// signal so self-generated telemetry cannot push future ticks over the
+// threshold on an otherwise-idle system.
+const GATE_INTERNAL_EVENT_MARKERS: readonly string[] = [
+  '"event_type":"health_check_skipped"',
+];
+
 export interface HealthGateDecision {
   skip: boolean;
   reason: string;
@@ -22,19 +29,34 @@ export interface HealthGateOptions {
   stateDir?: string;
 }
 
-function countLines(path: string): number | null {
+/** Count event lines eligible for the gate signal.
+ *  Excludes lines containing any GATE_INTERNAL_EVENT_MARKERS so the gate's
+ *  own skip telemetry cannot influence its future decisions. Returns null
+ *  on read error, 0 on empty/missing file. */
+export function countGateEligibleLines(path: string): number | null {
   try {
     if (!existsSync(path)) return null;
     const st = statSync(path);
     if (!st.isFile() || st.size === 0) return 0;
     const buf = readFileSync(path, "utf8");
     if (buf.length === 0) return 0;
-    let n = 0;
-    for (let i = 0; i < buf.length; i++) {
-      if (buf.charCodeAt(i) === 10) n++;
+
+    let count = 0;
+    let lineStart = 0;
+    for (let i = 0; i <= buf.length; i++) {
+      if (i === buf.length || buf.charCodeAt(i) === 10) {
+        if (i > lineStart) {
+          const line = buf.slice(lineStart, i);
+          let excluded = false;
+          for (const marker of GATE_INTERNAL_EVENT_MARKERS) {
+            if (line.includes(marker)) { excluded = true; break; }
+          }
+          if (!excluded) count++;
+        }
+        lineStart = i + 1;
+      }
     }
-    if (buf.charCodeAt(buf.length - 1) !== 10) n++;
-    return n;
+    return count;
   } catch {
     return null;
   }
@@ -59,7 +81,7 @@ export function shouldSkipHealthCheck(opts: HealthGateOptions = {}): HealthGateD
   const stateDir = opts.stateDir ?? harnessDir();
   const eventsFile = join(stateDir, "journal", "events.jsonl");
 
-  const count = countLines(eventsFile);
+  const count = countGateEligibleLines(eventsFile);
   if (count === null) {
     return {
       skip: false,
@@ -96,6 +118,16 @@ export function shouldSkipHealthCheck(opts: HealthGateOptions = {}): HealthGateD
   }
 
   const delta = count - prior.value;
+  if (delta < 0) {
+    // events.jsonl shrank vs the stored anchor (rotation, compaction, restore).
+    // The anchor is no longer trustworthy — fail open so a real run resets it.
+    return {
+      skip: false,
+      reason: `events.jsonl line count went backward (delta ${delta}) — anchor stale, fail open`,
+      currentLines: count,
+      priorLines: prior.value,
+    };
+  }
   if (delta < HEALTH_GATE_THRESHOLD) {
     return {
       skip: true,

--- a/src/mag-health-gate.test.ts
+++ b/src/mag-health-gate.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolveQueueRequestCommand } from "./mag.ts";
+
+describe("resolveQueueRequestCommand — health-check activity gate", () => {
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_CLUSTER_NAME = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  let stateDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), "mag-health-gate-"));
+    mkdirSync(join(stateDir, "journal"), { recursive: true });
+    mkdirSync(join(stateDir, "mag"), { recursive: true });
+    // Minimal config with no projects so runAllTestHealth() is a no-op
+    // when the gate does not skip.
+    configPath = join(stateDir, "config.yaml");
+    writeFileSync(configPath, "state_repo: test/state\nstate_path: harness\nprojects: []\n");
+    process.env.LUDICS_HARNESS_DIR = stateDir;
+    process.env.LUDICS_CONFIG = configPath;
+    delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+    else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_CLUSTER_NAME === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_CLUSTER_NAME;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  test("returns null and emits health_check_skipped when delta < 50", async () => {
+    const lines = Array.from({ length: 1030 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(
+      join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "2026-04-24T00:00:00Z", eventsJsonlLines: 1000, findings: [] }),
+    );
+
+    const result = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    expect(result).toBeNull();
+
+    const evPath = join(stateDir, "journal", "events.jsonl");
+    expect(existsSync(evPath)).toBe(true);
+    const evBody = readFileSync(evPath, "utf8").trim().split("\n");
+    const last = JSON.parse(evBody[evBody.length - 1]!);
+    expect(last.event_type).toBe("health_check_skipped");
+    expect(last.source).toBe("keepalive");
+    expect(last.scope).toBe("mag");
+    expect(last.currentLines).toBe(1030);
+    expect(last.priorLines).toBe(1000);
+    expect(last.delta).toBe(30);
+  });
+
+  test("peek path (executeProgrammatic=false) returns skill command regardless of gate", async () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(
+      join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "x", eventsJsonlLines: 9 }),
+    );
+
+    const result = await resolveQueueRequestCommand({ action: "health-check" }, false);
+    expect(result).toBe("/ludics-health-check");
+  });
+
+  test("first run (no health-last.json) returns skill command", async () => {
+    const lines = Array.from({ length: 5 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+
+    const result = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    expect(result).toBe("/ludics-health-check");
+  });
+
+  test("delta over threshold returns skill command", async () => {
+    const lines = Array.from({ length: 1200 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(
+      join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "x", eventsJsonlLines: 1000 }),
+    );
+
+    const result = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    expect(result).toBe("/ludics-health-check");
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1252,6 +1252,20 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
     } else if (action === "adopt-sessions") {
       adoptSessionsPrecomputeContext();
     } else if (action === "health-check") {
+      const { shouldSkipHealthCheck } = await import("./health-gate.ts");
+      const gate = shouldSkipHealthCheck();
+      if (gate.skip) {
+        emitEvent({
+          event_type: "health_check_skipped",
+          source: "keepalive",
+          scope: "mag",
+          message: gate.reason,
+          currentLines: gate.currentLines,
+          priorLines: gate.priorLines,
+          delta: gate.currentLines - gate.priorLines,
+        });
+        return null;
+      }
       try {
         const { runAllTestHealth } = await import("./health.ts");
         runAllTestHealth();


### PR DESCRIPTION
## Summary

Skip the periodic `/ludics-health-check` when fewer than 50 new lines have accumulated in `journal/events.jsonl` since the last executed check. The 4h launchd cadence currently fires a full skill run (task scan, slots/sessions reports, queue + test-health reads, LLM turn) regardless of activity volume; the gate short-circuits quiet intervals before both `runAllTestHealth()` and the Tier-2 skill resolution.

- New `src/health-gate.ts` exports `shouldSkipHealthCheck()` and `HEALTH_GATE_THRESHOLD=50`. Fail-open on missing/empty `events.jsonl`, first run, and missing/non-numeric `eventsJsonlLines` in `mag/health-last.json`.
- `resolveQueueRequestCommand` in `src/mag.ts` consults the gate on `action === "health-check"` when executing; on skip emits a `health_check_skipped` event with `currentLines`/`priorLines`/`delta` and returns `null` before `runAllTestHealth`. Peek path (`executeProgrammatic=false`) is unaffected.
- `skills/ludics-health-check.md` step 0 captures `EVENTS_LINES=$(wc -l < …)` at the start of the run; step 10 persists it into `mag/health-last.json` alongside `timestamp` + `findings`. Start-of-run capture is load-bearing — events the check itself emits must not inflate the anchor.
- Tests: `src/health-gate.test.ts` (9 cases: first run, missing field, deltas 30/50/200, missing and empty events, non-numeric field, no-trailing-newline) and `src/mag-health-gate.test.ts` (skip path returns `null` and writes the event; peek, first-run, and over-threshold paths return `/ludics-health-check`).

Proposal: `docs/proposals/task-4889872a-gate-health-check-on-activity.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run lint:contracts`
- [x] `bun test` (1390 tests across 71 files pass)
- [ ] Observe a live launchd tick on the controller: verify a `health_check_skipped` event lands in `journal/events.jsonl` on a quiet interval, and that a full check still runs once 50 events have accumulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)