### PR TITLE
slotAssign: default machine to real node in federated setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,11 @@ ludics flow check-cycle        # Check for dependency cycles
 ```bash
 ludics slots                   # Show all slots
 ludics slot <n>                # Show slot n details
-ludics slot <n> assign <task>  # Assign a task to slot n
+ludics slot <n> assign <task> [--machine <name>]  # Assign a task to slot n.
+                                                  # In a federated setup (cluster.machines configured),
+                                                  # --machine defaults to the current node (or the leader
+                                                  # if the current host is not in cluster.machines);
+                                                  # single-machine setups leave it null.
 ludics slot <n> clear          # Clear slot n
 ludics slot <n> start          # Start fresh agent session (use 'resume' for crash recovery)
 ludics slot <n> stop           # Stop agent session

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,8 +106,12 @@ Commands:
   slots                        Show all slots
   slots refresh                Refresh slot state from adapters
   slot <n>                     Show slot n
-  slot <n> assign <task|desc> [-a adapter] [-s session] [-p path] [-A "adapter args"]
-                               Assign a task to slot n
+  slot <n> assign <task|desc> [-a adapter] [-s session] [-p path] [-A "adapter args"] [--machine <name>]
+                               Assign a task to slot n. In a federated setup
+                               (cluster.machines configured), --machine defaults
+                               to the current node (or the leader if the current
+                               host is not in cluster.machines); in single-machine
+                               setups it stays null.
   slot <n> clear [in-progress|done|abandoned]
                                Clear slot n (optionally mark task in-progress/done/abandoned)
   slot <n> start               Start fresh agent session (use 'resume' for crash recovery)

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
 import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext } from "./index.ts";
 import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, type OrchestrationState } from "../orchestration/state.ts";
@@ -1606,5 +1606,150 @@ describe("slotAssign reaps prior assignment on reassignment (task-72a318c3)", ()
     content = readFileSync(join(tasksDir, "task-old-reset.md"), "utf-8");
     expect(content).toContain("slot: null");
     expect(content).toContain("status: ready");
+  });
+});
+
+describe("slotAssign machine default in federated setup", () => {
+  function writeClusterConfig(homeDir: string, yaml: string): string {
+    const configDir = join(homeDir, ".config", "ludics");
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, "config.yaml");
+    writeFileSync(configPath, yaml);
+    return configPath;
+  }
+
+  test("defaults machine to current node name when cluster config self-matches", async () => {
+    const sysHost = osHostname().toLowerCase();
+    // Configure a machine whose host matches os.hostname() so
+    // clusterCurrentMachine() returns it via the system-hostname candidate.
+    // Also include a second machine so we can prove we picked the self-match
+    // rather than, say, the leader.
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: self-match-node
+      host: ${sysHost}
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+    - name: leader-other
+      host: leader-other.test.local
+      os: linux
+      role: leader
+      always_on: false
+      gpu: ""
+`);
+
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-self-match", "Federated self-match");
+
+    await slotAssign(1, "task-self-match", "tmux");
+
+    const data = readSlotJson(1, harness);
+    expect(data.machine).toBe("self-match-node");
+  });
+
+  test("defaults machine to leader when current host is not in cluster.machines", async () => {
+    // No host entry matches os.hostname() (use a name/host guaranteed not to
+    // collide with any real machine). One machine is role: leader.
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: unmatched-leader-xyz789
+      host: unmatched-leader-xyz789.nowhere.invalid
+      os: linux
+      role: leader
+      always_on: false
+      gpu: ""
+    - name: unmatched-worker-xyz789
+      host: unmatched-worker-xyz789.nowhere.invalid
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-leader-fallback", "Federated leader fallback");
+
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    let warned = false;
+    try {
+      await slotAssign(1, "task-leader-fallback", "tmux");
+      warned = errSpy.mock.calls.some(call =>
+        String(call[0] ?? "").includes("defaulting machine to leader")
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+
+    const data = readSlotJson(1, harness);
+    expect(data.machine).toBe("unmatched-leader-xyz789");
+    expect(warned).toBe(true);
+  });
+
+  test("keeps machine null in non-federated (single-machine) setup", async () => {
+    // Default writeConfig() (set by beforeEach) has no cluster block →
+    // clusterEnabled() is false → defaultAssignMachine() returns null.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-nonfed", "Non-federated default");
+
+    await slotAssign(1, "task-nonfed", "tmux");
+
+    const data = readSlotJson(1, harness);
+    expect(data.machine).toBeNull();
+  });
+
+  test("explicit --machine argument short-circuits the default", async () => {
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: self-match-node
+      host: ${osHostname().toLowerCase()}
+      os: linux
+      role: leader
+      always_on: false
+      gpu: ""
+`);
+
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-explicit-machine", "Explicit machine overrides default");
+
+    await slotAssign(1, "task-explicit-machine", "tmux", "", "", "", "explicit-node");
+
+    const data = readSlotJson(1, harness);
+    expect(data.machine).toBe("explicit-node");
   });
 });

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -1707,6 +1707,55 @@ cluster:
     expect(warned).toBe(true);
   });
 
+  test("keeps machine null and warns when cluster configured but no self-match and no leader", async () => {
+    // Cluster is enabled, but no machine matches os.hostname() AND no machine
+    // has role: leader. defaultAssignMachine() should fall through to the
+    // final `return null` branch with the "no resolvable machine" stderr.
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: unmatched-worker-a-xyz789
+      host: unmatched-worker-a-xyz789.nowhere.invalid
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+    - name: unmatched-worker-b-xyz789
+      host: unmatched-worker-b-xyz789.nowhere.invalid
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-no-self-no-leader", "Cluster with no resolvable machine");
+
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    let warned = false;
+    try {
+      await slotAssign(1, "task-no-self-no-leader", "tmux");
+      warned = errSpy.mock.calls.some(call =>
+        String(call[0] ?? "").includes("no resolvable machine")
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+
+    const data = readSlotJson(1, harness);
+    expect(data.machine).toBeNull();
+    expect(warned).toBe(true);
+  });
+
   test("keeps machine null in non-federated (single-machine) setup", async () => {
     // Default writeConfig() (set by beforeEach) has no cluster block →
     // clusterEnabled() is false → defaultAssignMachine() returns null.

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -120,10 +120,17 @@ function defaultAssignMachine(): string | null {
     if (current) return current;
     const leader = resolveController();
     if (leader) {
-      console.error(`ludics: slot assign: current host not in cluster.machines; defaulting machine to leader "${leader.name}"`);
+      console.error(
+        `ludics: slot assign: current host not in cluster.machines; defaulting machine to leader "${leader.name}". ` +
+        `Subsequent 'slot start/stop/resume' must be run from "${leader.name}" (or another configured cluster node) — ` +
+        `this host cannot dispatch to the leader locally. Pass --machine <name> to override.`
+      );
       return leader.name;
     }
-    console.error("ludics: slot assign: cluster configured but no resolvable machine (no self-match, no leader) — storing machine: null");
+    console.error(
+      "ludics: slot assign: cluster configured but no resolvable machine (no self-match, no leader) — storing machine: null. " +
+      "Dashboard ttyd links will be missing until machine is set. Pass --machine <name> to override."
+    );
     return null;
   } catch {
     return null;

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -106,6 +106,30 @@ function isWorkerContext(): boolean {
   }
 }
 
+/** Resolve the machine field default for `slot assign` when --machine is omitted.
+ *  In a federated setup, `null` produces a silently-broken slot (dashboard's
+ *  generateTerminals/lookupSlotOrchestrationLinks bail on empty machine), so we
+ *  prefer the current node name, fall back to the leader, and only return null
+ *  when cluster is disabled or genuinely unresolvable. */
+function defaultAssignMachine(): string | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- circular-dep chain: cluster.ts imports emitEvent from events.ts
+    const { clusterEnabled, clusterCurrentMachineName, resolveController } = require("../cluster.ts") as typeof import("../cluster.ts");
+    if (!clusterEnabled()) return null;
+    const current = clusterCurrentMachineName();
+    if (current) return current;
+    const leader = resolveController();
+    if (leader) {
+      console.error(`ludics: slot assign: current host not in cluster.machines; defaulting machine to leader "${leader.name}"`);
+      return leader.name;
+    }
+    console.error("ludics: slot assign: cluster configured but no resolvable machine (no self-match, no leader) — storing machine: null");
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /** Write slot data locally, or POST runtime sections to controller on workers. */
 function writeSlotOrHttp(slotNum: number, data: SlotData): void {
   if (isWorkerContext()) {
@@ -312,7 +336,7 @@ export async function slotAssign(
     path: path || null,
     started,
     adapterArgs: adapterArgs || null,
-    machine: machine || null,
+    machine: machine || defaultAssignMachine(),
     sessionStarted: null,
     liveness: null,
     terminals: "",


### PR DESCRIPTION
## Summary

- `ludics slot N assign` without `--machine` used to write `"machine": null` into `slots/slot-N.json`, which silently broke the dashboard's terminal publisher in federated setups (`generateTerminals`/`lookupSlotOrchestrationLinks` bail on empty machine — observed during the gh-ludics-376 incident).
- New `defaultAssignMachine()` in `src/slots/index.ts` resolves the default: current node (`clusterCurrentMachineName()`) → leader fallback (`resolveController()`, with stderr warning) → null (only when cluster is disabled, or no self-match + no leader, with stderr warning).
- CLI help (`src/index.ts` USAGE) and README CLI Reference now both document `[--machine <name>]` and the federated default behaviour.
- Round-2 fixup (per pair-reviewer feedback): added the missing no-self/no-leader null-fallback regression test and synced the README.
- Round-3 fixup (per codex P1 review): stderr warnings now spell out the downstream implication — operators see that subsequent `slot start/stop/resume` must run from the chosen node (or pass `--machine` to override). The leader-fallback default itself is kept because AC bullet #2 explicitly mandates it; reverting to `null` would reopen the dashboard correctness bug this PR closes.

Proposal: `docs/proposals/slotassign-default-machine-federated.md`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (0 warnings)
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test src/slots/index.test.ts` → 65 pass / 0 fail (5 new tests)
  - Federated + self-match → current node name
  - Federated + no self-match + leader → leader name, stderr warning observed
  - Federated + no self + no leader → null, stderr warning observed
  - Non-federated (no `cluster:` block) → null (regression pin)
  - Explicit `--machine` short-circuits the default
- [x] Full suite `bun test` → 1490 pass / 0 fail across 74 files
- [x] Existing `"remote slot dispatch via HTTP"` tests (which pass an explicit `--machine`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)