### PR TITLE
triggers: extract shared installSimpleTriggers() helper

### DIFF
--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -124,17 +124,6 @@ function installPlist(label: string, content: string): void {
 function triggersInstallMacos(): void {
   const bin = binPath();
 
-  // Startup trigger
-  const startupAction = commandFromAction(triggerGet("startup", "action"));
-  installSimpleTrigger("startup", "startup trigger",
-    startupAction.split(" "),
-    triggerGet("startup", "enabled") === "true",
-    {
-      plistScheduling: `  <key>RunAtLoad</key>\n  <true/>`,
-      systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} ${startupAction}\n\n[Install]\nWantedBy=default.target\n`,
-    },
-    "startup");
-
   // Interval-based triggers
   installIntervalTrigger("sync", "sync trigger", 3600);
 
@@ -224,46 +213,7 @@ function triggersInstallMacos(): void {
 
   installIntervalTrigger("cluster", "cluster heartbeat", 300);
 
-  // Mag keepalive
-  const config = loadConfigSync();
-  const magEnabled = (config.mag as Record<string, unknown> | undefined)?.enabled;
-  const mag = config.mag as Record<string, unknown> | undefined;
-  const keepaliveInterval = String(mag?.keepalive_interval ?? "60");
-  const magSecs = parseInt(keepaliveInterval);
-  const intervalLabel = magSecs >= 60 ? `${Math.floor(magSecs / 60)}m${magSecs % 60 ? magSecs % 60 + "s" : ""}` : `${magSecs}s`;
-  installSimpleTrigger("mag", "Mag keepalive",
-    ["mag", "start"],
-    magEnabled === true || magEnabled === "true",
-    {
-      plistScheduling: `  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>${keepaliveInterval}</integer>`,
-      systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} mag start\n`,
-      systemdActivationUnit: "timer",
-      systemdActivationBody: `[Unit]\nDescription=ludics Mag keepalive timer\n\n[Timer]\nOnBootSec=60\nOnUnitActiveSec=${keepaliveInterval}s\nUnit=ludics-mag.service\n\n[Install]\nWantedBy=timers.target\n`,
-    },
-    `mag (keepalive every ${intervalLabel})`);
-
-  // Dashboard trigger
-  let dashPort = triggerGet("dashboard", "port");
-  if (!dashPort) dashPort = String(config.dashboard?.port ?? 7678);
-  installSimpleTrigger("dashboard", "dashboard server",
-    ["dashboard", "serve", dashPort],
-    triggerGet("dashboard", "enabled") === "true",
-    {
-      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
-      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} dashboard serve ${dashPort}\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
-    },
-    `dashboard (port ${dashPort}, KeepAlive)`);
-
-  // ntfy-subscribe (incoming messages)
-  const incomingTopic = config.notifications?.topics?.incoming;
-  installSimpleTrigger("ntfy-subscribe", "ntfy incoming message subscriber",
-    ["notify", "subscribe"],
-    !!incomingTopic,
-    {
-      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
-      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} notify subscribe\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
-    },
-    "ntfy-subscribe (KeepAlive)");
+  installSimpleTriggers();
 }
 
 // --- Linux systemd ---
@@ -364,7 +314,7 @@ function installIntervalTrigger(name: string, description: string, defaultInterv
   console.log(`Installed ${platform} trigger: ${name} (every ${desc})`);
 }
 
