### PR TITLE
Harden lint-template-safety: shared keys, disjoint scanner, command-list drift test

### DIFF
--- a/scripts/lint-template-safety.test.ts
+++ b/scripts/lint-template-safety.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   ALWAYS_POPULATED,
+  classifyLines,
   findFencedLines,
   findFencedShellBlocks,
   findInlineShellSpans,
@@ -116,6 +117,132 @@ describe("findInlineShellSpans", () => {
     const lines = ['Inspect `gh pr view --json x | jq ".title"` output.'];
     const spans = findInlineShellSpans(lines);
     expect(spans).toHaveLength(1);
+  });
+});
+
+describe("classifyLines — disjointness", () => {
+  // Hand-crafted mixed corpus: prose, ```sh, ```ts, indented ```bash inside a
+  // numbered list, and a few prose lines between blocks.
+  const corpus = [
+    "# Heading",
+    "",
+    "Some prose with a `gh pr view 1` backtick.",
+    "",
+    "```sh",
+    'echo "{{STATUS_FILE}}"',
+    "```",
+    "",
+    "Now a typescript block:",
+    "",
+    "```ts",
+    "// `gh pr view 2` is illustrative only",
+    "const x = 1;",
+    "```",
+    "",
+    "1. Indented bash example:",
+    "",
+    "   ```bash",
+    "   git status",
+    "   git log",
+    "   ```",
+    "",
+    "Trailing prose.",
+  ];
+
+  test("returns one classification per input line (length invariant)", () => {
+    const classes = classifyLines(corpus);
+    expect(classes).toHaveLength(corpus.length);
+  });
+
+  test("each element is well-formed (one of three kinds with expected fields)", () => {
+    for (const c of classifyLines(corpus)) {
+      if (c.kind === "prose") {
+        // No additional fields.
+      } else if (c.kind === "fence-marker") {
+        expect(c.blockKind === "shell" || c.blockKind === "other").toBe(true);
+      } else if (c.kind === "fence-body") {
+        expect(c.blockKind === "shell" || c.blockKind === "other").toBe(true);
+        expect(typeof c.indent).toBe("string");
+      } else {
+        // exhaustiveness — should be unreachable
+        throw new Error(`unexpected kind: ${JSON.stringify(c)}`);
+      }
+    }
+  });
+
+  test("disjointness: prose / fence-marker / fence-body never overlap on the same row", () => {
+    const classes = classifyLines(corpus);
+    let proseCount = 0;
+    let markerCount = 0;
+    let bodyCount = 0;
+    for (const c of classes) {
+      if (c.kind === "prose") proseCount++;
+      else if (c.kind === "fence-marker") markerCount++;
+      else if (c.kind === "fence-body") bodyCount++;
+    }
+    expect(proseCount + markerCount + bodyCount).toBe(corpus.length);
+  });
+
+  test("classifies ```sh body rows as fence-body shell", () => {
+    const classes = classifyLines(corpus);
+    // Line 5 is the body of the ```sh block (corpus[4] is the marker).
+    expect(classes[5]).toEqual({ kind: "fence-body", blockKind: "shell", indent: "" });
+  });
+
+  test("classifies ```ts body rows as fence-body other", () => {
+    const classes = classifyLines(corpus);
+    // Lines 11 and 12 are inside the ```ts block.
+    expect(classes[11]).toEqual({ kind: "fence-body", blockKind: "other", indent: "" });
+    expect(classes[12]).toEqual({ kind: "fence-body", blockKind: "other", indent: "" });
+  });
+
+  test("classifies indented ```bash body rows with the opening indent", () => {
+    const classes = classifyLines(corpus);
+    // corpus[17] is `   ```bash` (marker), bodies are 18 and 19.
+    expect(classes[18]).toEqual({ kind: "fence-body", blockKind: "shell", indent: "   " });
+    expect(classes[19]).toEqual({ kind: "fence-body", blockKind: "shell", indent: "   " });
+  });
+
+  test("disjointness invariant holds against a real orchestration template", () => {
+    // Pick a representative template; any one suffices since the invariant is
+    // structural. pair-coder-pr-create.md exists in skills/orchestration/.
+    const path = join(import.meta.dir, "..", "skills", "orchestration", "pair-coder-pr-create.md");
+    const text = readFileSync(path, "utf-8");
+    const lines = text.split(/\r?\n/);
+    const classes = classifyLines(lines);
+    expect(classes).toHaveLength(lines.length);
+    for (const c of classes) {
+      const ok =
+        c.kind === "prose" ||
+        c.kind === "fence-marker" ||
+        c.kind === "fence-body";
+      expect(ok).toBe(true);
+    }
+  });
+
+  test("ts-fence regression: inline-shell-shaped backtick inside ```ts is fence-body, not inline shell", () => {
+    // The round-2 Codex catch: a ```ts (non-shell) fence whose body contains a
+    // backtick span shaped like an inline shell command must classify as
+    // fence-body of blockKind: "other", and findInlineShellSpans must not
+    // emit a span pointing into that body.
+    const lines = [
+      "Example code:",
+      "",
+      "```ts",
+      '// `gh pr view 123` — illustrative only',
+      "const x: string = `hello`;",
+      "```",
+      "After the block.",
+    ];
+    const classes = classifyLines(lines);
+    // Body lines are 3 and 4.
+    expect(classes[3]).toEqual({ kind: "fence-body", blockKind: "other", indent: "" });
+    expect(classes[4]).toEqual({ kind: "fence-body", blockKind: "other", indent: "" });
+    // findInlineShellSpans must NOT emit a span pointing into the ```ts body.
+    const spans = findInlineShellSpans(lines);
+    for (const span of spans) {
+      expect(span.startLine === 3 || span.startLine === 4).toBe(false);
+    }
   });
 });
 

