### PR TITLE
Escalation DRY cleanups: setSlotLivenessOnData + processAlive reuse + checkEscalationHalt (task-d55e5398)

### DIFF
--- a/src/orchestration/runner.escalation.test.ts
+++ b/src/orchestration/runner.escalation.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, test, beforeEach, afterEach, spyOn, setDefaultTimeout } from "bun:test";
 import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { handleEscalation, runOrchestration } from "./runner.ts";
+import { checkEscalationHalt, handleEscalation, runOrchestration } from "./runner.ts";
 import * as events from "../events.ts";
 import * as notify from "../notify.ts";
 import type { OrchestrationTransport } from "./transport.ts";
@@ -312,5 +312,61 @@ describe("handleEscalation — isolated halt helper", () => {
       eventSpy.mockRestore();
       notifySpy.mockRestore();
     }
+  });
+});
+
+describe("checkEscalationHalt — named pollUntilDone halt guard", () => {
+  let origHarnessDir: string | undefined;
+
+  beforeEach(() => {
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+  });
+
+  afterEach(() => {
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+  });
+
+  test("returns false when no agent has the escalate status", () => {
+    const slot = 30;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    const state = makeState({
+      slot,
+      phase: "work",
+      harnessDir: harness,
+      agentStates: {
+        coder: { status: "done", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false },
+        reviewer: { status: "review-done", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false },
+      },
+    }, peerSyncDir);
+
+    expect(checkEscalationHalt(state)).toBe(false);
+  });
+
+  test("returns true and persists state when an agent has escalated", () => {
+    const slot = 31;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    const state = makeState({
+      slot,
+      phase: "work",
+      harnessDir: harness,
+      agentStates: {
+        coder: { status: "escalate", statusEpoch: 0, statusMessage: "stuck in a loop", prUrl: null, interrupted: false },
+        reviewer: { status: "review-done", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false },
+      },
+    }, peerSyncDir);
+
+    expect(checkEscalationHalt(state)).toBe(true);
+
+    // Persisted: orchestration state-<N>.json must exist after the guard fires.
+    const persistedPath = join(harness, "orchestration", `slot-${slot}.json`);
+    const persisted = JSON.parse(readFileSync(persistedPath, "utf-8"));
+    expect(persisted.slot).toBe(slot);
+    // Phase must NOT have advanced — the guard halts in place.
+    expect(persisted.phase).toBe("work");
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -23,6 +23,7 @@ import { findProjectConfig, globalAdapter, harnessDir as defaultHarnessDir, ludi
 import { taskFilePath } from "./paths.ts";
 import { notifyAgents, notifyOutgoing } from "../notify.ts";
 import { readSlotJson, writeSlotJson } from "../slots/json.ts";
+import { setSlotLivenessOnData } from "../slots/index.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
@@ -1424,10 +1425,7 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       // runOrchestration's caller-side handler can persist state, emit the
       // event + priority-5 notification, and flip slot liveness without any
       // intervening phase-advance work (nudge, auto-commit, verification gate).
-      if (isEscalated(state)) {
-        persistState(state, state.harnessDir ?? defaultHarnessDir());
-        return;
-      }
+      if (checkEscalationHalt(state)) return;
 
       // Detect hung agents (static terminal) and send nudges / force-settle.
       await detectAndNudgeHungAgents(state, transport);
@@ -1808,13 +1806,26 @@ export function handleEscalation(state: OrchestrationState): void {
 
   try {
     const data = readSlotJson(state.slot);
-    data.liveness = "escalated";
+    setSlotLivenessOnData(data, "escalated");
     writeSlotJson(state.slot, data);
   } catch (err) {
     console.error(`ludics: failed to set slot ${state.slot} liveness=escalated: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   persistState(state, state.harnessDir ?? defaultHarnessDir());
+}
+
+/**
+ * Named guard for the escalation halt point in `pollUntilDone`. Mirrors the
+ * shape of `checkZeroCommitsAutoBailOut`: returns `true` when the caller
+ * should stop. Persists state before halting so a mid-halt crash leaves the
+ * runner with the latest agent statuses on disk. Caller uses `return` (not
+ * `break`) — see `pollUntilDone`.
+ */
+export function checkEscalationHalt(state: OrchestrationState): boolean {
+  if (!isEscalated(state)) return false;
+  persistState(state, state.harnessDir ?? defaultHarnessDir());
+  return true;
 }
 
 export function checkZeroCommitsAutoBailOut(state: OrchestrationState): boolean {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -8,7 +8,7 @@ import { mergeAdapterState, addNoteToSlotData } from "./markdown.ts";
 import { readSlotJson, writeSlotJson, readAllSlotJson, emptySlotData, slotJsonDir, slotDataToMarkdown } from "./json.ts";
 import { migrateMarkdownToSlotData } from "./migration.ts";
 import { cleanupStaleItems } from "../t3code/index.ts";
-import type { SlotData } from "./types.ts";
+import type { SlotData, SlotLiveness } from "./types.ts";
 import { stateMarkDirty } from "../state.ts";
 import { journalAppend } from "../journal.ts";
 import { emitEvent } from "../events.ts";
@@ -18,7 +18,7 @@ import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, par
 import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
-import { readSlotState, writeSlotState } from "../t3code/server.ts";
+import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts";
 import { agentCliCommand, isAgentAlive, readTmuxSlotState, startTtyd, tmuxSessionName, ttydPort, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { tmuxHasSession, tmuxNewSession, tmuxSendCommand, tmuxSendKeys } from "../adapters/tmux.ts";
 import { selectOrchestrationFlagsForTask } from "../adapters/t3code.ts";
@@ -41,6 +41,15 @@ let workerSlotsOverride: Map<number, SlotData> | null = null;
  *  Call with null to clear. */
 export function setWorkerSlotsOverride(data: Map<number, SlotData> | null): void {
   workerSlotsOverride = data;
+}
+
+/** Mutator-only liveness writer: structural mirror of `parseSlotLiveness` on
+ *  the read side. Sets `data.liveness = value` in place and returns `data` for
+ *  chaining. Does NOT touch `sessionStarted` or other companion fields —
+ *  callers continue to set those alongside this call. */
+export function setSlotLivenessOnData(data: SlotData, value: SlotLiveness): SlotData {
+  data.liveness = value;
+  return data;
 }
 
 export function findSlotForTask(taskId: string): number | null {
@@ -541,7 +550,7 @@ export function markSlotSetupFailed(slotNum: number, error: string): void {
   const taskId = data.task;
 
   // Mark slot as interrupted
-  data.liveness = "interrupted";
+  setSlotLivenessOnData(data, "interrupted");
   data.sessionStarted = null;
   writeSlotJson(slotNum, data);
 
@@ -948,7 +957,7 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
   // Clear any prior interrupted liveness and stamp active session marker
   const sessionStartedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z").replace(/:\d{2}Z$/, "Z");
   data.sessionStarted = sessionStartedAt;
-  data.liveness = null;
+  setSlotLivenessOnData(data, null);
   writeSlotOrHttp(slotNum, data);
 
   journalAppend("slot", `Slot ${slotNum} started (adapter=${ctx.mode})`);
@@ -1011,13 +1020,8 @@ function readLiveOrchestratorPid(slotNum: number, mode: string, harness: string)
   } else {
     return null;
   }
-  if (pid === undefined || pid <= 0) return null;
-  try {
-    process.kill(pid, 0);
-    return pid;
-  } catch {
-    return null;
-  }
+  if (pid === undefined || !processAlive(pid)) return null;
+  return pid;
 }
 
 /**
@@ -1288,7 +1292,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
   // Clear interrupted liveness and stamp session-active marker
   const sessionStartedAt = new Date().toISOString().replace(/\.\d{3}Z$/, "Z").replace(/:\d{2}Z$/, "Z");
   data.sessionStarted = sessionStartedAt;
-  data.liveness = null;
+  setSlotLivenessOnData(data, null);
   writeSlotOrHttp(slotNum, data);
 
   journalAppend("slot", `Slot ${slotNum} resumed (adapter=${ctx.mode}, phase=${orchState.phase}, task=${ctx.taskId})`);


### PR DESCRIPTION
## Summary

Three small DRY cleanups in the escalation/orchestration surface introduced by `task-4cd94043` (bail-out: escalate feature). All flagged in the prior round's `suggestRefactorSummary` "Possible follow-ups" and bundled because each is ~3–8 LOC and they all touch the same orchestration runner / slot-state subsystem.

- **New mutator-only helper `setSlotLivenessOnData(data, value)`** in `src/slots/index.ts`. All four production liveness write sites now go through it: `markSlotSetupFailed`, `slotStart`, `slotResume`, and `handleEscalation` in `src/orchestration/runner.ts`. Helper does not touch `sessionStarted` or other companion fields — callers keep those adjacent. The `try/catch` wrapping in `handleEscalation` is preserved verbatim. No write-side validator (TypeScript already enforces the enum at compile time; runtime throwing has no useful recovery path).
- **`readLiveOrchestratorPid` reuses `processAlive`** from `src/t3code/server.ts` instead of inlining `process.kill(pid, 0)`. The redundant `pid <= 0` guard is dropped (`processAlive` already does `Number.isInteger(pid) && pid > 0`).
- **Inline `if (isEscalated(state)) { persistState(state); return; }` in `pollUntilDone`** is replaced by `if (checkEscalationHalt(state)) return;` at the same call-order position. New `checkEscalationHalt(state)` is exported from `runner.ts`, mirroring `checkZeroCommitsAutoBailOut`'s export pattern. Unit test covers both branches.

`src/cluster-http.ts` and `src/slots/migration.ts` are not touched (out of scope per AC5 — both already use `parseSlotLiveness` for external-input narrowing).

Proposal: `docs/proposals/escalation-dry-cleanups.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build` (compiles `bin/ludics`)
- [x] `bun test` — 1571 pass / 0 fail
- [x] Targeted: `bun test src/orchestration/runner.escalation.test.ts src/slots/index.test.ts` — 70 pass / 0 fail (existing escalation + slot suites unchanged); new `checkEscalationHalt — named pollUntilDone halt guard` describe block covers both branches (no-escalation → false, escalation → true + persisted state, phase not advanced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)