### PR TITLE
Replace redundant dynamic imports with static imports (task-1f04f963)

### DIFF
--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -1,7 +1,7 @@
 // tmux+ttyd adapter — implements the Adapter interface for tmux orchestration mode.
 // The existing src/adapters/tmux.ts holds shared tmux helpers; this file is the adapter entry point.
 
-import { existsSync, mkdirSync, readFileSync, unlinkSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { join, resolve } from "path";
 import { writeJsonFile } from "../json.ts";
 import { getMainRepoFromWorktree, latestMtime, resolveProjectDir, slotSessionName } from "./base.ts";
@@ -406,7 +406,6 @@ export async function sendPromptToAgent(
 
   // Atomic paste via load-buffer + paste-buffer for all providers.
   const promptFile = `/tmp/ludics-prompt-${target}-${Date.now()}.txt`;
-  const { writeFileSync, unlinkSync } = await import("fs");
   writeFileSync(promptFile, message);
   safeSyncOutput(["tmux", "load-buffer", promptFile]);
   safeSyncOutput(["tmux", "paste-buffer", "-t", target]);

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -27,7 +27,7 @@ import { readSlotJson, writeSlotJson } from "../slots/json.ts";
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
-import { readTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentPortRole, readTmuxSlotState, startTtyd, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { readSlotState } from "../t3code/server.ts";
 
 // --- Hung agent detection constants ---
@@ -662,8 +662,6 @@ async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
   if (now - lastTtydCheckAt < TTYD_HEALTH_CHECK_INTERVAL_S) return;
   lastTtydCheckAt = now;
 
-  const { readTmuxSlotState, writeTmuxSlotState, startTtyd, agentPortRole } =
-    await import("../adapters/tmux-adapter.ts");
   const dir = state.harnessDir ?? defaultHarnessDir();
   const tmuxState = readTmuxSlotState(state.slot, dir);
   if (!tmuxState) return;

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -19,7 +19,8 @@ import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
 import { readSlotState, writeSlotState } from "../t3code/server.ts";
-import { readTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentCliCommand, isAgentAlive, readTmuxSlotState, startTtyd, tmuxSessionName, ttydPort, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { tmuxHasSession, tmuxNewSession, tmuxSendCommand, tmuxSendKeys } from "../adapters/tmux.ts";
 import { selectOrchestrationFlagsForTask } from "../adapters/t3code.ts";
 import { readOrchestrationState, persistState, removeOrchestrationState } from "../orchestration/state.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
@@ -1162,8 +1163,6 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
 
   // --- tmux-specific: verify/recreate tmux session, windows, ttyd, agent CLIs ---
   if (ctx.mode === "tmux") {
-    const { tmuxHasSession, tmuxNewSession, tmuxSendCommand, tmuxSendKeys } = await import("../adapters/tmux.ts");
-    const { readTmuxSlotState, writeTmuxSlotState, tmuxSessionName, ttydPort, agentCliCommand, isAgentAlive, startTtyd } = await import("../adapters/tmux-adapter.ts");
     const tmuxState = readTmuxSlotState(slotNum, ctx.harnessDir);
 
     if (tmuxState?.orchestration?.pid) {
@@ -1277,7 +1276,6 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
       orchestration: { ...slotState.orchestration, pid: newPid },
     }, ctx.harnessDir);
   } else if (ctx.mode === "tmux") {
-    const { readTmuxSlotState, writeTmuxSlotState } = await import("../adapters/tmux-adapter.ts");
     const tmuxState = readTmuxSlotState(slotNum, ctx.harnessDir);
     if (tmuxState) {
       writeTmuxSlotState({


### PR DESCRIPTION
## Summary

Eliminates four production sites where `await import(...)` destructured names that were already (or trivially could be) imported statically at the top of the same file. These were redundant rebindings — not lazy-loading for circular-dep reasons — that shadowed the existing static imports.

- `src/adapters/tmux-adapter.ts`: add `writeFileSync` to top-level `from "fs"` import; drop the dynamic destructure in the paste-buffer submission helper.
- `src/orchestration/runner.ts`: extend the existing top-level tmux-adapter import with `agentPortRole`, `startTtyd`, `writeTmuxSlotState`; drop the dynamic destructure in `ensureTtydAlive`.
- `src/slots/index.ts`: extend the existing tmux-adapter import with six names; add a new top-level import from `../adapters/tmux.ts` for `tmuxHasSession`/`tmuxNewSession`/`tmuxSendCommand`/`tmuxSendKeys`; drop both dynamic destructures (resume path and orchestration-pid recovery).

No behavior changes — same exports from the same modules; only the binding shape moves from runtime to load time. Test files left untouched per proposal scope.

Repurposed from the original "Rename shadowed `harnessDir` imports" task; those original shadows were already resolved under gh-ludics-376. Related: gh-ludics-376. See `docs/proposals/replace-redundant-dynamic-imports.md`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (eslint --max-warnings=0)
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test` — 1571 pass / 0 fail across 78 files (includes `slots/index.test.ts` resume tests that traverse the edited tmux branches)
- [x] `grep -n 'await import' src/adapters/tmux-adapter.ts src/orchestration/runner.ts src/slots/index.ts` confirms the four target sites are gone; remaining dynamic imports target different modules (no shadow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)