### PR TITLE
refactor(t3code): dedup isoNow by importing from orchestration/util

### DIFF
--- a/src/t3code/server.ts
+++ b/src/t3code/server.ts
@@ -2,7 +2,7 @@ import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readF
 import { createServer } from "node:net";
 import { join, resolve } from "path";
 import { Database } from "bun:sqlite";
-import { setsidWrap, sleepMs } from "../orchestration/util.ts";
+import { isoNow, setsidWrap, sleepMs } from "../orchestration/util.ts";
 import { readJsonFile, writeJsonFile } from "../json.ts";
 
 /**
@@ -948,8 +948,4 @@ function checkAndRecoverDb(dbPath: string): boolean {
 
   console.error("t3code: no usable backup — starting with corrupt DB (may fail)");
   return false;
-}
-
-function isoNow(): string {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }


### PR DESCRIPTION
## Summary

Eliminates the file-private `isoNow` helper in `src/t3code/server.ts` that shadowed the canonical `isoNow` exported from `src/orchestration/util.ts`. Extends the existing `import { setsidWrap, sleepMs } from "../orchestration/util.ts"` to include `isoNow`, then deletes the local definition.

The two function bodies were verified byte-identical (`return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");`), so behavior is preserved by construction. The 4 call sites inside `server.ts` (lock `acquiredAt`, `t3codeStartingPath` write, crash-log append, `startedAt` record field) are untouched and now resolve transparently to the imported symbol.

Implements task-fc8f0e2b — natural follow-up to task-d1ab1125 (`sleep` → `sleepMs` dedup), deferred from that task to keep the rename focused. Scope is intentionally limited to `src/t3code/server.ts`; the other shadows in `src/t3code/index.ts`, `src/sessions/sweep.ts`, and `src/sessions/sweep-state.ts` remain as separate follow-ups (per [the proposal's `## Scope`](docs/proposals/dedup-iso-now-server.md)).

## Test plan

- [x] `bun run typecheck` — no diagnostics (proves all 4 call sites still resolve `isoNow: () => string`).
- [x] `bun run build` — `bin/ludics` compiled (166 modules bundled, no symbol-resolution errors).
- [x] `bun test` — 1469 pass / 0 fail / 3196 expect() calls across 73 files.
- [x] `bun run lint` — eslint --max-warnings=0 clean.
- [x] `git diff --name-only main..HEAD` returns only `src/t3code/server.ts` (no out-of-scope edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)