### PR TITLE
Git-runner API follow-ups: withCheckout type-level async rejection, expandHome consolidation, drop briefing-lag re-exports

### DIFF
--- a/src/briefing-lag.test.ts
+++ b/src/briefing-lag.test.ts
@@ -5,9 +5,8 @@ import { tmpdir } from "os";
 import {
   formatUpstreamLagSection,
   parseLeftRightCount,
-  detectDefaultBranches,
-  type RunGit,
 } from "./briefing-lag.ts";
+import { detectDefaultBranches, type RunGit } from "./git-runner.ts";
 import type { ProjectConfig } from "./config.ts";
 
 function tmp(): string {

--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -13,13 +13,7 @@
 import { existsSync, statSync } from "fs";
 import { join } from "path";
 import type { ProjectConfig } from "./config.ts";
-import { detectDefaultBranches, defaultRunGit, expandHome, hasRemote, type RunGit } from "./git-runner.ts";
-
-// Re-exports so existing importers of briefing-lag's public surface keep
-// working.
-export { detectDefaultBranches, defaultRunGit };
-export type { RunGit };
-export type { DetectedBranches, RunGitResult } from "./git-runner.ts";
+import { detectDefaultBranches, expandHome, hasRemote, type RunGit } from "./git-runner.ts";
 
 export interface FormatLagOptions {
   now: Date;

--- a/src/git-runner.test.ts
+++ b/src/git-runner.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test";
+import { resolve } from "path";
 import {
   detectDefaultBranches,
   detectDefaultBranchesAuthoritative,
@@ -24,13 +25,21 @@ function fakeGit(rules: Array<{ match: string[]; stdout: string; exitCode?: numb
 }
 
 describe("git-runner helpers", () => {
-  test("expandHome: expands ~/ prefix using $HOME", () => {
+  test("expandHome: expands ~/ prefix and normalizes via resolve semantics", () => {
     const origHome = process.env.HOME;
     process.env.HOME = "/home/alice";
     try {
+      // ~/ prefix expands to $HOME and normalizes the joined path.
       expect(expandHome("~/work/foo")).toBe("/home/alice/work/foo");
+      // Absolute paths pass through unchanged.
       expect(expandHome("/abs/path")).toBe("/abs/path");
-      expect(expandHome("relative")).toBe("relative");
+      // Relative inputs become absolute (anchored at cwd) — this is the
+      // behaviour the consolidation borrowed from the former expandHomePath.
+      expect(expandHome("relative")).toBe(resolve("relative"));
+      // Normalization: `..` segments are collapsed.
+      expect(expandHome("~/a/../b")).toBe("/home/alice/b");
+      // Normalization: trailing slashes are removed.
+      expect(expandHome("/abs/path/")).toBe("/abs/path");
     } finally {
       process.env.HOME = origHome;
     }

--- a/src/git-runner.test.ts
+++ b/src/git-runner.test.ts
@@ -220,36 +220,22 @@ describe("withCheckout", () => {
     expect(last).toEqual(["checkout", "topic"]);
   });
 
-  test("rejects async callbacks (Promise-returning) with a clear error and restores the branch", () => {
-    // Regression for PR #366 codex review: the finally-block runs as soon as
-    // the sync call returns, so an async fn's awaited git work would execute
-    // after checkout-back, on the wrong branch. Detect and throw.
-    const { run, calls } = recordingGit((args) => {
-      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
-        return { stdout: "topic\n", exitCode: 0 };
-      }
-      return { stdout: "", exitCode: 0 };
-    });
-    expect(() =>
-      withCheckout("/x", "master", run, () => Promise.resolve(42) as unknown as number),
-    ).toThrow(/async callbacks are not supported/);
-    // Restore must still run — the branch should be returned to `topic`.
-    const last = calls[calls.length - 1]!;
-    expect(last).toEqual(["checkout", "topic"]);
-  });
-
-  test("rejects async callbacks even when already on target branch (no checkout, no restore)", () => {
-    const { run, calls } = recordingGit((args) => {
-      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
-        return { stdout: "master\n", exitCode: 0 };
-      }
-      return { stdout: "", exitCode: 0 };
-    });
-    expect(() =>
-      withCheckout("/x", "master", run, () => Promise.resolve("ok") as unknown as string),
-    ).toThrow(/async callbacks are not supported/);
-    // No checkout was issued in this branch, which is correct (we never left).
-    expect(calls.some((c) => c[0] === "checkout")).toBe(false);
+  test("rejects async callbacks at compile time via the conditional-type constraint on fn", () => {
+    // The `fn` parameter is typed `() => T extends PromiseLike<unknown> ? never : T`,
+    // so any callback whose return type extends `PromiseLike` (including `async`
+    // functions and explicit `Promise<X>` returns) requires `() => never` and
+    // fails to typecheck. These `@ts-expect-error` lines assert that contract:
+    // if the constraint is ever weakened, tsc will flag the directive as unused
+    // and the test fails to compile.
+    const { run } = recordingGit(() => ({ stdout: "", exitCode: 0 }));
+    // @ts-expect-error async callback returns Promise — banned by conditional type
+    void withCheckout("/x", "master", run, async () => 42);
+    // @ts-expect-error explicit Promise.resolve return — banned by conditional type
+    void withCheckout("/x", "master", run, () => Promise.resolve("ok"));
+    // Sanity: the synchronous form still typechecks (no @ts-expect-error here
+    // would surface "Unused @ts-expect-error" if the line below were misclassified).
+    const r = withCheckout("/x", "master", run, () => 7);
+    expect(r).toBe(7);
   });
 
   test("checkout failure throws and does not invoke callback", () => {

--- a/src/git-runner.ts
+++ b/src/git-runner.ts
@@ -115,11 +115,6 @@ export function detectDefaultBranchesAuthoritative(
   return { origin: read("origin"), upstream: read("upstream") };
 }
 
-function isThenable(x: unknown): x is PromiseLike<unknown> {
-  return x !== null && (typeof x === "object" || typeof x === "function")
-    && typeof (x as { then?: unknown }).then === "function";
-}
-
 /**
  * Run `fn` with `targetBranch` checked out, restoring the prior branch (or
  * detached-HEAD SHA) afterwards. If the current branch is already
@@ -136,15 +131,17 @@ function isThenable(x: unknown): x is PromiseLike<unknown> {
  * Synchronous only: `fn` must not return a Promise. The finally block runs
  * as soon as `fn()` returns, so for an async callback the branch restore
  * would fire before the awaited git work settled — the awaited commands
- * would then execute on the wrong branch. If you need async, build a
- * dedicated `withCheckoutAsync` that awaits before restoring. Violations
- * throw at runtime (detected by inspecting the return value's `.then`).
+ * would then execute on the wrong branch. The conditional-type constraint
+ * on `fn` makes the misuse un-compilable: `T` must not extend `PromiseLike`,
+ * so an `async` callback or one returning a `Promise` fails to typecheck.
+ * If you need async, build a dedicated `withCheckoutAsync` that awaits
+ * before restoring.
  */
 export function withCheckout<T>(
   cwd: string,
   targetBranch: string,
   runGit: RunGit,
-  fn: () => T,
+  fn: () => T extends PromiseLike<unknown> ? never : T,
 ): T {
   const abbrev = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
   const rawName = abbrev.exitCode === 0 ? abbrev.stdout.trim() : "";
@@ -155,15 +152,7 @@ export function withCheckout<T>(
   })() : null;
 
   if (priorBranch === targetBranch) {
-    const result = fn();
-    if (isThenable(result)) {
-      throw new Error(
-        "withCheckout: async callbacks are not supported — the branch restore " +
-        "would fire before the Promise settled. Make `fn` synchronous or " +
-        "introduce a separate async helper that awaits before restoring.",
-      );
-    }
-    return result;
+    return fn() as T;
   }
 
   const co = runGit(["checkout", targetBranch], cwd);
@@ -171,15 +160,7 @@ export function withCheckout<T>(
     throw new Error(`checkout ${targetBranch} failed: ${co.stdout.trim().slice(0, 200)}`);
   }
   try {
-    const result = fn();
-    if (isThenable(result)) {
-      throw new Error(
-        "withCheckout: async callbacks are not supported — the branch restore " +
-        "would fire before the Promise settled. Make `fn` synchronous or " +
-        "introduce a separate async helper that awaits before restoring.",
-      );
-    }
-    return result;
+    return fn() as T;
   } finally {
     if (priorBranch) {
       runGit(["checkout", priorBranch], cwd);

--- a/src/git-runner.ts
+++ b/src/git-runner.ts
@@ -4,7 +4,7 @@
 // inject a fake; the production `defaultRunGit` routes through
 // `safeSyncOutput` per the spawn.ts policy.
 
-import { join } from "path";
+import { resolve } from "path";
 import { safeSyncOutput } from "./spawn.ts";
 
 export interface RunGitResult {
@@ -20,9 +20,19 @@ export interface DetectedBranches {
   upstream: string | null;
 }
 
-export function expandHome(path: string): string {
-  if (path.startsWith("~/")) return join(process.env.HOME ?? "~", path.slice(2));
-  return path;
+/**
+ * Resolve `~/`-prefixed and bare paths to absolute, normalized form.
+ *
+ * `~/foo` → `resolve($HOME, "foo")`; everything else → `resolve(raw)`.
+ * `resolve` collapses `..` segments and trailing slashes, and turns relative
+ * inputs into absolute paths anchored at the current working directory. This
+ * subsumes the `expandHomePath` helper that previously lived in
+ * `sessions/sweep-state.ts`, whose downstream consumers required absolute
+ * paths.
+ */
+export function expandHome(raw: string): string {
+  if (raw.startsWith("~/")) return resolve(process.env.HOME ?? "~", raw.slice(2));
+  return resolve(raw);
 }
 
 export function hasRemote(cwd: string, name: string, runGit: RunGit): boolean {

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, u
 import { tmpdir } from "os";
 import { join } from "path";
 import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext } from "./mag.ts";
-import type { RunGit } from "./briefing-lag.ts";
+import type { RunGit } from "./git-runner.ts";
 
 describe("normalizeLaunchAdapter", () => {
   test("t3code passes through unchanged", () => {

--- a/src/sessions/sweep-state.ts
+++ b/src/sessions/sweep-state.ts
@@ -3,10 +3,11 @@
 // This module owns the allowlist ("known sessions") written by adapter logic.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
-import { join, resolve } from "path";
+import { join } from "path";
 import { harnessDir } from "../config.ts";
 import { isPlainObject } from "../json.ts";
 import { isGitWorktree, getMainRepoFromWorktree } from "../adapters/base.ts";
+import { expandHome } from "../git-runner.ts";
 
 export type SweepMode = "agent-claude" | "agent-codex" | "t3code";
 
@@ -45,13 +46,8 @@ function isoNow(): string {
   return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
-function expandHomePath(raw: string): string {
-  if (raw.startsWith("~/")) return resolve(process.env.HOME ?? "~", raw.slice(2));
-  return resolve(raw);
-}
-
 export function normalizeProjectDirForSweep(raw: string): string {
-  const abs = expandHomePath(raw);
+  const abs = expandHome(raw);
   if (isGitWorktree(abs)) {
     const mainRepo = getMainRepoFromWorktree(abs);
     if (mainRepo) return mainRepo;

--- a/src/staging-ff.test.ts
+++ b/src/staging-ff.test.ts
@@ -6,7 +6,7 @@ import {
   syncStagingMainWithUpstream,
   type FastForwardProjectResult,
 } from "./staging-ff.ts";
-import type { RunGit } from "./briefing-lag.ts";
+import type { RunGit } from "./git-runner.ts";
 import type { ProjectConfig } from "./config.ts";
 
 function tmp(prefix: string): string {


### PR DESCRIPTION
## Summary

Three post-merge cleanups on the `src/git-runner.ts` API surface established by PR #366. Each item is independent and lives in its own commit for reviewability.

- **Item 1 (`61e9802`) — `withCheckout` compile-time async rejection.** Replace the runtime `.then`-sniffing guard with a conditional-type constraint on `fn`: `() => T extends PromiseLike<unknown> ? never : T`. Any `async` callback or `Promise`-returning callback now requires `() => never` and fails to typecheck. Drop the `isThenable` helper and both runtime branches; convert the two regression tests (which had to cast `Promise.resolve(...) as unknown as number` to reach the guard — the cast was the smell) into `@ts-expect-error` compile-time assertions that fire if the constraint is ever weakened.
- **Item 2 (`a8d885a`) — `expandHome` consolidation.** Rewrite `expandHome` in `src/git-runner.ts` to use `resolve` semantics (`raw.startsWith("~/") ? resolve(HOME ?? "~", raw.slice(2)) : resolve(raw)`), then delete the near-duplicate `expandHomePath` from `src/sessions/sweep-state.ts` and switch `normalizeProjectDirForSweep` to import the consolidated helper. The two production callers (`formatUpstreamLagSection`, the staging-ff worker) feed config-declared paths that are already absolute or `~/…`, so their output is byte-identical. Unit test updated and extended with `..` collapse and trailing-slash normalization coverage.
- **Item 3 (`6899c3c`) — drop `briefing-lag.ts` transitional re-exports.** PR #366 kept `briefing-lag.ts` re-exporting `detectDefaultBranches`, `defaultRunGit`, `RunGit`, `DetectedBranches`, `RunGitResult` so existing importers didn't have to churn. With the codebase settled, switch the three remaining importers (`src/briefing-lag.test.ts`, `src/staging-ff.test.ts`, `src/mag.test.ts`) to pull from `./git-runner.ts` directly, and delete the re-export block. `src/mag.ts`'s import of `formatUpstreamLagSection` (a native briefing-lag export) is unchanged.

Source: retrospective of task-b0d4f45b — `suggestRefactorSummary` items 1, 3, 4.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (no `--max-warnings=0` violations)
- [x] `bun run build` — `bin/ludics` compiles (166 modules)
- [x] `bun test` — 1468 pass / 0 fail / 3195 expect() calls
- [x] `bun run lint:cli-readme` — no CLI/README drift introduced
- [x] Each commit verified to pass typecheck/lint/test independently (Item 1 verified via `git stash` against the pre-Item-2 working tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)