### PR TITLE
test-utils: console capture/silence helpers + migrate 22 inline sites (task-95310454)

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os";
 import { join } from "path";
 import type { SlotData } from "./slots/types.ts";
+import { silenceConsoleError } from "./test-utils.ts";
 
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
@@ -238,13 +239,7 @@ describe("generateNotifications shape guard", () => {
     );
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "notifications.json");
     const notifications = JSON.parse(readFileSync(outFile, "utf-8")) as unknown[];
@@ -290,13 +285,7 @@ describe("generateRecentlyCompleted shape guards", () => {
     );
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "recently-completed.json");
     const recent = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -314,13 +303,7 @@ describe("generateRecentlyCompleted shape guards", () => {
     writeFileSync(join(retroDir, "task-retro-1.json"), '"just a string"');
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "recently-completed.json");
     const recent = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -339,13 +322,7 @@ describe("generateT3code shape guard", () => {
     writeFileSync(join(t3Dir, "starting.json"), '"hello"');
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "t3code.json");
     const t3code = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
@@ -371,13 +348,7 @@ describe("deferred-launch sorting", () => {
     writeDeferredTask("task-no-date", "No date", null);
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "deferred-launch.json");
     const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -406,13 +377,7 @@ describe("needs-confirmation sorting", () => {
     writeNeedsConfirmationTask("task-nc-no-date", "No date", null);
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "needs-confirmation.json");
     const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -449,13 +414,7 @@ describe("tasks-tree link renders task.html", () => {
     writeTask("task-abc123", "Example task");
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "tasks-tree.json");
     const tree = JSON.parse(readFileSync(outFile, "utf-8")) as unknown[];
@@ -471,13 +430,7 @@ describe("tasks-tree link renders task.html", () => {
     writeTask("task-with space", "Needs encoding");
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "tasks-tree.json");
     const tree = JSON.parse(readFileSync(outFile, "utf-8")) as unknown[];
@@ -527,13 +480,7 @@ describe("slots.json field shape", () => {
     writeSlotJson(1, data);
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "slots.json");
     const slots = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -557,13 +504,7 @@ describe("slots.json field shape", () => {
     writeSlotJson(1, data);
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "slots.json");
     const slots = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -586,13 +527,7 @@ describe("slots.json field shape", () => {
     writeSlotJson(1, data);
 
     const { dashboardGenerate } = await import("./dashboard.ts");
-    const origErr = console.error;
-    console.error = () => {};
-    try {
-      dashboardGenerate();
-    } finally {
-      console.error = origErr;
-    }
+    silenceConsoleError(() => dashboardGenerate());
 
     const outFile = join(harnessDir(), "dashboard", "data", "slots.json");
     const slots = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
@@ -612,14 +547,10 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     mkdirSync(dashboardDir, { recursive: true });
     mkdirSync(join(dashboardDir, "data"), { recursive: true });
     // Silence boot logging + lazy-regeneration complaints
-    const origErr = console.error;
-    console.error = () => {};
-    let server: ReturnType<typeof startDashboardServer>;
-    try {
+    let server!: ReturnType<typeof startDashboardServer>;
+    silenceConsoleError(() => {
       server = startDashboardServer(0, dashboardDir, 3600);
-    } finally {
-      console.error = origErr;
-    }
+    });
     return {
       baseUrl: `http://localhost:${server.port}`,
       stop: () => { void server.stop(true); },

--- a/src/flow.test.ts
+++ b/src/flow.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { flowBlocked } from "./flow.ts";
+import { captureConsoleLog } from "./test-utils.ts";
 
 const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
 let TMP = "";
@@ -55,14 +56,7 @@ describe("flowBlocked", () => {
     writeTask("task-b1", "B", ["task-blocker"]);
     writeTask("task-a1", "A", ["task-blocker"]);
 
-    const lines: string[] = [];
-    const orig = console.log;
-    console.log = (msg?: unknown) => { lines.push(String(msg ?? "")); };
-    try {
-      flowBlocked();
-    } finally {
-      console.log = orig;
-    }
+    const lines = captureConsoleLog(() => flowBlocked());
 
     const ids = lines.map((l) => l.split(" ")[0]);
     expect(ids).toEqual(["task-s1", "task-a1", "task-b1", "task-c1", "task-d1"]);
@@ -73,14 +67,7 @@ describe("flowBlocked", () => {
     writeTask("task-x1", "X", ["task-blocker"]);
     writeTask("task-s1", "S", ["task-blocker"]);
 
-    const lines: string[] = [];
-    const orig = console.log;
-    console.log = (msg?: unknown) => { lines.push(String(msg ?? "")); };
-    try {
-      flowBlocked();
-    } finally {
-      console.log = orig;
-    }
+    const lines = captureConsoleLog(() => flowBlocked());
 
     const ids = lines.map((l) => l.split(" ")[0]);
     expect(ids).toEqual(["task-s1", "task-d1", "task-x1"]);

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import { composeSkillMessage, resolveTemplatePath, substituteTemplate } from "./skills.ts";
 import { defaultOrchestrationConfig, initAgentRuntimeState, type OrchestrationState } from "./state.ts";
 import { ludicsRoot } from "../config.ts";
+import { captureConsoleError } from "../test-utils.ts";
 
 function makeState(): OrchestrationState {
   return {
@@ -436,15 +437,14 @@ describe("skills", () => {
   test("substituteTemplate: warns in dev mode for unknown placeholders", () => {
     const origDev = process.env.LUDICS_DEV;
     process.env.LUDICS_DEV = "1";
-    const warnings: string[] = [];
-    const origError = console.error;
-    console.error = (...args: unknown[]) => warnings.push(String(args[0]));
+    let text = "";
+    const warnings = captureConsoleError(() => {
+      text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
+    });
     try {
-      const text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
       expect(text).toBe("hello  world");
       expect(warnings.some((w) => w.includes("TYPO_VAR"))).toBe(true);
     } finally {
-      console.error = origError;
       if (origDev !== undefined) process.env.LUDICS_DEV = origDev;
       else delete process.env.LUDICS_DEV;
     }
@@ -455,15 +455,14 @@ describe("skills", () => {
     const origDebug = process.env.DEBUG;
     delete process.env.LUDICS_DEV;
     delete process.env.DEBUG;
-    const warnings: string[] = [];
-    const origError = console.error;
-    console.error = (...args: unknown[]) => warnings.push(String(args[0]));
+    let text = "";
+    const warnings = captureConsoleError(() => {
+      text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
+    });
     try {
-      const text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
       expect(text).toBe("hello  world");
       expect(warnings.length).toBe(0);
     } finally {
-      console.error = origError;
       if (origDev !== undefined) process.env.LUDICS_DEV = origDev;
       if (origDebug !== undefined) process.env.DEBUG = origDebug;
     }

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { autoCommitWorktree, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, orchBranchName, orchWorktreeStem, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
+import { captureConsoleError } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -557,14 +558,7 @@ describe("ensureGitExcludes", () => {
     const countBefore = gitLogCount(repo);
 
     // Silence the expected warning so test output stays clean
-    const origErr = console.error;
-    const warnings: string[] = [];
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-    try {
-      ensureGitExcludes(repo);
-    } finally {
-      console.error = origErr;
-    }
+    const warnings = captureConsoleError(() => ensureGitExcludes(repo));
 
     // Warning emitted about the skip
     expect(warnings.some((w) => w.includes("skipping untrack") && w.includes("pre-existing staged"))).toBe(true);
@@ -743,14 +737,9 @@ describe("removeWorktreeByPath prefix guard", () => {
     const repo = join(TMP, "remove-guard");
     initRepo(repo);
 
-    const warnings: string[] = [];
-    const origErr = console.error;
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-    try {
+    const warnings = captureConsoleError(() => {
       removeWorktreeByPath(repo, "/some/random/path");
-    } finally {
-      console.error = origErr;
-    }
+    });
 
     expect(warnings.some((w) => w.includes("refusing") && w.includes("random"))).toBe(true);
   });
@@ -760,17 +749,12 @@ describe("removeWorktreeByPath prefix guard", () => {
     const repo = join(TMP, "remove-guard-generic");
     initRepo(repo);
 
-    const warnings: string[] = [];
-    const origErr = console.error;
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-    try {
+    const warnings = captureConsoleError(() => {
       // These share the repo prefix but are not orchestration worktrees
       removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-backup"));
       removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-scratch"));
       removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-OLD"));
-    } finally {
-      console.error = origErr;
-    }
+    });
 
     expect(warnings).toHaveLength(3);
     expect(warnings.every((w) => w.includes("refusing"))).toBe(true);
@@ -786,14 +770,9 @@ describe("removeWorktreeByPath prefix guard", () => {
     const setup = createWorktrees(repo, "task-abc123", [{ name: "a1" }], "main", 1);
 
     // Should not warn — path matches orchestration naming
-    const warnings: string[] = [];
-    const origErr = console.error;
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-    try {
+    const warnings = captureConsoleError(() => {
       removeWorktreeByPath(repo, setup.rootWorktree);
-    } finally {
-      console.error = origErr;
-    }
+    });
 
     expect(warnings.filter((w) => w.includes("refusing"))).toHaveLength(0);
 
@@ -810,14 +789,9 @@ describe("removeWorktreeByPath prefix guard", () => {
     // Create a worktree with single-token taskId + slot
     const setup = createWorktrees(repo, "feat", [{ name: "a1" }], "main", 1);
 
-    const warnings: string[] = [];
-    const origErr = console.error;
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-    try {
+    const warnings = captureConsoleError(() => {
       removeWorktreeByPath(repo, setup.rootWorktree);
-    } finally {
-      console.error = origErr;
-    }
+    });
 
     expect(warnings.filter((w) => w.includes("refusing"))).toHaveLength(0);
 
@@ -841,20 +815,14 @@ describe("deleteBranches prefix guard", () => {
     run(["git", "branch", "feature-safe"], repo);
 
     // Capture stderr to verify warning
-    const origErr = console.error;
-    const warnings: string[] = [];
-    console.error = (...args: unknown[]) => { warnings.push(args.join(" ")); };
-
-    try {
+    const warnings = captureConsoleError(() => {
       deleteBranches(repo, [
         "ludics/test-task-s1/root",
         "main",
         "feature-safe",
         "master",
       ]);
-    } finally {
-      console.error = origErr;
-    }
+    });
 
     // The ludics/ branch should have been deleted
     const branchList = Bun.spawnSync(["git", "branch", "--list"], {

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { withTestHarness } from "./test-utils.ts";
+import {
+  captureConsoleError,
+  captureConsoleLog,
+  silenceConsoleError,
+  silenceConsoleWarn,
+  withTestHarness,
+} from "./test-utils.ts";
 
 function captureHooks(): {
   before: (fn: () => void) => void;
@@ -113,5 +119,114 @@ describe("withTestHarness", () => {
       if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
       else process.env.LUDICS_HARNESS_DIR = pre;
     }
+  });
+});
+
+describe("captureConsoleLog", () => {
+  test("returns lines and restores console.log", () => {
+    const orig = console.log;
+    const lines = captureConsoleLog(() => {
+      console.log("hello");
+      console.log("world", 42);
+    });
+    expect(lines).toEqual(["hello", "world 42"]);
+    expect(console.log).toBe(orig);
+  });
+
+  test("restores console.log when fn throws and propagates", () => {
+    const orig = console.log;
+    expect(() => {
+      captureConsoleLog(() => {
+        console.log("before throw");
+        throw new Error("boom");
+      });
+    }).toThrow("boom");
+    expect(console.log).toBe(orig);
+  });
+
+  test("stringifies null arg as empty string (not 'null')", () => {
+    const lines = captureConsoleLog(() => {
+      console.log(null);
+    });
+    expect(lines).toEqual([""]);
+  });
+});
+
+describe("captureConsoleError", () => {
+  test("returns lines and restores console.error", () => {
+    const orig = console.error;
+    const lines = captureConsoleError(() => {
+      console.error("a", "b");
+      console.error("c");
+    });
+    expect(lines).toEqual(["a b", "c"]);
+    expect(console.error).toBe(orig);
+  });
+
+  test("restores console.error when fn throws and propagates", () => {
+    const orig = console.error;
+    expect(() => {
+      captureConsoleError(() => {
+        console.error("oops");
+        throw new Error("kaboom");
+      });
+    }).toThrow("kaboom");
+    expect(console.error).toBe(orig);
+  });
+});
+
+describe("silenceConsoleError", () => {
+  test("suppresses output and restores console.error", () => {
+    const orig = console.error;
+    const seen: unknown[] = [];
+    console.error = (...args: unknown[]) => { seen.push(args); };
+    try {
+      silenceConsoleError(() => {
+        console.error("must not be seen");
+      });
+      expect(seen).toEqual([]);
+      console.error("seen-after");
+      expect(seen).toEqual([["seen-after"]]);
+    } finally {
+      console.error = orig;
+    }
+  });
+
+  test("restores console.error when fn throws and propagates", () => {
+    const orig = console.error;
+    expect(() => {
+      silenceConsoleError(() => {
+        throw new Error("silence-err");
+      });
+    }).toThrow("silence-err");
+    expect(console.error).toBe(orig);
+  });
+});
+
+describe("silenceConsoleWarn", () => {
+  test("suppresses output and restores console.warn", () => {
+    const orig = console.warn;
+    const seen: unknown[] = [];
+    console.warn = (...args: unknown[]) => { seen.push(args); };
+    try {
+      silenceConsoleWarn(() => {
+        console.warn("must not be seen");
+      });
+      expect(seen).toEqual([]);
+      console.warn("seen-after");
+      expect(seen).toEqual([["seen-after"]]);
+    } finally {
+      console.warn = orig;
+    }
+  });
+
+  test("restores console.warn when fn throws and propagates", () => {
+    const orig = console.warn;
+    expect(() => {
+      silenceConsoleWarn(() => {
+        throw new Error("silence-warn");
+      });
+    }).toThrow("silence-warn");
+    expect(console.warn).toBe(orig);
   });
 });

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -21,6 +21,50 @@ try {
   canBindSocket = false;
 }
 
+type ConsoleChannel = "log" | "error" | "warn";
+
+function withConsoleOverride(
+  channel: ConsoleChannel,
+  override: (...args: unknown[]) => void,
+  fn: () => void,
+): void {
+  const orig = console[channel];
+  console[channel] = override;
+  try {
+    fn();
+  } finally {
+    console[channel] = orig;
+  }
+}
+
+function captureLines(channel: ConsoleChannel, fn: () => void): string[] {
+  const lines: string[] = [];
+  withConsoleOverride(channel, (...args: unknown[]) => {
+    lines.push(args.map((a) => String(a ?? "")).join(" "));
+  }, fn);
+  return lines;
+}
+
+/** Capture lines written to `console.log` while running `fn`; restores on return or throw. */
+export function captureConsoleLog(fn: () => void): string[] {
+  return captureLines("log", fn);
+}
+
+/** Capture lines written to `console.error` while running `fn`; restores on return or throw. */
+export function captureConsoleError(fn: () => void): string[] {
+  return captureLines("error", fn);
+}
+
+/** Run `fn` with `console.error` no-op'd; restores on return or throw. */
+export function silenceConsoleError(fn: () => void): void {
+  withConsoleOverride("error", () => {}, fn);
+}
+
+/** Run `fn` with `console.warn` no-op'd; restores on return or throw. */
+export function silenceConsoleWarn(fn: () => void): void {
+  withConsoleOverride("warn", () => {}, fn);
+}
+
 /** Isolate LUDICS_HARNESS_DIR to a fresh tmpdir per test; returns a getter for the current path. */
 export function withTestHarness(
   before: (fn: () => void) => void,


### PR DESCRIPTION
## Summary

- Add four named helpers to `src/test-utils.ts` — `captureConsoleLog`, `captureConsoleError`, `silenceConsoleError`, `silenceConsoleWarn` — all routed through one private `withConsoleOverride` primitive so the try/finally restore plumbing isn't duplicated.
- Migrate 22 inline `console.{log,error}` reassignment blocks to the new helpers: 2 in `src/flow.test.ts`, 6 in `src/orchestration/worktrees.test.ts`, 2 in `src/orchestration/skills.test.ts`, 12 in `src/dashboard.test.ts`.
- Cover the helpers in `src/test-utils.test.ts`: capture+restore, silence+restore, throw-still-restores for all four, plus an explicit `String(a ?? "")` null-stringification contract test.

Follow-up to PR #349 / gh-ludics-306. Source: retrospective of task-da3cf294. Proposal: `docs/proposals/console-capture-silence-helpers.md`.

## Notes

- Stringification unifies on `args.map(a => String(a ?? "")).join(" ")` — strict superset of the previous inline patterns (`String(args[0])` / `args.join(" ")` / `String(msg ?? "")`); no migrated assertion depends on a literal `null` arg.
- Out of scope per the proposal: `src/events.test.ts::captureOutput` (keeps its async wrapper) and `src/test-utils.ts`'s `void probe.stop(true)` (different purpose).
- The `startDashboardServer` migration in `src/dashboard.test.ts` is the only one that materially changed shape — declares `let server!: ...` outside the helper because the assignment must escape.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test` — 1580 pass / 0 fail across 78 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)