### PR TITLE
ci: wire lint:contracts into build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Lint — no mock.module() in tests
         run: bun run lint:no-mock-module
 
+      - name: Lint worker/orchestrator contracts
+        run: bun run lint:contracts
+
       - name: Lint — eslint
         run: bun run lint


### PR DESCRIPTION
## Summary

Adds a `Lint worker/orchestrator contracts` step to the `build` job in
`.github/workflows/ci.yml` so `bun run lint:contracts` runs alongside the
other four `lint:*` scripts. The omission was accidental (per elaboration of
gh-ludics-376, 2026-04-24); `lint:contracts` was the only `scripts/lint-*.ts`
sibling not wired into CI.

Inserted between `lint:no-mock-module` and `lint` (eslint), keeping the
`scripts/lint-*.ts`-style checks grouped with the broader eslint pass last.

Proposal: `docs/proposals/wire-lint-contracts-into-ci.md`.

## Test plan

- [x] `bun run lint:contracts` passes locally against the current tree
- [ ] CI green on this PR (new step executes and passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)