### PR TITLE
task-29bea074: convert deferred atomic-write sites + transactional slot-assign

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -110,12 +110,16 @@ export function readStatusFile(path: string): AgentStatus | null {
   };
 }
 
-/** Write a pipe-delimited status file (atomic). */
-export function writeStatusFile(path: string, status: string, message: string = ""): void {
+/** Write a pipe-delimited status file (atomic). When `epoch` is supplied the
+ * caller's value is written verbatim — useful when the on-disk timestamp must
+ * stay byte-identical with a runtime field (e.g. orchestration bail-out, where
+ * `runtime.statusEpoch` is asserted against the file by verification tests).
+ * Otherwise a fresh epoch is allocated from `Date.now()`. */
+export function writeStatusFile(path: string, status: string, message: string = "", epoch?: number): void {
   mkdirSync(dirname(path), { recursive: true });
-  const epoch = Math.floor(Date.now() / 1000);
+  const ts = epoch ?? Math.floor(Date.now() / 1000);
   const tmp = path + ".tmp";
-  writeFileSync(tmp, `${status}|${epoch}|${message}\n`);
+  writeFileSync(tmp, `${status}|${ts}|${message}\n`);
   renameSync(tmp, path);
 }
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,11 +1,12 @@
 // Cluster — static controller role for multi-machine coordination
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { loadConfigSync, stateRepoDir } from "./config.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { hostnameTailscale } from "./network.ts";
 import { emitEvent } from "./events.ts";
+import { writeJsonFileCompact } from "./json.ts";
 
 const HEARTBEAT_TIMEOUT = parseInt(process.env.LUDICS_HEARTBEAT_TIMEOUT ?? "900", 10);
 
@@ -155,7 +156,7 @@ export function heartbeatPublish(): boolean {
   };
 
   // Write local heartbeat file
-  writeFileSync(join(dir, `${nodeName}.json`), JSON.stringify(heartbeatData) + "\n");
+  writeJsonFileCompact(join(dir, `${nodeName}.json`), heartbeatData);
   emitEvent({ event_type: "cluster_heartbeat", source: "cluster", scope: "cluster", message: nodeName });
   console.error(`ludics: cluster: published heartbeat for ${nodeName}`);
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -7,7 +7,7 @@ import { formatUpstreamLagSection } from "./briefing-lag.ts";
 import { defaultRunGit, type RunGit } from "./git-runner.ts";
 import { clearSentinel, readSentinelEpoch, sentinelExists, sentinelFresh, touchSentinel } from "./sentinel.ts";
 import { syncStagingMainWithUpstream } from "./staging-ff.ts";
-import { atomicWriteFileSync, isPlainObject } from "./json.ts";
+import { atomicWriteFileSync, isPlainObject, writeJsonFile, writeJsonFileCompact } from "./json.ts";
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
@@ -470,7 +470,7 @@ function loadStartupAlertState(): Record<string, number> {
 
 function saveStartupAlertState(state: Record<string, number>): void {
   mkdirSync(magStateDir(), { recursive: true });
-  writeFileSync(startupAlertStateFile(), JSON.stringify(state, null, 2) + "\n");
+  writeJsonFile(startupAlertStateFile(), state);
 }
 
 function clearStartupAlertsForEpoch(startupEpoch: number): void {
@@ -671,7 +671,7 @@ function markFeedbackDigestQueued(repo: string): void {
   const state = readFeedbackDigestQueueState();
   state[repo] = Math.floor(Date.now() / 1000);
   mkdirSync(magStateDir(), { recursive: true });
-  writeFileSync(feedbackDigestStateFile(), JSON.stringify(state));
+  writeJsonFileCompact(feedbackDigestStateFile(), state);
 }
 
 function tryQueueFeedbackDigest(repo: string): { queued: boolean; reason?: string } {

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1,6 +1,8 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { emitEvent } from "../events.ts";
+import { atomicWriteFileSync } from "../json.ts";
+import { writeStatusFile } from "../adapters/base.ts";
 import { mergedPlanFilePath } from "./plan-files.ts";
 import { DONE_STATUSES, PHASE_CATEGORIES, allAgentsDone, agentParticipatesInPhase, escalatingAgents, evaluateTransition, findPlanFiles, isAgentDone, isBailedOut, isEscalated, pairReviewVerdict, phaseTimeoutExpired, requiredArtifactPath } from "./phases.ts";
 import {
@@ -781,7 +783,7 @@ async function enterPhase(
     for (const agent of state.agents) {
       if (!agentParticipatesInPhase(state, agent)) continue;
       const statusPath = join(state.peerSyncDir, `${agent.name}.status`);
-      writeFileSync(statusPath, `pr-comments-done|${nowEpoch()}|awaiting-comments`);
+      writeStatusFile(statusPath, "pr-comments-done", "awaiting-comments");
       const rt = state.agentStates[agent.name];
       if (rt) {
         rt.status = "pr-comments-done";
@@ -842,8 +844,7 @@ async function enterPhase(
     // clobber a real <phase>-done written by an agent that completed while the
     // orchestrator was down.
     const statusPath = join(state.peerSyncDir, `${agent.name}.status`);
-    const resetValue = `${state.phase}-pending|${nowEpoch()}|awaiting`;
-    writeFileSync(statusPath, resetValue);
+    writeStatusFile(statusPath, `${state.phase}-pending`, "awaiting");
 
     // Capture fingerprint from the reset .status file written above.
     const dispatchFp = statusFileFingerprint(state.peerSyncDir, agent.name);
@@ -1003,7 +1004,7 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
       // Uniform post-merge handling: the working-repo (staging) PR merge IS the
       // completion signal. Upstream-specific marker/event paths were removed — the
       // upstream repo is now only used for issue tracking and briefing lag reporting.
-      writeFileSync(markerFile, "merged\n");
+      atomicWriteFileSync(markerFile, "merged\n");
       state.agentStates[agent.name]!.status = "merged";
       state.agentStates[agent.name]!.statusMessage = "PR merged externally";
       emitEvent({
@@ -1568,7 +1569,7 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
     const mergedPath = mergedPlanFilePath(state.peerSyncDir, state.round, 0);
     if (!existsSync(mergedPath)) {
       mkdirSync(join(state.peerSyncDir, "plans"), { recursive: true });
-      writeFileSync(mergedPath, [
+      atomicWriteFileSync(mergedPath, [
         "# Stub Plan (planning phase skipped)",
         "",
         "## Pre-existing test failures (baseline)",
@@ -1724,9 +1725,10 @@ export function triggerCoderBailOut(
     runtime.status = "bail-out";
     runtime.statusEpoch = nowEpoch();
     runtime.statusMessage = statusMessage;
-    writeFileSync(
+    writeStatusFile(
       join(state.peerSyncDir, `${coder.name}.status`),
-      `bail-out|${runtime.statusEpoch}|${runtime.statusMessage}\n`,
+      "bail-out",
+      runtime.statusMessage,
     );
     emitEvent({
       event_type: "bail_out",

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1725,10 +1725,16 @@ export function triggerCoderBailOut(
     runtime.status = "bail-out";
     runtime.statusEpoch = nowEpoch();
     runtime.statusMessage = statusMessage;
+    // Pass runtime.statusEpoch through so the on-disk timestamp stays
+    // byte-identical with the in-memory runtime field — verification tests
+    // assert this equality, and a second-boundary crossing between
+    // nowEpoch() above and writeStatusFile's internal Date.now() would
+    // otherwise produce divergent bail-out timestamps for the same event.
     writeStatusFile(
       join(state.peerSyncDir, `${coder.name}.status`),
       "bail-out",
       runtime.statusMessage,
+      runtime.statusEpoch,
     );
     emitEvent({
       event_type: "bail_out",

--- a/src/orchestration/runner.verification.test.ts
+++ b/src/orchestration/runner.verification.test.ts
@@ -702,6 +702,49 @@ describe("triggerCoderBailOut", () => {
       message: "0 commits ahead of base branch — no PR possible, skipping to done",
     });
   });
+
+  test("on-disk epoch matches runtime.statusEpoch even when Date.now() crosses a second boundary mid-call (gh-ludics-416)", () => {
+    // Codex review on PR #416 (task-29bea074): after the writeStatusFile
+    // migration, the helper stamps its own epoch from Date.now(). If the
+    // wall clock crosses a second boundary between the caller's nowEpoch()
+    // (recorded into runtime.statusEpoch) and the helper's Date.now()
+    // inside writeStatusFile, the on-disk timestamp would diverge from
+    // runtime.statusEpoch — silently breaking byte-identity asserted by
+    // the tests above. The fix passes runtime.statusEpoch through to
+    // writeStatusFile's optional epoch parameter; this test pins it.
+    const peerDir = makeTmpDir();
+    const state = makeState({ phase: "work" }, peerDir);
+    const coder = state.agents.find(a => a.role === "coder")!;
+
+    let dateNowCalls = 0;
+    const baseTimeMs = 1_700_000_000_000; // arbitrary fixed wall-clock anchor
+    const dateNowSpy = spyOn(Date, "now").mockImplementation(() => {
+      // First call → caller's nowEpoch(); subsequent calls → simulate
+      // crossing the next-second boundary inside writeStatusFile.
+      dateNowCalls += 1;
+      return dateNowCalls === 1 ? baseTimeMs : baseTimeMs + 1500;
+    });
+
+    let runtimeEpoch: number;
+    let onDiskEpoch: string;
+    try {
+      triggerCoderBailOut(
+        state, coder,
+        "work-phase no-op detection",
+        "Coder worktree has 0 commits ahead and no uncommitted diffs — triggering bail-out protocol",
+      );
+      runtimeEpoch = state.agentStates.coder!.statusEpoch;
+      const statusContents = readFileSync(join(peerDir, "coder.status"), "utf-8");
+      onDiskEpoch = statusContents.split("|")[1]!;
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+
+    // Pre-fix: runtimeEpoch = floor(baseTimeMs/1000), on-disk = that+1 →
+    // expect(onDiskEpoch).toBe(String(runtimeEpoch)) would fail.
+    expect(onDiskEpoch).toBe(String(runtimeEpoch));
+    expect(runtimeEpoch).toBe(Math.floor(baseTimeMs / 1000));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -132,6 +132,86 @@ describe("slotAssign", () => {
     expect(data.process).toBe("Investigate slot detection");
     expect(data.task).toBeNull();
   });
+
+  test("batches the three frontmatter field updates into a single atomic write (task-29bea074)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-tx-assign", "Transactional assign");
+
+    const taskFile = join(tasksDir, "task-tx-assign.md");
+    const jsonMod = await import("../json.ts");
+    const writeSpy = spyOn(jsonMod, "atomicWriteFileSync");
+
+    let writesToTaskFile: Array<[string, string]>;
+    try {
+      void slotAssign(1, "task-tx-assign", "manual");
+
+      // Capture before mockRestore wipes call history.
+      writesToTaskFile = writeSpy.mock.calls
+        .filter((call) => call[0] === taskFile)
+        .map((call) => [String(call[0]), String(call[1])] as [string, string]);
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    // Exactly two atomic writes hit the task file:
+    //   1) transitionStatus flipping status: ready → in-progress
+    //   2) the batched (slot, adapter, started) write
+    // The pre-task-29bea074 behaviour did three separate per-field writes for
+    // (2) — yielding 4 here — which left the file partially populated if the
+    // process crashed mid-sequence (e.g. slot set, but adapter/started absent).
+    expect(writesToTaskFile).toHaveLength(2);
+
+    const batchedContent = writesToTaskFile[1]![1];
+    expect(batchedContent).toContain("slot: 1");
+    expect(batchedContent).toContain("adapter: manual");
+    expect(batchedContent).toMatch(/started: 20\d\d-/);
+
+    // Round-trip: persisted file matches the in-memory batched content for all 3 fields.
+    const persisted = readFileSync(taskFile, "utf-8");
+    expect(persisted).toContain("slot: 1");
+    expect(persisted).toContain("adapter: manual");
+    expect(persisted).toMatch(/started: 20\d\d-/);
+  });
+
+  test("slotClear single-field frontmatter updates remain atomic (task-29bea074 / AC11)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-tx-clear", "Transactional clear");
+    void slotAssign(1, "task-tx-clear", "manual");
+
+    const taskFile = join(tasksDir, "task-tx-clear.md");
+    const jsonMod = await import("../json.ts");
+    const writeSpy = spyOn(jsonMod, "atomicWriteFileSync");
+
+    let writesToTaskFile: Array<[string, string]>;
+    try {
+      await slotClear(1, "done");
+      writesToTaskFile = writeSpy.mock.calls
+        .filter((call) => call[0] === taskFile)
+        .map((call) => [String(call[0]), String(call[1])] as [string, string]);
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    // slotClear does: transitionStatus (status: in-progress → done),
+    // then taskUpdateFrontmatter("slot","null"), then ("completed", ...).
+    // After AC9, every write is atomic. Each is still a single-field update —
+    // we don't batch slot+completed because a crash between them is benign
+    // (slot=null is the load-bearing field for slot reuse; completed is metadata).
+    expect(writesToTaskFile).toHaveLength(3);
+
+    const persisted = readFileSync(taskFile, "utf-8");
+    expect(persisted).toContain("status: done");
+    expect(persisted).toContain("slot: null");
+    expect(persisted).toMatch(/completed: 20\d\d-/);
+  });
 });
 
 describe("slotResume guards", () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1,8 +1,9 @@
 // Slot operations — list, show, assign, clear, note, start, stop, refresh
 
-import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync } from "fs";
+import { existsSync, readFileSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { globalAdapter, harnessDir, slotsCount, stateRepoDir, resolveProjectPath } from "../config.ts";
+import { atomicWriteFileSync } from "../json.ts";
 import { mergeAdapterState, addNoteToSlotData } from "./markdown.ts";
 import { readSlotJson, writeSlotJson, readAllSlotJson, emptySlotData, slotJsonDir, slotDataToMarkdown } from "./json.ts";
 import { migrateMarkdownToSlotData } from "./migration.ts";
@@ -180,14 +181,21 @@ function readRawEffortField(content: string): string | null {
   return raw;
 }
 
-function taskUpdateFrontmatter(taskId: string, field: string, value: string): void {
+/**
+ * Apply a batch of frontmatter field updates in a single read → mutate-in-memory →
+ * atomic-write cycle. Each field is matched on its first occurrence inside the
+ * `---`-delimited frontmatter block. Used by `taskUpdateForSlotAssign` to make
+ * the (slot, adapter, started) write transactional — a crash mid-sequence would
+ * otherwise leave the task with partial assignment (e.g. slot but no adapter).
+ */
+function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, string>): void {
   const file = taskFilePath(taskId);
   if (!existsSync(file)) return;
 
   const content = readFileSync(file, "utf-8");
   const lines = content.split("\n");
+  const remaining = new Set(Object.keys(updates));
   let inFrontmatter = false;
-  let done = false;
 
   const output: string[] = [];
   for (const line of lines) {
@@ -201,15 +209,26 @@ function taskUpdateFrontmatter(taskId: string, field: string, value: string): vo
       output.push(line);
       continue;
     }
-    if (inFrontmatter && !done && line.startsWith(`${field}:`)) {
-      output.push(`${field}: ${value}`);
-      done = true;
-      continue;
+    if (inFrontmatter && remaining.size > 0) {
+      let matched = false;
+      for (const field of remaining) {
+        if (line.startsWith(`${field}:`)) {
+          output.push(`${field}: ${updates[field]}`);
+          remaining.delete(field);
+          matched = true;
+          break;
+        }
+      }
+      if (matched) continue;
     }
     output.push(line);
   }
 
-  writeFileSync(file, output.join("\n"));
+  atomicWriteFileSync(file, output.join("\n"));
+}
+
+function taskUpdateFrontmatter(taskId: string, field: string, value: string): void {
+  taskUpdateFrontmatterFields(taskId, { [field]: value });
 }
 
 function taskUpdateForSlotAssign(taskId: string, slot: number, adapter: string, started: string): void {
@@ -224,9 +243,11 @@ function taskUpdateForSlotAssign(taskId: string, slot: number, adapter: string, 
     console.error(`ludics: skipping slot assign for ${taskId}: status is '${actual}', expected one of [ready, deferred, blocked, needs-confirmation, preempted]`);
     return;
   }
-  taskUpdateFrontmatter(taskId, "slot", String(slot));
-  taskUpdateFrontmatter(taskId, "adapter", adapter);
-  taskUpdateFrontmatter(taskId, "started", started);
+  taskUpdateFrontmatterFields(taskId, {
+    slot: String(slot),
+    adapter,
+    started,
+  });
 }
 
 function taskUpdateForSlotClear(taskId: string, finalStatus: string): void {


### PR DESCRIPTION
## Summary

Sweeps the 8 raw `writeFileSync` sites that gh-ludics-303 (PR #369) explicitly deferred, and refactors `taskUpdateForSlotAssign` so its three frontmatter field updates (slot, adapter, started) become a single read → mutate-in-memory → atomic-write cycle. Per the proposal at `docs/proposals/task-29bea074.md`.

| File | Site | New helper |
|------|------|------------|
| `src/mag.ts:473` | `saveStartupAlertState` | `writeJsonFile` (byte-exact) |
| `src/mag.ts:674` | `markFeedbackDigestQueued` | `writeJsonFileCompact` (gains `\n`, Q1) |
| `src/cluster.ts:158` | `publishHeartbeat` | `writeJsonFileCompact` (byte-exact) |
| `src/orchestration/runner.ts:784` | pr-comments-done reset | `writeStatusFile` (gains `\n`, Q2) |
| `src/orchestration/runner.ts:846` | phase-entry reset | `writeStatusFile` (gains `\n`, Q2) |
| `src/orchestration/runner.ts:1006` | `.merged` marker | `atomicWriteFileSync` (byte-exact) |
| `src/orchestration/runner.ts:1571` | stub merged plan | `atomicWriteFileSync` (byte-exact) |
| `src/orchestration/runner.ts:1733` | `triggerCoderBailOut` | `writeStatusFile` (byte-exact, epoch passed through) |
| `src/slots/index.ts` | `taskUpdateFrontmatter` | introduces `taskUpdateFrontmatterFields` (atomic, batched) |

`taskUpdateFrontmatter` becomes a thin one-field wrapper over `taskUpdateFrontmatterFields`, so single-field callers (`taskUpdateForSlotClear`, mode toggle, etc.) keep their atomic-write upgrade without behaviour change.

## Format-drift acknowledgments

- `mag.ts:674` gains a trailing `\n` (Q1 resolution — accepted in elaboration; aligns with every other compact-JSON state file).
- `runner.ts:784`/`:846` gain a trailing `\n` (Q2 resolution — `writeStatusFile` defines the canonical pipe-delimited shape; aligns with PR #369's standardisation).
- All other conversions are byte-exact.

## Reviewer-driven follow-up (commit cca5d48)

Codex review on `fb6cb39` flagged a real second-boundary flakiness: `writeStatusFile` originally stamped its own epoch via `Date.now()`, so `runtime.statusEpoch` (set from `nowEpoch()` above the call in `triggerCoderBailOut`) and the on-disk `.status` epoch could diverge across a second boundary. `runner.verification.test.ts:586,663,692` asserts byte-identity between the two, so this was real flakiness, not the cosmetic sub-millisecond drift the proposal described. Fix:

- Added an optional `epoch` parameter to `writeStatusFile` in `src/adapters/base.ts`. Defaults to `Date.now()`, so unaffected callers (`runner.ts:784`/`:846`, which set `runtime.statusEpoch` *after* the file write) stay simple.
- `triggerCoderBailOut` now passes `runtime.statusEpoch` through, restoring byte-identity.
- New regression test in `runner.verification.test.ts` mocks `Date.now()` to deterministically simulate a second-boundary cross between the caller's `nowEpoch()` and the helper's internal read; pre-fix it asserts `onDiskEpoch == runtimeEpoch + 1` (i.e. would fail).

## Test plan

- [x] `bun test` — 1574 pass / 0 fail (was 1571 + 3 new regression tests across `src/slots/index.test.ts` and `src/orchestration/runner.verification.test.ts`).
- [x] `bun run typecheck` — clean.
- [x] `bun run build` — clean (167 modules, `bin/ludics` produced).
- [x] Regression test: `batches the three frontmatter field updates into a single atomic write` — spies on `atomicWriteFileSync`, asserts exactly two writes hit the task file during `slotAssign` (one from `transitionStatus`, one for the batched fields). Would fail to 4 if the code reverted to three sequential `taskUpdateFrontmatter` calls.
- [x] Regression test: `slotClear single-field frontmatter updates remain atomic` — asserts `slotClear` performs three atomic writes through the same helper, proving AC11.
- [x] Regression test: `on-disk epoch matches runtime.statusEpoch even when Date.now() crosses a second boundary mid-call` — pins the Codex-flagged invariant.

## Out of scope (per gh-ludics-303 plan)

- Dashboard writes in `src/dashboard.ts` — intentionally self-healing.
- Ephemeral/sentinel files (`src/sentinel.ts`, `src/state.ts`, `src/mag.ts:268`/`786`/`1243`/`2226`/`3576`) — intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)