### PR TITLE
Add scripts/lint-test-isolation.ts for test-harness-isolation anti-patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:config-reference": "bun run scripts/lint-config-reference.ts",
     "lint:contracts": "bun run scripts/lint-contracts.ts",
     "lint:template-safety": "bun run scripts/lint-template-safety.ts",
+    "lint:test-isolation": "bun run scripts/lint-test-isolation.ts",
     "lint:no-mock-module": "! grep -r 'mock\\.module(' src/ templates/ --include='*.test.ts' -l"
   },
   "devDependencies": {

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -166,7 +166,17 @@ describe("parseImports", () => {
       "import 'polyfill';",
       "const c = 1;",
     ].join("\n");
-    expect(parseImports(src)).toEqual(["./a.ts", "../b"]);
+    // Side-effect `import 'polyfill';` is also captured — load-bearing for rule 3.
+    expect(parseImports(src)).toEqual(["./a.ts", "../b", "polyfill"]);
+  });
+
+  test("captures side-effect imports (`import './foo.ts';`) for rule-3 coverage", () => {
+    const src = [
+      "import './config.ts';",
+      "import \"./events.ts\";",
+      "import type { X } from './types.ts';",
+    ].join("\n");
+    expect(parseImports(src)).toEqual(["./config.ts", "./events.ts"]);
   });
 });
 