--- a/scripts/lint-template-safety.test.ts
+++ b/scripts/lint-template-safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -356,6 +356,118 @@ describe("ALWAYS_POPULATED set", () => {
     ]) {
       expect(ALWAYS_POPULATED.has(v)).toBe(false);
     }
+  });
+});
+
+describe("ALWAYS_POPULATED_KEYS drift", () => {
+  // Bidirectional invariant against `buildSkillContext`'s `result` object literal
+  // in src/orchestration/skills.ts. Catches the classic drift case where someone
+  // adds a literally-non-empty assignment but forgets to register the key as
+  // always-populated, or removes a key from one side without the other.
+
+  /** Extract the `result: Record<string, string> = { ... };` block from skills.ts
+   *  by locating the opening `= {` and matching closing `};` via brace depth. */
+  function extractResultBlock(text: string): { keys: { name: string; rhs: string }[] } {
+    const startMarker = "const result: Record<string, string> = {";
+    const startIdx = text.indexOf(startMarker);
+    if (startIdx < 0) throw new Error("could not locate result literal in skills.ts");
+    const bodyStart = startIdx + startMarker.length;
+    let depth = 1;
+    let i = bodyStart;
+    while (i < text.length && depth > 0) {
+      const ch = text[i]!;
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+      if (depth === 0) break;
+      i++;
+    }
+    if (depth !== 0) throw new Error("unbalanced braces in result literal");
+    const body = text.slice(bodyStart, i);
+    // Walk top-level entries (depth 0 within `body`) and collect "KEY: rhs,"
+    // pairs. We need to track nested braces/brackets/parens so that ternaries
+    // or template literals containing `,` don't fragment a single entry.
+    const keys: { name: string; rhs: string }[] = [];
+    let bd = 0; // brace depth
+    let pd = 0; // paren depth
+    let sd = 0; // square-bracket depth
+    let entryStart = 0;
+    let inString: '"' | "'" | "`" | null = null;
+    let escape = false;
+    const flush = (end: number) => {
+      const entry = body.slice(entryStart, end).trim();
+      entryStart = end + 1;
+      if (!entry) return;
+      const m = entry.match(/^([A-Z][A-Z0-9_]*)\s*:\s*([\s\S]*)$/);
+      if (!m) return; // skip comments / non-identifier lines
+      keys.push({ name: m[1]!, rhs: m[2]!.trim() });
+    };
+    for (let j = 0; j < body.length; j++) {
+      const ch = body[j]!;
+      if (escape) { escape = false; continue; }
+      if (inString) {
+        if (ch === "\\") { escape = true; continue; }
+        if (ch === inString) inString = null;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") { inString = ch; continue; }
+      if (ch === "{") bd++;
+      else if (ch === "}") bd--;
+      else if (ch === "(") pd++;
+      else if (ch === ")") pd--;
+      else if (ch === "[") sd++;
+      else if (ch === "]") sd--;
+      else if (ch === "," && bd === 0 && pd === 0 && sd === 0) {
+        flush(j);
+      }
+    }
+    flush(body.length);
+    return { keys };
+  }
+
+  /** A right-hand-side expression has an empty-default marker if it contains
+   *  one of the canonical idioms `?? ""`, `: ""`, or `|| ""` (single-quoted
+   *  variants accepted too) at any position outside string literals. */
+  function hasEmptyDefault(rhs: string): boolean {
+    return /(?:\?\?|:|\|\|)\s*""(?!")|(?:\?\?|:|\|\|)\s*''(?!')/.test(rhs);
+  }
+
+  const skillsPath = join(import.meta.dir, "..", "src", "orchestration", "skills.ts");
+  const skillsText = readFileSync(skillsPath, "utf-8");
+  const { keys } = extractResultBlock(skillsText);
+
+  test("every literally-non-empty assignment is in ALWAYS_POPULATED_KEYS", () => {
+    const missing: string[] = [];
+    for (const { name, rhs } of keys) {
+      if (hasEmptyDefault(rhs)) continue;
+      if (!ALWAYS_POPULATED.has(name)) {
+        missing.push(`${name}  (rhs: ${rhs.slice(0, 60)})`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("every key in ALWAYS_POPULATED_KEYS appears as a non-empty-default assignment", () => {
+    const byName = new Map(keys.map((k) => [k.name, k.rhs]));
+    const missing: string[] = [];
+    for (const key of ALWAYS_POPULATED) {
+      const rhs = byName.get(key);
+      if (rhs == null) {
+        missing.push(`${key} (no assignment found in result literal)`);
+        continue;
+      }
+      if (hasEmptyDefault(rhs)) {
+        missing.push(`${key} (rhs has empty-default marker: ${rhs.slice(0, 60)})`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("the set has the expected size for the current result literal", () => {
+    // Sanity check: 33 keys today. Update when buildSkillContext gains/loses an
+    // always-populated key — failure here is a prompt to also update the tests
+    // above with an explanatory comment in the same change.
+    const nonEmpty = keys.filter((k) => !hasEmptyDefault(k.rhs)).map((k) => k.name);
+    expect(new Set(nonEmpty)).toEqual(new Set(ALWAYS_POPULATED));
   });
 });
 

--- a/scripts/lint-template-safety.test.ts
+++ b/scripts/lint-template-safety.test.ts
@@ -4,10 +4,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 import {
   ALWAYS_POPULATED,
+  ENV_ASSIGNMENT_PREFIX,
+  SHELL_COMMANDS,
+  SHELL_KEYWORDS,
   classifyLines,
   findFencedLines,
   findFencedShellBlocks,
   findInlineShellSpans,
+  listTemplates,
   looksLikeShell,
   parseIfRanges,
   lintTemplate,
@@ -679,6 +683,202 @@ describe("runLint — CLI integration", () => {
       const stderr = new TextDecoder().decode(proc.stderr);
       expect(stderr).toContain("PROJECT_REPO");
       expect(stderr).toContain("bad.md");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("SHELL_COMMANDS drift", () => {
+  // Meta-test (NOT a runtime lint rule templates must pass): walks every
+  // fenced shell block in skills/orchestration/*.md, tokenizes the first
+  // command of each chain segment, and asserts the token is a known dispatch
+  // form, a {{VAR}}-as-command, or a member of SHELL_COMMANDS ∪ SHELL_KEYWORDS.
+  // An unknown token means a template has started using a new tool — bump the
+  // static lists deliberately rather than weaken this test.
+
+  /** Quote-aware shell-chain split: respects single-quoted, double-quoted, and
+   *  backtick strings so `printf '%s|%s' "$a" "$b"` stays one segment. */
+  function splitOnShellChain(line: string): string[] {
+    const parts: string[] = [];
+    let buf = "";
+    let i = 0;
+    let quote: '"' | "'" | "`" | null = null;
+    while (i < line.length) {
+      const ch = line[i]!;
+      if (quote) {
+        if (ch === "\\" && i + 1 < line.length) {
+          buf += ch + line[i + 1]!;
+          i += 2;
+          continue;
+        }
+        if (ch === quote) quote = null;
+        buf += ch;
+        i++;
+        continue;
+      }
+      if (ch === "\\" && i + 1 < line.length) {
+        buf += ch + line[i + 1]!;
+        i += 2;
+        continue;
+      }
+      if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch;
+        buf += ch;
+        i++;
+        continue;
+      }
+      if (ch === ";") {
+        parts.push(buf);
+        buf = "";
+        i++;
+        continue;
+      }
+      if (ch === "|") {
+        // `||` and `|` both terminate a segment.
+        parts.push(buf);
+        buf = "";
+        i += line[i + 1] === "|" ? 2 : 1;
+        continue;
+      }
+      if (ch === "&" && line[i + 1] === "&") {
+        parts.push(buf);
+        buf = "";
+        i += 2;
+        continue;
+      }
+      buf += ch;
+      i++;
+    }
+    parts.push(buf);
+    return parts;
+  }
+
+  /** Strip leading env-var assignments, including those with `$(...)`,
+   *  `"..."`, `'...'` values that may contain whitespace. Returns null when
+   *  the entire line is a pure assignment statement (no command follows),
+   *  signalling "skip this line". Otherwise returns the remainder starting
+   *  at the first command token. Falls back to the simple
+   *  `ENV_ASSIGNMENT_PREFIX` regex when the leading text doesn't look like
+   *  an assignment, preserving the runtime lint's behavior. */
+  function stripLeadingEnvAssignments(line: string): string | null {
+    let i = 0;
+    while (true) {
+      // Skip leading whitespace at this iteration.
+      while (i < line.length && /\s/.test(line[i]!)) i++;
+      const m = line.slice(i).match(/^[A-Z_][A-Z0-9_]*=/);
+      if (!m) {
+        // No assignment here — return remainder (or empty if we consumed all).
+        return i >= line.length ? null : line.slice(i);
+      }
+      i += m[0].length;
+      if (i >= line.length) return null; // pure `NAME=` with no value
+      const ch = line[i]!;
+      if (ch === '"' || ch === "'") {
+        const quote = ch;
+        i++;
+        while (i < line.length && line[i] !== quote) {
+          if (line[i] === "\\" && i + 1 < line.length) i += 2;
+          else i++;
+        }
+        if (i < line.length) i++; // skip closing quote
+      } else if (ch === "$" && line[i + 1] === "(") {
+        i += 2;
+        let depth = 1;
+        while (i < line.length && depth > 0) {
+          const c = line[i]!;
+          if (c === "(") depth++;
+          else if (c === ")") depth--;
+          if (depth === 0) break;
+          i++;
+        }
+        if (i < line.length) i++; // skip closing )
+      } else {
+        // Bare value: consume until whitespace.
+        while (i < line.length && !/\s/.test(line[i]!)) i++;
+      }
+      if (i >= line.length) return null; // pure assignment, no command after
+      // Whitespace follows: there may be more assignments or a command. Loop.
+    }
+  }
+
+  /** Strip leading `{{#IF VAR}}` / `{{/IF}}` template tags (one or more,
+   *  separated by whitespace). A line like
+   *  `{{#IF FOO}}{{#IF BAR}}command ...` becomes `command ...`. */
+  function stripLeadingTemplateTags(line: string): string {
+    return line.replace(/^(?:\{\{#IF\s+[A-Z0-9_]+\}\}\s*|\{\{\/IF\}\}\s*)+/, "");
+  }
+
+  function isKnownDispatchForm(token: string): boolean {
+    return /^\$\(/.test(token) || /^\[/.test(token) || /^\{/.test(token) || /^\(/.test(token);
+  }
+
+  function isVariableAsCommand(token: string): boolean {
+    return /^\{\{[A-Z0-9_]+\}\}/.test(token);
+  }
+
+  const known: ReadonlySet<string> = new Set([...SHELL_COMMANDS, ...SHELL_KEYWORDS]);
+
+  function collectFailures(dir: string): string[] {
+    const failures: string[] = [];
+    for (const name of listTemplates(dir)) {
+      const text = readFileSync(join(dir, name), "utf-8");
+      const lines = text.split(/\r?\n/);
+      const spans = findFencedShellBlocks(lines);
+      for (const span of spans) {
+        for (let i = span.startLine; i <= span.endLine; i++) {
+          const raw = lines[i]!;
+          let line = raw.replace(/^\s+/, "");
+          line = stripLeadingTemplateTags(line);
+          if (!line) continue;
+          if (line.startsWith("#")) continue; // shell comment
+          if (/^\\\s*$/.test(line)) continue; // line continuation only
+          // First, try the smart env-var stripper (handles `$(...)` values).
+          const stripped = stripLeadingEnvAssignments(line);
+          if (stripped === null) continue; // pure assignment line, no command
+          const segments = splitOnShellChain(stripped);
+          for (const seg of segments) {
+            const trimmed = seg.replace(/^\s+/, "");
+            if (!trimmed) continue;
+            // Each subsequent segment may also start with env-var prefixes
+            // (rare, but possible); apply the runtime regex to be safe.
+            const segBody = trimmed.replace(ENV_ASSIGNMENT_PREFIX, "");
+            const token = segBody.split(/\s+/)[0] ?? "";
+            if (!token) continue;
+            if (isKnownDispatchForm(token)) continue;
+            if (isVariableAsCommand(token)) continue;
+            if (known.has(token)) continue;
+            failures.push(
+              `${name}:${i + 1}: unknown shell first-token \`${token}\`; add to SHELL_COMMANDS or document exemption`,
+            );
+          }
+        }
+      }
+    }
+    return failures;
+  }
+
+  test("every fenced shell block in skills/orchestration/* uses a known first-token", () => {
+    const dir = join(import.meta.dir, "..", "skills", "orchestration");
+    const failures = collectFailures(dir);
+    expect(failures).toEqual([]);
+  });
+
+  test("the meta-test catches a synthetic unknown token", () => {
+    // Sanity: the test isn't trivially passing because the directory walks
+    // are short-circuiting somewhere. Build a tiny temp dir with a template
+    // that uses `helmfoo` (definitely not in SHELL_COMMANDS) and assert the
+    // failure surfaces.
+    const dir = mkdtempSync(join(tmpdir(), "lint-shell-drift-synthetic-"));
+    try {
+      writeFileSync(
+        join(dir, "x.md"),
+        ["```sh", "helmfoo deploy --release {{TASK_ID}}", "```"].join("\n"),
+      );
+      const failures = collectFailures(dir);
+      expect(failures.length).toBeGreaterThan(0);
+      expect(failures[0]).toContain("helmfoo");
+      expect(failures[0]).toContain("x.md");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -18,42 +18,14 @@
 
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
+import { ALWAYS_POPULATED_KEYS } from "../src/orchestration/skills.ts";
 
-export const ALWAYS_POPULATED: ReadonlySet<string> = new Set([
-  "PHASE",
-  "ROUND",
-  "MODE",
-  "TASK_ID",
-  "AGENT_NAME",
-  "AGENT_PROVIDER",
-  "AGENT_ROLE",
-  "PEER_NAME",
-  "PEER_PROVIDER",
-  "TASK_SPEC",
-  "TASK_SPEC_BRIEF",
-  "PEER_REVIEW",
-  "PEER_STATUS",
-  "PEER_PLAN",
-  "GIT_DIFF_STAT",
-  "PREVIOUS_ROUND_SUMMARY",
-  "MERGE_VOTES",
-  "WORKTREE_PATH",
-  "PEER_WORKTREE_PATH",
-  "STATUS_FILE",
-  "PLAN_FILE",
-  "MERGED_PLAN_FILE",
-  "PLAN_MERGE_ROUND",
-  "REVIEW_FILE",
-  "PR_FILE",
-  "INTERRUPT_FILE",
-  "MERGE_VOTE_FILE",
-  "SUGGEST_REFACTOR_FILE",
-  "WORKFLOW_FEEDBACK_FILE",
-  "MERGE_REVIEW_DECISION_FILE",
-  "MERGED_MARKER_FILE",
-  "PEER_SYNC_DIR",
-  "DONE_STATUS",
-]);
+/** Re-exported for back-compat; canonical source is `ALWAYS_POPULATED_KEYS` in
+ *  `src/orchestration/skills.ts`, co-located with `buildSkillContext`'s
+ *  `result` literal so a maintainer adding a new always-populated assignment
+ *  touches one file. CI-drift-pair: see `scripts/lint-template-safety.test.ts`
+ *  ALWAYS_POPULATED_KEYS drift test. */
+export const ALWAYS_POPULATED: ReadonlySet<string> = ALWAYS_POPULATED_KEYS;
 
 /** Per-file allowlist for variables that the lint would otherwise flag but are
  *  guaranteed non-empty by the template's resolution context. Add an entry

--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -105,35 +105,98 @@ interface ShellSpan {
   readonly kind: "fenced" | "inline";
 }
 
-/** Find fenced shell code blocks. Recognizes leading whitespace on the fence
- *  markers so indented code blocks inside numbered lists are detected too.
- *  Returns spans covering the block body (excluding the fence lines). */
-export function findFencedShellBlocks(lines: string[]): ShellSpan[] {
-  const spans: ShellSpan[] = [];
-  let openLine: number | null = null;
-  let openIndent = "";
+/** Single-pass row-bucketed classification of every line in `lines`. Each
+ *  index maps to exactly one of three disjoint kinds:
+ *    - `prose`        — outside any fenced block.
+ *    - `fence-marker` — the opening or closing ``` line of a block (shell or
+ *                       otherwise; `blockKind` reflects the language tag).
+ *    - `fence-body`   — a line strictly between an opening and closing fence
+ *                       marker; `blockKind` reflects the language tag and
+ *                       `indent` records the opening fence's leading whitespace.
+ *
+ *  The partition guarantee — `classifyLines(lines).length === lines.length`
+ *  with each element well-formed — replaces the previous two-pass scan
+ *  (`findFencedShellBlocks` + `findFencedLines` consulted ad-hoc by
+ *  `findInlineShellSpans`) where overlapping responsibility allowed a future
+ *  scanner to forget the skip-set and re-flag inline-shell-shaped backticks
+ *  inside ```ts fences. Downstream scanners now derive their slice from this
+ *  one source of truth. */
+export type LineClass =
+  | { kind: "prose" }
+  | { kind: "fence-marker"; blockKind: "shell" | "other" }
+  | { kind: "fence-body"; blockKind: "shell" | "other"; indent: string };
+
+const FENCE_OPEN_RE = /^(\s*)```([A-Za-z0-9_-]*)\s*$/;
+const SHELL_LANG_RE = /^(?:sh|bash|shell)$/;
+
+export function classifyLines(lines: string[]): LineClass[] {
+  const out: LineClass[] = [];
+  let openIndent: string | null = null;
+  let openBlockKind: "shell" | "other" | null = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (openLine == null) {
-      const m = line.match(/^(\s*)```(sh|bash|shell)\s*$/);
+    if (openIndent == null) {
+      const m = line.match(FENCE_OPEN_RE);
       if (m) {
-        openLine = i;
-        openIndent = m[1]!;
+        const indent = m[1]!;
+        const lang = m[2]!;
+        const blockKind: "shell" | "other" = SHELL_LANG_RE.test(lang) ? "shell" : "other";
+        openIndent = indent;
+        openBlockKind = blockKind;
+        out.push({ kind: "fence-marker", blockKind });
+        continue;
       }
+      out.push({ kind: "prose" });
       continue;
     }
     // Closing fence: ``` on its own line, matching indentation (or less).
-    if (new RegExp(`^${openIndent}\`\`\`\\s*$`).test(line) || /^\s*```\s*$/.test(line)) {
-      if (i > openLine + 1) {
+    // Mirrors the original two-pass scanners' close pattern so derived
+    // exports keep their existing behavior.
+    const exactIndentClose = new RegExp(`^${openIndent}\`\`\`\\s*$`);
+    if (exactIndentClose.test(line) || /^\s*```\s*$/.test(line)) {
+      out.push({ kind: "fence-marker", blockKind: openBlockKind! });
+      openIndent = null;
+      openBlockKind = null;
+      continue;
+    }
+    out.push({ kind: "fence-body", blockKind: openBlockKind!, indent: openIndent });
+  }
+  return out;
+}
+
+/** Find fenced shell code blocks. Recognizes leading whitespace on the fence
+ *  markers so indented code blocks inside numbered lists are detected too.
+ *  Returns spans covering the block body (excluding the fence lines).
+ *
+ *  Derived from `classifyLines`: collapses consecutive `fence-body` rows with
+ *  `blockKind === "shell"` into one span. An unterminated shell fence at EOF
+ *  is not emitted (matches the original two-pass behavior). */
+export function findFencedShellBlocks(lines: string[]): ShellSpan[] {
+  const classes = classifyLines(lines);
+  const spans: ShellSpan[] = [];
+  let runStart = -1;
+  for (let i = 0; i < classes.length; i++) {
+    const c = classes[i]!;
+    const isShellBody = c.kind === "fence-body" && c.blockKind === "shell";
+    if (isShellBody) {
+      if (runStart < 0) runStart = i;
+      continue;
+    }
+    if (runStart >= 0) {
+      // Run ended at the closing fence-marker (or first non-shell-body row).
+      // Only emit when the prior class is fence-marker — i.e., the fence was
+      // properly closed. EOF without closing leaves runStart open and is
+      // intentionally dropped to mirror the original behavior.
+      if (c.kind === "fence-marker") {
         spans.push({
-          startLine: openLine + 1,
+          startLine: runStart,
           endLine: i - 1,
           startCol: 0,
           endCol: lines[i - 1]!.length,
           kind: "fenced",
         });
       }
-      openLine = null;
+      runStart = -1;
     }
   }
   return spans;
@@ -144,27 +207,14 @@ export function findFencedShellBlocks(lines: string[]): ShellSpan[] {
  *  Inline-backtick scanning must skip these — a backtick span inside a
  *  ```ts example is not an inline shell command, and a span inside a
  *  ```sh block is already covered by the fenced-block scan, so re-counting
- *  it as inline would double-report the same violation. */
+ *  it as inline would double-report the same violation.
+ *
+ *  Derived from `classifyLines`: every non-`prose` row contributes its index. */
 export function findFencedLines(lines: string[]): Set<number> {
+  const classes = classifyLines(lines);
   const fenced = new Set<number>();
-  let openLine: number | null = null;
-  let openIndent = "";
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!;
-    if (openLine == null) {
-      // Any opening fence: ```sh, ```ts, ```, etc.
-      const m = line.match(/^(\s*)```[A-Za-z0-9_-]*\s*$/);
-      if (m) {
-        openLine = i;
-        openIndent = m[1]!;
-        fenced.add(i); // fence marker line itself
-      }
-      continue;
-    }
-    fenced.add(i);
-    if (new RegExp(`^${openIndent}\`\`\`\\s*$`).test(line) || /^\s*```\s*$/.test(line)) {
-      openLine = null;
-    }
+  for (let i = 0; i < classes.length; i++) {
+    if (classes[i]!.kind !== "prose") fenced.add(i);
   }
   return fenced;
 }
@@ -173,12 +223,22 @@ export function findFencedLines(lines: string[]): Set<number> {
  *  recognized command token). Skips any line that is inside a fenced code
  *  block — shell-language blocks are handled by `findFencedShellBlocks`
  *  (no double-reporting), and non-shell blocks (e.g., ```ts) must not be
- *  inline-scanned at all. */
+ *  inline-scanned at all.
+ *
+ *  Default skip is `classifyLines(lines)[i].kind !== "prose"` — the same
+ *  partition the other scanners derive from. The optional `fencedLines`
+ *  parameter is preserved for back-compat callers but is no longer the
+ *  load-bearing skip mechanism. */
 export function findInlineShellSpans(lines: string[], fencedLines?: Set<number>): ShellSpan[] {
-  const inFence = fencedLines ?? findFencedLines(lines);
+  const skip: (i: number) => boolean = fencedLines
+    ? (i: number) => fencedLines.has(i)
+    : (() => {
+        const classes = classifyLines(lines);
+        return (i: number) => classes[i]!.kind !== "prose";
+      })();
   const spans: ShellSpan[] = [];
   for (let i = 0; i < lines.length; i++) {
-    if (inFence.has(i)) continue;
+    if (skip(i)) continue;
     const line = lines[i]!;
     // Scan for single-backtick spans. We accept only spans enclosed in `…`
     // that do NOT contain a backtick inside (i.e., a minimal match).

--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -38,7 +38,7 @@ export const TEMPLATE_ALLOWLIST: Readonly<Record<string, ReadonlySet<string>>> =
 };
 
 /** Command/keyword tokens that start a shell command. */
-const SHELL_COMMANDS = [
+export const SHELL_COMMANDS = [
   "git", "gh", "printf", "cat", "rm", "mkdir", "cp", "mv", "cd", "ls", "ln",
   "touch", "test", "chmod", "chown", "find", "awk", "sed", "grep", "egrep", "fgrep",
   "npm", "bun", "node", "python", "python3", "echo", "date", "eval", "source",
@@ -49,7 +49,7 @@ const SHELL_COMMANDS = [
 ] as const;
 
 /** Shell control-flow / compound-command keywords that start shell syntax. */
-const SHELL_KEYWORDS = [
+export const SHELL_KEYWORDS = [
   "if", "for", "while", "case", "until", "do", "done", "then", "else", "elif",
   "fi", "esac", "select", "function", "time",
 ] as const;
@@ -62,7 +62,7 @@ const SHELL_COMMAND_PREFIX = new RegExp(
 );
 
 /** A shell-style leading env-var assignment: `NAME=value ` (one or more). */
-const ENV_ASSIGNMENT_PREFIX = /^(?:[A-Z_][A-Z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/;
+export const ENV_ASSIGNMENT_PREFIX = /^(?:[A-Z_][A-Z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/;
 
 /** A pipe / logical chain / command separator followed by a command token —
  *  strong evidence that the span is shell and not prose. */
@@ -314,8 +314,9 @@ export function lintTemplate(
 ): Violation[] {
   const lines = text.split(/\r?\n/);
   const fencedSpans = findFencedShellBlocks(lines);
-  const fencedLines = findFencedLines(lines);
-  const inlineSpans = findInlineShellSpans(lines, fencedLines);
+  // No need to pre-compute findFencedLines: findInlineShellSpans now derives
+  // its skip set from classifyLines internally.
+  const inlineSpans = findInlineShellSpans(lines);
   const ifRanges = parseIfRanges(text);
   const violations: Violation[] = [];
   const varRe = /\{\{([A-Z0-9_]+)\}\}/g;
@@ -350,7 +351,7 @@ export function lintTemplate(
   return violations;
 }
 
-function listTemplates(dir: string): string[] {
+export function listTemplates(dir: string): string[] {
   return readdirSync(dir)
     .filter((name) => name.endsWith(".md"))
     .sort();

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -250,6 +250,56 @@ export function resolveTemplatePath(
   throw new Error(`missing orchestration template for ${mode}:${role ?? "agent"}:${phase}`);
 }
 
+/**
+ * Keys in `buildSkillContext`'s `result` literal that are guaranteed
+ * non-empty at template-substitution time. Templates may use these
+ * variables freely inside shell contexts without `{{#IF VAR}}` guards.
+ *
+ * CI-drift-pair — see `scripts/lint-template-safety.test.ts`
+ * "ALWAYS_POPULATED_KEYS drift" describe block: a bidirectional invariant
+ * test parses the `result` object literal below and asserts every
+ * non-empty-default assignment is in this set, and every key in this set
+ * has such an assignment. Maintainers adding a new always-populated key
+ * touch only this file (this set + the `result` literal). Empty-default
+ * assignments must surface a `?? ""`, `: ""`, or `|| ""` marker on the
+ * assignment line so the drift test can classify them correctly.
+ */
+export const ALWAYS_POPULATED_KEYS: ReadonlySet<string> = new Set([
+  "PHASE",
+  "ROUND",
+  "MODE",
+  "TASK_ID",
+  "AGENT_NAME",
+  "AGENT_PROVIDER",
+  "AGENT_ROLE",
+  "PEER_NAME",
+  "PEER_PROVIDER",
+  "TASK_SPEC",
+  "TASK_SPEC_BRIEF",
+  "PEER_REVIEW",
+  "PEER_STATUS",
+  "PEER_PLAN",
+  "GIT_DIFF_STAT",
+  "PREVIOUS_ROUND_SUMMARY",
+  "MERGE_VOTES",
+  "WORKTREE_PATH",
+  "PEER_WORKTREE_PATH",
+  "STATUS_FILE",
+  "PLAN_FILE",
+  "MERGED_PLAN_FILE",
+  "PLAN_MERGE_ROUND",
+  "REVIEW_FILE",
+  "PR_FILE",
+  "INTERRUPT_FILE",
+  "MERGE_VOTE_FILE",
+  "SUGGEST_REFACTOR_FILE",
+  "WORKFLOW_FEEDBACK_FILE",
+  "MERGE_REVIEW_DECISION_FILE",
+  "MERGED_MARKER_FILE",
+  "PEER_SYNC_DIR",
+  "DONE_STATUS",
+]);
+
 export function buildSkillContext(
   state: OrchestrationState,
   agent: AgentConfig,
@@ -322,10 +372,10 @@ export function buildSkillContext(
     PEER_PROVIDER: peer?.provider ?? "none",
     TASK_SPEC: state.round <= 1 ? taskSpecText(state) : taskSpecBriefText(state),
     TASK_SPEC_BRIEF: taskSpecBriefText(state),
-    PROPOSAL_PATH: proposalPath,
-    PROPOSAL_INSTRUCTION: proposalInstruction,
-    PROPOSAL_FRESHNESS_WARNING: proposalFreshnessWarningText,
-    TASK_AC: extractAcceptanceCriteria(state.taskId),
+    PROPOSAL_PATH: proposalPath || "",
+    PROPOSAL_INSTRUCTION: proposalInstruction || "",
+    PROPOSAL_FRESHNESS_WARNING: proposalFreshnessWarningText || "",
+    TASK_AC: extractAcceptanceCriteria(state.taskId) || "",
     PEER_REVIEW: peerReview ?? "(no review yet)",
     PEER_STATUS: peer ? (state.agentStates[peer.name]?.status ?? "unknown") : "unknown",
     PEER_PLAN: peerPlan ?? "(no plan yet)",


### PR DESCRIPTION
## Summary

Three follow-up hardening items for `scripts/lint-template-safety.ts`, bundled per the `task-3b906d0f` retrospective. Each closes a specific drift / double-count class that nearly bit us during the original lint's review.

- **Item 1 — Shared `ALWAYS_POPULATED_KEYS`**: move the canonical always-populated key set to `src/orchestration/skills.ts` next to `buildSkillContext`'s `result` literal so a maintainer adding a new always-populated assignment touches one file. The lint script imports + re-exports as `ALWAYS_POPULATED` for back-compat. New bidirectional drift test parses the `result` block by brace depth and asserts every literally-non-empty assignment is in the set and every set member has such an assignment.
- **Item 2 — `classifyLines` disjoint-region scanner**: replace the two ad-hoc fence scanners with one row-bucketed single-pass partition (`prose` / `fence-marker` / `fence-body` with `blockKind: shell | other`). `findFencedShellBlocks` and `findFencedLines` are now thin derivations; their public shapes and existing test coverage are unchanged. `findInlineShellSpans` defaults to `classifyLines`-derived skip — so a future scanner can't forget to consult fence state and re-flag inline-shell-shaped backticks inside ` ```ts ` (the round-2 Codex catch). The `fencedLines` arg is preserved for back-compat.
- **Item 3 — `SHELL_COMMANDS` drift meta-test**: walk every fenced shell block in `skills/orchestration/*.md`, tokenize the first command of each chain segment, assert the token is in `SHELL_COMMANDS ∪ SHELL_KEYWORDS`, a known dispatch form (`$(`, `[`, `{`, `(`), or a `{{VAR}}`-as-command. Unknown tokens fail loud. Ships with a quote-aware shell-chain splitter (so `printf '%s|%s'` stays one segment) and a `$(...)`-aware env-stripper (so `PR_URL=$(cat ... 2>/dev/null)` classifies as a pure assignment instead of spuriously flagging `pr` as the next "command"). A synthetic-failure sanity test guards against the walker silently short-circuiting.

Anchor comments on both sides of the CI-drift-pair (Item 1) and a small documentation note in `lintTemplate` explaining why `findFencedLines` is no longer pre-computed (Item 2) keep the structural intent visible.

## Test plan

- [x] `bun test scripts/lint-template-safety.test.ts` — 60 pass / 0 fail (47 pre-existing + 13 new across the three items)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (eslint over `src/**`)
- [x] `bun run lint:template-safety` — exits 0 against the live `skills/orchestration/` template set; runtime exit semantics unchanged
- [x] Disjointness invariant test passes against a real orchestration template (`pair-coder-pr-create.md`) plus the hand-crafted mixed corpus
- [x] ts-fence regression test asserts `findInlineShellSpans` returns no span pointing into a ` ```ts ` body containing an inline-shell-shaped backtick
- [x] Synthetic-unknown-token test (`helmfoo deploy ...`) confirms the meta-test's failure path actually fires