### PR TITLE
mag: extract magSecondsConfig() and export clearStaleSettled() for direct testing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,6 +212,7 @@ The queue module (`src/queue.ts`) handles FIFO request/response:
 - `magLogs()` — show recent terminal activity
 - `magDoctor()` — health check for Mag setup
 - Keepalive/nudge mechanism to keep Mag responsive
+  - Settled-sentinel grace window: genuine Mag activity within ~90s of settle (`keepalive_interval × 1.5`) cannot clear the sentinel — the stop hook's own response text keeps rendering into the pane after `markMagSettled()`, so the guard preserves the sentinel until `maybeFeedMagQueue` can claim it for instant delivery (see `clearStaleSettled` in `src/mag.ts`, gh-ludics-308).
 - Terminal publishing: captures last 50 tmux lines, deduplicates via hash, publishes to ntfy.sh
 
 ### Skill Context Isolation

--- a/scripts/lint-config-helpers.ts
+++ b/scripts/lint-config-helpers.ts
@@ -187,6 +187,7 @@ function extractPathsFromBody(
  *   - magXxx?.property (alternative variable names like magConfig, magCfg)
  *   - (config.mag as ...)?.property (inline cast)
  *   - config.mag?.property (direct optional chaining)
+ *   - magSecondsConfig("property", ...) (shared helper for *_seconds keys)
  */
 export function extractMagPathsFromSource(sourceDir: string): Set<string> {
   const magProps = new Set<string>();
@@ -197,6 +198,9 @@ export function extractMagPathsFromSource(sourceDir: string): Set<string> {
   const p2 = /\bmag[A-Z]\w*\?\.(\w+)/g;
   // Pattern 3: (config.mag as Type)?.prop (inline cast)
   const p3 = /\.mag\b[^;]*?\)\?\.(\w+)/g;
+  // Pattern 4: magSecondsConfig("prop", ...) — shared helper that reads
+  // mag?.[key] dynamically, so the literal key only appears in the call site.
+  const p4 = /\bmagSecondsConfig\(\s*["'`](\w+)["'`]/g;
 
   function scanDir(dir: string): void {
     for (const entry of readdirSync(dir)) {
@@ -207,7 +211,7 @@ export function extractMagPathsFromSource(sourceDir: string): Set<string> {
           scanDir(full);
         } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
           const content = readFileSync(full, "utf-8");
-          for (const pattern of [p1, p2, p3]) {
+          for (const pattern of [p1, p2, p3, p4]) {
             pattern.lastIndex = 0;
             let m: RegExpExecArray | null;
             while ((m = pattern.exec(content)) !== null) {

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled } from "./mag.ts";
 import type { RunGit } from "./git-runner.ts";
 
 describe("normalizeLaunchAdapter", () => {
@@ -522,155 +522,128 @@ describe("briefingPrecomputeContext — Upstream vs Staging Lag section", () => 
 });
 
 describe("stale settled sentinel detection", () => {
-  let tmpDir: string;
+  // Migrated to call the production clearStaleSettled() directly (task-1b44d17b).
+  // Tests drive the function via injected { nowMs, graceMs, currentHash } and
+  // assert side effects on real harness files (mag/settled, mag/last-pane.hash)
+  // by pointing LUDICS_HARNESS_DIR at a temp directory.
+  let tmpHarness: string;
+  let magDir: string;
+  let sentinelPath: string;
+  let hashPath: string;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "mag-stale-settled-"));
+    tmpHarness = mkdtempSync(join(tmpdir(), "mag-stale-settled-"));
+    process.env.LUDICS_HARNESS_DIR = tmpHarness;
+    magDir = join(tmpHarness, "mag");
+    mkdirSync(magDir, { recursive: true });
+    sentinelPath = join(magDir, "settled");
+    hashPath = join(magDir, "last-pane.hash");
   });
 
   afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    rmSync(tmpHarness, { recursive: true, force: true });
   });
 
-  // Mirror of the production clearStaleSettled() in src/mag.ts, with "now" and
-  // grace window parameterized so tests can drive the timestamp guard
-  // deterministically. Default grace of 90s matches the production default
-  // (keepalive_interval=60s × 1.5).
-  function clearStaleSettled(
-    currentHash: string | null,
-    opts: { nowMs?: number; graceMs?: number } = {},
-  ): boolean {
-    const nowMs = opts.nowMs ?? Date.now();
-    const graceMs = opts.graceMs ?? 90_000;
-
-    const sentinelPath = join(tmpDir, "settled");
-    const hashPath = join(tmpDir, "last-pane.hash");
-    if (!existsSync(sentinelPath)) return false;
-
-    // Timestamp guard (mirrors production)
-    try {
-      const content = readFileSync(sentinelPath, "utf-8").trim();
-      const epoch = parseInt(content, 10);
-      if (Number.isFinite(epoch) && epoch > 0) {
-        const ageMs = nowMs - epoch * 1000;
-        if (ageMs < graceMs) return false;
-      }
-    } catch { /* fall through */ }
-
-    if (currentHash === null) return false;
-    let previousHash: string | null = null;
-    try { previousHash = readFileSync(hashPath, "utf-8").trim() || null; } catch { /* ignore */ }
-    if (previousHash !== null && currentHash !== previousHash) {
-      try { unlinkSync(sentinelPath); } catch { /* ignore */ }
-      writeFileSync(hashPath, currentHash);
-      return true; // sentinel was stale
-    } else if (previousHash === null) {
-      writeFileSync(hashPath, currentHash);
-    }
-    return false;
-  }
-
   // Existing tests seed sentinel content "1234" (epoch 1970-01-01) — that age
-  // is trivially past the 90s grace window under any realistic Date.now(), so
-  // the new guard does not short-circuit these cases.
+  // is trivially past any realistic grace window, so the timestamp guard does
+  // not short-circuit these cases.
 
   test("clears settled when pane hash has changed", () => {
-    writeFileSync(join(tmpDir, "settled"), "1234");
-    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
-    const cleared = clearStaleSettled("newhash");
-    expect(cleared).toBe(true);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(false);
+    writeFileSync(sentinelPath, "1234");
+    writeFileSync(hashPath, "oldhash");
+    clearStaleSettled({ currentHash: "newhash" });
+    expect(existsSync(sentinelPath)).toBe(false);
+    expect(readFileSync(hashPath, "utf-8")).toBe("newhash");
   });
 
   test("keeps settled when pane hash unchanged", () => {
-    writeFileSync(join(tmpDir, "settled"), "1234");
-    writeFileSync(join(tmpDir, "last-pane.hash"), "samehash");
-    const cleared = clearStaleSettled("samehash");
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    writeFileSync(sentinelPath, "1234");
+    writeFileSync(hashPath, "samehash");
+    clearStaleSettled({ currentHash: "samehash" });
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(readFileSync(hashPath, "utf-8")).toBe("samehash");
   });
 
   test("keeps settled on first observation (no prior hash)", () => {
-    writeFileSync(join(tmpDir, "settled"), "1234");
-    const cleared = clearStaleSettled("firsthash");
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
-    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("firsthash");
+    writeFileSync(sentinelPath, "1234");
+    clearStaleSettled({ currentHash: "firsthash" });
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(readFileSync(hashPath, "utf-8")).toBe("firsthash");
   });
 
   test("no-op when settled does not exist", () => {
-    const cleared = clearStaleSettled("anyhash");
-    expect(cleared).toBe(false);
+    clearStaleSettled({ currentHash: "anyhash" });
+    expect(existsSync(sentinelPath)).toBe(false);
+    expect(existsSync(hashPath)).toBe(false);
   });
 
   test("no-op when pane hash is null (tmux capture failed)", () => {
-    writeFileSync(join(tmpDir, "settled"), "1234");
-    const cleared = clearStaleSettled(null);
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    writeFileSync(sentinelPath, "1234");
+    clearStaleSettled({ currentHash: null });
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(existsSync(hashPath)).toBe(false);
   });
 
   // gh-ludics-308: timestamp-guard regression tests
 
   test("keeps settled when sentinel is young despite hash change", () => {
     const now = Date.now();
-    writeFileSync(join(tmpDir, "settled"), String(Math.floor(now / 1000)));
-    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
-    const cleared = clearStaleSettled("newhash", { nowMs: now });
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    writeFileSync(sentinelPath, String(Math.floor(now / 1000)));
+    writeFileSync(hashPath, "oldhash");
+    clearStaleSettled({ currentHash: "newhash", nowMs: now });
+    expect(existsSync(sentinelPath)).toBe(true);
     // Prior hash is untouched — guard returns before any write
-    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("oldhash");
+    expect(readFileSync(hashPath, "utf-8")).toBe("oldhash");
   });
 
   test("clears settled when sentinel is old and hash changed", () => {
     const now = Date.now();
     const oldEpoch = Math.floor((now - 5 * 60_000) / 1000); // 5 minutes ago
-    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
-    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
-    const cleared = clearStaleSettled("newhash", { nowMs: now });
-    expect(cleared).toBe(true);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(false);
-    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("newhash");
+    writeFileSync(sentinelPath, String(oldEpoch));
+    writeFileSync(hashPath, "oldhash");
+    clearStaleSettled({ currentHash: "newhash", nowMs: now });
+    expect(existsSync(sentinelPath)).toBe(false);
+    expect(readFileSync(hashPath, "utf-8")).toBe("newhash");
   });
 
   test("keeps settled when sentinel is old but hash unchanged", () => {
     const now = Date.now();
     const oldEpoch = Math.floor((now - 5 * 60_000) / 1000);
-    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
-    writeFileSync(join(tmpDir, "last-pane.hash"), "samehash");
-    const cleared = clearStaleSettled("samehash", { nowMs: now });
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    writeFileSync(sentinelPath, String(oldEpoch));
+    writeFileSync(hashPath, "samehash");
+    clearStaleSettled({ currentHash: "samehash", nowMs: now });
+    expect(existsSync(sentinelPath)).toBe(true);
   });
 
   test("keeps settled on first observation regardless of sentinel age", () => {
     const now = Date.now();
     const oldEpoch = Math.floor((now - 5 * 60_000) / 1000);
-    writeFileSync(join(tmpDir, "settled"), String(oldEpoch));
+    writeFileSync(sentinelPath, String(oldEpoch));
     // No prior hash written
-    const cleared = clearStaleSettled("firsthash", { nowMs: now });
-    expect(cleared).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
-    expect(readFileSync(join(tmpDir, "last-pane.hash"), "utf-8")).toBe("firsthash");
+    clearStaleSettled({ currentHash: "firsthash", nowMs: now });
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(readFileSync(hashPath, "utf-8")).toBe("firsthash");
   });
 
   test("respects non-default keepalive interval (grace scales)", () => {
     const now = Date.now();
     // Sentinel written 100 seconds ago
     const epoch = Math.floor((now - 100_000) / 1000);
-    writeFileSync(join(tmpDir, "settled"), String(epoch));
-    writeFileSync(join(tmpDir, "last-pane.hash"), "oldhash");
+    writeFileSync(sentinelPath, String(epoch));
+    writeFileSync(hashPath, "oldhash");
 
     // keepalive_interval=120 → grace=180s → 100s is still within grace
-    const keptWithLargerGrace = clearStaleSettled("newhash", { nowMs: now, graceMs: 180_000 });
-    expect(keptWithLargerGrace).toBe(false);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(true);
+    clearStaleSettled({ currentHash: "newhash", nowMs: now, graceMs: 180_000 });
+    expect(existsSync(sentinelPath)).toBe(true);
+    expect(readFileSync(hashPath, "utf-8")).toBe("oldhash");
 
     // keepalive_interval=40 → grace=60s → 100s is past grace, clears on hash change
-    const clearedWithSmallerGrace = clearStaleSettled("newhash", { nowMs: now, graceMs: 60_000 });
-    expect(clearedWithSmallerGrace).toBe(true);
-    expect(existsSync(join(tmpDir, "settled"))).toBe(false);
+    clearStaleSettled({ currentHash: "newhash", nowMs: now, graceMs: 60_000 });
+    expect(existsSync(sentinelPath)).toBe(false);
+    expect(readFileSync(hashPath, "utf-8")).toBe("newhash");
   });
 });
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -181,17 +181,30 @@ function isMagReady(): boolean {
  * rendering into the pane after markMagSettled(), so without this guard the
  * next keepalive tick would see a hash change and clear the sentinel before
  * maybeFeedMagQueue could claim it for instant delivery (gh-ludics-308).
+ *
+ * @internal Exported for direct testing. Production callers use the zero-arg form.
+ * @param opts.nowMs Override `Date.now()` for deterministic age comparisons.
+ * @param opts.graceMs Override `keepaliveIntervalMs() * 1.5` for the sentinel grace window.
+ * @param opts.currentHash Override `captureLastMessageHash(MAG_SESSION_NAME)` to bypass tmux.
+ *   When the property is present (even as `null`), the override is used instead of capturing.
  */
-function clearStaleSettled(): void {
+export function clearStaleSettled(
+  opts: { nowMs?: number; graceMs?: number; currentHash?: string | null } = {},
+): void {
   if (!isMagSettled()) return;
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const graceMs = opts.graceMs ?? keepaliveIntervalMs() * 1.5;
 
   const settledEpoch = readSentinelEpoch(settledSentinelFile());
   if (settledEpoch !== null) {
-    const ageMs = Date.now() - settledEpoch * 1000;
-    if (ageMs < keepaliveIntervalMs() * 1.5) return;
+    const ageMs = nowMs - settledEpoch * 1000;
+    if (ageMs < graceMs) return;
   }
 
-  const currentHash = captureLastMessageHash(MAG_SESSION_NAME);
+  const currentHash = "currentHash" in opts
+    ? opts.currentHash ?? null
+    : captureLastMessageHash(MAG_SESSION_NAME);
   if (currentHash === null) return;
   const previousHash = readPaneHash();
   if (previousHash !== null && currentHash !== previousHash) {
@@ -208,28 +221,31 @@ function clearStaleSettled(): void {
 
 // --- Stall detection helpers (file-persisted, keepalive is per-tick) ---
 
-function stallThresholdMs(): number {
+/**
+ * Read a `mag.<key>` config value, treat it as a number of seconds, and
+ * return milliseconds. Falls back to `defaultMs` if the value is missing,
+ * non-finite, or not strictly positive.
+ */
+function magSecondsConfig(key: string, defaultMs: number): number {
   const config = loadConfigSync();
   const mag = config.mag as Record<string, unknown> | undefined;
-  const configured = Number(mag?.stall_threshold_seconds);
+  const configured = Number(mag?.[key]);
   if (Number.isFinite(configured) && configured > 0) return configured * 1000;
-  return DEFAULT_STALL_THRESHOLD_MS;
+  return defaultMs;
+}
+
+function stallThresholdMs(): number {
+  return magSecondsConfig("stall_threshold_seconds", DEFAULT_STALL_THRESHOLD_MS);
 }
 
 function keepaliveIntervalMs(): number {
-  const config = loadConfigSync();
-  const mag = config.mag as Record<string, unknown> | undefined;
-  const configured = Number(mag?.keepalive_interval);
-  if (Number.isFinite(configured) && configured > 0) return configured * 1000;
-  return 60_000; // matches templates/launchd and templates/systemd via triggers.ts
+  // Key is `keepalive_interval` (no `_seconds`) — shared with launchd/systemd
+  // templates expanded by src/triggers.ts.
+  return magSecondsConfig("keepalive_interval", 60_000);
 }
 
 function stallNudgeCooldownMs(): number {
-  const config = loadConfigSync();
-  const mag = config.mag as Record<string, unknown> | undefined;
-  const configured = Number(mag?.stall_nudge_cooldown_seconds);
-  if (Number.isFinite(configured) && configured > 0) return configured * 1000;
-  return DEFAULT_STALL_NUDGE_COOLDOWN_MS;
+  return magSecondsConfig("stall_nudge_cooldown_seconds", DEFAULT_STALL_NUDGE_COOLDOWN_MS);
 }
 
 function paneHashFile(): string {


### PR DESCRIPTION
## Summary

Three bundled cleanups from the `gh-ludics-308` retrospective (task-1b44d17b):

- **DRY config readers.** `stallThresholdMs` / `stallNudgeCooldownMs` / `keepaliveIntervalMs` were three copies of the same six-line "load config → `Number(...)` → finite-and-positive → ×1000 → fall back to default" shape. Collapsed into a single `magSecondsConfig(key, defaultMs)` helper; each caller is now a one-line delegate. No behaviour change. `keepaliveIntervalMs` continues reading `mag.keepalive_interval` (no `_seconds`) because that key is shared with the launchd/systemd templates expanded by `src/triggers.ts`.
- **Production `clearStaleSettled` exported with injectable `{ nowMs?, graceMs?, currentHash? }`.** The keepalive call site stays zero-arg; only tests inject options. The local `clearStaleSettled` mirror in `src/mag.test.ts` is gone — all 10 tests in the `stale settled sentinel detection` block (5 legacy + 5 grace-window regressions from PR #341) now drive the imported function via `LUDICS_HARNESS_DIR`-pointed temp harness and assert side effects on real `mag/settled` and `mag/last-pane.hash` files. The mirror's silent divergence from production (it skipped the grace-window guard) can no longer hide.
- **Architecture-doc note** under the Mag-lifecycle keepalive bullet so a future "I typed into Mag right after settle and the next queue item still pasted on top of me" report maps back to `clearStaleSettled` and `gh-ludics-308`.

### Scope expansion (declared in commit trailer)

`scripts/lint-config-helpers.ts` gained a 4th regex pattern matching `magSecondsConfig("…", …)`. Without it, the helper consolidation hides the literal keys `stall_threshold_seconds` and `stall_nudge_cooldown_seconds` from `extractMagPathsFromSource()`, and `bun run scripts/lint-config-reference.ts` fails (`config.reference.yaml has keys not in TypeScript interface`). That script is the CI drift surface for the mag config schema.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun run scripts/lint-config-reference.ts` — passes (verifies the new regex pattern picks up both `stall_*_seconds` keys)
- [x] `bun test src/mag.test.ts` — 61/61 passing (10 in `stale settled sentinel detection` describe block)
- [x] `bun test scripts/lint-config-helpers.test.ts` — 24/24 passing (incl. `lint-config-reference exits 0 on current repo`)
- [x] Full `bun test` — 1469/0 across 73 files
- [x] `bun run build` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)