-function triggersInstallLinux(): void {
+function installSimpleTriggers(): void {
   const bin = binPath();
 
   // Startup
@@ -377,6 +327,51 @@ function triggersInstallLinux(): void {
       systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} ${startupAction}\n\n[Install]\nWantedBy=default.target\n`,
     },
     "startup");
+
+  // Mag keepalive
+  const config = loadConfigSync();
+  const mag = config.mag as Record<string, unknown> | undefined;
+  const magEnabled = mag?.enabled;
+  const keepaliveInterval = String(mag?.keepalive_interval ?? "60");
+  const magSecs = parseInt(keepaliveInterval);
+  const intervalLabel = magSecs >= 60 ? `${Math.floor(magSecs / 60)}m${magSecs % 60 ? magSecs % 60 + "s" : ""}` : `${magSecs}s`;
+  installSimpleTrigger("mag", "Mag keepalive",
+    ["mag", "start"],
+    magEnabled === true || magEnabled === "true",
+    {
+      plistScheduling: `  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>${keepaliveInterval}</integer>`,
+      systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} mag start\n`,
+      systemdActivationUnit: "timer",
+      systemdActivationBody: `[Unit]\nDescription=ludics Mag keepalive timer\n\n[Timer]\nOnBootSec=60\nOnUnitActiveSec=${keepaliveInterval}s\nUnit=ludics-mag.service\n\n[Install]\nWantedBy=timers.target\n`,
+    },
+    `mag (keepalive every ${intervalLabel})`);
+
+  // Dashboard
+  let dashPort = triggerGet("dashboard", "port");
+  if (!dashPort) dashPort = String(config.dashboard?.port ?? 7678);
+  installSimpleTrigger("dashboard", "dashboard server",
+    ["dashboard", "serve", dashPort],
+    triggerGet("dashboard", "enabled") === "true",
+    {
+      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
+      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} dashboard serve ${dashPort}\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
+    },
+    `dashboard (port ${dashPort}, KeepAlive)`);
+
+  // ntfy-subscribe (incoming messages)
+  const incomingTopic = config.notifications?.topics?.incoming;
+  installSimpleTrigger("ntfy-subscribe", "ntfy incoming message subscriber",
+    ["notify", "subscribe"],
+    !!incomingTopic,
+    {
+      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
+      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} notify subscribe\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
+    },
+    "ntfy-subscribe (KeepAlive)");
+}
+
+function triggersInstallLinux(): void {
+  const bin = binPath();
 
   // Interval-based triggers
   installIntervalTrigger("sync", "sync trigger", 3600);
@@ -443,46 +438,7 @@ function triggersInstallLinux(): void {
 
   installIntervalTrigger("cluster", "cluster heartbeat", 300);
 
-  // Mag keepalive
-  const config = loadConfigSync();
-  const magEnabled = (config.mag as Record<string, unknown> | undefined)?.enabled;
-  const mag = config.mag as Record<string, unknown> | undefined;
-  const keepaliveInterval = String(mag?.keepalive_interval ?? "60");
-  const magSecs = parseInt(keepaliveInterval);
-  const intervalLabel = magSecs >= 60 ? `${Math.floor(magSecs / 60)}m${magSecs % 60 ? magSecs % 60 + "s" : ""}` : `${magSecs}s`;
-  installSimpleTrigger("mag", "Mag keepalive",
-    ["mag", "start"],
-    magEnabled === true || magEnabled === "true",
-    {
-      plistScheduling: `  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>${keepaliveInterval}</integer>`,
-      systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} mag start\n`,
-      systemdActivationUnit: "timer",
-      systemdActivationBody: `[Unit]\nDescription=ludics Mag keepalive timer\n\n[Timer]\nOnBootSec=60\nOnUnitActiveSec=${keepaliveInterval}s\nUnit=ludics-mag.service\n\n[Install]\nWantedBy=timers.target\n`,
-    },
-    `mag (keepalive every ${intervalLabel})`);
-
-  // Dashboard
-  let dashPort = triggerGet("dashboard", "port");
-  if (!dashPort) dashPort = String(config.dashboard?.port ?? 7678);
-  installSimpleTrigger("dashboard", "dashboard server",
-    ["dashboard", "serve", dashPort],
-    triggerGet("dashboard", "enabled") === "true",
-    {
-      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
-      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} dashboard serve ${dashPort}\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
-    },
-    `dashboard (port ${dashPort}, KeepAlive)`);
-
-  // ntfy-subscribe (incoming messages)
-  const incomingTopic = config.notifications?.topics?.incoming;
-  installSimpleTrigger("ntfy-subscribe", "ntfy incoming message subscriber",
-    ["notify", "subscribe"],
-    !!incomingTopic,
-    {
-      plistScheduling: `  <key>KeepAlive</key>\n  <true/>\n  <key>RunAtLoad</key>\n  <true/>`,
-      systemdServiceBody: `[Service]\nType=simple\nExecStart=${bin} notify subscribe\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n`,
-    },
-    "ntfy-subscribe (KeepAlive)");
+  installSimpleTriggers();
 }
 
 // --- Pause/Disable ---


### PR DESCRIPTION
## Summary

- Dedupes the four byte-identical `installSimpleTrigger` call sites (`startup`, `mag`, `dashboard`, `ntfy-subscribe`) that lived in both `triggersInstallMacos` and `triggersInstallLinux`, plus their shared `loadConfigSync` / `magEnabled` / `keepaliveInterval` / `dashPort` / `incomingTopic` prelude.
- Introduces a single top-level `installSimpleTriggers()` in `src/triggers.ts`, called once from each platform installer — the same pattern as the existing `installIntervalTrigger` helper.
- Unifies the two incidental comment-text deltas (`// Startup trigger` / `// Startup`; `// Dashboard trigger` / `// Dashboard`) into a single canonical comment per group.

Net: 48 insertions, 92 deletions in `src/triggers.ts`. The interleaved platform-specific blocks (morning/health/watch plists on macOS, morning/health/watch systemd units on Linux) and all `installIntervalTrigger` invocations stay in place. `installSimpleTrigger` itself is unchanged.

Follow-up to task-3e21bf8b (which introduced `installSimpleTrigger`); its retrospective flagged this exact cleanup.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` (1469 pass / 0 fail)

Refactor is test-equivalent by construction — `installSimpleTrigger` is untouched, and the four call sites' arguments / enablement conditions / log labels are preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)