### PR TITLE
lint: honor ^_ prefix in no-unused-vars; drop void-param workarounds

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,13 @@ export default tseslint.config(
       },
     },
     rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unsafe-assignment": "error",
       "@typescript-eslint/no-unsafe-member-access": "error",

--- a/scripts/lint-unused-vars-underscore.test.ts
+++ b/scripts/lint-unused-vars-underscore.test.ts
@@ -1,0 +1,103 @@
+// Regression test for eslint.config.js honoring the `^_` prefix convention
+// for `@typescript-eslint/no-unused-vars`.
+//
+// Invariant: the `src/**/*.ts` rule block configures
+// `@typescript-eslint/no-unused-vars` with both `argsIgnorePattern: "^_"`
+// and `varsIgnorePattern: "^_"`. Dropping either pattern — or the whole
+// rule entry — will fail an assertion below.
+//
+// The test loads eslint.config.js via its actual export so it catches
+// semantic removal, not just text edits. A second behavioral check lints
+// a fixture written into src/ to prove the rule does what the config
+// says: `_unused` passes, bare `unused` errors.
+
+import { describe, test, expect, afterAll } from "bun:test";
+import { ESLint } from "eslint";
+import { writeFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
+import eslintConfig from "../eslint.config.js";
+
+const repoRoot = join(import.meta.dirname, "..");
+
+type RuleEntry =
+  | string
+  | [string, ...unknown[]]
+  | undefined;
+
+function findSrcUnusedVarsEntry(): RuleEntry {
+  // The flat config is an array. Find the block whose `files` includes
+  // "src/**/*.ts" and read `rules["@typescript-eslint/no-unused-vars"]`.
+  const blocks = eslintConfig as Array<{
+    files?: string[];
+    rules?: Record<string, RuleEntry>;
+  }>;
+  for (const block of blocks) {
+    const files = block.files;
+    if (!Array.isArray(files)) continue;
+    if (!files.includes("src/**/*.ts")) continue;
+    const rule = block.rules?.["@typescript-eslint/no-unused-vars"];
+    if (rule !== undefined) return rule;
+  }
+  return undefined;
+}
+
+describe("eslint.config.js: no-unused-vars ignore patterns", () => {
+  test("src/**/*.ts block configures no-unused-vars with ^_ patterns", () => {
+    const entry = findSrcUnusedVarsEntry();
+    expect(Array.isArray(entry)).toBe(true);
+    const [severity, options] = entry as [string, Record<string, unknown>];
+    expect(severity).toBe("error");
+    expect(options.argsIgnorePattern).toBe("^_");
+    expect(options.varsIgnorePattern).toBe("^_");
+  });
+});
+
+// Behavioral check — lint a real file written to src/ so tsconfig's
+// `include: ["src/**/*.ts"]` covers it. Assertions prove the rule behaves
+// per the config: underscore-prefixed unused identifiers pass, bare ones
+// error.
+
+const fixturePath = join(repoRoot, "src", "__fixture_unused_vars_probe.ts");
+
+afterAll(() => {
+  if (existsSync(fixturePath)) unlinkSync(fixturePath);
+});
+
+function makeLinter() {
+  return new ESLint({
+    cwd: repoRoot,
+    overrideConfigFile: join(repoRoot, "eslint.config.js"),
+  });
+}
+
+async function lintFixture(source: string) {
+  writeFileSync(fixturePath, source);
+  const results = await makeLinter().lintFiles([fixturePath]);
+  return results
+    .flatMap((r) => r.messages)
+    .filter((m) => m.ruleId === "@typescript-eslint/no-unused-vars");
+}
+
+describe("no-unused-vars behavior in src/ (live ESLint run)", () => {
+  test("underscore-prefixed unused param does not error", async () => {
+    const messages = await lintFixture(
+      `export function f(_unused: number): void { void 0; }\n`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  test("underscore-prefixed unused local does not error", async () => {
+    const messages = await lintFixture(
+      `export function f(): void { const _unused = 42; }\n`,
+    );
+    expect(messages).toEqual([]);
+  });
+
+  test("bare unused local still errors (rule is configured, not disabled)", async () => {
+    const messages = await lintFixture(
+      `export function f(): void { const unused = 42; }\n`,
+    );
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages[0].message).toMatch(/unused/);
+  });
+});

--- a/src/orchestration/transport-t3code.ts
+++ b/src/orchestration/transport-t3code.ts
@@ -129,9 +129,8 @@ export class T3CodeTransport implements OrchestrationTransport {
     return commandId;
   }
 
-  async sendEnter(state: OrchestrationState, agent: AgentConfig): Promise<void> {
+  async sendEnter(_state: OrchestrationState, _agent: AgentConfig): Promise<void> {
     // No-op for t3code — turns are dispatched via WebSocket, not terminal input.
-    void state; void agent;
   }
 
   async refreshAgentTransportState(state: OrchestrationState): Promise<void> {

--- a/src/sessions/enrich.ts
+++ b/src/sessions/enrich.ts
@@ -48,9 +48,8 @@ function enrichFromT3codeSlots(): Map<string, Orchestration> {
  * Enrich sessions with orchestration data from t3code slot state files.
  */
 export async function enrichSessions(
-  sessions: DiscoveredSession[],
+  _sessions: DiscoveredSession[],
 ): Promise<Map<string, Orchestration>> {
-  void sessions;
   return enrichFromT3codeSlots();
 }
 

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -1526,15 +1526,13 @@ describe("slotAssign reaps prior assignment on reassignment (task-72a318c3)", ()
     // Seed a stale state file with no prior assignment in slot JSON —
     // empty-slot assign should not hit adapter.stop, but the fallback
     // unlinks WILL remove the stale file (existing pre-fix behavior).
-    const stateFile = seedTmuxSlotState(harness, 1);
+    seedTmuxSlotState(harness, 1);
 
     await slotAssign(1, "task-fresh", "tmux");
     // fallback unlink runs on the stale file — that's the pre-existing
     // path. Test passes regardless of whether the file is removed; the
     // guarantee we care about is no exception from slotStop.
     expect(readSlotJson(1, harness).task).toBe("task-fresh");
-    // Silence unused-var lint on stateFile
-    void stateFile;
   });
 
   test("old task frontmatter reset still happens on reassignment (regression guard)", async () => {


### PR DESCRIPTION
## Summary

- Add `argsIgnorePattern: "^_"` and `varsIgnorePattern: "^_"` to `@typescript-eslint/no-unused-vars` in the `src/**/*.ts` block of `eslint.config.js`.
- Rename interface-mandated unused params with `_` prefix and drop the inline `void x` workarounds at `src/sessions/enrich.ts` (`enrichSessions`) and `src/orchestration/transport-t3code.ts` (`sendEnter`).
- Clean up the one discard-local workaround in `src/slots/index.test.ts` by dropping the unused `stateFile` binding (keeping the side-effecting `seedTmuxSlotState` call).
- Add `scripts/lint-unused-vars-underscore.test.ts` as a regression test that (a) structurally asserts both patterns are present in the config and (b) runs live ESLint to confirm `_unused` passes while bare `unused` still errors.

Proposal: `docs/proposals/eslint-args-ignore-pattern-underscore.md`
Task: `task-f84148cc`

## Test plan

- [x] `bun run lint` exits 0
- [x] `bun run typecheck` clean
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test` — 1473 pass / 0 fail (includes the 4 new regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)