### PR TITLE
Unify readFrontmatterField into cached parseTaskFrontmatter (task-d68d485a)

### DIFF
--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { readFrontmatterField } from "../tasks/markdown.ts";
+import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { basename, resolve } from "path";
 import {
   getGitBranch,
@@ -788,7 +788,7 @@ export function selectOrchestrationFlagsForTask(
   effort: string,
   config?: LudicsFullConfig,
 ): { adapter: string; args: string; isDuo: boolean } {
-  const skipPlan = readFrontmatterField(taskContent, "skip_plan") === "true";
+  const skipPlan = parseTaskFrontmatter(taskContent).skip_plan === true;
   return selectOrchestrationFlags(effort, config, { skipPlan });
 }
 

--- a/src/adapters/task-launch.ts
+++ b/src/adapters/task-launch.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "fs";
 import { join, normalize, resolve } from "path";
-import { readFrontmatterField } from "../tasks/markdown.ts";
+import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 
 /** Throws if `rawPath` is not repo-relative (absolute, home-relative, or escapes tree). */
 export function assertRepoRelativeProposalPath(rawPath: string): void {
@@ -47,7 +47,7 @@ export function readProposalLaunchMetadata(
   if (!existsSync(taskFile)) return null;
 
   const taskContent = readFileSync(taskFile, "utf-8");
-  const proposalValue = readFrontmatterField(taskContent, "proposal");
+  const proposalValue = parseTaskFrontmatter(taskContent).proposal;
   if (!proposalValue) return null;
 
   // Deprecated sentinel — kept for backward compat; no file-based proposal to resolve.

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -10,7 +10,7 @@ import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson } from "./slots/json.ts";
 import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
-import { updateFrontmatterField, addFrontmatterField, readFrontmatterField, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
+import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
 import { setQueueHold, maybeFeedMagQueue } from "./mag.ts";
@@ -45,7 +45,7 @@ export function startDashboardServer(
     return path.startsWith(homeRoot) && existsSync(path) && !statSync(path).isDirectory();
   }
 
-  function parseTaskFrontmatter(taskFilePath: string): { project: string; proposal: string | null } | null {
+  function readDashboardTaskInfo(taskFilePath: string): { project: string; proposal: string | null } | null {
     try {
       const content = readFileSync(taskFilePath, "utf-8");
       const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
@@ -96,7 +96,7 @@ export function startDashboardServer(
       return null;
     }
 
-    const parsed = parseTaskFrontmatter(taskFilePath);
+    const parsed = readDashboardTaskInfo(taskFilePath);
     if (!parsed || !parsed.proposal) return null;
 
     // Deprecated sentinel — kept for backward compat; resolve inline to the task file itself.
@@ -256,7 +256,7 @@ export function startDashboardServer(
               if (!("error" in taskResolved)) {
                 const taskFile = taskResolved.path;
                 const content = readFileSync(taskFile, "utf-8");
-                const currentPriority = readFrontmatterField(content, "priority") ?? "B";
+                const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
                 const newPriority = PRIORITY_DECREASE[currentPriority] ?? currentPriority;
                 if (newPriority !== currentPriority) {
                   // Capture the write as a closure; execute only after clear succeeds.
@@ -290,7 +290,7 @@ export function startDashboardServer(
           if ("error" in resolved) return resolved.error;
           const taskFile = resolved.path;
           const content = readFileSync(taskFile, "utf-8");
-          const currentPriority = readFrontmatterField(content, "priority") ?? "B";
+          const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
           const newPriority = PRIORITY_INCREASE[currentPriority] ?? currentPriority;
           if (newPriority !== currentPriority) {
             addFrontmatterField(taskFile, "priority", newPriority);
@@ -315,7 +315,7 @@ export function startDashboardServer(
           if ("error" in resolved) return resolved.error;
           const taskFile = resolved.path;
           const content = readFileSync(taskFile, "utf-8");
-          const currentStatus = readFrontmatterField(content, "status") ?? "";
+          const currentStatus = parseTaskFrontmatter(content).status ?? "";
           if (currentStatus !== "needs-confirmation") {
             return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
               status: 409, headers: { "Content-Type": "application/json" },
@@ -342,7 +342,7 @@ export function startDashboardServer(
           if ("error" in resolved) return resolved.error;
           const taskFile = resolved.path;
           const content = readFileSync(taskFile, "utf-8");
-          const currentStatus = readFrontmatterField(content, "status") ?? "";
+          const currentStatus = parseTaskFrontmatter(content).status ?? "";
           if (currentStatus !== "needs-confirmation") {
             return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
               status: 409, headers: { "Content-Type": "application/json" },
@@ -369,7 +369,7 @@ export function startDashboardServer(
           if ("error" in resolved) return resolved.error;
           const taskFile = resolved.path;
           const approveContent = readFileSync(taskFile, "utf-8");
-          const approveStatus = readFrontmatterField(approveContent, "status");
+          const approveStatus = parseTaskFrontmatter(approveContent).status;
           if (approveStatus !== "deferred") {
             return new Response(
               JSON.stringify({ error: `task is ${approveStatus}, not deferred` }),

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -29,7 +29,7 @@ import {
   expirePendingRevises,
   expirePendingFollowupRevises,
 } from "./notify.ts";
-import { updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, readFrontmatterField, priorityValue } from "./tasks/markdown.ts";
+import { updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, priorityValue } from "./tasks/markdown.ts";
 import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
@@ -816,10 +816,10 @@ function isTaskDeferred(taskId: string): boolean {
   const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
   if (!existsSync(taskFile)) return false;
   const content = readFileSync(taskFile, "utf-8");
-  const status = readFrontmatterField(content, "status");
-  if (status === "deferred") return true;
+  const fm = parseTaskFrontmatter(content);
+  if (fm.status === "deferred") return true;
   // Legacy shim: treat deferred_launch: true as deferred, opportunistically migrate in-place
-  if (readFrontmatterField(content, "deferred_launch") === "true") {
+  if (fm.deferred_launch === "true") {
     updateFrontmatterField(taskFile, "status", "deferred");
     removeFrontmatterField(taskFile, "deferred_launch");
     removeFrontmatterField(taskFile, "approved");
@@ -959,7 +959,7 @@ function readTaskProject(taskId: string): string {
   const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
   if (!existsSync(taskFile)) return "";
   const content = readFileSync(taskFile, "utf-8");
-  return readFrontmatterField(content, "project") ?? "";
+  return parseTaskFrontmatter(content).project ?? "";
 }
 
 function resolveTaskProjectPath(taskId: string): string {
@@ -1295,7 +1295,7 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
           const tf = join(harnessDir(), "tasks", `${tid}.md`);
           if (existsSync(tf)) {
             const tfContent = readFileSync(tf, "utf-8");
-            const tfStatus = readFrontmatterField(tfContent, "status");
+            const tfStatus = parseTaskFrontmatter(tfContent).status;
             if (tfStatus === "deferred") {
               updateFrontmatterField(tf, "status", "ready");
               console.error(`ludics: approved deferred task ${tid} for auto-start`);
@@ -1448,43 +1448,40 @@ async function cleanupDoneTaskThreads(): Promise<void> {
   const tasksDir = join(harness, "tasks");
   if (!existsSync(tasksDir)) return;
 
-  // Collect thread IDs from completed tasks
+  // Collect thread IDs from completed tasks, and queue retrospective fallback
+  // for any done/abandoned task that does not yet have one. Both loops read the
+  // same files and test the same `status in {done, abandoned}` predicate, so we
+  // fold them into a single pass.
   const threadIdsToDelete: string[] = [];
+  const retroDir = join(harness, "retrospectives");
+  const retroFallbacks: string[] = [];
   try {
     const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
     for (const f of files) {
       const content = readFileSync(join(tasksDir, f), "utf-8");
-      const status = readFrontmatterField(content, "status") ?? "";
+      const fm = parseTaskFrontmatter(content);
+      const status = fm.status ?? "";
       if (status !== "done" && status !== "abandoned") continue;
-      const threadsStr = readFrontmatterField(content, "t3code_threads");
-      if (!threadsStr) continue;
-      const ids = threadsStr.split(",").map((s) => s.trim()).filter(Boolean);
-      threadIdsToDelete.push(...ids);
+
+      if (fm.t3code_threads && fm.t3code_threads.length > 0) {
+        threadIdsToDelete.push(...fm.t3code_threads);
+      }
+
+      const taskId = f.replace(/\.md$/, "");
+      const retroFile = join(retroDir, `${taskId}.json`);
+      if (!existsSync(retroFile)) retroFallbacks.push(taskId);
     }
   } catch {
     return;
   }
 
-  // Fallback: collect retrospective for done tasks that don't have one yet
-  {
-    const retroDir = join(harness, "retrospectives");
+  if (retroFallbacks.length > 0) {
     try {
-      const taskFiles = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
-      for (const f of taskFiles) {
-        const content = readFileSync(join(tasksDir, f), "utf-8");
-        const taskStatus = readFrontmatterField(content, "status") ?? "";
-        if (taskStatus !== "done" && taskStatus !== "abandoned") continue;
-
-        const taskId = f.replace(/\.md$/, "");
-        const retroFile = join(retroDir, `${taskId}.json`);
-        if (!existsSync(retroFile)) {
-          try {
-            const { collectRetrospectiveFallback } = await import("./retrospective.ts");
-            await collectRetrospectiveFallback(taskId);
-          } catch { /* best effort — ignore */ }
-        }
+      const { collectRetrospectiveFallback } = await import("./retrospective.ts");
+      for (const taskId of retroFallbacks) {
+        try { await collectRetrospectiveFallback(taskId); } catch { /* best effort — ignore */ }
       }
-    } catch { /* ignore */ }
+    } catch { /* ignore module load failure */ }
   }
 
   if (threadIdsToDelete.length === 0) return;
@@ -1820,7 +1817,7 @@ function computeSessionProjectMatches(): string {
         const taskFile = join(harness, "tasks", `${taskId}.md`);
         if (existsSync(taskFile)) {
           const content = readFileSync(taskFile, "utf-8");
-          const pm = readFrontmatterField(content, "project");
+          const pm = parseTaskFrontmatter(content).project;
           if (pm) projectsInSlots.set(pm, i);
         }
       }
@@ -1850,30 +1847,21 @@ function computeSessionProjectMatches(): string {
 
     for (const f of taskFiles) {
       const content = readFileSync(join(tasksDir, f), "utf-8");
-      const id = readFrontmatterField(content, "id");
+      const fm = parseTaskFrontmatter(content);
+      const id = fm.id;
       if (!id) continue;
       if (tasksInSlots.has(id)) continue;
 
-      const status = readFrontmatterField(content, "status");
-      if (status !== "ready") continue;
+      if (fm.status !== "ready") continue;
 
-      // Check blocked_by
-      const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-      if (fmMatch) {
-        try {
-          const fm = YAML.parse(fmMatch[1]!, { uniqueKeys: false }) as Record<string, unknown>;
-          const deps = fm.dependencies as Record<string, unknown> | undefined;
-          const blockedBy = deps?.blocked_by;
-          if (Array.isArray(blockedBy) && blockedBy.length > 0) continue;
-        } catch { /* skip parse errors */ }
-      }
+      const blockedBy = fm.dependencies?.blocked_by ?? [];
+      if (blockedBy.length > 0) continue;
 
-      const project = readFrontmatterField(content, "project") ?? "";
+      const project = fm.project ?? "";
       if (!project) continue;
 
-      const title = readFrontmatterField(content, "title") ?? id;
-
-      const priority = readFrontmatterField(content, "priority") ?? "B";
+      const title = fm.title || id;
+      const priority = fm.priority ?? "B";
 
       const elaborated = isElaborated(content);
 
@@ -2077,7 +2065,7 @@ async function maybeAutoStartSlots(): Promise<void> {
     if (isTaskDeferred(taskId)) continue;
 
     // Skip tasks from postponed projects
-    const projectName = readFrontmatterField(content, "project");
+    const projectName = parseTaskFrontmatter(content).project;
     if (projectName && postponedProjectSet().has(projectName.toLowerCase())) continue;
 
     // Task has a proposal but no session — auto-start
@@ -2129,7 +2117,7 @@ function maybeUnstickAssignedSlots(): void {
     const content = readFileSync(taskFile, "utf-8");
 
     // Task already completed or abandoned — nothing to unstick
-    const unstickStatus = readFrontmatterField(content, "status");
+    const unstickStatus = parseTaskFrontmatter(content).status;
     if (unstickStatus === "done" || unstickStatus === "abandoned" || unstickStatus === "merged") continue;
 
     // Already has proposal — maybeAutoStartSlots handles this
@@ -2650,7 +2638,7 @@ async function maybeClearDoneSlots(): Promise<void> {
     if (!existsSync(taskFile)) continue;
 
     const content = readFileSync(taskFile, "utf-8");
-    const taskStatus = readFrontmatterField(content, "status") ?? "";
+    const taskStatus = parseTaskFrontmatter(content).status ?? "";
 
     if (taskStatus === "done") {
       console.error(`ludics: auto-clearing slot ${slotNum} (task ${taskId} is ${taskStatus})`);
@@ -3480,7 +3468,7 @@ export async function runMag(args: string[]): Promise<void> {
         } else {
           // Only clear deferred — do not downgrade other statuses
           const evalContent = readFileSync(evalTaskFile, "utf-8");
-          const evalStatus = readFrontmatterField(evalContent, "status");
+          const evalStatus = parseTaskFrontmatter(evalContent).status;
           if (evalStatus === "deferred") {
             updateFrontmatterField(evalTaskFile, "status", "ready");
           }
@@ -3506,7 +3494,7 @@ export async function runMag(args: string[]): Promise<void> {
         const reviseTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
         if (existsSync(reviseTaskFile)) {
           const revContent = readFileSync(reviseTaskFile, "utf-8");
-          const revStatus = readFrontmatterField(revContent, "status");
+          const revStatus = parseTaskFrontmatter(revContent).status;
           if (revStatus === "ready" || revStatus === "in-progress") {
             const revSlot = findSlotForTask(taskId);
             if (revSlot !== null) {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -9,7 +9,7 @@ import { queueRequest } from "./queue.ts";
 import { emitEvent } from "./events.ts";
 import { readAllSlotJson } from "./slots/json.ts";
 import { getUrl } from "./network.ts";
-import { readFrontmatterField } from "./tasks/markdown.ts";
+import { parseTaskFrontmatter } from "./tasks/markdown.ts";
 import { proposalLink } from "./dashboard.ts";
 
 function notificationLogFile(): string {
@@ -156,7 +156,7 @@ function taskProject(taskId: string): string {
     const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
     if (!existsSync(taskFile)) return "";
     const content = readFileSync(taskFile, "utf-8");
-    return readFrontmatterField(content, "project") ?? "";
+    return parseTaskFrontmatter(content).project ?? "";
   } catch {
     return "";
   }

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { assertRepoRelativeProposalPath } from "../adapters/task-launch.ts";
-import { readFrontmatterField } from "../tasks/markdown.ts";
+import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { findProjectConfig, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
 import { taskFilePath } from "./paths.ts";
 import { safeSyncOutput } from "../spawn.ts";
@@ -112,7 +112,7 @@ function taskSpecBriefText(state: OrchestrationState): string {
   const title = state.slotTitle?.trim() || state.taskId;
   const path = taskFilePath(taskId, state.harnessDir ?? defaultHarnessDir());
   const content = readFileIfExists(path);
-  const proposalValue = (content ? readFrontmatterField(content, "proposal") : null) ?? "";
+  const proposalValue = (content ? parseTaskFrontmatter(content).proposal : undefined) ?? "";
   const proposalRef =
     proposalValue && proposalValue !== "inline" // deprecated sentinel — kept for backward compat
       ? proposalValue
@@ -147,7 +147,7 @@ function taskSpecText(state: OrchestrationState): string {
   if (!content) return taskId;
 
   // When proposal is a file path, append a pointer + summary rather than inlining content.
-  const proposalValue = readFrontmatterField(content, "proposal");
+  const proposalValue = parseTaskFrontmatter(content).proposal ?? null;
   if (proposalValue) {
     // Deprecated sentinel — kept for backward compat; skip file resolution for inline proposals.
     if (proposalValue !== "inline") {
@@ -355,7 +355,7 @@ export function buildSkillContext(
   const stateHarnessDir = state.harnessDir ?? defaultHarnessDir();
   const _taskPath = state.taskId ? taskFilePath(state.taskId, stateHarnessDir) : null;
   const _taskContent = _taskPath ? readFileIfExists(_taskPath) : null;
-  const _proposalPath = (_taskContent ? readFrontmatterField(_taskContent, "proposal") : null) ?? "";
+  const _proposalPath = (_taskContent ? parseTaskFrontmatter(_taskContent).proposal : undefined) ?? "";
   const proposalPath = _proposalPath && _proposalPath !== "inline" // deprecated sentinel — kept for backward compat
     ? _proposalPath : "";
   const proposalFreshnessWarningText = proposalPath

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -520,6 +520,57 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     expect(args).toContain("--pair");
   });
 
+  test("task without explicit effort field gets small-orchestration flags (codex P2 regression)", async () => {
+    // Regression for codex P2: parseTaskFrontmatter normalizes a missing
+    // effort field to "medium", which would silently upgrade legacy / manual
+    // tasks that never declared effort to medium-orchestration flags. The
+    // readRawEffortField helper restores the pre-unification "small" default
+    // by inspecting the raw YAML block. This test would fail if the site
+    // reverted to `parseTaskFrontmatter(content).effort ?? "small"`, because
+    // that expression yields "medium" for any frontmatter missing `effort:`.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+
+    writeFileSync(join(tasksDir, "task-no-effort-1.md"), [
+      "---",
+      "id: task-no-effort-1",
+      'title: "Legacy task no effort"',
+      "project: demo",
+      "status: ready",
+      "priority: B",
+      "dependencies:",
+      "  blocks: []",
+      "  blocked_by: []",
+      "  relates_to: []",
+      "  subtask_of: null",
+      // NOTE: no `effort:` line — this is the regression case.
+      "context: demo",
+      "uses_browser: false",
+      "slot: null",
+      "adapter: null",
+      "created: 2026-03-07",
+      "started: null",
+      "completed: null",
+      "modified: null",
+      "source: local",
+      "---",
+      "",
+    ].join("\n"));
+
+    void slotAssign(1, "task-no-effort-1", "t3code");
+    const data = readSlotJson(1, harness);
+    const ctx = makeAdapterContext(1, data);
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    // Invariant: `effort` reported by autoFillAdapterArgs must equal "small"
+    // for a task file without an explicit effort field. A regression to the
+    // normalized default would surface this as "medium".
+    expect(result!.effort).toBe("small");
+  });
+
   test("auto-fills medium task with skip_plan: true — omits --plan", async () => {
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -132,6 +132,23 @@ function taskFilePath(taskId: string): string {
   return join(harnessDir(), "tasks", `${taskId}.md`);
 }
 
+/**
+ * Read the raw `effort:` value from the frontmatter block without applying
+ * parseTaskFrontmatter's "medium" normalization for missing fields. Returns
+ * null when effort is absent, explicitly null, or when frontmatter is missing.
+ * Scoped to orchestration-flag selection which needs to distinguish "legacy
+ * task, field absent" (→ "small") from "explicit medium".
+ */
+function readRawEffortField(content: string): string | null {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return null;
+  const m = fmMatch[1]!.match(/^effort:\s*(.+)$/m);
+  if (!m) return null;
+  const raw = m[1]!.trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+  if (!raw || raw.toLowerCase() === "null") return null;
+  return raw;
+}
+
 function taskUpdateFrontmatter(taskId: string, field: string, value: string): void {
   const file = taskFilePath(taskId);
   if (!existsSync(file)) return;
@@ -811,7 +828,14 @@ export async function autoFillAdapterArgs(
     throw new Error(`slot ${ctx.slot}: ${ctx.mode} adapter requires orchestration flags but task file not found`);
   }
 
-  const effort = parseTaskFrontmatter(content).effort ?? "small";
+  // parseTaskFrontmatter normalizes a missing `effort:` field to "medium" as
+  // its documented default, collapsing "field absent" with "field == medium".
+  // Pre-unification this site used readFrontmatterField which returned null
+  // for missing fields, so `?? "small"` fired for legacy/manual tasks that
+  // never declared effort. Preserve that small-orchestration default by
+  // consulting the raw frontmatter block before falling back on the parser's
+  // normalized value.
+  const effort = readRawEffortField(content) ?? "small";
   const { args: autoArgs } = selectOrchestrationFlagsForTask(content, effort);
   if (!autoArgs.trim()) {
     throw new Error(`slot ${ctx.slot}: selectOrchestrationFlagsForTask returned empty args for effort="${effort}"`);

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -13,7 +13,7 @@ import { journalAppend } from "../journal.ts";
 import { emitEvent } from "../events.ts";
 import { runAdapterAction, readAdapterState, readAdapterLastActivity } from "../adapters/index.ts";
 import type { AdapterContext } from "../adapters/index.ts";
-import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus, readFrontmatterField } from "../tasks/markdown.ts";
+import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus } from "../tasks/markdown.ts";
 import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
@@ -172,7 +172,7 @@ function taskUpdateForSlotAssign(taskId: string, slot: number, adapter: string, 
   }
   if (!transitionStatus(file, ["ready", "deferred", "blocked", "needs-confirmation", "preempted"], "in-progress")) {
     const content = readFileSync(file, "utf-8");
-    const actual = readFrontmatterField(content, "status") ?? "unknown";
+    const actual = parseTaskFrontmatter(content).status ?? "unknown";
     console.error(`ludics: skipping slot assign for ${taskId}: status is '${actual}', expected one of [ready, deferred, blocked, needs-confirmation, preempted]`);
     return;
   }
@@ -200,7 +200,7 @@ function taskUpdateForSlotClear(taskId: string, finalStatus: string): void {
 
   if (!transitionStatus(file, expectedFrom, finalStatus)) {
     const content = readFileSync(file, "utf-8");
-    const actual = readFrontmatterField(content, "status") ?? "unknown";
+    const actual = parseTaskFrontmatter(content).status ?? "unknown";
     console.error(`ludics: skipping slot clear for ${taskId}: status is '${actual}', expected one of [${expectedFrom.join(", ")}]`);
     return;
   }
@@ -263,7 +263,7 @@ export async function slotAssign(
   if (existsSync(tf)) {
     taskId = taskOrDesc;
     const content = readFileSync(tf, "utf-8");
-    processDesc = readFrontmatterField(content, "title") ?? taskId;
+    processDesc = parseTaskFrontmatter(content).title || taskId;
   } else {
     taskId = null;
     processDesc = taskOrDesc;
@@ -310,7 +310,7 @@ export async function slotAssign(
     if (existsSync(oldTaskFile)) {
       updateFrontmatterField(oldTaskFile, "slot", "null");
       const oldContent = readFileSync(oldTaskFile, "utf-8");
-      const oldStatus = readFrontmatterField(oldContent, "status");
+      const oldStatus = parseTaskFrontmatter(oldContent).status;
       if (oldStatus === "in-progress" || oldStatus === "deferred") {
         updateFrontmatterField(oldTaskFile, "status", "ready");
       }
@@ -480,7 +480,7 @@ export function markSlotSetupFailed(slotNum: number, error: string): void {
     const taskFile = taskFilePath(taskId);
     if (existsSync(taskFile)) {
       const content = readFileSync(taskFile, "utf-8");
-      const status = readFrontmatterField(content, "status");
+      const status = parseTaskFrontmatter(content).status;
       if (status === "in-progress" || status === "deferred") {
         taskUpdateFrontmatter(taskId, "status", "ready");
       }
@@ -513,7 +513,7 @@ export function taskCompleteDirectly(taskId: string): void {
   }
   if (!transitionStatus(file, ["in-progress", "deferred"], "done")) {
     const content = readFileSync(file, "utf-8");
-    const actual = readFrontmatterField(content, "status") ?? "unknown";
+    const actual = parseTaskFrontmatter(content).status ?? "unknown";
     console.error(`ludics: skipping direct completion for ${taskId}: status is '${actual}', expected one of [in-progress, deferred]`);
     return;
   }
@@ -611,7 +611,7 @@ export async function slotPreempt(
     const taskFile = taskFilePath(data.task);
     if (!transitionStatus(taskFile, ["in-progress"], "preempted")) {
       const content = existsSync(taskFile) ? readFileSync(taskFile, "utf-8") : "";
-      const actual = readFrontmatterField(content, "status") ?? "unknown";
+      const actual = parseTaskFrontmatter(content).status ?? "unknown";
       console.error(`ludics: skipping preempt status update for ${data.task}: status is '${actual}', expected 'in-progress'`);
     }
   }
@@ -713,7 +713,7 @@ export function makeAdapterContext(slotNum: number, data: SlotData): AdapterCont
     const taskFile = join(harnessDir(), "tasks", `${data.task}.md`);
     if (existsSync(taskFile)) {
       const content = readFileSync(taskFile, "utf-8");
-      const project = readFrontmatterField(content, "project");
+      const project = parseTaskFrontmatter(content).project;
       if (project) {
         resolvedPath = resolveProjectPath(project);
       }
@@ -811,7 +811,7 @@ export async function autoFillAdapterArgs(
     throw new Error(`slot ${ctx.slot}: ${ctx.mode} adapter requires orchestration flags but task file not found`);
   }
 
-  const effort = readFrontmatterField(content, "effort") ?? "small";
+  const effort = parseTaskFrontmatter(content).effort ?? "small";
   const { args: autoArgs } = selectOrchestrationFlagsForTask(content, effort);
   if (!autoArgs.trim()) {
     throw new Error(`slot ${ctx.slot}: selectOrchestrationFlagsForTask returned empty args for effort="${effort}"`);

--- a/src/t3code/index.ts
+++ b/src/t3code/index.ts
@@ -6,7 +6,7 @@ import type { AgentConfig } from "../orchestration/state.ts";
 import { T3CodeClient, waitForNewTurn } from "./client.ts";
 import { doctorServer, ensureServer, readServerRecord, readSlotState, serverStatus, stopServer, t3codeServerPath } from "./server.ts";
 import type { T3ThreadMessage } from "./types.ts";
-import { readFrontmatterField } from "../tasks/markdown.ts";
+import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -296,7 +296,7 @@ function readTaskStatus(taskId: string, harness: string): string | null {
   if (!existsSync(file)) return null;
   try {
     const content = readFileSync(file, "utf-8");
-    return readFrontmatterField(content, "status");
+    return parseTaskFrontmatter(content).status ?? null;
   } catch {
     return null;
   }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, renameSync } from "fs";
 import { extname, join } from "path";
 import { harnessDir } from "../config.ts";
-import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, readFrontmatterField } from "./markdown.ts";
+import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus } from "./markdown.ts";
 import { tasksSync, tasksConvert, tasksUpdate, tasksNeedsElaborationList, tasksQueueElaborations, contentFingerprint } from "./sync.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
@@ -265,7 +265,7 @@ function tasksMerge(targetId: string, sourceIds: string[]): void {
     const srcFile = join(dir, `${srcId}.md`);
     if (!transitionStatus(srcFile, ["ready", "blocked", "needs-confirmation", "deferred"], "merged")) {
       const content = readFileSync(srcFile, "utf-8");
-      const actual = readFrontmatterField(content, "status") ?? "unknown";
+      const actual = parseTaskFrontmatter(content).status ?? "unknown";
       console.error(`ludics: skipping merge for ${srcId}: status is '${actual}', expected one of [ready, blocked, needs-confirmation, deferred]`);
       continue;
     }
@@ -319,7 +319,7 @@ function tasksUnmerge(sourceId: string): void {
   // Restore source task
   if (!transitionStatus(srcFile, ["merged"], "ready")) {
     const currentContent = readFileSync(srcFile, "utf-8");
-    const actual = readFrontmatterField(currentContent, "status") ?? "unknown";
+    const actual = parseTaskFrontmatter(currentContent).status ?? "unknown";
     console.error(`ludics: skipping unmerge for ${sourceId}: status is '${actual}', expected 'merged'`);
     return;
   }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -365,7 +365,7 @@ function tasksDuplicates(): void {
     const content = readFileSync(join(dir, f), "utf-8");
     const fm = parseTaskFrontmatter(content);
     if (["done", "abandoned", "merged"].includes(fm.status ?? "")) continue;
-    if (!fm.title) continue;
+    if (!fm.title || !fm.id) continue;
 
     const fp = contentFingerprint(fm.title);
     if (!groups.has(fp)) groups.set(fp, []);
@@ -471,8 +471,8 @@ function tasksMigrateRefs(dryRun: boolean = false): void {
       continue;
     }
 
-    if (!isLegacyManualTaskId(fm.id)) continue;
-    const title = fm.title.trim();
+    if (!fm.id || !isLegacyManualTaskId(fm.id)) continue;
+    const title = (fm.title ?? "").trim();
     if (!title) {
       conflicts.push(`${fm.id}: missing title; cannot derive deterministic ID`);
       continue;

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -603,19 +603,76 @@ describe("parseTaskFrontmatter cache", () => {
     expect(again.title).toBe("First");
   });
 
-  test("LRU eviction kicks in past 512 entries (oldest evicted)", () => {
+  test("nested arrays in cached entry cannot be mutated (dependencies.blocks)", () => {
+    _resetParseTaskFrontmatterCache();
+    const content = [
+      "---",
+      "id: task-1",
+      "title: Test",
+      "dependencies:",
+      "  blocks: [a]",
+      "  blocked_by: []",
+      "  relates_to: []",
+      "  subtask_of: null",
+      "---",
+    ].join("\n");
+    const first = parseTaskFrontmatter(content);
+    expect(first.dependencies?.blocks).toEqual(["a"]);
+    // A mutation attempt must not silently succeed: either throw (strict mode
+    // frozen array) or leave the array unchanged (sloppy mode), but never land
+    // as a cached side effect on the next read.
+    try {
+      (first.dependencies!.blocks as string[]).push("b");
+    } catch { /* frozen-array throw is fine */ }
+    const second = parseTaskFrontmatter(content);
+    expect(second.dependencies?.blocks).toEqual(["a"]);
+    expect(second).toBe(first);
+  });
+
+  test("nested arrays in cached entry cannot be mutated (merged_from, t3code_threads)", () => {
+    _resetParseTaskFrontmatterCache();
+    const content = [
+      "---",
+      "id: task-1",
+      "title: Test",
+      "merged_from: [task-x]",
+      "t3code_threads: [thread-1]",
+      "---",
+    ].join("\n");
+    const first = parseTaskFrontmatter(content);
+    try { (first.merged_from as string[]).push("task-y"); } catch { /* frozen */ }
+    try { (first.t3code_threads as string[]).push("thread-2"); } catch { /* frozen */ }
+    const second = parseTaskFrontmatter(content);
+    expect(second.merged_from).toEqual(["task-x"]);
+    expect(second.t3code_threads).toEqual(["thread-1"]);
+  });
+
+  test("LRU eviction kicks in past 512 entries — 513th distinct insert evicts the oldest", () => {
     _resetParseTaskFrontmatterCache();
     const first = "---\nid: task-first\ntitle: First\n---\n";
-    parseTaskFrontmatter(first);
-    // Fill cache with 512 distinct entries → first entry should be evicted
-    for (let i = 0; i < 512; i++) {
+    const beforeEviction = parseTaskFrontmatter(first);
+
+    // Confirm a repeat read with the same content string is a cache hit while
+    // the entry is still live — same reference proves the cache is serving it.
+    expect(parseTaskFrontmatter(first)).toBe(beforeEviction);
+
+    // Fill the cache with 511 more distinct entries → cache is now exactly at
+    // PARSE_CACHE_MAX=512 (first + 511 pads). Re-reading `first` must still
+    // hit the cache and return the same reference.
+    for (let i = 0; i < 511; i++) {
       parseTaskFrontmatter(`---\nid: task-pad-${i}\ntitle: Pad ${i}\n---\n`);
     }
-    // Cache should be bounded at 512
-    expect(_parseTaskFrontmatterCacheSize()).toBeLessThanOrEqual(512);
-    // Re-reading `first` should produce a fresh parse (cache miss) — a new reference
-    const refreshed = parseTaskFrontmatter(first);
-    expect(refreshed.id).toBe("task-first");
+    expect(_parseTaskFrontmatterCacheSize()).toBe(512);
+    expect(parseTaskFrontmatter(first)).toBe(beforeEviction);
+
+    // The 513th distinct insert must evict the oldest entry (`first`). After
+    // that, re-reading `first` must be a cache miss and produce a fresh
+    // object with identity different from `beforeEviction`.
+    parseTaskFrontmatter(`---\nid: task-trigger\ntitle: Trigger\n---\n`);
+    expect(_parseTaskFrontmatterCacheSize()).toBe(512);
+    const afterEviction = parseTaskFrontmatter(first);
+    expect(afterEviction).not.toBe(beforeEviction);
+    expect(afterEviction.id).toBe("task-first");
   });
 });
 

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -513,6 +513,102 @@ describe("parseTaskFrontmatter skip_plan", () => {
     const content = '---\nid: task-1\ntitle: Test\nskip_plan: "true"\n---\n';
     const fm = parseTaskFrontmatter(content);
     expect(fm.skip_plan).toBe(true);
+  });
+});
+
+describe("parseTaskFrontmatter non-throwing semantics", () => {
+  test("returns empty object when no frontmatter delimiters present", () => {
+    const content = "# Just a title\n\nBody.\n";
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.id).toBeUndefined();
+    expect(fm.status).toBeUndefined();
+  });
+
+  test("returns {} without throwing on malformed YAML with unrecognized structure", () => {
+    const content = "---\n: : :\n  bad:\n    - [\n---\n";
+    expect(() => parseTaskFrontmatter(content)).not.toThrow();
+    const fm = parseTaskFrontmatter(content);
+    // fallback populates nothing because no parseable field: value lines
+    expect(fm.status).toBeUndefined();
+  });
+
+  test("malformed YAML: line-regex fallback populates recognizable fields", () => {
+    const content = [
+      "---",
+      "id: task-1",
+      "status: done",
+      "dependencies: [unclosed",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.id).toBe("task-1");
+    expect(fm.status).toBe("done");
+  });
+
+  test("malformed YAML fallback strips quotes and treats literal null as missing", () => {
+    const content = [
+      "---",
+      'title: "quoted"',
+      "status: null",
+      "dependencies: [unclosed",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.title).toBe("quoted");
+    expect(fm.status).toBeUndefined();
+  });
+
+  test("populates proposal and deferred_launch fields", () => {
+    const content = [
+      "---",
+      "id: task-1",
+      "title: Test",
+      "proposal: docs/proposals/foo.md",
+      "deferred_launch: true",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.proposal).toBe("docs/proposals/foo.md");
+    expect(fm.deferred_launch).toBe("true");
+  });
+});
+
+describe("parseTaskFrontmatter cache", () => {
+  test("returns the same frozen reference for identical content strings", () => {
+    _resetParseTaskFrontmatterCache();
+    const content = "---\nid: task-1\ntitle: Test\n---\n";
+    const first = parseTaskFrontmatter(content);
+    const second = parseTaskFrontmatter(content);
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+
+  test("mutation of returned object is prevented by freeze", () => {
+    _resetParseTaskFrontmatterCache();
+    const content = "---\nid: task-1\ntitle: First\n---\n";
+    const fm = parseTaskFrontmatter(content);
+    // strict-mode frozen: direct assignment throws; sloppy: silently ignored.
+    // Either way, subsequent read must still see "First".
+    expect(() => {
+      (fm as { title?: string }).title = "Mutated";
+    }).toThrow();
+    const again = parseTaskFrontmatter(content);
+    expect(again.title).toBe("First");
+  });
+
+  test("LRU eviction kicks in past 512 entries (oldest evicted)", () => {
+    _resetParseTaskFrontmatterCache();
+    const first = "---\nid: task-first\ntitle: First\n---\n";
+    parseTaskFrontmatter(first);
+    // Fill cache with 512 distinct entries → first entry should be evicted
+    for (let i = 0; i < 512; i++) {
+      parseTaskFrontmatter(`---\nid: task-pad-${i}\ntitle: Pad ${i}\n---\n`);
+    }
+    // Cache should be bounded at 512
+    expect(_parseTaskFrontmatterCacheSize()).toBeLessThanOrEqual(512);
+    // Re-reading `first` should produce a fresh parse (cache miss) — a new reference
+    const refreshed = parseTaskFrontmatter(first);
+    expect(refreshed.id).toBe("task-first");
   });
 });
 

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, frontmatterBounds, readFrontmatterField, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -50,7 +50,7 @@ describe("updateFrontmatterField upsert", () => {
     expect(fmMatch![1]).toContain("completed: 2026-04-13");
   });
 
-  test("round-trip: inserted field is readable by readFrontmatterField", () => {
+  test("round-trip: inserted field is readable by parseTaskFrontmatter", () => {
     const f = tmpFile("roundtrip.md", [
       "---",
       "id: task-1",
@@ -62,10 +62,11 @@ describe("updateFrontmatterField upsert", () => {
 
     updateFrontmatterField(f, "completed", "2026-04-13T18:00Z");
     const content = readFileSync(f, "utf-8");
-    expect(readFrontmatterField(content, "completed")).toBe("2026-04-13T18:00Z");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.completed).toBe("2026-04-13T18:00Z");
     // Existing fields preserved
-    expect(readFrontmatterField(content, "id")).toBe("task-1");
-    expect(readFrontmatterField(content, "status")).toBe("ready");
+    expect(fm.id).toBe("task-1");
+    expect(fm.status).toBe("ready");
   });
 
   test("inserts into frontmatter, not at body horizontal rule", () => {
@@ -191,64 +192,68 @@ describe("addFrontmatterField", () => {
   });
 });
 
-describe("readFrontmatterField", () => {
-  test("reads basic scalar value", () => {
+describe("parseTaskFrontmatter field reads", () => {
+  test("reads basic scalar value (proposal)", () => {
     const content = "---\nproposal: docs/proposals/foo.md\n---\n\n# Title";
-    expect(readFrontmatterField(content, "proposal")).toBe("docs/proposals/foo.md");
+    expect(parseTaskFrontmatter(content).proposal).toBe("docs/proposals/foo.md");
   });
 
-  test("reads double-quoted string", () => {
+  test("reads double-quoted proposal string", () => {
     const content = '---\nproposal: "docs/proposals/foo.md"\n---\n';
-    expect(readFrontmatterField(content, "proposal")).toBe("docs/proposals/foo.md");
+    expect(parseTaskFrontmatter(content).proposal).toBe("docs/proposals/foo.md");
   });
 
-  test("reads single-quoted string", () => {
+  test("reads single-quoted proposal string", () => {
     const content = "---\nproposal: 'docs/proposals/foo.md'\n---\n";
-    expect(readFrontmatterField(content, "proposal")).toBe("docs/proposals/foo.md");
+    expect(parseTaskFrontmatter(content).proposal).toBe("docs/proposals/foo.md");
   });
 
-  test("returns null for missing field", () => {
+  test("returns undefined for missing optional field (proposal)", () => {
     const content = "---\nid: task-1\nstatus: ready\n---\n";
-    expect(readFrontmatterField(content, "proposal")).toBeNull();
+    expect(parseTaskFrontmatter(content).proposal).toBeUndefined();
   });
 
-  test("returns null when no frontmatter", () => {
+  test("returns {} when no frontmatter", () => {
     const content = "# Just a markdown file\n\nNo frontmatter here.";
-    expect(readFrontmatterField(content, "proposal")).toBeNull();
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.proposal).toBeUndefined();
+    expect(fm.id).toBeUndefined();
   });
 
-  test("returns null for bare null value", () => {
+  test("bare null value for optional field → undefined", () => {
     const content = "---\nproposal: null\n---\n";
-    expect(readFrontmatterField(content, "proposal")).toBeNull();
+    expect(parseTaskFrontmatter(content).proposal).toBeUndefined();
   });
 
-  test("returns null for quoted 'null' string (backward compat)", () => {
+  test("quoted 'null' string for optional field → undefined", () => {
     const content = '---\nproposal: "null"\n---\n';
-    expect(readFrontmatterField(content, "proposal")).toBeNull();
+    expect(parseTaskFrontmatter(content).proposal).toBeUndefined();
   });
 
-  test("returns null for empty frontmatter", () => {
+  test("empty frontmatter yields empty-ish object", () => {
     const content = "---\n\n---\n";
-    expect(readFrontmatterField(content, "proposal")).toBeNull();
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.proposal).toBeUndefined();
+    expect(fm.id).toBeUndefined();
   });
 
-  test("coerces boolean to string", () => {
+  test("boolean uses_browser is typed as boolean", () => {
     const content = "---\nuses_browser: true\n---\n";
-    expect(readFrontmatterField(content, "uses_browser")).toBe("true");
+    expect(parseTaskFrontmatter(content).uses_browser).toBe(true);
   });
 
-  test("coerces number to string", () => {
+  test("numeric slot is coerced to string", () => {
     const content = "---\nslot: 2\n---\n";
-    expect(readFrontmatterField(content, "slot")).toBe("2");
+    expect(parseTaskFrontmatter(content).slot).toBe("2");
   });
 
   test("reads only from frontmatter, not body", () => {
     const content = "---\nproject: real\n---\n\nproject: fake\n";
-    expect(readFrontmatterField(content, "project")).toBe("real");
+    expect(parseTaskFrontmatter(content).project).toBe("real");
   });
 
-  test("body code-block shadowing: frontmatter status wins over body-scoped status (task-485dcb6a)", () => {
-    // Regression guard for the body-scope vulnerability closed by the
+  test("body code-block shadowing: frontmatter status wins (task-485dcb6a)", () => {
+    // Regression guard for the body-scope vulnerability closed by the original
     // regex → readFrontmatterField migration (task-485dcb6a / task-808ee2c7).
     // A naive /^status:\s*(.+)$/m would capture the code-block line "status: wrong".
     const content = [
@@ -270,28 +275,28 @@ describe("readFrontmatterField", () => {
       "Inline prose also mentions status: wrong here.",
     ].join("\n");
 
-    expect(readFrontmatterField(content, "status")).toBe("ready");
-    expect(readFrontmatterField(content, "priority")).toBe("B");
-    // Document the shadowing that the migration fixes: naive regex sees the code block.
-    expect(content.match(/^status:\s*(.+)$/m)?.[1]).toBe("ready");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.status).toBe("ready");
+    expect(fm.priority).toBe("B");
+    // Document the shadowing that the YAML-scoped parse fixes:
     const allStatusMatches = [...content.matchAll(/^status:\s*(.+)$/gm)].map((m) => m[1]);
     expect(allStatusMatches).toContain("wrong");
   });
 
-  test("stringifies array values", () => {
-    const content = "---\nblocks: [a, b]\n---\n";
-    expect(readFrontmatterField(content, "blocks")).toBe("a,b");
+  test("dependencies.blocks is typed as string[] (not joined)", () => {
+    const content = "---\ndependencies:\n  blocks: [a, b]\n---\n";
+    expect(parseTaskFrontmatter(content).dependencies?.blocks).toEqual(["a", "b"]);
   });
 
   test("duplicate keys use last value (uniqueKeys: false)", () => {
     const content = "---\nproject: first\nproject: second\n---\n";
-    expect(readFrontmatterField(content, "project")).toBe("second");
+    expect(parseTaskFrontmatter(content).project).toBe("second");
   });
 
-  test("returns null without throwing on malformed YAML", () => {
+  test("does not throw on malformed YAML; returns line-fallback object", () => {
     const content = "---\n: : :\n  bad:\n    - [\n---\n";
-    expect(() => readFrontmatterField(content, "project")).not.toThrow();
-    expect(readFrontmatterField(content, "project")).toBeNull();
+    expect(() => parseTaskFrontmatter(content)).not.toThrow();
+    expect(parseTaskFrontmatter(content).project).toBeUndefined();
   });
 
   test("malformed YAML: explicit status line still readable via frontmatter-scoped fallback (codex P2)", () => {
@@ -310,8 +315,9 @@ describe("readFrontmatterField", () => {
       "status: wrong",
     ].join("\n");
 
-    expect(readFrontmatterField(content, "status")).toBe("done");
-    expect(readFrontmatterField(content, "id")).toBe("task-1");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.status).toBe("done");
+    expect(fm.id).toBe("task-1");
   });
 
   test("malformed YAML fallback strips surrounding quotes and treats literal null as missing", () => {
@@ -323,8 +329,9 @@ describe("readFrontmatterField", () => {
       "---",
     ].join("\n");
 
-    expect(readFrontmatterField(content, "title")).toBe("quoted");
-    expect(readFrontmatterField(content, "status")).toBeNull();
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.title).toBe("quoted");
+    expect(fm.status).toBeUndefined();
   });
 });
 
@@ -619,9 +626,9 @@ describe("parseTaskFrontmatter effort: tiny", () => {
     expect(fm.effort).toBe("tiny");
   });
 
-  test("round-trips effort: tiny via readFrontmatterField", () => {
+  test("round-trips effort: tiny via parseTaskFrontmatter", () => {
     const content = "---\nid: task-1\ntitle: Test\neffort: tiny\n---\n\nbody\n";
-    expect(readFrontmatterField(content, "effort")).toBe("tiny");
+    expect(parseTaskFrontmatter(content).effort).toBe("tiny");
   });
 
   test("updateFrontmatterField preserves effort: tiny on write", () => {
@@ -631,7 +638,7 @@ describe("parseTaskFrontmatter effort: tiny", () => {
     // Update an unrelated field; verify effort stays "tiny"
     updateFrontmatterField(tmpFile, "priority", "A");
     const after = readFileSync(tmpFile, "utf-8");
-    expect(readFrontmatterField(after, "effort")).toBe("tiny");
+    expect(parseTaskFrontmatter(after).effort).toBe("tiny");
     unlinkSync(tmpFile);
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -34,60 +34,156 @@ function asBoolean(value: unknown): boolean {
   return false;
 }
 
-export function parseTaskFrontmatter(content: string): Partial<TaskFrontmatter> & { id: string; title: string } {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) throw new Error("no frontmatter found");
+export type ParsedTaskFrontmatter = Partial<TaskFrontmatter>;
 
-  const data = YAML.parse(fmMatch[1]!, { uniqueKeys: false }) as Record<string, unknown>;
-  const deps = (data.dependencies as Record<string, unknown>) ?? {};
+const PARSE_CACHE = new Map<string, ParsedTaskFrontmatter>();
+const PARSE_CACHE_MAX = 512;
+
+/** Test-only: reset the module-level cache. Not exported via index. */
+export function _resetParseTaskFrontmatterCache(): void {
+  PARSE_CACHE.clear();
+}
+
+/** Test-only: peek cache size. */
+export function _parseTaskFrontmatterCacheSize(): number {
+  return PARSE_CACHE.size;
+}
+
+export function parseTaskFrontmatter(content: string): ParsedTaskFrontmatter {
+  const hit = PARSE_CACHE.get(content);
+  if (hit) return hit;
+  const parsed = parseTaskFrontmatterUncached(content);
+  Object.freeze(parsed);
+  if (parsed.dependencies) Object.freeze(parsed.dependencies);
+  if (PARSE_CACHE.size >= PARSE_CACHE_MAX) {
+    const firstKey = PARSE_CACHE.keys().next().value;
+    if (firstKey !== undefined) PARSE_CACHE.delete(firstKey);
+  }
+  PARSE_CACHE.set(content, parsed);
+  return parsed;
+}
+
+function parseTaskFrontmatterUncached(content: string): ParsedTaskFrontmatter {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return {};
+  const fmBlock = fmMatch[1]!;
+
+  let data: unknown;
+  try {
+    data = YAML.parse(fmBlock, { uniqueKeys: false });
+  } catch {
+    return parseTaskFrontmatterLineFallback(fmBlock);
+  }
+  if (typeof data !== "object" || data == null) {
+    return parseTaskFrontmatterLineFallback(fmBlock);
+  }
+
+  const d = data as Record<string, unknown>;
+  const deps = (d.dependencies as Record<string, unknown>) ?? {};
   return {
-    id: String(data.id ?? ""),
-    title: String(data.title ?? ""),
-    project: String(data.project ?? ""),
-    status: String(data.status ?? "ready"),
-    priority: String(data.priority ?? "B"),
-    deadline: data.deadline ? String(data.deadline) : null,
+    id: String(d.id ?? ""),
+    title: String(d.title ?? ""),
+    project: String(d.project ?? ""),
+    status: String(d.status ?? "ready"),
+    priority: String(d.priority ?? "B"),
+    deadline: d.deadline ? String(d.deadline) : null,
     dependencies: {
       blocks: Array.isArray(deps.blocks) ? (deps.blocks as string[]) : [],
       blocked_by: Array.isArray(deps.blocked_by) ? (deps.blocked_by as string[]) : [],
       relates_to: Array.isArray(deps.relates_to) ? (deps.relates_to as string[]) : [],
       subtask_of: deps.subtask_of ? String(deps.subtask_of) : null,
     },
-    effort: String(data.effort ?? "medium"),
-    skip_plan: asBoolean(data.skip_plan),
-    requirements: data.requirements ? data.requirements as { os?: string; gpu?: string } : undefined,
-    context: String(data.context ?? ""),
-    uses_browser: asBoolean(data.uses_browser),
-    slot: data.slot ? String(data.slot) : null,
-    adapter: data.adapter ? String(data.adapter) : null,
-    created: String(data.created ?? ""),
-    started: data.started ? String(data.started) : null,
-    completed: data.completed ? String(data.completed) : null,
-    modified: data.modified ? String(data.modified) : null,
-    source: String(data.source ?? ""),
-    url: data.url ? String(data.url) : undefined,
-    github_issue: data.github_issue ? Number(data.github_issue) : undefined,
-    github_title: data.github_title ? String(data.github_title) : undefined,
-    github_repo: data.github_repo ? String(data.github_repo) : undefined,
-    github_labels: data.github_labels ? String(data.github_labels) : undefined,
-    github_state: data.github_state ? String(data.github_state) : undefined,
-    github_state_reason: data.github_state !== undefined && data.github_state_reason === null
+    effort: String(d.effort ?? "medium"),
+    skip_plan: asBoolean(d.skip_plan),
+    requirements: d.requirements ? d.requirements as { os?: string; gpu?: string } : undefined,
+    context: String(d.context ?? ""),
+    uses_browser: asBoolean(d.uses_browser),
+    slot: d.slot ? String(d.slot) : null,
+    adapter: d.adapter ? String(d.adapter) : null,
+    created: String(d.created ?? ""),
+    started: d.started ? String(d.started) : null,
+    completed: d.completed ? String(d.completed) : null,
+    modified: d.modified ? String(d.modified) : null,
+    source: String(d.source ?? ""),
+    url: d.url ? String(d.url) : undefined,
+    github_issue: d.github_issue ? Number(d.github_issue) : undefined,
+    github_title: d.github_title ? String(d.github_title) : undefined,
+    github_repo: d.github_repo ? String(d.github_repo) : undefined,
+    github_labels: d.github_labels ? String(d.github_labels) : undefined,
+    github_state: d.github_state ? String(d.github_state) : undefined,
+    github_state_reason: d.github_state !== undefined && d.github_state_reason === null
       ? null
-      : (data.github_state_reason ? String(data.github_state_reason) : undefined),
-    github_updated_at: data.github_updated_at !== undefined && data.github_updated_at === null
+      : (d.github_state_reason ? String(d.github_state_reason) : undefined),
+    github_updated_at: d.github_updated_at !== undefined && d.github_updated_at === null
       ? null
-      : (data.github_updated_at ? String(data.github_updated_at) : undefined),
-    github_closed_at: data.github_closed_at !== undefined && data.github_closed_at === null
+      : (d.github_updated_at ? String(d.github_updated_at) : undefined),
+    github_closed_at: d.github_closed_at !== undefined && d.github_closed_at === null
       ? null
-      : (data.github_closed_at ? String(data.github_closed_at) : undefined),
-    milestone: data.milestone ? String(data.milestone) : undefined,
-    elaborated: data.elaborated ? String(data.elaborated) : undefined,
-    merged_into: data.merged_into ? String(data.merged_into) : undefined,
-    merged_from: Array.isArray(data.merged_from) ? (data.merged_from as string[]) : undefined,
-    t3code_threads: Array.isArray(data.t3code_threads) ? (data.t3code_threads as string[]) : undefined,
+      : (d.github_closed_at ? String(d.github_closed_at) : undefined),
+    milestone: d.milestone ? String(d.milestone) : undefined,
+    elaborated: d.elaborated ? String(d.elaborated) : undefined,
+    merged_into: d.merged_into ? String(d.merged_into) : undefined,
+    merged_from: Array.isArray(d.merged_from) ? (d.merged_from as string[]) : undefined,
+    t3code_threads: Array.isArray(d.t3code_threads) ? (d.t3code_threads as string[]) : undefined,
+    proposal: normalizeOptionalString(d.proposal),
+    deferred_launch: normalizeOptionalString(d.deferred_launch),
   };
 }
 
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  const s = String(value);
+  if (!s || s.toLowerCase() === "null") return undefined;
+  return s;
+}
+
+/**
+ * Malformed-YAML fallback: parse individual `field: value` lines from the
+ * frontmatter block with a line regex. Populates only the string-shaped fields
+ * we can recognize — arrays / nested blocks stay undefined. Mirrors the
+ * null-literal and surrounding-quote handling of the old readFrontmatterField
+ * line fallback (task-485dcb6a round 2).
+ */
+function parseTaskFrontmatterLineFallback(fmBlock: string): ParsedTaskFrontmatter {
+  const out: Record<string, string> = {};
+  const lineRe = /^([A-Za-z_][A-Za-z0-9_]*):\s*(.+)$/gm;
+  for (const m of fmBlock.matchAll(lineRe)) {
+    const key = m[1]!;
+    const raw = m[2]!.trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
+    if (!raw || raw.toLowerCase() === "null") continue;
+    out[key] = raw;
+  }
+  const fm: ParsedTaskFrontmatter = {};
+  if (out.id !== undefined) fm.id = out.id;
+  if (out.title !== undefined) fm.title = out.title;
+  if (out.project !== undefined) fm.project = out.project;
+  if (out.status !== undefined) fm.status = out.status;
+  if (out.priority !== undefined) fm.priority = out.priority;
+  if (out.effort !== undefined) fm.effort = out.effort;
+  if (out.context !== undefined) fm.context = out.context;
+  if (out.created !== undefined) fm.created = out.created;
+  if (out.source !== undefined) fm.source = out.source;
+  if (out.proposal !== undefined) fm.proposal = out.proposal;
+  if (out.deferred_launch !== undefined) fm.deferred_launch = out.deferred_launch;
+  if (out.url !== undefined) fm.url = out.url;
+  if (out.slot !== undefined) fm.slot = out.slot;
+  if (out.adapter !== undefined) fm.adapter = out.adapter;
+  if (out.milestone !== undefined) fm.milestone = out.milestone;
+  if (out.elaborated !== undefined) fm.elaborated = out.elaborated;
+  if (out.merged_into !== undefined) fm.merged_into = out.merged_into;
+  if (out.skip_plan !== undefined) fm.skip_plan = asBoolean(out.skip_plan);
+  if (out.uses_browser !== undefined) fm.uses_browser = asBoolean(out.uses_browser);
+  if (out.started !== undefined) fm.started = out.started;
+  if (out.completed !== undefined) fm.completed = out.completed;
+  if (out.modified !== undefined) fm.modified = out.modified;
+  if (out.deadline !== undefined) fm.deadline = out.deadline;
+  return fm;
+}
+
+/**
+ * @deprecated Use `parseTaskFrontmatter(content).<field>` instead. Kept as a
+ * temporary shim during migration; removed once all call sites migrate.
+ */
 export function readFrontmatterField(content: string, field: string): string | null {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return null;
@@ -97,9 +193,6 @@ export function readFrontmatterField(content: string, field: string): string | n
   try {
     data = YAML.parse(fmBlock, { uniqueKeys: false });
   } catch {
-    // YAML parse failed — fall back to a frontmatter-scoped line regex so an
-    // explicit `field: value` line is still readable when some other field is
-    // malformed. Body-safe because the regex only sees the extracted block.
     return readFrontmatterFieldLineFallback(fmBlock, field);
   }
   if (typeof data !== "object" || data == null) {

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -180,41 +180,6 @@ function parseTaskFrontmatterLineFallback(fmBlock: string): ParsedTaskFrontmatte
   return fm;
 }
 
-/**
- * @deprecated Use `parseTaskFrontmatter(content).<field>` instead. Kept as a
- * temporary shim during migration; removed once all call sites migrate.
- */
-export function readFrontmatterField(content: string, field: string): string | null {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return null;
-  const fmBlock = fmMatch[1]!;
-
-  let data: unknown;
-  try {
-    data = YAML.parse(fmBlock, { uniqueKeys: false });
-  } catch {
-    return readFrontmatterFieldLineFallback(fmBlock, field);
-  }
-  if (typeof data !== "object" || data == null) {
-    return readFrontmatterFieldLineFallback(fmBlock, field);
-  }
-
-  const value = (data as Record<string, unknown>)[field];
-  if (value == null) return null;
-  const str = String(value);
-  if (!str || str.toLowerCase() === "null") return null;
-  return str;
-}
-
-function readFrontmatterFieldLineFallback(fmBlock: string, field: string): string | null {
-  const rx = new RegExp(`^${field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}:\\s*(.+)$`, "m");
-  const m = fmBlock.match(rx);
-  if (!m) return null;
-  const raw = m[1]!.trim().replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
-  if (!raw || raw.toLowerCase() === "null") return null;
-  return raw;
-}
-
 /** Return line indices of the opening and closing `---` delimiters.
  *  Returns null if no valid frontmatter block is found. */
 export function frontmatterBounds(lines: string[]): { openLine: number; closeLine: number } | null {
@@ -269,7 +234,7 @@ export function transitionStatus(
 ): boolean {
   if (!existsSync(filePath)) throw new Error(`task file not found: ${filePath}`);
   const content = readFileSync(filePath, "utf-8");
-  const current = readFrontmatterField(content, "status") ?? "ready";
+  const current = parseTaskFrontmatter(content).status ?? "ready";
   const allowed = Array.isArray(expectedFrom) ? expectedFrom : [expectedFrom];
   if (!allowed.includes(current)) {
     return false;

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -53,14 +53,31 @@ export function parseTaskFrontmatter(content: string): ParsedTaskFrontmatter {
   const hit = PARSE_CACHE.get(content);
   if (hit) return hit;
   const parsed = parseTaskFrontmatterUncached(content);
-  Object.freeze(parsed);
-  if (parsed.dependencies) Object.freeze(parsed.dependencies);
+  deepFreezeParsed(parsed);
   if (PARSE_CACHE.size >= PARSE_CACHE_MAX) {
     const firstKey = PARSE_CACHE.keys().next().value;
     if (firstKey !== undefined) PARSE_CACHE.delete(firstKey);
   }
   PARSE_CACHE.set(content, parsed);
   return parsed;
+}
+
+/**
+ * Freeze the parsed object and every nested container it owns so cached
+ * reads cannot be mutated through `.dependencies.blocks.push(...)` or
+ * similar nested paths. Shallow freeze alone leaves those arrays writable.
+ */
+function deepFreezeParsed(parsed: ParsedTaskFrontmatter): void {
+  if (parsed.dependencies) {
+    Object.freeze(parsed.dependencies.blocks);
+    Object.freeze(parsed.dependencies.blocked_by);
+    Object.freeze(parsed.dependencies.relates_to);
+    Object.freeze(parsed.dependencies);
+  }
+  if (parsed.merged_from) Object.freeze(parsed.merged_from);
+  if (parsed.t3code_threads) Object.freeze(parsed.t3code_threads);
+  if (parsed.requirements) Object.freeze(parsed.requirements);
+  Object.freeze(parsed);
 }
 
 function parseTaskFrontmatterUncached(content: string): ParsedTaskFrontmatter {

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -255,4 +255,38 @@ describe("tasksReconcileBlockedStatus", () => {
     expect(readFileSync(join(tasksDir, "task-already-ready.md"), "utf-8")).toContain("status: ready");
     expect(readFileSync(join(tasksDir, "task-already-blocked.md"), "utf-8")).toContain("status: blocked");
   });
+
+  test("malformed YAML with status: blocked is not silently rewritten to ready", () => {
+    // Regression for codex P1: parseTaskFrontmatter's line-regex fallback
+    // salvages top-level scalars (status) but cannot reconstruct nested
+    // dependencies.blocked_by. Before the dependencies-undefined guard,
+    // this file would have been rewritten to `status: ready` because
+    // `fm.dependencies?.blocked_by ?? []` returned an empty array.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    const malformedFile = join(tasksDir, "task-malformed.md");
+    writeFileSync(malformedFile, [
+      "---",
+      "id: task-malformed",
+      "title: Malformed",
+      "status: blocked",
+      "dependencies: [unclosed",
+      "---",
+      "",
+      "# Body",
+      "",
+    ].join("\n"));
+    const before = readFileSync(malformedFile, "utf-8");
+
+    tasksReconcileBlockedStatus(tasksDir);
+
+    const after = readFileSync(malformedFile, "utf-8");
+    // Invariant: malformed files must not be rewritten. `status: blocked`
+    // survives verbatim; no status mutation.
+    expect(after).toBe(before);
+    expect(after).toContain("status: blocked");
+    expect(after).not.toContain("status: ready");
+  });
 });

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { loadConfigSync, harnessDir, priorityProjects, preemptAutonomy, slotsCount, milestonesEnabledProjects } from "../config.ts";
 import { readAllSlotJson } from "../slots/json.ts";
 import { listStashes } from "../slots/preempt.ts";
-import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray, readFrontmatterField } from "./markdown.ts";
+import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray } from "./markdown.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
 import { queueRequest, parseQueueLines } from "../queue.ts";
@@ -253,7 +253,7 @@ function readTaskProjectName(tasksDir: string, taskId: string): string {
   const taskFile = join(tasksDir, `${taskId}.md`);
   if (!existsSync(taskFile)) return "";
   const taskContent = readFileSync(taskFile, "utf-8");
-  return readFrontmatterField(taskContent, "project") ?? "";
+  return parseTaskFrontmatter(taskContent).project ?? "";
 }
 
 function collectProjectsWithQueuedPreemption(tasksDir: string, queueContent: string, priProjects: string[]): Set<string> {
@@ -278,8 +278,9 @@ function collectProjectsWithQueuedPreemption(tasksDir: string, queueContent: str
   const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
   for (const file of files) {
     const content = readFileSync(join(tasksDir, file), "utf-8");
-    if (readFrontmatterField(content, "status") !== "preempt-queued") continue;
-    const project = readFrontmatterField(content, "project") ?? "";
+    const fm = parseTaskFrontmatter(content);
+    if (fm.status !== "preempt-queued") continue;
+    const project = fm.project ?? "";
     if (project && priProjects.includes(project)) {
       projects.add(project);
     }
@@ -807,8 +808,8 @@ function tasksQueueElaborations(): void {
     if (!existsSync(file)) continue;
 
     const content = readFileSync(file, "utf-8");
-    const status = readFrontmatterField(content, "status");
-    if (status !== null && status !== "ready") continue;
+    const status = parseTaskFrontmatter(content).status;
+    if (status !== undefined && status !== "ready") continue;
 
     if (isElaborated(content)) continue;
 
@@ -830,10 +831,11 @@ function tasksNeedsElaborationList(tasksDir: string): string[] {
 
   for (const f of files) {
     const content = readFileSync(join(tasksDir, f), "utf-8");
-    const id = readFrontmatterField(content, "id");
+    const fm = parseTaskFrontmatter(content);
+    const id = fm.id;
     if (!id) continue;
 
-    const status = readFrontmatterField(content, "status") ?? "";
+    const status = fm.status ?? "";
     if (["merged", "done", "abandoned", "needs-confirmation"].includes(status)) continue;
 
     if (!isElaborated(content)) result.push(id);
@@ -881,12 +883,13 @@ function tasksQueuePreemptions(): void {
 
   for (const f of files) {
     const content = readFileSync(join(tasksDir, f), "utf-8");
-    const id = readFrontmatterField(content, "id");
+    const fm = parseTaskFrontmatter(content);
+    const id = fm.id;
     if (!id) continue;
 
-    if (readFrontmatterField(content, "status") !== "ready") continue;
+    if (fm.status !== "ready") continue;
 
-    const project = readFrontmatterField(content, "project") ?? "";
+    const project = fm.project ?? "";
     if (!project) continue;
 
     if (!priProjects.includes(project)) continue;

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -677,6 +677,12 @@ function healBlockedByLinks(tasksDir: string): void {
     let fm;
     try { fm = parseTaskFrontmatter(content); } catch { continue; }
     if (!fm.id) continue;
+    // Malformed YAML falls through the line-regex recovery path, which can
+    // salvage top-level fields but cannot reconstruct the nested dependencies
+    // block. Skip such files here rather than treating absent `dependencies`
+    // as "no blockers" — otherwise pruning / backlink-healing would silently
+    // rewrite files we could not fully parse. See tasksReconcileBlockedStatus.
+    if (!fm.dependencies) continue;
     taskMap.set(fm.id, { status: fm.status ?? "ready", filePath, fm });
   }
 
@@ -730,8 +736,16 @@ function tasksReconcileBlockedStatus(tasksDir: string): void {
       fm = parseTaskFrontmatter(content);
     } catch { continue; }
 
+    // Guard against the malformed-YAML line-regex fallback: it populates
+    // top-level fields (e.g. status) but leaves nested `dependencies`
+    // undefined. Without this check, a partially-malformed task with
+    // `status: blocked` would be seen as having no blockers and rewritten
+    // to `ready` — silent state corruption. Pre-unification the parser
+    // threw on such files and the catch above short-circuited.
+    if (!fm.dependencies) continue;
+
     const status = fm.status ?? "ready";
-    const blockedBy = fm.dependencies?.blocked_by ?? [];
+    const blockedBy = fm.dependencies.blocked_by;
 
     // Skip terminal and active statuses
     if (["done", "abandoned", "merged", "in-progress", "deferred", "preempt-queued", "preempted"].includes(status)) continue;

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -675,6 +675,7 @@ function healBlockedByLinks(tasksDir: string): void {
     const content = readFileSync(filePath, "utf-8");
     let fm;
     try { fm = parseTaskFrontmatter(content); } catch { continue; }
+    if (!fm.id) continue;
     taskMap.set(fm.id, { status: fm.status ?? "ready", filePath, fm });
   }
 
@@ -773,7 +774,7 @@ function tasksMilestoneWarnings(tasksDir: string): void {
 
     if (!milestonesProjects.has(fm.project ?? "")) continue;
 
-    if (!fm.milestone) {
+    if (!fm.milestone && fm.id) {
       missing.push(fm.id);
     }
   }

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -40,6 +40,8 @@ export interface TaskFrontmatter {
   merged_into?: string;
   merged_from?: string[];
   t3code_threads?: string[];
+  proposal?: string;
+  deferred_launch?: string;
 }
 
 export interface TaskYamlEntry {


### PR DESCRIPTION
## Summary

- Collapses the two overlapping frontmatter parsing helpers in `src/tasks/markdown.ts` into a single cached `parseTaskFrontmatter` API. `readFrontmatterField` (and its internal line-fallback helper) are removed; every call site across the codebase switches over.
- The cached parser is bounded by a FIFO-on-insert 512-entry Map. Cached entries are **deep-frozen** (top-level object, `dependencies` subobject, and every nested array — `dependencies.{blocks,blocked_by,relates_to}`, `merged_from`, `t3code_threads`, `requirements`) so callers cannot contaminate a cache entry via `fm.dependencies.blocks.push(...)`.
- The parser no longer throws on missing/malformed frontmatter — it returns a `Partial<TaskFrontmatter>` and preserves the malformed-YAML line-regex fallback introduced in task-485dcb6a round 2.
- Absorbs task-277f8670 scope in `src/mag.ts`: merges the two `cleanupDoneTaskThreads` passes, eliminates the `t3code_threads` split-on-comma coercion, collapses the adopt-sessions scanner's five field reads + inline `YAML.parse` into one helper call with typed `fm.dependencies.blocked_by`.
- Extends `TaskFrontmatter` with optional `proposal?: string` and `deferred_launch?: string`. Renames the local `parseTaskFrontmatter` in `src/dashboard-server.ts` to `readDashboardTaskInfo` so the imported helper is unambiguous.
- **Default-drift audit fixes** (codex review round 2):
  - `tasksReconcileBlockedStatus` / `healBlockedByLinks` in `src/tasks/sync.ts` now skip when `fm.dependencies` is undefined, preserving the pre-unification "skip malformed files" behavior that the `try/catch` around the thrower provided. Without this guard, a malformed task with `status: blocked, dependencies: [unclosed` would be silently rewritten to `status: ready`.
  - `autoFillAdapterArgs` in `src/slots/index.ts` uses a dedicated `readRawEffortField` helper to preserve the "small" default for legacy tasks without an explicit `effort:` line — `parseTaskFrontmatter` normalizes missing effort to "medium", which would silently upgrade those tasks to medium-effort orchestration flags.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 1481 pass / 0 fail. New tests: cache identity, deep-freeze on dependency/merged_from/t3code_threads arrays, identity-based LRU eviction (pre- vs post-513th-insert object reference), malformed-YAML reconcile regression, missing-effort → "small" regression.
- [x] `bun run build` compiles `bin/ludics`
- [x] `ludics init --no-triggers` runs cleanly
- [x] `grep -rn readFrontmatterField src/` → zero non-historical hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)