### PR TITLE
final-merge: rescue gh pr merge non-zero exit when server-side merge landed

### DIFF
--- a/skills/orchestration/final-merge.md
+++ b/skills/orchestration/final-merge.md
@@ -5,7 +5,14 @@ Merge the feature branch into main from `{{WORKTREE_PATH}}`.
 Rebase onto `origin/main`, force-push with lease, verify the build is green, then merge:
 ```sh
 PR_URL=$(cat "{{PR_FILE}}" 2>/dev/null)
-gh pr merge "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--merge --delete-branch
+if gh pr merge "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--merge --delete-branch; then
+  :
+else
+  # gh exits non-zero when local-side cleanup (worktree remove / branch -D)
+  # fails even though the server-side merge landed. Re-check via gh pr view.
+  state=$(gh pr view "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--json state -q .state)
+  [ "$state" = "MERGED" ] || exit 1
+fi
 ```
 
 On success, create `{{MERGED_MARKER_FILE}}`. Retry up to 3 times on transient failures.

--- a/skills/orchestration/final-merge.md
+++ b/skills/orchestration/final-merge.md
@@ -13,10 +13,8 @@ else
   state=$(gh pr view "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--json state -q .state)
   [ "$state" = "MERGED" ] || exit 1
 fi
-```
-
-On success, create `{{MERGED_MARKER_FILE}}`. Retry up to 3 times on transient failures.
-
-```sh
+touch "{{MERGED_MARKER_FILE}}"
 printf '%s|%s|final merge complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```
+
+Retry up to 3 times on transient failures.

--- a/skills/orchestration/final-merge.md
+++ b/skills/orchestration/final-merge.md
@@ -13,7 +13,7 @@ else
   state=$(gh pr view "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--json state -q .state)
   [ "$state" = "MERGED" ] || exit 1
 fi
-touch "{{MERGED_MARKER_FILE}}"
+printf 'merged\n' > "{{MERGED_MARKER_FILE}}"
 printf '%s|%s|final merge complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
 ```
 

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -373,6 +373,11 @@ describe("skills", () => {
     // Wrapper treats only state == "MERGED" as success, otherwise exits non-zero
     // so the runner's verifyPhaseOutcome retry/escalation takes over.
     expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
+    // Success path (primary merge OR rescue) reaches both MERGED_MARKER_FILE
+    // touch and STATUS_FILE write — the marker line must sit AFTER `fi` so
+    // both branches reach it, and BEFORE the STATUS_FILE printf so a missing
+    // marker can never coexist with a done STATUS_FILE.
+    expect(rendered).toMatch(/fi\ntouch "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
   });
 
   test("final-merge template omits --repo when PROJECT_REPO is empty but still passes the PR URL", () => {
@@ -384,6 +389,8 @@ describe("skills", () => {
     // Post-merge view fallback present without --repo when PROJECT_REPO is empty.
     expect(rendered).toContain('gh pr view "$PR_URL" --json state');
     expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
+    // Marker + STATUS_FILE sequence pinned: rescue path reaches both writes.
+    expect(rendered).toMatch(/fi\ntouch "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
   });
 
   test("buildSkillContext: hierarchical duo suppresses UPSTREAM_REPO when duoPeerSlot is set", async () => {

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -374,10 +374,13 @@ describe("skills", () => {
     // so the runner's verifyPhaseOutcome retry/escalation takes over.
     expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
     // Success path (primary merge OR rescue) reaches both MERGED_MARKER_FILE
-    // touch and STATUS_FILE write — the marker line must sit AFTER `fi` so
+    // write and STATUS_FILE write — the marker line must sit AFTER `fi` so
     // both branches reach it, and BEFORE the STATUS_FILE printf so a missing
-    // marker can never coexist with a done STATUS_FILE.
-    expect(rendered).toMatch(/fi\ntouch "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
+    // marker can never coexist with a done STATUS_FILE. Marker must carry a
+    // non-empty payload because peer-sync.ts:readMarker treats empty files as
+    // null (`return value || null` after trim).
+    expect(rendered).toMatch(/fi\nprintf 'merged\\n' > "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
+    expect(rendered).not.toMatch(/touch "\/tmp\/merged"/);
   });
 
   test("final-merge template omits --repo when PROJECT_REPO is empty but still passes the PR URL", () => {
@@ -390,7 +393,9 @@ describe("skills", () => {
     expect(rendered).toContain('gh pr view "$PR_URL" --json state');
     expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
     // Marker + STATUS_FILE sequence pinned: rescue path reaches both writes.
-    expect(rendered).toMatch(/fi\ntouch "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
+    // Marker payload must be non-empty (readMarker rejects empty files).
+    expect(rendered).toMatch(/fi\nprintf 'merged\\n' > "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);
+    expect(rendered).not.toMatch(/touch "\/tmp\/merged"/);
   });
 
   test("buildSkillContext: hierarchical duo suppresses UPSTREAM_REPO when duoPeerSlot is set", async () => {

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -367,6 +367,12 @@ describe("skills", () => {
     expect(rendered).toContain('PR_URL=$(cat "/tmp/coder.pr"');
     expect(rendered).toContain('gh pr merge "$PR_URL" --repo "owner/my-staging" --merge --delete-branch');
     expect(rendered).not.toMatch(/gh pr merge --merge/);
+    // Post-merge view fallback rescues benign worktree-cleanup non-zero exits;
+    // must target the same staging repo as the primary merge.
+    expect(rendered).toContain('gh pr view "$PR_URL" --repo "owner/my-staging" --json state');
+    // Wrapper treats only state == "MERGED" as success, otherwise exits non-zero
+    // so the runner's verifyPhaseOutcome retry/escalation takes over.
+    expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
   });
 
   test("final-merge template omits --repo when PROJECT_REPO is empty but still passes the PR URL", () => {
@@ -375,6 +381,9 @@ describe("skills", () => {
     const rendered = substituteTemplate(template, { ...baseCtx(), PR_FILE: "/tmp/coder.pr" });
     expect(rendered).toContain('gh pr merge "$PR_URL" --merge --delete-branch');
     expect(rendered).not.toContain("--repo");
+    // Post-merge view fallback present without --repo when PROJECT_REPO is empty.
+    expect(rendered).toContain('gh pr view "$PR_URL" --json state');
+    expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
   });
 
   test("buildSkillContext: hierarchical duo suppresses UPSTREAM_REPO when duoPeerSlot is set", async () => {


### PR DESCRIPTION
## Summary

When pair-mode slot worktrees live alongside the main ludics checkout, `gh pr merge --delete-branch`'s local cleanup (`git worktree remove` / `git branch -D`) is blocked by the main worktree, so gh exits non-zero even though the server-side merge succeeded. The non-zero exit causes the agent to skip writing `MERGED_MARKER_FILE` / `STATUS_FILE`, triggering redispatch and `gh pr merge` retries against an already-merged PR until `MAX_VERIFY_ATTEMPTS` is exhausted.

- Wrap the merge in `if/else`; on non-zero exit, run `gh pr view --json state -q .state` and treat `MERGED` as success, otherwise `exit 1` so the runner's `verifyPhaseOutcome` retry/escalation logic takes over.
- Mirror the existing `{{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}` conditional onto the fallback `gh pr view`, so staging-PR projects target the correct repo on both calls.
- Promote `MERGED_MARKER_FILE` creation from prose ("On success, create …") to an explicit `printf 'merged\n' > "{{MERGED_MARKER_FILE}}"` placed structurally between `fi` and the STATUS_FILE `printf`. Both primary-success and rescue-success branches reach both writes; the non-MERGED branch hits `exit 1` first. Payload matches the runner-side `writeFileSync(markerFile, "merged\n")` at `runner.ts:1006` so `peer-sync.ts:readMarker` (which treats empty files as `null`) actually observes the marker (per Codex review feedback, fixed in 59b531d).

`runner.ts` / `github.ts` are untouched — `FINAL_MERGE_GATE` / `getPrVerification` already trust the server.

Source: retrospective of `task-d6c774b8` (relates_to). No GitHub issue.

## Test plan

- [x] `bun test src/orchestration/skills.test.ts` — 100 pass / 0 fail / 281 expect() calls
- [x] `bun run typecheck`
- [x] Both `final-merge template …` test cases assert the fallback shape (with and without `--repo`) and pin the `fi\nprintf 'merged\n' > …\nprintf …` sequence as a literal regex so reordering or dropping the marker line fails the assertion
- [x] `expect(rendered).not.toMatch(/touch …/)` rejects a regression to an empty marker payload
- [x] Existing `gh pr merge "$PR_URL" … --merge --delete-branch` assertions retained verbatim — `--delete-branch` is preserved on successful runs