### PR TITLE
fix(harness): thread ctx.harnessDir through adapters + orchestration (task-f60547cd)

### DIFF
--- a/src/adapters/base.test.ts
+++ b/src/adapters/base.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
+  adapterStateDir,
+  ensureAdapterStateDir,
   readStateFile,
   writeStateFile,
   readStateKey,
@@ -254,5 +257,49 @@ describe("resolveProjectDir", () => {
   test("returns cwd for empty session", () => {
     expect(resolveProjectDir("")).toBe(process.cwd());
     expect(resolveProjectDir("null")).toBe(process.cwd());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adapterStateDir / ensureAdapterStateDir — harnessDir parametrization
+// ---------------------------------------------------------------------------
+
+describe("adapterStateDir (harnessDir parametrization)", () => {
+  const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  let ISO_TMP = "";
+  let DECOY = "";
+
+  beforeEach(() => {
+    ISO_TMP = mkdtempSync(join(tmpdir(), "ludics-adapterStateDir-"));
+    DECOY = mkdtempSync(join(tmpdir(), "ludics-adapterStateDir-decoy-"));
+    process.env.LUDICS_HARNESS_DIR = DECOY;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+    rmSync(ISO_TMP, { recursive: true, force: true });
+    rmSync(DECOY, { recursive: true, force: true });
+  });
+
+  test("explicit harnessDir arg is authoritative over LUDICS_HARNESS_DIR", () => {
+    expect(adapterStateDir("manual", ISO_TMP)).toBe(join(ISO_TMP, "manual"));
+  });
+
+  test("default arg falls back to LUDICS_HARNESS_DIR", () => {
+    expect(adapterStateDir("manual")).toBe(join(DECOY, "manual"));
+  });
+
+  test("ensureAdapterStateDir creates under explicit harnessDir, not the decoy", () => {
+    const dir = ensureAdapterStateDir("manual", ISO_TMP);
+    expect(dir).toBe(join(ISO_TMP, "manual"));
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(join(DECOY, "manual"))).toBe(false);
+  });
+
+  test("ensureAdapterStateDir default arg creates under LUDICS_HARNESS_DIR", () => {
+    const dir = ensureAdapterStateDir("manual");
+    expect(dir).toBe(join(DECOY, "manual"));
+    expect(existsSync(dir)).toBe(true);
   });
 });

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -5,7 +5,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, statSync } from "fs";
 import { join, dirname } from "path";
-import { harnessDir } from "../config.ts";
+import { harnessDir as defaultHarnessDir } from "../config.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import { PEER_SYNC_DIRNAME } from "../orchestration/peer-sync.ts";
 import type { AgentStatus } from "./types.ts";
@@ -32,13 +32,13 @@ export function slotSessionName(slot: number, role?: string, taskId?: string, fa
 // ---------------------------------------------------------------------------
 
 /** Get the state directory for a named adapter (e.g. "manual", "claude-ai"). */
-export function adapterStateDir(name: string): string {
-  return join(harnessDir(), name);
+export function adapterStateDir(name: string, harnessDir: string = defaultHarnessDir()): string {
+  return join(harnessDir, name);
 }
 
 /** Ensure the adapter state directory exists, creating it if needed. */
-export function ensureAdapterStateDir(name: string): string {
-  const dir = adapterStateDir(name);
+export function ensureAdapterStateDir(name: string, harnessDir: string = defaultHarnessDir()): string {
+  const dir = adapterStateDir(name, harnessDir);
   mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/src/adapters/manual.test.ts
+++ b/src/adapters/manual.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { readState } from "./manual.ts";
+import { readState, start, stop } from "./manual.ts";
 import { persistState, defaultOrchestrationConfig, type OrchestrationState } from "../orchestration/state.ts";
 import type { AdapterContext } from "./types.ts";
 
@@ -133,5 +133,79 @@ describe("manual readState — paused orchestration fallback", () => {
     const ctx = makeCtx(1);
     const result = readState(ctx);
     expect(result).toBeNull();
+  });
+});
+
+describe("manual adapter: ctx.harnessDir is authoritative over env", () => {
+  test("start/stop/readState write under ctx.harnessDir when LUDICS_HARNESS_DIR points elsewhere", () => {
+    // Point the env var at a decoy that must remain untouched.
+    const decoy = mkdtempSync(join(tmpdir(), "ludics-manual-decoy-"));
+    process.env.LUDICS_HARNESS_DIR = decoy;
+
+    // ctx.harnessDir points at the test's real harness — this must win.
+    const ctx = makeCtx(7);
+    const realHarness = harness();
+    expect(ctx.harnessDir).toBe(realHarness);
+    expect(decoy).not.toBe(realHarness);
+
+    try {
+      start(ctx);
+      const status = readState(ctx);
+      expect(status).not.toBeNull();
+      expect(status).toContain("manual (human work)");
+
+      // Files land under ctx.harnessDir, not under the decoy.
+      const manualDirReal = join(realHarness, "manual");
+      const manualDirDecoy = join(decoy, "manual");
+      expect(existsSync(join(manualDirReal, "slot-7.status"))).toBe(true);
+      expect(existsSync(join(manualDirReal, "slot-7.md"))).toBe(true);
+      expect(existsSync(manualDirDecoy)).toBe(false);
+
+      // stop also uses ctx.harnessDir — archive goes under real harness, decoy stays clean.
+      stop(ctx);
+      expect(existsSync(join(manualDirReal, "archive"))).toBe(true);
+      expect(existsSync(manualDirDecoy)).toBe(false);
+    } finally {
+      rmSync(decoy, { recursive: true, force: true });
+    }
+  });
+
+  test("readState resolves status file from ctx.harnessDir even when env points elsewhere", () => {
+    const decoy = mkdtempSync(join(tmpdir(), "ludics-manual-decoy-r-"));
+    // Seed the decoy with a conflicting status file so a bypass would pick it up.
+    const decoyManual = join(decoy, "manual");
+    mkdirSync(decoyManual, { recursive: true });
+    writeFileSync(
+      join(decoyManual, "slot-3.status"),
+      "status=active\nstarted=2026-01-01T00:00:00Z\ntask=DECOY\n",
+    );
+    writeFileSync(join(decoyManual, "slot-3.md"), "# DECOY NOTES\n");
+    process.env.LUDICS_HARNESS_DIR = decoy;
+
+    // Real ctx harness has no status file; must return null (not decoy content).
+    const ctx = makeCtx(3);
+
+    try {
+      const result = readState(ctx);
+      expect(result).toBeNull();
+    } finally {
+      rmSync(decoy, { recursive: true, force: true });
+    }
+  });
+
+  test("start writes notes content readable through ctx.harnessDir (round trip)", () => {
+    const decoy = mkdtempSync(join(tmpdir(), "ludics-manual-decoy-w-"));
+    process.env.LUDICS_HARNESS_DIR = decoy;
+
+    const ctx = makeCtx(5);
+    try {
+      start(ctx);
+      const notesPath = join(harness(), "manual", "slot-5.md");
+      expect(existsSync(notesPath)).toBe(true);
+      const body = readFileSync(notesPath, "utf-8");
+      expect(body).toContain("Manual Work Notes - Slot 5");
+    } finally {
+      rmSync(decoy, { recursive: true, force: true });
+    }
   });
 });

--- a/src/adapters/manual.ts
+++ b/src/adapters/manual.ts
@@ -17,11 +17,11 @@ import { readOrchestrationState } from "../orchestration/state.ts";
 const ADAPTER_NAME = "manual";
 
 function slotFile(ctx: AdapterContext): string {
-  return join(adapterStateDir(ADAPTER_NAME), `slot-${ctx.slot}.md`);
+  return join(adapterStateDir(ADAPTER_NAME, ctx.harnessDir), `slot-${ctx.slot}.md`);
 }
 
 function statusFile(ctx: AdapterContext): string {
-  return join(adapterStateDir(ADAPTER_NAME), `slot-${ctx.slot}.status`);
+  return join(adapterStateDir(ADAPTER_NAME, ctx.harnessDir), `slot-${ctx.slot}.status`);
 }
 
 export function readState(ctx: AdapterContext): string | null {
@@ -67,7 +67,7 @@ export function readState(ctx: AdapterContext): string | null {
 }
 
 export function start(ctx: AdapterContext): string {
-  ensureAdapterStateDir(ADAPTER_NAME);
+  ensureAdapterStateDir(ADAPTER_NAME, ctx.harnessDir);
 
   const now = isoTimestamp();
   const data = new Map<string, string>();
@@ -96,7 +96,7 @@ export function stop(ctx: AdapterContext): string {
   // Archive notes
   const nf = slotFile(ctx);
   if (existsSync(nf)) {
-    const archiveDir = join(adapterStateDir(ADAPTER_NAME), "archive");
+    const archiveDir = join(adapterStateDir(ADAPTER_NAME, ctx.harnessDir), "archive");
     mkdirSync(archiveDir, { recursive: true });
     const archiveName = `slot-${ctx.slot}-${now.replace(/[:.]/g, "-")}.md`;
     renameSync(nf, join(archiveDir, archiveName));

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -979,6 +979,7 @@ async function startOrchestratedThreads(
     branches: setup.branches,
     slotTitle: title,
     duoPeerSlot: orchestration.duoPeerSlot ?? null,
+    harnessDir: ctx.harnessDir,
   };
   persistState(state, ctx.harnessDir);
 

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1135,7 +1135,7 @@ async function stop(ctx: AdapterContext, options?: { preserveState?: boolean }):
     if (orchestrationState) {
       recordDeferredCleanup(buildCleanupEntry(orchestrationState, ctx.slot, {
         t3codeThreadIds: threadIds,
-      }));
+      }), ctx.harnessDir);
       removeOrchestrationState(ctx.slot, ctx.harnessDir);
     } else if (threadIds.length > 0) {
       // Non-orchestrated single-thread sessions: defer thread deletion only.
@@ -1153,7 +1153,7 @@ async function stop(ctx: AdapterContext, options?: { preserveState?: boolean }):
         tmuxSessionNames: [],
         peerSyncLink: null,
         t3codeThreadIds: threadIds,
-      });
+      }, ctx.harnessDir);
     }
     removeSlotState(ctx.slot, ctx.harnessDir);
   }

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -534,6 +534,7 @@ async function start(ctx: AdapterContext): Promise<string> {
     branches: setup.branches,
     slotTitle: options.title ?? slotSessionName(ctx.slot, undefined, taskId),
     duoPeerSlot: orchestration.duoPeerSlot ?? null,
+    harnessDir: ctx.harnessDir,
   };
   persistState(state, ctx.harnessDir);
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -576,7 +576,7 @@ async function stop(ctx: AdapterContext, options?: { preserveState?: boolean }):
       recordDeferredCleanup(buildCleanupEntry(orchState, ctx.slot, {
         tmuxSessionNames: orchState.agents.map((a) =>
           tmuxSessionName(ctx.slot, a.name, orchState.taskId)),
-      }));
+      }), ctx.harnessDir);
       removeOrchestrationState(ctx.slot, ctx.harnessDir);
     }
   }

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -1,7 +1,8 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { cleanupDelayHours } from "../config.ts";
+import * as t3codeServer from "../t3code/server.ts";
 
 // Redirect harnessDir() to a temp directory via env var
 const tmpDir = join(import.meta.dir, ".test-tmp-deferred-cleanup");