@@ -494,6 +504,57 @@ describe("runCli", () => {
       // Error prefix vs warning prefix is distinguishable.
       expect(r.err.filter((l) => l.startsWith("❌")).length).toBe(2);
       expect(r.err.filter((l) => l.startsWith("⚠")).length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rule-3 fires on a direct side-effect import of a target module", () => {
+    // Reviewer regression: `import "./config.ts";` (no `from`, no bindings)
+    // must still trigger rule 3 — the module-level code of config.ts runs on
+    // load and touches harnessDir().
+    const { dir, cleanup } = makeRepoFixture({
+      "src/side.test.ts": "import './config.ts';\n",
+      "src/config.ts": "export function harnessDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some(
+          (l) =>
+            l.includes("src/side.test.ts") &&
+            l.includes("src/config.ts") &&
+            l.includes("rule-3"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rule-3 fires on a one-level transitive side-effect import", () => {
+    // Test → helper (named import) → base.ts (side-effect import).
+    const { dir, cleanup } = makeRepoFixture({
+      "src/adapters/m.test.ts": "import { start } from './manual.ts';\n",
+      "src/adapters/manual.ts": "import './base.ts';\n",
+      "src/adapters/base.ts": "export function adapterStateDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some(
+          (l) =>
+            l.includes("src/adapters/m.test.ts") &&
+            l.includes("src/adapters/base.ts") &&
+            l.includes("src/adapters/manual.ts"),
+        ),
+      ).toBe(true);
     } finally {
       cleanup();
     }

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -1,0 +1,586 @@
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "bun";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  checkRule1,
+  checkRule2,
+  checkRule3,
+  parseImports,
+  hasIsolationSetup,
+  resolveImport,
+  listTestFiles,
+  runCli,
+  RULE_3_TARGETS,
+} from "./lint-test-isolation.ts";
+
+// ---------------------------------------------------------------------------
+// Rule 1 — unconditional `delete process.env.LUDICS_HARNESS_DIR`
+// ---------------------------------------------------------------------------
+
+describe("checkRule1", () => {
+  test("flags a bare unconditional delete", () => {
+    const src = [
+      "afterEach(() => {",
+      "  delete process.env.LUDICS_HARNESS_DIR;",
+      "});",
+    ].join("\n");
+    const issues = checkRule1(src, "t.test.ts");
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.rule).toBe("rule-1");
+    expect(issues[0]!.severity).toBe("error");
+    expect(issues[0]!.line).toBe(2);
+  });
+
+  test("accepts same-line `=== undefined` guard", () => {
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG === undefined) delete process.env.LUDICS_HARNESS_DIR;",
+      "  else process.env.LUDICS_HARNESS_DIR = ORIG;",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("accepts two-line braced guard", () => {
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG === undefined) {",
+      "    delete process.env.LUDICS_HARNESS_DIR;",
+      "  } else {",
+      "    process.env.LUDICS_HARNESS_DIR = ORIG;",
+      "  }",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("accepts three-line lookback with intermediate blank", () => {
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG === undefined)",
+      "  {",
+      "",
+      "    delete process.env.LUDICS_HARNESS_DIR;",
+      "  }",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("accepts inverse `!== undefined` guard (else delete form)", () => {
+    // Widely-used shape in the real suite; semantically equivalent.
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG !== undefined) process.env.LUDICS_HARNESS_DIR = ORIG;",
+      "  else delete process.env.LUDICS_HARNESS_DIR;",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("whole-file exemption when `withTestHarness(` appears anywhere", () => {
+    // Even a shape that would otherwise flag is exempted when the helper is in use.
+    const src = [
+      "import { withTestHarness } from './test-utils.ts';",
+      "const getHarness = withTestHarness(beforeEach, afterEach);",
+      "",
+      "afterEach(() => {",
+      "  delete process.env.LUDICS_HARNESS_DIR;  // would flag without the exemption",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("flags when guard is further back than 3 non-blank lines", () => {
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG === undefined) {",
+      "    someStatement();",
+      "    anotherStatement();",
+      "    yetAnother();",
+      "    delete process.env.LUDICS_HARNESS_DIR;",
+      "  }",
+      "});",
+    ].join("\n");
+    const issues = checkRule1(src, "t.test.ts");
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.line).toBe(6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rule 2 — `process.env.X = Y ?? undefined`
+// ---------------------------------------------------------------------------
+
+describe("checkRule2", () => {
+  test("flags `process.env.X = Y ?? undefined`", () => {
+    const src = "process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR ?? undefined;";
+    const issues = checkRule2(src, "t.test.ts");
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.rule).toBe("rule-2");
+    expect(issues[0]!.severity).toBe("error");
+    expect(issues[0]!.line).toBe(1);
+  });
+
+  test("accepts the canonical conditional-restore pattern", () => {
+    const src = [
+      "if (orig === undefined) delete process.env.LUDICS_HARNESS_DIR;",
+      "else process.env.LUDICS_HARNESS_DIR = orig;",
+    ].join("\n");
+    expect(checkRule2(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("does not flag `?? undefined` outside a process.env LHS", () => {
+    const src = [
+      "const name = rawName ?? undefined;",
+      "const config: Config = provided ?? undefined;",
+      "fn(param ?? undefined);",
+    ].join("\n");
+    expect(checkRule2(src, "t.test.ts")).toEqual([]);
+  });
+
+  test("flags every offending line, with correct line numbers", () => {
+    const src = [
+      "// header",
+      "process.env.FOO = orig1 ?? undefined;",
+      "const safe = x ?? undefined;",
+      "process.env.BAR = orig2 ?? undefined;",
+    ].join("\n");
+    const issues = checkRule2(src, "t.test.ts");
+    expect(issues.map((i) => i.line)).toEqual([2, 4]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseImports / hasIsolationSetup / resolveImport
+// ---------------------------------------------------------------------------
+
+describe("parseImports", () => {
+  test("extracts relative and bare import paths; skips `import type`", () => {
+    const src = [
+      "import { a } from './a.ts';",
+      "import type { T } from './types.ts';",
+      "import { b } from '../b';",
+      "import 'polyfill';",
+      "const c = 1;",
+    ].join("\n");
+    expect(parseImports(src)).toEqual(["./a.ts", "../b"]);
+  });
+});
+
+describe("hasIsolationSetup", () => {
+  test("true if source sets LUDICS_HARNESS_DIR", () => {
+    expect(
+      hasIsolationSetup("process.env.LUDICS_HARNESS_DIR = join(TMP, 'x');"),
+    ).toBe(true);
+  });
+  test("true if source calls withTestHarness(", () => {
+    expect(hasIsolationSetup("const g = withTestHarness(beforeEach, afterEach);")).toBe(true);
+  });
+  test("false when neither token is present", () => {
+    expect(hasIsolationSetup("const x = 1;")).toBe(false);
+  });
+});
+
+describe("resolveImport", () => {
+  test("resolves an extensionless relative import to the .ts file", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/foo.test.ts": "",
+      "src/foo.ts": "",
+    });
+    try {
+      expect(resolveImport("src/foo.test.ts", "./foo", dir)).toBe("src/foo.ts");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("resolves a `.ts` relative import verbatim", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/a/b.test.ts": "",
+      "src/a/b.ts": "",
+    });
+    try {
+      expect(resolveImport("src/a/b.test.ts", "./b.ts", dir)).toBe("src/a/b.ts");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("resolves `../` into sibling directory", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/adapters/m.test.ts": "",
+      "src/config.ts": "",
+    });
+    try {
+      expect(resolveImport("src/adapters/m.test.ts", "../config.ts", dir)).toBe("src/config.ts");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns null for bare package imports", () => {
+    const { dir, cleanup } = makeRepoFixture({ "src/t.test.ts": "" });
+    try {
+      expect(resolveImport("src/t.test.ts", "bun:test", dir)).toBeNull();
+      expect(resolveImport("src/t.test.ts", "yaml", dir)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns null when no candidate exists", () => {
+    const { dir, cleanup } = makeRepoFixture({ "src/t.test.ts": "" });
+    try {
+      expect(resolveImport("src/t.test.ts", "./missing.ts", dir)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkRule3 — standalone (no runCli)
+// ---------------------------------------------------------------------------
+
+describe("checkRule3", () => {
+  function rule3(opts: {
+    file: string;
+    source: string;
+    directImports: string[];
+    neighbours?: Record<string, string[]>;
+    allowlist?: Set<string>;
+    resolver?: (importer: string, rawPath: string) => string | null;
+  }) {
+    const neighbours = new Map<string, string[]>(Object.entries(opts.neighbours ?? {}));
+    const resolver =
+      opts.resolver ??
+      ((_importer: string, raw: string) => {
+        // Default test resolver: treat any path ending in `.ts` as repo-relative
+        // after stripping leading `./`. `../config.ts` → `config.ts` keeps the
+        // tests simple since we pick our own repo-relative names in fixtures.
+        if (raw.startsWith(".")) {
+          const stripped = raw.replace(/^(\.\.?\/)+/, "");
+          return stripped.endsWith(".ts") ? stripped : stripped + ".ts";
+        }
+        return null;
+      });
+    return checkRule3({
+      file: opts.file,
+      source: opts.source,
+      directImports: opts.directImports,
+      neighbourImports: neighbours,
+      targets: RULE_3_TARGETS,
+      allowlist: opts.allowlist ?? new Set(),
+      resolve: resolver,
+    });
+  }
+
+  test("positive: direct import of a target module", () => {
+    const issues = rule3({
+      file: "src/x.test.ts",
+      source: "import { harnessDir } from './config.ts';",
+      directImports: ["./config.ts"],
+      resolver: () => "src/config.ts",
+    });
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.severity).toBe("warning");
+    expect(issues[0]!.message).toContain("src/config.ts");
+  });
+
+  test("positive: one-level transitive via a helper", () => {
+    // Mirrors gh-ludics-306: test → helper → base.ts.
+    const resolver = (importer: string, raw: string): string | null => {
+      if (importer === "src/adapters/m.test.ts" && raw === "./manual.ts")
+        return "src/adapters/manual.ts";
+      if (importer === "src/adapters/manual.ts" && raw === "./base.ts")
+        return "src/adapters/base.ts";
+      return null;
+    };
+    const issues = rule3({
+      file: "src/adapters/m.test.ts",
+      source: "import { start } from './manual.ts';",
+      directImports: ["./manual.ts"],
+      neighbours: { "src/adapters/manual.ts": ["./base.ts"] },
+      resolver,
+    });
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.message).toContain("src/adapters/base.ts");
+    expect(issues[0]!.message).toContain("src/adapters/manual.ts");
+  });
+
+  test("negative: file sets LUDICS_HARNESS_DIR (lexical presence sufficient)", () => {
+    const issues = rule3({
+      file: "src/x.test.ts",
+      source: [
+        "import { harnessDir } from './config.ts';",
+        "beforeEach(() => { process.env.LUDICS_HARNESS_DIR = '/tmp/x'; });",
+      ].join("\n"),
+      directImports: ["./config.ts"],
+      resolver: () => "src/config.ts",
+    });
+    expect(issues).toEqual([]);
+  });
+
+  test("negative: file uses withTestHarness", () => {
+    const issues = rule3({
+      file: "src/x.test.ts",
+      source: [
+        "import { harnessDir } from './config.ts';",
+        "const getHarness = withTestHarness(beforeEach, afterEach);",
+      ].join("\n"),
+      directImports: ["./config.ts"],
+      resolver: () => "src/config.ts",
+    });
+    expect(issues).toEqual([]);
+  });
+
+  test("negative: file is on the allowlist", () => {
+    const issues = rule3({
+      file: "src/adapters/task-launch.test.ts",
+      source: "import { foo } from './config.ts';",
+      directImports: ["./config.ts"],
+      allowlist: new Set(["src/adapters/task-launch.test.ts"]),
+      resolver: () => "src/config.ts",
+    });
+    expect(issues).toEqual([]);
+  });
+
+  test("negative: imports don't reach any target module", () => {
+    const resolver = (_importer: string, raw: string): string | null => {
+      if (raw === "./helper.ts") return "src/helper.ts";
+      if (raw === "./inert.ts") return "src/inert.ts";
+      return null;
+    };
+    const issues = rule3({
+      file: "src/x.test.ts",
+      source: "import { h } from './helper.ts';",
+      directImports: ["./helper.ts"],
+      neighbours: { "src/helper.ts": ["./inert.ts"] },
+      resolver,
+    });
+    expect(issues).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listTestFiles
+// ---------------------------------------------------------------------------
+
+describe("listTestFiles", () => {
+  test("recurses and filters to *.test.ts", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/a.test.ts": "",
+      "src/a.ts": "",
+      "src/sub/b.test.ts": "",
+      "src/sub/b.ts": "",
+      "src/.hidden/skip.test.ts": "",
+    });
+    try {
+      const files = listTestFiles(join(dir, "src")).map((p) => p.replace(dir, ""));
+      expect(files.some((p) => p.endsWith("/a.test.ts"))).toBe(true);
+      expect(files.some((p) => p.endsWith("/b.test.ts"))).toBe(true);
+      expect(files.some((p) => p.endsWith("/a.ts"))).toBe(false);
+      // Hidden dirs are skipped.
+      expect(files.some((p) => p.includes(".hidden"))).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCli — end-to-end with temp fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a repo-root-style fixture. `files` maps repo-relative paths to file
+ * contents (parent dirs auto-created). Returns the absolute fixture root.
+ */
+function makeRepoFixture(files: Record<string, string>): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "lint-test-iso-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function driveRunCli(repoRoot: string, allowlist?: Set<string>): {
+  exitCode: number;
+  err: string[];
+  out: string[];
+  errorCount: number;
+  warningCount: number;
+} {
+  const err: string[] = [];
+  const out: string[] = [];
+  const result = runCli({
+    srcDir: join(repoRoot, "src"),
+    repoRoot,
+    allowlist,
+    writeErr: (m) => err.push(m),
+    writeOut: (m) => out.push(m),
+  });
+  return {
+    exitCode: result.exitCode,
+    err,
+    out,
+    errorCount: result.errorCount,
+    warningCount: result.warningCount,
+  };
+}
+
+describe("runCli", () => {
+  test("clean fixture: no errors, exit 0, success line on stdout", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/safe.test.ts": [
+        "import { foo } from './foo.ts';",
+        "beforeEach(() => { process.env.LUDICS_HARNESS_DIR = '/tmp/x'; });",
+      ].join("\n"),
+      "src/foo.ts": "export const foo = 1;",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(0);
+      expect(r.out.some((l) => l.includes("No test-isolation"))).toBe(true);
+      expect(r.err).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("mixed errors + warnings: exit 1, correct counts, stderr formatting", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      // rule-1 error
+      "src/r1.test.ts": [
+        "afterEach(() => {",
+        "  delete process.env.LUDICS_HARNESS_DIR;",
+        "});",
+      ].join("\n"),
+      // rule-2 error
+      "src/r2.test.ts": [
+        "afterEach(() => {",
+        "  process.env.LUDICS_HARNESS_DIR = ORIG ?? undefined;",
+        "});",
+      ].join("\n"),
+      // rule-3 warning (direct)
+      "src/r3.test.ts": "import { harnessDir } from './config.ts';\n",
+      "src/config.ts": "export function harnessDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(1);
+      expect(r.errorCount).toBe(2);
+      expect(r.warningCount).toBe(1);
+      // Error lines include file:line and rule name.
+      expect(
+        r.err.some((l) => l.includes("src/r1.test.ts:2") && l.includes("rule-1")),
+      ).toBe(true);
+      expect(
+        r.err.some((l) => l.includes("src/r2.test.ts:2") && l.includes("rule-2")),
+      ).toBe(true);
+      expect(
+        r.err.some((l) => l.includes("src/r3.test.ts") && l.includes("rule-3")),
+      ).toBe(true);
+      // Error prefix vs warning prefix is distinguishable.
+      expect(r.err.filter((l) => l.startsWith("❌")).length).toBe(2);
+      expect(r.err.filter((l) => l.startsWith("⚠")).length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("transitive rule-3 warning fires through a one-level helper", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/adapters/m.test.ts": "import { start } from './manual.ts';\n",
+      "src/adapters/manual.ts": "import { adapterStateDir } from './base.ts';\n",
+      "src/adapters/base.ts": "export function adapterStateDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some(
+          (l) =>
+            l.includes("src/adapters/m.test.ts") &&
+            l.includes("src/adapters/base.ts") &&
+            l.includes("src/adapters/manual.ts"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("allowlisted file is exempt from rule 3", () => {
+    const { dir, cleanup } = makeRepoFixture({
+      "src/adapters/task-launch.test.ts": "import { x } from './task-launch.ts';\n",
+      "src/adapters/task-launch.ts": "import { harnessDir } from '../config.ts';\n",
+      "src/config.ts": "export function harnessDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir, new Set(["src/adapters/task-launch.test.ts"]));
+      expect(r.exitCode).toBe(0);
+      expect(r.warningCount).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("scan excludes `src/test-setup.ts` and `src/test-utils.ts`", () => {
+    // These files contain the canonical implementation; flagging them is circular.
+    // `*.test.ts` extension matters for the walker — we use a parallel .test.ts
+    // sibling to prove the scan ran, then confirm the helpers' content wouldn't
+    // matter even if it were unsafe by omitting them from the reported set.
+    const { dir, cleanup } = makeRepoFixture({
+      // If this were scanned, it'd flag rule 1. But it's excluded by name.
+      "src/test-utils.ts": [
+        "afterEach(() => { delete process.env.LUDICS_HARNESS_DIR; });",
+      ].join("\n"),
+      "src/test-setup.ts": [
+        "process.env.LUDICS_HARNESS_DIR = ORIG ?? undefined;",
+      ].join("\n"),
+      // Plus a clean test to confirm the walker did run.
+      "src/safe.test.ts": "beforeEach(() => { process.env.LUDICS_HARNESS_DIR = '/tmp/y'; });",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — drive the real CLI against the real repo
+// ---------------------------------------------------------------------------
+
+describe("integration", () => {
+  test("lint-test-isolation exits 0 on current repo", () => {
+    const result = spawnSync({
+      cmd: ["bun", "run", join(import.meta.dir, "lint-test-isolation.ts")],
+      cwd: join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (result.exitCode !== 0) {
+      console.error(result.stderr.toString());
+      console.error(result.stdout.toString());
+    }
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -93,6 +93,45 @@ describe("checkRule1", () => {
     expect(checkRule1(src, "t.test.ts")).toEqual([]);
   });
 
+  test("flags when a nearby `if (X === undefined)` does not control the delete (codex P1)", () => {
+    // The prior line's `if (orig === undefined) log();` is self-terminated by
+    // `;` — the delete on the next line is unconditional and must flag.
+    const src = [
+      "afterEach(() => {",
+      "  if (orig === undefined) log();",
+      "  delete process.env.LUDICS_HARNESS_DIR;",
+      "});",
+    ].join("\n");
+    const issues = checkRule1(src, "t.test.ts");
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.line).toBe(3);
+  });
+
+  test("flags when an earlier `!== undefined` block already closed", () => {
+    // The `!== undefined` guard belongs to a closed block; the later delete is
+    // unguarded but the old 3-line lookback saw both `if (` and `undefined`.
+    const src = [
+      "if (orig !== undefined) { doSomething(); }",
+      "delete process.env.LUDICS_HARNESS_DIR;",
+    ].join("\n");
+    const issues = checkRule1(src, "t.test.ts");
+    expect(issues.length).toBe(1);
+    expect(issues[0]!.line).toBe(2);
+  });
+
+  test("accepts `} else { delete ...; }` (two-line else-braced form)", () => {
+    const src = [
+      "afterEach(() => {",
+      "  if (ORIG !== undefined) {",
+      "    process.env.LUDICS_HARNESS_DIR = ORIG;",
+      "  } else {",
+      "    delete process.env.LUDICS_HARNESS_DIR;",
+      "  }",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
   test("flags when guard is further back than 3 non-blank lines", () => {
     const src = [
       "afterEach(() => {",
@@ -178,6 +217,36 @@ describe("parseImports", () => {
     ].join("\n");
     expect(parseImports(src)).toEqual(["./config.ts", "./events.ts"]);
   });
+
+  test("captures multi-line `import { ... } from '...'` (codex P2)", () => {
+    // Formatted imports spanning multiple lines were silently dropped by the
+    // prior line-by-line parser — rule 3 regressed to under-matching in
+    // real test files (e.g. src/adapters/base.test.ts).
+    const src = [
+      "import {",
+      "  readStateFile,",
+      "  writeStateFile,",
+      "} from './base.ts';",
+      "",
+      "import {",
+      "  a,",
+      "  b",
+      "}",
+      "from '../config.ts';",
+    ].join("\n");
+    expect(parseImports(src)).toEqual(["./base.ts", "../config.ts"]);
+  });
+
+  test("multi-line `import type { ... } from '...'` is still skipped", () => {
+    const src = [
+      "import type {",
+      "  ProjectConfig,",
+      "  OtherType,",
+      "} from './config.ts';",
+      "import { runtime } from './runtime.ts';",
+    ].join("\n");
+    expect(parseImports(src)).toEqual(["./runtime.ts"]);
+  });
 });
 
 describe("hasIsolationSetup", () => {
@@ -191,6 +260,21 @@ describe("hasIsolationSetup", () => {
   });
   test("false when neither token is present", () => {
     expect(hasIsolationSetup("const x = 1;")).toBe(false);
+  });
+
+  test("false when the env var is only *compared*, not assigned (codex P1)", () => {
+    // `===`, `==`, `!==` must not count as setup — the file only reads the
+    // variable. Before the `(?!=)` lookahead, each of these silently
+    // suppressed rule-3 warnings.
+    expect(
+      hasIsolationSetup("if (process.env.LUDICS_HARNESS_DIR === undefined) {}"),
+    ).toBe(false);
+    expect(
+      hasIsolationSetup("if (process.env.LUDICS_HARNESS_DIR == null) {}"),
+    ).toBe(false);
+    expect(
+      hasIsolationSetup("if (process.env.LUDICS_HARNESS_DIR !== 'x') {}"),
+    ).toBe(false);
   });
 });
 
@@ -504,6 +588,58 @@ describe("runCli", () => {
       // Error prefix vs warning prefix is distinguishable.
       expect(r.err.filter((l) => l.startsWith("❌")).length).toBe(2);
       expect(r.err.filter((l) => l.startsWith("⚠")).length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rule-3 fires through a multi-line import of a target module (codex P2)", () => {
+    // The single-line parser missed this shape; rule 3 silently under-matched.
+    const { dir, cleanup } = makeRepoFixture({
+      "src/ml.test.ts": [
+        "import {",
+        "  harnessDir,",
+        "  stateRepoDir,",
+        "} from './config.ts';",
+      ].join("\n"),
+      "src/config.ts": "export function harnessDir(){}\nexport function stateRepoDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some(
+          (l) =>
+            l.includes("src/ml.test.ts") &&
+            l.includes("src/config.ts") &&
+            l.includes("rule-3"),
+        ),
+      ).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rule-3 still fires when the file only *reads* LUDICS_HARNESS_DIR (codex P1)", () => {
+    // A file that only compares the env var (`=== undefined`) does not
+    // establish isolation and must not suppress rule-3 warnings.
+    const { dir, cleanup } = makeRepoFixture({
+      "src/r.test.ts": [
+        "import { harnessDir } from './config.ts';",
+        "test('reads env', () => {",
+        "  if (process.env.LUDICS_HARNESS_DIR === undefined) throw new Error('x');",
+        "});",
+      ].join("\n"),
+      "src/config.ts": "export function harnessDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.warningCount).toBe(1);
+      expect(
+        r.err.some((l) => l.includes("src/r.test.ts") && l.includes("rule-3")),
+      ).toBe(true);
     } finally {
       cleanup();
     }

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env bun
+/**
+ * lint-test-isolation.ts
+ *
+ * Catches the three test-harness-isolation anti-patterns documented in
+ * `docs/testing-patterns.md#harness-isolation` that motivated the
+ * gh-ludics-306 retrospective. Scans `src/**\/*.test.ts` and reports:
+ *
+ *   Rule 1 (error)   Unconditional `delete process.env.LUDICS_HARNESS_DIR`
+ *                    that destroys the `src/test-setup.ts` preload safety net
+ *                    for every subsequent test file in the same Bun process.
+ *   Rule 2 (error)   `process.env.X = Y ?? undefined`, which coerces the
+ *                    right-hand `undefined` into the literal string
+ *                    `"undefined"`.
+ *   Rule 3 (warning) Test file that directly or one-level-transitively
+ *                    imports `src/config.ts`, `src/events.ts`,
+ *                    `src/slots/json.ts`, or `src/adapters/base.ts` without
+ *                    either setting `LUDICS_HARNESS_DIR` or invoking
+ *                    `withTestHarness(`.
+ *
+ * Exit code: 1 iff errorCount > 0. Warnings never fail.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from "fs";
+import { join, dirname, relative, resolve, sep } from "path";
+
+const repoRoot = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Target modules and rule-3 allowlist
+// ---------------------------------------------------------------------------
+
+/** Repo-relative paths (forward-slash) whose import pulls `harnessDir()`. */
+export const RULE_3_TARGETS = new Set<string>([
+  "src/config.ts",
+  "src/events.ts",
+  "src/slots/json.ts",
+  "src/adapters/base.ts",
+]);
+
+/**
+ * Test files known-safe despite no explicit harness setup. Repo-relative with
+ * forward slashes. Keep this list short — prefer adding `withTestHarness(` or
+ * an explicit `process.env.LUDICS_HARNESS_DIR = ` in the test itself.
+ */
+export const RULE_3_ALLOWLIST = new Set<string>([
+  "src/adapters/task-launch.test.ts",
+]);
+
+/** Test files exempt from the whole lint (the helpers that implement it). */
+const SCAN_EXCLUDE = new Set<string>([
+  "src/test-setup.ts",
+  "src/test-utils.ts",
+]);
+
+// ---------------------------------------------------------------------------
+// Issue shape
+// ---------------------------------------------------------------------------
+
+export type LintRule = "rule-1" | "rule-2" | "rule-3";
+export type LintSeverity = "error" | "warning";
+
+export interface LintIssue {
+  rule: LintRule;
+  severity: LintSeverity;
+  /** Repo-relative test-file path, forward slashes. */
+  file: string;
+  /** 1-based line number (rules 1 & 2). */
+  line?: number;
+  /** Human-readable message fragment — the rule name + file are added elsewhere. */
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 1: unconditional `delete process.env.LUDICS_HARNESS_DIR`
+// ---------------------------------------------------------------------------
+
+const DELETE_PATTERN = /\bdelete\s+process\.env\.LUDICS_HARNESS_DIR\b/;
+const GUARD_IF = /\bif\s*\(/;
+// Accept either `=== undefined` (the canonical shape from the proposal) or
+// `!== undefined` (the inverse shape — `if (X !== undefined) set; else delete;`
+// is equally conditional and widely used in the existing suite). The intent of
+// rule 1 is catching *unconditional* deletes; both shapes guard correctly.
+const GUARD_EQ = /[!=]==\s*undefined\b/;
+
+/**
+ * A `delete` is accepted when:
+ *   (a) the same line also has `if (` + `=== undefined`, or
+ *   (b) the previous three non-blank lines (concatenated) contain both
+ *       `if (` and `=== undefined`, or
+ *   (c) the whole-file source contains the literal `withTestHarness(`.
+ */
+export function checkRule1(source: string, file: string): LintIssue[] {
+  const out: LintIssue[] = [];
+  const hasHelperExemption = source.includes("withTestHarness(");
+  if (hasHelperExemption) return out;
+
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!DELETE_PATTERN.test(line)) continue;
+
+    if (GUARD_IF.test(line) && GUARD_EQ.test(line)) continue; // (a)
+
+    // (b) previous three non-blank lines.
+    const lookback: string[] = [];
+    for (let j = i - 1; j >= 0 && lookback.length < 3; j--) {
+      const prev = lines[j]!;
+      if (prev.trim().length === 0) continue;
+      lookback.push(prev);
+    }
+    const joined = lookback.join("\n");
+    if (GUARD_IF.test(joined) && GUARD_EQ.test(joined)) continue;
+
+    out.push({
+      rule: "rule-1",
+      severity: "error",
+      file,
+      line: i + 1,
+      message: "unconditional delete of process.env.LUDICS_HARNESS_DIR",
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 2: `process.env.X = Y ?? undefined`
+// ---------------------------------------------------------------------------
+
+const RULE_2_PATTERN =
+  /process\.env\.[A-Z_][A-Z0-9_]*\s*=\s*[A-Za-z_][\w.]*\s*\?\?\s*undefined\b/;
+
+export function checkRule2(source: string, file: string): LintIssue[] {
+  const out: LintIssue[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (RULE_2_PATTERN.test(lines[i]!)) {
+      out.push({
+        rule: "rule-2",
+        severity: "error",
+        file,
+        line: i + 1,
+        message:
+          "process.env assignment with `?? undefined` coerces to the string \"undefined\"",
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rule 3: transitive unsafe imports without isolation setup
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the raw import-path strings used as the `from "..."` target of each
+ * runtime import. Skips `import type` statements (erased at compile time) and
+ * plain side-effect imports without a `from` are ignored too (they don't
+ * typically name the target modules).
+ */
+export function parseImports(source: string): string[] {
+  const out: string[] = [];
+  // Line-level scan is sufficient; imports always live at top of file.
+  const lines = source.split("\n");
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line.startsWith("import")) continue;
+    if (line.startsWith("import type")) continue;
+    const m = /from\s+["']([^"']+)["']/.exec(line);
+    if (m) out.push(m[1]!);
+  }
+  return out;
+}
+
+/** True if the test source lexically contains one of the accepted setup tokens. */
+export function hasIsolationSetup(source: string): boolean {
+  return (
+    source.includes("withTestHarness(") ||
+    /process\.env\.LUDICS_HARNESS_DIR\s*=/.test(source)
+  );
+}
+
+/**
+ * Resolve a raw import path, as written in `importer`, to a repo-relative
+ * path with forward slashes. Returns null if the import is not a relative
+ * path into this repo (bare package, absolute URL, etc.) or if no candidate
+ * file exists on disk.
+ */
+export function resolveImport(
+  importer: string,
+  rawPath: string,
+  repoRootAbs: string,
+): string | null {
+  if (!rawPath.startsWith(".")) return null;
+  const importerAbs = resolve(repoRootAbs, importer);
+  const baseAbs = resolve(dirname(importerAbs), rawPath);
+  const candidates = [baseAbs, baseAbs + ".ts", join(baseAbs, "index.ts")];
+  for (const cand of candidates) {
+    if (existsSync(cand) && statSync(cand).isFile()) {
+      const rel = relative(repoRootAbs, cand).split(sep).join("/");
+      return rel;
+    }
+  }
+  return null;
+}
+
+export interface Rule3Input {
+  /** Repo-relative path of the test file (forward slashes). */
+  file: string;
+  /** Source of the test file. */
+  source: string;
+  /** Direct import raw paths, pre-extracted. */
+  directImports: string[];
+  /** Map from repo-relative neighbour path → its `parseImports` output. */
+  neighbourImports: Map<string, string[]>;
+  /** Set of RULE_3_TARGETS for injection-friendliness. */
+  targets: Set<string>;
+  /** Repo-relative allowlist. */
+  allowlist: Set<string>;
+  /**
+   * Resolver bound to the repo root. Accepts `(importer, rawPath)` and
+   * returns the repo-relative resolved path or null.
+   */
+  resolve: (importer: string, rawPath: string) => string | null;
+}
+
+export function checkRule3(input: Rule3Input): LintIssue[] {
+  if (input.allowlist.has(input.file)) return [];
+  if (hasIsolationSetup(input.source)) return [];
+
+  // Direct hit?
+  const directResolved: { raw: string; resolved: string }[] = [];
+  for (const raw of input.directImports) {
+    const r = input.resolve(input.file, raw);
+    if (r) directResolved.push({ raw, resolved: r });
+  }
+  for (const { raw, resolved } of directResolved) {
+    if (input.targets.has(resolved)) {
+      return [
+        {
+          rule: "rule-3",
+          severity: "warning",
+          file: input.file,
+          message: `imports ${resolved} without LUDICS_HARNESS_DIR setup or withTestHarness() (direct import "${raw}")`,
+        },
+      ];
+    }
+  }
+
+  // One-level transitive.
+  for (const { raw, resolved } of directResolved) {
+    const neighbours = input.neighbourImports.get(resolved);
+    if (!neighbours) continue;
+    for (const nraw of neighbours) {
+      const nres = input.resolve(resolved, nraw);
+      if (nres && input.targets.has(nres)) {
+        return [
+          {
+            rule: "rule-3",
+            severity: "warning",
+            file: input.file,
+            message: `imports ${nres} via ${resolved} ("${raw}") without LUDICS_HARNESS_DIR setup or withTestHarness()`,
+          },
+        ];
+      }
+    }
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/** Recursively list `*.test.ts` files under `dir`, returning absolute paths. */
+export function listTestFiles(dir: string): string[] {
+  const out: string[] = [];
+  function walk(d: string): void {
+    for (const entry of readdirSync(d)) {
+      if (entry.startsWith(".")) continue;
+      const full = join(d, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && entry.endsWith(".test.ts")) out.push(full);
+    }
+  }
+  walk(dir);
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// runCli
+// ---------------------------------------------------------------------------
+
+export interface RunCliOptions {
+  /** Source dir to scan. Defaults to `<repo-root>/src`. */
+  srcDir?: string;
+  /** Repo root (used to resolve repo-relative import paths). Defaults to `<srcDir>/..`. */
+  repoRoot?: string;
+  /** Rule-3 allowlist override (for tests). */
+  allowlist?: Set<string>;
+  /** Sink for warning/error lines (default: process.stderr.write). */
+  writeErr?: (msg: string) => void;
+  /** Sink for the success summary line (default: process.stdout.write). */
+  writeOut?: (msg: string) => void;
+}
+
+export interface RunCliResult {
+  exitCode: number;
+  errorCount: number;
+  warningCount: number;
+  issues: LintIssue[];
+}
+
+export function runCli(options: RunCliOptions = {}): RunCliResult {
+  const srcDir = options.srcDir ?? join(repoRoot, "src");
+  const root = options.repoRoot ?? dirname(srcDir);
+  const allowlist = options.allowlist ?? RULE_3_ALLOWLIST;
+  const writeErr =
+    options.writeErr ??
+    ((msg) => {
+      process.stderr.write(msg + "\n");
+    });
+  const writeOut =
+    options.writeOut ??
+    ((msg) => {
+      process.stdout.write(msg + "\n");
+    });
+
+  const resolveBound = (importer: string, rawPath: string) =>
+    resolveImport(importer, rawPath, root);
+
+  const neighbourCache = new Map<string, string[]>();
+  function loadNeighbourImports(relPath: string): string[] {
+    const cached = neighbourCache.get(relPath);
+    if (cached) return cached;
+    const abs = join(root, relPath);
+    let imports: string[] = [];
+    try {
+      imports = parseImports(readFileSync(abs, "utf-8"));
+    } catch {
+      imports = [];
+    }
+    neighbourCache.set(relPath, imports);
+    return imports;
+  }
+
+  const issues: LintIssue[] = [];
+  for (const abs of listTestFiles(srcDir)) {
+    const rel = relative(root, abs).split(sep).join("/");
+    if (SCAN_EXCLUDE.has(rel)) continue;
+    const source = readFileSync(abs, "utf-8");
+
+    issues.push(...checkRule1(source, rel));
+    issues.push(...checkRule2(source, rel));
+
+    const directImports = parseImports(source);
+    // Pre-resolve neighbours we care about for rule 3 (keeps checkRule3 pure).
+    const neighbourImports = new Map<string, string[]>();
+    for (const raw of directImports) {
+      const resolved = resolveBound(rel, raw);
+      if (resolved && !RULE_3_TARGETS.has(resolved)) {
+        neighbourImports.set(resolved, loadNeighbourImports(resolved));
+      }
+    }
+    issues.push(
+      ...checkRule3({
+        file: rel,
+        source,
+        directImports,
+        neighbourImports,
+        targets: RULE_3_TARGETS,
+        allowlist,
+        resolve: resolveBound,
+      }),
+    );
+  }
+
+  let errorCount = 0;
+  let warningCount = 0;
+  for (const iss of issues) {
+    const where =
+      iss.line !== undefined ? `${iss.file}:${iss.line}` : iss.file;
+    if (iss.severity === "error") {
+      errorCount++;
+      writeErr(`❌  [${where}] ${iss.rule}: ${iss.message}`);
+    } else {
+      warningCount++;
+      writeErr(`⚠️   [${where}] ${iss.rule}: ${iss.message}`);
+    }
+  }
+
+  if (errorCount === 0) {
+    const suffix =
+      warningCount > 0
+        ? ` (${warningCount} warning${warningCount === 1 ? "" : "s"})`
+        : "";
+    writeOut(`✅  No test-isolation anti-patterns detected${suffix}.`);
+    return { exitCode: 0, errorCount, warningCount, issues };
+  }
+  writeErr(
+    `\n${errorCount} error${errorCount === 1 ? "" : "s"}, ${warningCount} warning${warningCount === 1 ? "" : "s"}.`,
+  );
+  return { exitCode: 1, errorCount, warningCount, issues };
+}
+
+if (import.meta.main) {
+  process.exit(runCli().exitCode);
+}

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -84,33 +84,86 @@ const GUARD_IF = /\bif\s*\(/;
 const GUARD_EQ = /[!=]==\s*undefined\b/;
 
 /**
- * A `delete` is accepted when:
- *   (a) the same line also has `if (` + `=== undefined`, or
- *   (b) the previous three non-blank lines (concatenated) contain both
- *       `if (` and `=== undefined`, or
- *   (c) the whole-file source contains the literal `withTestHarness(`.
+ * A `delete process.env.LUDICS_HARNESS_DIR;` is accepted only when an `if`/`else`
+ * guard *structurally controls* the delete. We look for one of these shapes:
+ *
+ *   (A) Same-line if-then form: `if (... === undefined) delete ...;`
+ *   (B) Same-line else-then form: current line starts with `else ` (or
+ *       `} else`) and contains the `delete`, and the immediately prior
+ *       non-blank line contains `if (` + `!== undefined`.
+ *   (C) Two-line braced form: the prior non-blank line *ends with `{`* and
+ *       contains `if (` + `=== undefined` (then delete is inside the block).
+ *   (D) Two-line else-braced form: the prior non-blank line is `} else {` or
+ *       `else {` (ending with `{`), and the line before that ends with `}`
+ *       and a recent `if (` + `!== undefined` is visible.
+ *   (E) Three-line brace-on-own-line form: the prior non-blank is exactly
+ *       `{`, and the line before ends with `)` and contains `if (` +
+ *       `=== undefined`.
+ *   (F) File-wide exemption: the source contains the literal
+ *       `withTestHarness(` anywhere.
+ *
+ * Crucially the bare 3-line lookback of "`if (` + `undefined` present somewhere
+ * nearby" is *not* sufficient — codex (PR #402) flagged that pattern as a
+ * false negative because `if (X === undefined) log(); delete ...;` would pass
+ * even though the delete is unconditional.
  */
 export function checkRule1(source: string, file: string): LintIssue[] {
   const out: LintIssue[] = [];
-  const hasHelperExemption = source.includes("withTestHarness(");
-  if (hasHelperExemption) return out;
+  if (source.includes("withTestHarness(")) return out; // (F)
 
   const lines = source.split("\n");
+
+  /** Index of the nth previous non-blank line (0 = immediate predecessor). */
+  function prevNonBlank(i: number, n: number): number {
+    let remaining = n;
+    for (let j = i - 1; j >= 0; j--) {
+      if (lines[j]!.trim().length === 0) continue;
+      if (remaining === 0) return j;
+      remaining--;
+    }
+    return -1;
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
     if (!DELETE_PATTERN.test(line)) continue;
 
-    if (GUARD_IF.test(line) && GUARD_EQ.test(line)) continue; // (a)
+    // (A) Same-line `if (...) delete ...;` — guard and delete co-located.
+    if (GUARD_IF.test(line) && GUARD_EQ.test(line)) continue;
 
-    // (b) previous three non-blank lines.
-    const lookback: string[] = [];
-    for (let j = i - 1; j >= 0 && lookback.length < 3; j--) {
-      const prev = lines[j]!;
-      if (prev.trim().length === 0) continue;
-      lookback.push(prev);
+    // (B) Same-line else-branch: `else delete ...` or `} else delete ...`.
+    //     Prior non-blank must have the `if (...) ... !== undefined` partner.
+    const pIdx = prevNonBlank(i, 0);
+    const prev = pIdx >= 0 ? lines[pIdx]! : "";
+    if (/^\s*(\}\s*)?else\b/.test(line) && GUARD_IF.test(prev) && GUARD_EQ.test(prev)) continue;
+
+    // (C) Prior non-blank ends with `{` and is the `if (...) {` opener.
+    if (/\{\s*$/.test(prev) && GUARD_IF.test(prev) && GUARD_EQ.test(prev)) continue;
+
+    // (D) Prior non-blank is `} else {` or `else {` opener. The matching
+    //     `if (...)` header lives further back (past the if-branch body);
+    //     walk up to 4 non-blank lines and accept if we find the partner.
+    if (/^\s*(\}\s*)?else\s*\{\s*$/.test(prev)) {
+      let matched = false;
+      for (let back = 1; back <= 4; back++) {
+        const idx = prevNonBlank(i, back);
+        if (idx < 0) break;
+        const candidate = lines[idx]!;
+        if (GUARD_IF.test(candidate) && GUARD_EQ.test(candidate)) {
+          matched = true;
+          break;
+        }
+      }
+      if (matched) continue;
     }
-    const joined = lookback.join("\n");
-    if (GUARD_IF.test(joined) && GUARD_EQ.test(joined)) continue;
+
+    // (E) Prior non-blank is a bare `{`, and the line before that is the
+    //     `if (...)` header ending with `)`.
+    if (/^\s*\{\s*$/.test(prev)) {
+      const ppIdx = prevNonBlank(i, 1);
+      const pp = ppIdx >= 0 ? lines[ppIdx]! : "";
+      if (/\)\s*$/.test(pp) && GUARD_IF.test(pp) && GUARD_EQ.test(pp)) continue;
+    }
 
     out.push({
       rule: "rule-1",
@@ -154,40 +207,52 @@ export function checkRule2(source: string, file: string): LintIssue[] {
 
 /**
  * Return the raw import-path strings for every runtime import in `source`:
- * both the `import ... from "..."` forms and bare side-effect imports
- * (`import "./foo.ts";`). Skips `import type` statements since they are
- * erased at compile time and cannot trigger module-load side effects.
+ * both the `import ... from "..."` forms (including multi-line) and bare
+ * side-effect imports (`import "./foo.ts";`). Skips `import type` statements
+ * since they are erased at compile time and cannot trigger module-load side
+ * effects.
  *
  * Side-effect imports are load-bearing for rule 3: `import "./config.ts";`
  * runs module-level code that touches `harnessDir()` even though it binds
  * no names — ignoring that shape would let a test regress into the
- * gh-ludics-306 class of bug without lint coverage.
+ * gh-ludics-306 class of bug without lint coverage. Formatted multi-line
+ * imports (`import {\n  a,\n  b,\n} from "./x.ts"`) are also load-bearing;
+ * codex (PR #402) flagged the prior single-line-only parser as a rule-3
+ * false negative for those shapes.
  */
 export function parseImports(source: string): string[] {
   const out: string[] = [];
-  // Line-level scan is sufficient; imports always live at top of file.
-  const lines = source.split("\n");
-  for (const raw of lines) {
-    const line = raw.trim();
-    if (!line.startsWith("import")) continue;
-    if (line.startsWith("import type")) continue;
-    const fromMatch = /from\s+["']([^"']+)["']/.exec(line);
-    if (fromMatch) {
-      out.push(fromMatch[1]!);
-      continue;
-    }
-    // Side-effect import: `import "path";` (no `from`, no bindings).
-    const sideEffect = /^import\s+["']([^"']+)["']\s*;?\s*$/.exec(line);
-    if (sideEffect) out.push(sideEffect[1]!);
+  // Multi-line `import ... from "..."`. The body is `[^;]*?` so the match
+  // cannot cross statement boundaries — prevents false positives from e.g.
+  // a later import plus a stray `from "..."` substring in between.
+  const withFromRe = /\bimport\b\s+([^;]*?)from\s+["']([^"']+)["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = withFromRe.exec(source)) !== null) {
+    const body = m[1]!;
+    if (/^\s*type\s+/.test(body)) continue; // `import type ... from "..."`
+    out.push(m[2]!);
+  }
+  // Side-effect imports: `import "path";` with no `from`, no bindings. Must
+  // sit on their own line so line-anchored matching is accurate.
+  const sideEffectRe = /^\s*import\s+["']([^"']+)["']\s*;?\s*$/gm;
+  while ((m = sideEffectRe.exec(source)) !== null) {
+    out.push(m[1]!);
   }
   return out;
 }
 
-/** True if the test source lexically contains one of the accepted setup tokens. */
+/**
+ * True if the test source lexically contains one of the accepted setup
+ * tokens. The `= <value>` probe uses a negative lookahead `(?!=)` so that
+ * comparison operators (`==`, `===`) do not count as a setup assignment —
+ * a file that only *reads* `process.env.LUDICS_HARNESS_DIR` must not
+ * suppress rule-3 warnings. Codex (PR #402) flagged the lookahead-less
+ * regex as a false-positive vector.
+ */
 export function hasIsolationSetup(source: string): boolean {
   return (
     source.includes("withTestHarness(") ||
-    /process\.env\.LUDICS_HARNESS_DIR\s*=/.test(source)
+    /process\.env\.LUDICS_HARNESS_DIR\s*=(?!=)/.test(source)
   );
 }
 

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -153,10 +153,15 @@ export function checkRule2(source: string, file: string): LintIssue[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Return the raw import-path strings used as the `from "..."` target of each
- * runtime import. Skips `import type` statements (erased at compile time) and
- * plain side-effect imports without a `from` are ignored too (they don't
- * typically name the target modules).
+ * Return the raw import-path strings for every runtime import in `source`:
+ * both the `import ... from "..."` forms and bare side-effect imports
+ * (`import "./foo.ts";`). Skips `import type` statements since they are
+ * erased at compile time and cannot trigger module-load side effects.
+ *
+ * Side-effect imports are load-bearing for rule 3: `import "./config.ts";`
+ * runs module-level code that touches `harnessDir()` even though it binds
+ * no names — ignoring that shape would let a test regress into the
+ * gh-ludics-306 class of bug without lint coverage.
  */
 export function parseImports(source: string): string[] {
   const out: string[] = [];
@@ -166,8 +171,14 @@ export function parseImports(source: string): string[] {
     const line = raw.trim();
     if (!line.startsWith("import")) continue;
     if (line.startsWith("import type")) continue;
-    const m = /from\s+["']([^"']+)["']/.exec(line);
-    if (m) out.push(m[1]!);
+    const fromMatch = /from\s+["']([^"']+)["']/.exec(line);
+    if (fromMatch) {
+      out.push(fromMatch[1]!);
+      continue;
+    }
+    // Side-effect import: `import "path";` (no `from`, no bindings).
+    const sideEffect = /^import\s+["']([^"']+)["']\s*;?\s*$/.exec(line);
+    if (sideEffect) out.push(sideEffect[1]!);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-test-isolation.ts` — three rules catching the test-harness-isolation anti-patterns behind [gh-ludics-306](https://github.com/lukstafi/ludics/issues/306):
  - **Rule 1 (error)**: unconditional `delete process.env.LUDICS_HARNESS_DIR` (destroys the `src/test-setup.ts` preload safety net for every subsequent test file). Accepts same-line / two-line-braced / `} else {` / brace-on-own-line guard shapes, both `=== undefined` and the idiomatic inverse `!== undefined`, plus a whole-file `withTestHarness(` exemption. The guard must structurally control the delete — codex (commit `abefdf9`) caught a false negative where a nearby but unrelated `if (X === undefined) log();` suppressed the warning.
  - **Rule 2 (error)**: `process.env.X = Y ?? undefined` (coerces to literal string `"undefined"`), scoped to a `process.env` LHS.
  - **Rule 3 (warning)**: `src/**/*.test.ts` that directly or one-level-transitively imports `src/config.ts` / `src/events.ts` / `src/slots/json.ts` / `src/adapters/base.ts` without `process.env.LUDICS_HARNESS_DIR = ...` (assignment, not `===`/`==` comparison) or `withTestHarness(`. Covers the `from "..."` form (single- and multi-line) and bare side-effect `import "./foo.ts";` imports.
- Adds paired `scripts/lint-test-isolation.test.ts` — 44 tests covering every rule positive + each negative shape, plus an integration test spawning the real CLI against the real repo and asserting exit 0.
- Wires `lint:test-isolation` into `package.json` as a sibling of `lint:contracts` / `lint:config-reference`.

Inline `RULE_3_ALLOWLIST = { "src/adapters/task-launch.test.ts" }` per the proposal; sidecar-allowlist graduation explicitly deferred. One-level transitive scan only.

Structure mirrors `scripts/lint-contracts.ts`: pure helpers + thin `runCli({ srcDir?, repoRoot?, allowlist?, writeErr?, writeOut? })` returning `{ exitCode, errorCount, warningCount, issues }`. `exitCode === 1` iff `errorCount > 0`; warnings alone yield exit 0.

### Commits

1. `049289c` — initial lint + paired test + `package.json` wiring.
2. `616ec17` — `parseImports` extended to cover bare side-effect imports (reviewer fix).
3. `abefdf9` — codex P1/P1/P2 review follow-up: structural rule-1 guard check, `hasIsolationSetup` `(?!=)` lookahead, multi-line import parser. +8 regression assertions.

Proposal: `docs/proposals/lint-test-isolation.md`.

## Test plan

- [x] `bun test scripts/lint-test-isolation.test.ts` — 44 pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run lint:test-isolation` — exits 0 on current branch (0 errors, 20 rule-3 warnings surfacing transitive unsafe imports in existing tests; these are warnings-only by design, to be tightened by sibling task-f60547cd)
- [x] Integration test asserts the real CLI exits 0 against the real repo — gates future regressions that would introduce a violating test

🤖 Generated with [Claude Code](https://claude.com/claude-code)