@@ -320,17 +321,17 @@ describe("explicit harnessDir argument (isolation)", () => {
 
   // Reviewer AC7 blocking item: prove the t3codeThreadIds branch passes the
   // explicit harnessDir arg through to serverStatus({ harnessDir }).
-  // Stub the dynamically-imported ../t3code/server.ts so the test captures the
-  // argument and observes no connection-time I/O.
+  // Uses the spyOn() pattern (see docs/testing-patterns.md) so the
+  // replacement does not leak across test files in the Bun runner.
   test("processDeferredCleanups(_, ISO) passes ISO to serverStatus({ harnessDir }) in the t3codeThreadIds branch", async () => {
     const capturedHarnessDirs: string[] = [];
-    mock.module("../t3code/server.ts", () => ({
-      serverStatus: async (options: { harnessDir?: string } = {}) => {
+    const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockImplementation(
+      async (options: { harnessDir?: string } = {}) => {
         capturedHarnessDirs.push(options.harnessDir ?? "<default>");
         // Return "not running" to short-circuit before any T3CodeClient construction.
         return { running: false, record: null, snapshot: null, reason: "stubbed" };
       },
-    }));
+    );
 
     try {
       // Entry must be old enough to process AND carry t3codeThreadIds to enter the branch.
@@ -355,8 +356,7 @@ describe("explicit harnessDir argument (isolation)", () => {
       expect(remaining).toHaveLength(1);
       expect(remaining[0]!.t3codeThreadIds).toEqual(["thread-abc", "thread-def"]);
     } finally {
-      // Restore the real module so subsequent tests are unaffected.
-      mock.module("../t3code/server.ts", () => import("../t3code/server.ts"));
+      serverStatusSpy.mockRestore();
     }
   });
 });

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -261,3 +261,60 @@ describe("config cleanupDelayHours", () => {
     expect(cleanupDelayHours()).toBe(25);
   });
 });
+
+// task-f60547cd: explicit harnessDir argument must isolate cleanup manifests from
+// the process-global LUDICS_HARNESS_DIR. The env-var-based tests above only prove
+// backward compatibility via default-arg fallback; these tests prove the bypass
+// is actually closed for callers who pass an explicit harnessDir.
+describe("explicit harnessDir argument (isolation)", () => {
+  let ISO = "";
+  beforeEach(() => {
+    ISO = join(tmpDir, "iso");
+    mkdirSync(join(ISO, "mag"), { recursive: true });
+  });
+
+  test("recordDeferredCleanup writes manifest under explicit harnessDir, not the env-var decoy", () => {
+    const entry = makeEntry({ taskId: "task-iso" });
+    // tmpDir is the env-var harness (the decoy here). ISO is the explicit target.
+    recordDeferredCleanup(entry, ISO);
+
+    const isoFile = join(ISO, "mag", "cleanup-pending.json");
+    const envFile = join(tmpDir, "mag", "cleanup-pending.json");
+    expect(existsSync(isoFile)).toBe(true);
+    expect(existsSync(envFile)).toBe(false);
+
+    // cleanupPendingPath reports the correct path for the explicit arg.
+    expect(cleanupPendingPath(ISO)).toBe(isoFile);
+  });
+
+  test("loadDeferredCleanups(ISO) ignores manifests under the env-var harness", () => {
+    // Seed the env-var harness with an entry — loading with the explicit arg must not see it.
+    recordDeferredCleanup(makeEntry({ taskId: "env-task" })); // default arg → env-var harness
+    recordDeferredCleanup(makeEntry({ taskId: "iso-task" }), ISO); // explicit → ISO
+
+    const envEntries = loadDeferredCleanups(); // default arg → env-var harness
+    const isoEntries = loadDeferredCleanups(ISO);
+
+    expect(envEntries.map((e) => e.taskId)).toEqual(["env-task"]);
+    expect(isoEntries.map((e) => e.taskId)).toEqual(["iso-task"]);
+  });
+
+  test("cancelDeferredCleanup(taskId, slot, ISO) only affects the explicit-harness manifest", () => {
+    recordDeferredCleanup(makeEntry({ taskId: "shared", slot: 1 })); // env-var harness
+    recordDeferredCleanup(makeEntry({ taskId: "shared", slot: 1 }), ISO);
+    cancelDeferredCleanup("shared", 1, ISO);
+    expect(loadDeferredCleanups().map((e) => e.taskId)).toEqual(["shared"]); // env-var unchanged
+    expect(loadDeferredCleanups(ISO)).toEqual([]); // ISO cleared
+  });
+
+  test("processDeferredCleanups(_, ISO) reads and clears the explicit-harness manifest", async () => {
+    // Old-enough entry (30h ago) with no worktrees/branches so cleanup is a no-op.
+    const entry = makeEntry({
+      timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+      worktreePaths: [], branches: [], tmuxSessionNames: [], peerSyncLink: null,
+    });
+    recordDeferredCleanup(entry, ISO);
+    await processDeferredCleanups(25, ISO);
+    expect(loadDeferredCleanups(ISO)).toEqual([]);
+  });
+});

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { cleanupDelayHours } from "../config.ts";
@@ -316,5 +316,47 @@ describe("explicit harnessDir argument (isolation)", () => {
     recordDeferredCleanup(entry, ISO);
     await processDeferredCleanups(25, ISO);
     expect(loadDeferredCleanups(ISO)).toEqual([]);
+  });
+
+  // Reviewer AC7 blocking item: prove the t3codeThreadIds branch passes the
+  // explicit harnessDir arg through to serverStatus({ harnessDir }).
+  // Stub the dynamically-imported ../t3code/server.ts so the test captures the
+  // argument and observes no connection-time I/O.
+  test("processDeferredCleanups(_, ISO) passes ISO to serverStatus({ harnessDir }) in the t3codeThreadIds branch", async () => {
+    const capturedHarnessDirs: string[] = [];
+    mock.module("../t3code/server.ts", () => ({
+      serverStatus: async (options: { harnessDir?: string } = {}) => {
+        capturedHarnessDirs.push(options.harnessDir ?? "<default>");
+        // Return "not running" to short-circuit before any T3CodeClient construction.
+        return { running: false, record: null, snapshot: null, reason: "stubbed" };
+      },
+    }));
+
+    try {
+      // Entry must be old enough to process AND carry t3codeThreadIds to enter the branch.
+      // Empty worktreePaths/branches/sessions so the other cleanup steps are no-ops.
+      const entry = makeEntry({
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        worktreePaths: [], branches: [], tmuxSessionNames: [], peerSyncLink: null,
+        t3codeThreadIds: ["thread-abc", "thread-def"],
+      });
+      recordDeferredCleanup(entry, ISO);
+
+      await processDeferredCleanups(25, ISO);
+
+      // serverStatus was invoked exactly once, with ISO — not the env-var decoy (tmpDir).
+      expect(capturedHarnessDirs).toHaveLength(1);
+      expect(capturedHarnessDirs[0]).toBe(ISO);
+      expect(capturedHarnessDirs[0]).not.toBe(tmpDir);
+
+      // Because the stub returned {running: false}, the branch marks failed=true and the
+      // entry remains in the ISO manifest (proves the path-handling also threaded ISO).
+      const remaining = loadDeferredCleanups(ISO);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.t3codeThreadIds).toEqual(["thread-abc", "thread-def"]);
+    } finally {
+      // Restore the real module so subsequent tests are unaffected.
+      mock.module("../t3code/server.ts", () => import("../t3code/server.ts"));
+    }
   });
 });

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -3,7 +3,7 @@
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { join } from "path";
-import { harnessDir, cleanupDelayHours } from "../config.ts";
+import { harnessDir as defaultHarnessDir, cleanupDelayHours } from "../config.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
 import { removeWorktreeByPath, deleteBranches, orchBranchName } from "./worktrees.ts";
@@ -23,12 +23,12 @@ export interface CleanupEntry {
   t3codeThreadIds?: string[];
 }
 
-export function cleanupPendingPath(): string {
-  return join(harnessDir(), "mag", "cleanup-pending.json");
+export function cleanupPendingPath(harnessDir: string = defaultHarnessDir()): string {
+  return join(harnessDir, "mag", "cleanup-pending.json");
 }
 
-export function loadDeferredCleanups(): CleanupEntry[] {
-  const file = cleanupPendingPath();
+export function loadDeferredCleanups(harnessDir: string = defaultHarnessDir()): CleanupEntry[] {
+  const file = cleanupPendingPath(harnessDir);
   if (!existsSync(file)) return [];
   try {
     const raw: unknown = JSON.parse(readFileSync(file, "utf-8"));
@@ -39,10 +39,13 @@ export function loadDeferredCleanups(): CleanupEntry[] {
   }
 }
 
-export function saveDeferredCleanups(entries: CleanupEntry[]): void {
+export function saveDeferredCleanups(
+  entries: CleanupEntry[],
+  harnessDir: string = defaultHarnessDir(),
+): void {
   try {
-    const file = cleanupPendingPath();
-    mkdirSync(join(harnessDir(), "mag"), { recursive: true });
+    const file = cleanupPendingPath(harnessDir);
+    mkdirSync(join(harnessDir, "mag"), { recursive: true });
     const tmp = file + ".tmp";
     writeFileSync(tmp, JSON.stringify(entries, null, 2) + "\n");
     renameSync(tmp, file);
@@ -107,24 +110,34 @@ export function buildCleanupEntry(
 }
 
 /** Append a deferred cleanup entry to the manifest. */
-export function recordDeferredCleanup(entry: CleanupEntry): void {
-  const entries = loadDeferredCleanups();
+export function recordDeferredCleanup(
+  entry: CleanupEntry,
+  harnessDir: string = defaultHarnessDir(),
+): void {
+  const entries = loadDeferredCleanups(harnessDir);
   entries.push(entry);
-  saveDeferredCleanups(entries);
+  saveDeferredCleanups(entries, harnessDir);
 }
 
 /** Cancel pending cleanup entries matching taskId + slot (e.g., on resume). */
-export function cancelDeferredCleanup(taskId: string, slot: number): void {
-  const entries = loadDeferredCleanups();
+export function cancelDeferredCleanup(
+  taskId: string,
+  slot: number,
+  harnessDir: string = defaultHarnessDir(),
+): void {
+  const entries = loadDeferredCleanups(harnessDir);
   const filtered = entries.filter((e) => !(e.taskId === taskId && e.slot === slot));
   if (filtered.length !== entries.length) {
-    saveDeferredCleanups(filtered);
+    saveDeferredCleanups(filtered, harnessDir);
   }
 }
 
 /** Process deferred cleanup entries older than threshold. */
-export async function processDeferredCleanups(thresholdHours?: number): Promise<void> {
-  const entries = loadDeferredCleanups();
+export async function processDeferredCleanups(
+  thresholdHours?: number,
+  harnessDir: string = defaultHarnessDir(),
+): Promise<void> {
+  const entries = loadDeferredCleanups(harnessDir);
   if (entries.length === 0) return;
 
   const hours = thresholdHours ?? cleanupDelayHours();
@@ -183,7 +196,7 @@ export async function processDeferredCleanups(thresholdHours?: number): Promise<
         const { serverStatus } = await import("../t3code/server.ts");
         const { T3CodeClient } = await import("../t3code/client.ts");
         const { makeId, isoNow } = await import("./util.ts");
-        const status = await serverStatus({ harnessDir: harnessDir() });
+        const status = await serverStatus({ harnessDir });
         if (!status.running || !status.record) {
           console.error("ludics: deferred t3code cleanup: server not running, will retry");
           failed = true;
@@ -227,5 +240,5 @@ export async function processDeferredCleanups(thresholdHours?: number): Promise<
     }
   }
 
-  saveDeferredCleanups(remaining);
+  saveDeferredCleanups(remaining, harnessDir);
 }

--- a/src/orchestration/paths.test.ts
+++ b/src/orchestration/paths.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { taskFilePath } from "./paths.ts";
+
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-paths-"));
+  process.env.LUDICS_HARNESS_DIR = TMP;
+});
+
+afterEach(() => {
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("taskFilePath", () => {
+  test("explicit harnessDir is authoritative", () => {
+    expect(taskFilePath("task-abc", "/custom/harness")).toBe(
+      "/custom/harness/tasks/task-abc.md",
+    );
+  });
+
+  test("default arg falls back to LUDICS_HARNESS_DIR at call time", () => {
+    expect(taskFilePath("task-xyz")).toBe(join(TMP, "tasks", "task-xyz.md"));
+  });
+
+  test("explicit decoy-proof: env is ignored when explicit harnessDir is given", () => {
+    const decoy = "/decoy/should/not/appear";
+    process.env.LUDICS_HARNESS_DIR = decoy;
+    expect(taskFilePath("task-abc", "/real")).toBe("/real/tasks/task-abc.md");
+  });
+});

--- a/src/orchestration/paths.ts
+++ b/src/orchestration/paths.ts
@@ -1,0 +1,7 @@
+import { join } from "path";
+import { harnessDir as defaultHarnessDir } from "../config.ts";
+
+/** Resolve the absolute path to a task spec file under a specific harness. */
+export function taskFilePath(taskId: string, harnessDir: string = defaultHarnessDir()): string {
+  return join(harnessDir, "tasks", `${taskId}.md`);
+}

--- a/src/orchestration/runner.surface-manual.test.ts
+++ b/src/orchestration/runner.surface-manual.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { surfaceManualIntervention } from "./runner.ts";
+
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+let REAL = "";
+let DECOY = "";
+
+beforeEach(() => {
+  REAL = mkdtempSync(join(tmpdir(), "ludics-surface-real-"));
+  DECOY = mkdtempSync(join(tmpdir(), "ludics-surface-decoy-"));
+  mkdirSync(join(REAL, "tasks"), { recursive: true });
+  mkdirSync(join(DECOY, "tasks"), { recursive: true });
+  process.env.LUDICS_HARNESS_DIR = DECOY;
+});
+
+afterEach(() => {
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(REAL, { recursive: true, force: true });
+  rmSync(DECOY, { recursive: true, force: true });
+});
+
+const TASK_ID = "task-surf-1";
+const INITIAL_BODY = [
+  "---",
+  `id: ${TASK_ID}`,
+  "title: Surface test",
+  "status: in-progress",
+  "---",
+  "",
+  "# Surface test",
+  "",
+  "## Questions",
+  "",
+  "## Context",
+  "",
+  "Some context.",
+].join("\n");
+
+describe("surfaceManualIntervention (harnessDir parametrization)", () => {
+  test("writes to the task file under explicit harnessDir, not the LUDICS_HARNESS_DIR decoy", () => {
+    const realTaskFile = join(REAL, "tasks", `${TASK_ID}.md`);
+    const decoyTaskFile = join(DECOY, "tasks", `${TASK_ID}.md`);
+    writeFileSync(realTaskFile, INITIAL_BODY);
+    writeFileSync(decoyTaskFile, INITIAL_BODY);
+
+    surfaceManualIntervention(TASK_ID, "- **Real harness question**", REAL);
+
+    const realAfter = readFileSync(realTaskFile, "utf-8");
+    const decoyAfter = readFileSync(decoyTaskFile, "utf-8");
+
+    // Real harness was updated: has_questions frontmatter + question appended.
+    expect(realAfter).toContain("has_questions: true");
+    expect(realAfter).toContain("- **Real harness question**");
+
+    // Decoy was NOT touched (byte-for-byte preserved).
+    expect(decoyAfter).toBe(INITIAL_BODY);
+    expect(decoyAfter).not.toContain("has_questions: true");
+    expect(decoyAfter).not.toContain("Real harness question");
+  });
+
+  test("default arg still works via LUDICS_HARNESS_DIR for backward compat", () => {
+    const decoyTaskFile = join(DECOY, "tasks", `${TASK_ID}.md`);
+    writeFileSync(decoyTaskFile, INITIAL_BODY);
+
+    // No explicit harnessDir → falls back to defaultHarnessDir() → writes to the env-var harness.
+    surfaceManualIntervention(TASK_ID, "- **Default fallback question**");
+
+    const decoyAfter = readFileSync(decoyTaskFile, "utf-8");
+    expect(decoyAfter).toContain("has_questions: true");
+    expect(decoyAfter).toContain("Default fallback question");
+  });
+
+  test("is a no-op when the task file is absent under the given harness (cluster-worker branch still reachable)", () => {
+    // Neither harness has a task file — local write is skipped, cluster forwarding path runs and is swallowed in standalone mode.
+    // Must not throw.
+    expect(() => surfaceManualIntervention(TASK_ID, "- **Q**", REAL)).not.toThrow();
+  });
+});

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -873,7 +873,7 @@ async function enterPhase(
     };
 
     // Persist after each agent dispatch — crash recovery will have lifecycle data
-    persistState(state);
+    persistState(state, state.harnessDir ?? defaultHarnessDir());
   }
 
   state.phaseDispatched = true;
@@ -1426,7 +1426,7 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       // event + priority-5 notification, and flip slot liveness without any
       // intervening phase-advance work (nudge, auto-commit, verification gate).
       if (isEscalated(state)) {
-        persistState(state);
+        persistState(state, state.harnessDir ?? defaultHarnessDir());
         return;
       }
 
@@ -1445,12 +1445,12 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       // so the quiet-period tracking and re-dispatch logic run on the tick when agents finish.
       if (state.phase === "pr-comments") {
         await checkAndRedispatchPrComments(state, transport);
-        persistState(state);
+        persistState(state, state.harnessDir ?? defaultHarnessDir());
         // Return to the main loop so evaluateTransition can check quiet-period expiry.
         if (evaluateTransition(state) !== null) return;
       }
 
-      persistState(state);
+      persistState(state, state.harnessDir ?? defaultHarnessDir());
 
       if (allAgentsDone(state)) return;
 
@@ -1501,7 +1501,7 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
           stallType: "interrupted",
           message: `${agent.name}: nudged with status-write instruction (turn settled without done status)`,
         });
-        persistState(state);
+        persistState(state, state.harnessDir ?? defaultHarnessDir());
       }
 
       if (nowEpoch() >= deadline) {
@@ -1735,7 +1735,7 @@ export function triggerCoderBailOut(
       action, status: eventStatus, message,
     });
   }
-  persistState(state);
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
 }
 
 /**
@@ -1759,7 +1759,7 @@ export function handleEscalation(state: OrchestrationState): void {
   const raisers = escalatingAgents(state);
   if (raisers.length === 0) return; // defensive: caller should have gated
 
-  persistState(state);
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
 
   const reasonFor = (name: string): { reason: string; warned: boolean } => {
     const raw = (state.agentStates[name]?.statusMessage ?? "").trim();
@@ -1808,7 +1808,7 @@ export function handleEscalation(state: OrchestrationState): void {
     console.error(`ludics: failed to set slot ${state.slot} liveness=escalated: ${err instanceof Error ? err.message : String(err)}`);
   }
 
-  persistState(state);
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
 }
 
 export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean {
@@ -1820,7 +1820,7 @@ export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean 
   // solo contract (lone coder). Skip PR creation and transition directly to done.
   if (isBailedOut(state)) {
     state.phase = "done";
-    persistState(state);
+    persistState(state, state.harnessDir ?? defaultHarnessDir());
     return true;
   }
 
@@ -1839,7 +1839,7 @@ export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean 
   // (agentParticipatesInPhase returns false for reviewer), so waiting for
   // bail-out-confirmed would deadlock.
   state.phase = "done";
-  persistState(state);
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
   return true;
 }
 
@@ -1852,7 +1852,7 @@ export async function runOrchestration(
   }
   // Ensure every downstream persistState preserves the caller-selected harness.
   state.harnessDir ??= defaultHarnessDir();
-  persistState(state);
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
 
   // Startup grace for the sibling-state self-guard. The adapter writes
   // tmux-slot-<N>.json / t3code/slot-<N>.json only AFTER
@@ -1893,7 +1893,7 @@ export async function runOrchestration(
     }
 
     await enterPhase(state, transport);
-    persistState(state);
+    persistState(state, state.harnessDir ?? defaultHarnessDir());
 
     await pollUntilDone(state, transport);
 
@@ -1940,7 +1940,7 @@ export async function runOrchestration(
     const gateDecision = [prCreateDecision, finalMergeDecision].find(d => d !== "skip") ?? "skip";
 
     if (gateDecision === "redispatch" || gateDecision === "hold") {
-      persistState(state);
+      persistState(state, state.harnessDir ?? defaultHarnessDir());
       await sleepMs(state.config.pollInterval * 1000);
       continue; // re-enter loop: redispatch runs enterPhase, hold waits for timeout/human
     }
@@ -1950,7 +1950,7 @@ export async function runOrchestration(
     const next = maybeOverrideTransition(state, evaluated);
 
     if (!next) {
-      persistState(state);
+      persistState(state, state.harnessDir ?? defaultHarnessDir());
       await sleepMs(state.config.pollInterval * 1000);
       continue;
     }
@@ -2041,7 +2041,7 @@ export async function runOrchestration(
     state.confirmedPhase = null;
     state.phaseDispatched = false;
     state.currentPhaseToken = undefined;
-    persistState(state);
+    persistState(state, state.harnessDir ?? defaultHarnessDir());
   }
 
   // Orchestration complete — mark the task as done so maybeClearDoneSlots()

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -17,7 +17,8 @@ import {
 import { isoNow, makeId, nowEpoch, sleepMs } from "./util.ts";
 import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, postPrDriftComment, validateAndFixPrFile, type PrVerification } from "./github.ts";
 import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
-import { findProjectConfig, globalAdapter, harnessDir, ludicsRoot } from "../config.ts";
+import { findProjectConfig, globalAdapter, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
+import { taskFilePath } from "./paths.ts";
 import { notifyAgents, notifyOutgoing } from "../notify.ts";
 import { readSlotJson, writeSlotJson } from "../slots/json.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
@@ -351,7 +352,7 @@ export function handleVerifyFailure(
     // Surface in dashboard via has_questions tile.
     // Use cluster forwarding when running as a worker so the controller's task file is updated.
     const questionLine = `- **Manual intervention required (slot ${state.slot})**: ${phaseLabel} failed after ${MAX_VERIFY_ATTEMPTS} attempts`;
-    surfaceManualIntervention(state.taskId, questionLine);
+    surfaceManualIntervention(state.taskId, questionLine, state.harnessDir ?? defaultHarnessDir());
     return "hold";
   }
 
@@ -362,9 +363,13 @@ export function handleVerifyFailure(
 }
 
 /** Set has_questions on the task and append the reason to ## Questions, cluster-safe. */
-export function surfaceManualIntervention(taskId: string, questionLine: string): void {
+export function surfaceManualIntervention(
+  taskId: string,
+  questionLine: string,
+  harnessDir: string = defaultHarnessDir(),
+): void {
   // Always write locally first so the data is persisted even if cluster forwarding fails.
-  const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+  const taskFile = taskFilePath(taskId, harnessDir);
   if (existsSync(taskFile)) {
     addFrontmatterField(taskFile, "has_questions", "true");
     appendToSection(taskFile, "Questions", questionLine);
@@ -657,7 +662,7 @@ async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
 
   const { readTmuxSlotState, writeTmuxSlotState, startTtyd, agentPortRole } =
     await import("../adapters/tmux-adapter.ts");
-  const dir = harnessDir();
+  const dir = state.harnessDir ?? defaultHarnessDir();
   const tmuxState = readTmuxSlotState(state.slot, dir);
   if (!tmuxState) return;
 
@@ -1845,6 +1850,8 @@ export async function runOrchestration(
   if (!transport) {
     transport = await createTransport(state);
   }
+  // Ensure every downstream persistState preserves the caller-selected harness.
+  state.harnessDir ??= defaultHarnessDir();
   persistState(state);
 
   // Startup grace for the sibling-state self-guard. The adapter writes
@@ -1862,9 +1869,10 @@ export async function runOrchestration(
     // path deleted it without signaling us), exit cleanly instead of continuing
     // to corrupt orchestration/slot-<N>.json on the next persistState tick.
     {
+      const dir = state.harnessDir ?? defaultHarnessDir();
       const sibling = state.backend === "t3code"
-        ? readSlotState(state.slot, harnessDir())
-        : readTmuxSlotState(state.slot, harnessDir());
+        ? readSlotState(state.slot, dir)
+        : readTmuxSlotState(state.slot, dir);
       if (!sibling) {
         if (Date.now() - runnerStartMs < startupGraceMs) {
           // Parent adapter hasn't written sibling state yet — re-check.
@@ -2051,7 +2059,7 @@ export async function runOrchestration(
       }
     } catch { /* standalone mode */ }
     if (!taskUpdated) {
-      const taskFile = join(harnessDir(), "tasks", `${state.taskId}.md`);
+      const taskFile = taskFilePath(state.taskId, state.harnessDir ?? defaultHarnessDir());
       if (existsSync(taskFile)) {
         updateFrontmatterField(taskFile, "status", "done");
         updateFrontmatterField(taskFile, "completed", isoNow());

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -1801,4 +1801,98 @@ describe("skills", () => {
     expect(raw).toContain("git diff <commit>^..<commit> --stat");
     expect(raw).toContain("main-side drift");
   });
+
+  // task-f60547cd: state.harnessDir must be authoritative over the process-global
+  // harnessDir() when resolving task files and acceptance criteria.
+  test("buildSkillContext: reads task file from state.harnessDir even when LUDICS_HARNESS_DIR points elsewhere", async () => {
+    const { rmSync } = await import("fs");
+    const realTmp = mkdtempSync(join(tmpdir(), "ludics-skills-harnessdir-real-"));
+    const decoyTmp = mkdtempSync(join(tmpdir(), "ludics-skills-harnessdir-decoy-"));
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      mkdirSync(join(realTmp, "tasks"), { recursive: true });
+      mkdirSync(join(decoyTmp, "tasks"), { recursive: true });
+      // Real harness contains the authoritative task spec with distinctive AC text.
+      writeFileSync(
+        join(realTmp, "tasks", "task-hd1.md"),
+        [
+          "---", "id: task-hd1", "title: Real Title", "proposal: inline", "---",
+          "", "## Acceptance Criteria",
+          "- [ ] REAL_AC_MARKER do the real thing",
+        ].join("\n"),
+      );
+      // Decoy harness has a conflicting task with different AC text — a bypass
+      // would pick this up.
+      writeFileSync(
+        join(decoyTmp, "tasks", "task-hd1.md"),
+        [
+          "---", "id: task-hd1", "title: Decoy Title", "proposal: inline", "---",
+          "", "## Acceptance Criteria",
+          "- [ ] DECOY_AC_MARKER should never appear",
+        ].join("\n"),
+      );
+      process.env.LUDICS_HARNESS_DIR = decoyTmp;
+
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = {
+        ...makeState(),
+        taskId: "task-hd1",
+        slotTitle: "Real Title",
+        round: 1,
+        harnessDir: realTmp,
+      };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+
+      // TASK_SPEC and TASK_AC must reflect the real harness, not the decoy.
+      expect(ctx["TASK_SPEC"]).toContain("REAL_AC_MARKER");
+      expect(ctx["TASK_SPEC"]).not.toContain("DECOY_AC_MARKER");
+      expect(ctx["TASK_AC"]).toContain("REAL_AC_MARKER");
+      expect(ctx["TASK_AC"]).not.toContain("DECOY_AC_MARKER");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(realTmp, { recursive: true, force: true });
+      rmSync(decoyTmp, { recursive: true, force: true });
+    }
+  });
+
+  test("buildSkillContext: brief round (round > 1) also reads task file from state.harnessDir", async () => {
+    const { rmSync } = await import("fs");
+    const realTmp = mkdtempSync(join(tmpdir(), "ludics-skills-harnessdir-brief-"));
+    const decoyTmp = mkdtempSync(join(tmpdir(), "ludics-skills-harnessdir-brief-decoy-"));
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      mkdirSync(join(realTmp, "tasks"), { recursive: true });
+      mkdirSync(join(decoyTmp, "tasks"), { recursive: true });
+      writeFileSync(
+        join(realTmp, "tasks", "task-hd2.md"),
+        ["---", "id: task-hd2", "title: Real Brief", "proposal: docs/proposals/real-p.md", "---", ""].join("\n"),
+      );
+      writeFileSync(
+        join(decoyTmp, "tasks", "task-hd2.md"),
+        ["---", "id: task-hd2", "title: Decoy Brief", "proposal: docs/proposals/decoy-p.md", "---", ""].join("\n"),
+      );
+      process.env.LUDICS_HARNESS_DIR = decoyTmp;
+
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = {
+        ...makeState(),
+        taskId: "task-hd2",
+        slotTitle: "Real Brief",
+        round: 2,
+        harnessDir: realTmp,
+      };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+
+      // Brief form: proposal path comes from frontmatter; must be the real one, not the decoy one.
+      expect(ctx["PROPOSAL_PATH"]).toBe("docs/proposals/real-p.md");
+      expect(ctx["TASK_SPEC"]).toContain("docs/proposals/real-p.md");
+      expect(ctx["TASK_SPEC"]).not.toContain("docs/proposals/decoy-p.md");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(realTmp, { recursive: true, force: true });
+      rmSync(decoyTmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -2,7 +2,8 @@ import { existsSync, readFileSync, readdirSync } from "fs";
 import { join } from "path";
 import { assertRepoRelativeProposalPath } from "../adapters/task-launch.ts";
 import { readFrontmatterField } from "../tasks/markdown.ts";
-import { findProjectConfig, harnessDir, ludicsRoot } from "../config.ts";
+import { findProjectConfig, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
+import { taskFilePath } from "./paths.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import { defaultRunGit, detectDefaultBranches } from "../git-runner.ts";
 import type { Phase } from "./phases.ts";
@@ -109,7 +110,7 @@ function taskSpecBriefText(state: OrchestrationState): string {
   const taskId = state.taskId?.trim();
   if (!taskId) return state.slotTitle?.trim() || state.taskId;
   const title = state.slotTitle?.trim() || state.taskId;
-  const path = join(harnessDir(), "tasks", `${taskId}.md`);
+  const path = taskFilePath(taskId, state.harnessDir ?? defaultHarnessDir());
   const content = readFileIfExists(path);
   const proposalValue = (content ? readFrontmatterField(content, "proposal") : null) ?? "";
   const proposalRef =
@@ -141,7 +142,7 @@ function taskSpecText(state: OrchestrationState): string {
   if (!taskId) {
     return state.slotTitle?.trim() || state.taskId;
   }
-  const path = join(harnessDir(), "tasks", `${taskId}.md`);
+  const path = taskFilePath(taskId, state.harnessDir ?? defaultHarnessDir());
   const content = readFileIfExists(path);
   if (!content) return taskId;
 
@@ -180,9 +181,12 @@ function taskSpecText(state: OrchestrationState): string {
 /** Extract the body under `## Acceptance Criteria` from tasks/{taskId}.md.
  *  Returns "" when the task file, the section, or the non-placeholder body
  *  is missing. Stops at the next `##` heading or EOF. */
-function extractAcceptanceCriteria(taskId: string | undefined): string {
+function extractAcceptanceCriteria(
+  taskId: string | undefined,
+  harnessDir: string = defaultHarnessDir(),
+): string {
   if (!taskId) return "";
-  const path = join(harnessDir(), "tasks", `${taskId}.md`);
+  const path = taskFilePath(taskId, harnessDir);
   const content = readFileIfExists(path);
   if (!content) return "";
   const headingMatch = content.match(/^##\s+Acceptance Criteria\s*$/m);
@@ -348,7 +352,8 @@ export function buildSkillContext(
   const upstreamRepo = state.duoPeerSlot == null ? (_projectEntry?.upstream_repo ?? null) : null;
 
   // Extract proposal path from task frontmatter for templates that need just a reference
-  const _taskPath = state.taskId ? join(harnessDir(), "tasks", `${state.taskId}.md`) : null;
+  const stateHarnessDir = state.harnessDir ?? defaultHarnessDir();
+  const _taskPath = state.taskId ? taskFilePath(state.taskId, stateHarnessDir) : null;
   const _taskContent = _taskPath ? readFileIfExists(_taskPath) : null;
   const _proposalPath = (_taskContent ? readFrontmatterField(_taskContent, "proposal") : null) ?? "";
   const proposalPath = _proposalPath && _proposalPath !== "inline" // deprecated sentinel — kept for backward compat
@@ -375,7 +380,7 @@ export function buildSkillContext(
     PROPOSAL_PATH: proposalPath || "",
     PROPOSAL_INSTRUCTION: proposalInstruction || "",
     PROPOSAL_FRESHNESS_WARNING: proposalFreshnessWarningText || "",
-    TASK_AC: extractAcceptanceCriteria(state.taskId) || "",
+    TASK_AC: extractAcceptanceCriteria(state.taskId, stateHarnessDir) || "",
     PEER_REVIEW: peerReview ?? "(no review yet)",
     PEER_STATUS: peer ? (state.agentStates[peer.name]?.status ?? "unknown") : "unknown",
     PEER_PLAN: peerPlan ?? "(no plan yet)",

--- a/src/orchestration/state.harnessdir.test.ts
+++ b/src/orchestration/state.harnessdir.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  defaultOrchestrationConfig,
+  persistState,
+  readOrchestrationState,
+  type OrchestrationState,
+} from "./state.ts";
+
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+let REAL = "";
+let DECOY = "";
+
+function baseState(slot: number, harnessDir?: string): OrchestrationState {
+  return {
+    slot,
+    taskId: "task-hdtest",
+    mode: "pair",
+    phase: "setup",
+    round: 1,
+    mergeRound: 0,
+    agents: [],
+    agentStates: {},
+    config: defaultOrchestrationConfig(),
+    phaseStartedAt: 0,
+    startedAt: new Date().toISOString(),
+    projectDir: "/tmp/project",
+    rootWorktree: "/tmp/root",
+    peerSyncDir: "/tmp/peer-sync",
+    threadIds: {},
+    backend: "tmux",
+    ...(harnessDir !== undefined ? { harnessDir } : {}),
+  };
+}
+
+beforeEach(() => {
+  REAL = mkdtempSync(join(tmpdir(), "ludics-state-real-"));
+  DECOY = mkdtempSync(join(tmpdir(), "ludics-state-decoy-"));
+  mkdirSync(join(REAL, "orchestration"), { recursive: true });
+  process.env.LUDICS_HARNESS_DIR = DECOY;
+});
+
+afterEach(() => {
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(REAL, { recursive: true, force: true });
+  rmSync(DECOY, { recursive: true, force: true });
+});
+
+describe("OrchestrationState.harnessDir", () => {
+  test("round-trip persistence: persistState + readOrchestrationState preserves harnessDir field", () => {
+    const state = baseState(1, REAL);
+    persistState(state, REAL);
+    const loaded = readOrchestrationState(1, REAL);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.harnessDir).toBe(REAL);
+  });
+
+  test("legacy state (no harnessDir field) is backfilled from the readOrchestrationState arg", () => {
+    // Simulate a state file persisted before the field was introduced — write the JSON
+    // directly with the field omitted.
+    const legacy = baseState(2);
+    delete (legacy as Partial<OrchestrationState>).harnessDir;
+    expect((legacy as Partial<OrchestrationState>).harnessDir).toBeUndefined();
+
+    const path = join(REAL, "orchestration", "slot-2.json");
+    writeFileSync(path, JSON.stringify(legacy, null, 2));
+
+    const loaded = readOrchestrationState(2, REAL);
+    expect(loaded).not.toBeNull();
+    // Backfilled to the caller-supplied harness, NOT the decoy (LUDICS_HARNESS_DIR).
+    expect(loaded!.harnessDir).toBe(REAL);
+    expect(loaded!.harnessDir).not.toBe(DECOY);
+  });
+
+  test("backfill uses `??=` — an existing non-empty harnessDir wins over the arg", () => {
+    // If the state was persisted with harnessDir already set, the arg must not overwrite
+    // (otherwise the caller's re-parametrization would silently clobber committed intent).
+    const state = baseState(3, "/already/set");
+    const path = join(REAL, "orchestration", "slot-3.json");
+    writeFileSync(path, JSON.stringify(state, null, 2));
+
+    const loaded = readOrchestrationState(3, REAL);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.harnessDir).toBe("/already/set");
+  });
+});

--- a/src/orchestration/state.harnessdir.test.ts
+++ b/src/orchestration/state.harnessdir.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -85,5 +85,47 @@ describe("OrchestrationState.harnessDir", () => {
     const loaded = readOrchestrationState(3, REAL);
     expect(loaded).not.toBeNull();
     expect(loaded!.harnessDir).toBe("/already/set");
+  });
+
+  // task-f60547cd PR #399 P1: runner.ts now invokes
+  // `persistState(state, state.harnessDir ?? defaultHarnessDir())` at every
+  // in-body site (previously bare `persistState(state)`), so orchestration
+  // snapshots land in the caller-selected harness instead of the process
+  // global when runOrchestrationForSlot(slot, harnessDir) is invoked with
+  // a harness that differs from LUDICS_HARNESS_DIR. This test exercises
+  // the exact pattern runner.ts now uses.
+  test("persistState(state, state.harnessDir ?? defaultHarnessDir()) writes to state.harnessDir, not LUDICS_HARNESS_DIR", () => {
+    mkdirSync(join(REAL, "orchestration"), { recursive: true });
+    mkdirSync(join(DECOY, "orchestration"), { recursive: true });
+
+    const state = baseState(4, REAL); // state.harnessDir = REAL; env points at DECOY
+
+    // Exact pattern used throughout runner.ts (line 876, 1429, 1448, …, 1855, …).
+    persistState(state, state.harnessDir ?? DECOY);
+
+    // Snapshot lands in REAL harness only.
+    const realPath = join(REAL, "orchestration", "slot-4.json");
+    const decoyPath = join(DECOY, "orchestration", "slot-4.json");
+    expect(existsSync(realPath)).toBe(true);
+    expect(existsSync(decoyPath)).toBe(false);
+  });
+
+  test("persistState with a literal state (no harnessDir set) falls through to the global — runner seeds it at top of runOrchestration to avoid this", () => {
+    // Regression anchor: without the top-of-runOrchestration seed
+    // (runner.ts:1854 `state.harnessDir ??= defaultHarnessDir()`), a
+    // literal state with no harnessDir would coerce to the env-var global
+    // in this ??-fallback pattern. The seed is what guarantees the
+    // in-body persistState calls never silently default to the global
+    // once runOrchestration has been entered.
+    mkdirSync(join(DECOY, "orchestration"), { recursive: true });
+
+    const state = baseState(5); // no harnessDir
+    expect(state.harnessDir).toBeUndefined();
+
+    persistState(state, state.harnessDir ?? DECOY);
+
+    // Fallback writes to DECOY (defaultHarnessDir() target) — this is the
+    // behaviour the top-of-runOrchestration seed prevents for real runs.
+    expect(existsSync(join(DECOY, "orchestration", "slot-5.json"))).toBe(true);
   });
 });

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -196,6 +196,10 @@ export interface OrchestrationState {
   /** Commit count at which the stale-base warning last fired within
    *  staleBaseLastWarnedRound. Re-fire only when a new count exceeds this. */
   staleBaseLastWarnedCount?: number;
+  /** Caller-selected harness directory; populated at orchestration init and
+   *  backfilled from the readOrchestrationState() harnessDir arg for legacy
+   *  state files. Consumers should read via `state.harnessDir ?? defaultHarnessDir()`. */
+  harnessDir?: string;
 }
 
 export const DEFAULT_TIMEOUTS: Record<string, number> = {
@@ -301,13 +305,17 @@ export function readOrchestrationState(
   // Worker: read from non-harness cache
   if (isWorkerContext()) {
     const state = readJsonFile<OrchestrationState>(workerCacheFilePath(slot));
-    if (state) return migrateState(state, slot);
-    return null;
+    if (!state) return null;
+    const migrated = migrateState(state, slot);
+    migrated.harnessDir ??= harnessDir;
+    return migrated;
   }
   // Controller/standalone: read from harness
   const state = readJsonFile<OrchestrationState>(stateFilePath(slot, harnessDir));
   if (!state) return null;
-  return migrateState(state, slot);
+  const migrated = migrateState(state, slot);
+  migrated.harnessDir ??= harnessDir;
+  return migrated;
 }
 
 export function persistState(

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -972,7 +972,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
   // Cancel any pending deferred cleanup for this task+slot
   try {
     const { cancelDeferredCleanup } = await import("../orchestration/deferred-cleanup.ts");
-    cancelDeferredCleanup(ctx.taskId, slotNum);
+    cancelDeferredCleanup(ctx.taskId, slotNum, ctx.harnessDir);
   } catch { /* non-critical */ }
 
   // Recoverable-from-fresh-start fallback: triggered when the slot was flagged


### PR DESCRIPTION
## Summary

Make `ctx.harnessDir` (and the equivalent caller-supplied harness dir in orchestration code paths) an *authoritative* boundary rather than an advisory hint. Several functions that accepted an `AdapterContext` or operated on `OrchestrationState` loaded from a caller-specified harness dir were internally re-resolving paths through the global `harnessDir()` from `src/config.ts`, silently defeating the parametrization.

Scope per `docs/proposals/audit-adapter-context-harnessdir-bypass.md` (AC 1–10):

- `src/adapters/base.ts` — widen `adapterStateDir` / `ensureAdapterStateDir` to accept `harnessDir = defaultHarnessDir()`.
- `src/adapters/manual.ts` — thread `ctx.harnessDir` through all four production sites.
- `src/orchestration/paths.ts` (new) — `taskFilePath(taskId, harnessDir)` helper.
- `src/orchestration/state.ts` — add optional `harnessDir?: string` to `OrchestrationState`; backfill `state.harnessDir ??= harnessDir` in `readOrchestrationState` so legacy state files pick up the caller's harness without a migration step.
- `src/orchestration/skills.ts` — four sites use `taskFilePath(..., state.harnessDir ?? defaultHarnessDir())`; widen `extractAcceptanceCriteria`.
- `src/orchestration/runner.ts` — fix `surfaceManualIntervention`, `ensureTtydAlive`, self-guard block, completion block; seed `state.harnessDir` at top of `runOrchestration`.
- `src/orchestration/deferred-cleanup.ts` — widen all six exported helpers; thread through `serverStatus({ harnessDir })`.
- Callers updated in `src/adapters/t3code.ts`, `src/adapters/tmux-adapter.ts`, `src/slots/index.ts`; `src/mag.ts` unchanged (default arg = global is correct).

Explicitly out of scope per AC 10: `src/events.ts::emitEvent` (deferred to the parameter-injection epic), `src/config.ts::harnessDir()` itself.

## Why

Tests that passed `{ harnessDir: tmpDir }` through `AdapterContext` appeared isolated but could mutate the global harness state when production code reached `harnessDir()` transitively — this was exactly the bug that escalated PR #349 from 5 to 7 files (gh-ludics-306). Multi-harness scenarios (federation, cluster) would silently collapse to the single global.

## Regression tests (per file)

- `src/adapters/base.test.ts` — explicit `harnessDir` arg is authoritative over `LUDICS_HARNESS_DIR`; `ensureAdapterStateDir` creates under the arg, not the env var.
- `src/adapters/manual.test.ts` — `start/stop/readState` write under `ctx.harnessDir` even when `LUDICS_HARNESS_DIR` points at a decoy; decoy directory remains untouched.
- `src/orchestration/paths.test.ts` — `taskFilePath` ignores the env var when given an explicit arg.
- `src/orchestration/state.harnessdir.test.ts` — legacy state files (no `harnessDir` field) are backfilled from the `readOrchestrationState` arg, not the global; `??=` semantics preserve pre-existing values.
- `src/orchestration/skills.test.ts` — `buildSkillContext` reads `TASK_AC` / `TASK_SPEC` from `state.harnessDir` (decoy marker never appears).
- `src/orchestration/runner.surface-manual.test.ts` — `surfaceManualIntervention` mutates only the task file under the explicit harness; the `LUDICS_HARNESS_DIR` decoy stays byte-for-byte identical.
- `src/orchestration/deferred-cleanup.test.ts` — explicit `harnessDir` arg isolates `record/load/cancel/process`; a `mock.module`-stubbed test captures the arg passed to `serverStatus({ harnessDir })` in the `t3codeThreadIds` branch and asserts it equals ISO, not the decoy.

## Test plan

- [x] `bun test` — 1492 pass, 0 fail (1469 baseline + 23 new)
- [x] `bun run typecheck` — clean
- [x] `grep -rn "harnessDir()" src/adapters/manual.ts src/orchestration/skills.ts src/orchestration/deferred-cleanup.ts` → no bare calls remain
- [x] `grep -n "harnessDir()" src/orchestration/runner.ts` → only parameter-name references remain
- [x] `git diff main...HEAD -- src/events.ts src/config.ts` → empty (out-of-scope files untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)