### PR TITLE
fix: SHELL_COMMANDS drift in final-merge.md rescue path (task-f4ac6ff0)

### DIFF
--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -42,10 +42,10 @@ export const SHELL_COMMANDS = [
   "git", "gh", "printf", "cat", "rm", "mkdir", "cp", "mv", "cd", "ls", "ln",
   "touch", "test", "chmod", "chown", "find", "awk", "sed", "grep", "egrep", "fgrep",
   "npm", "bun", "node", "python", "python3", "echo", "date", "eval", "source",
-  "export", "unset", "read", "xargs", "jq", "yq", "curl", "wget", "sudo", "kill",
+  "export", "unset", "read", "exit", "xargs", "jq", "yq", "curl", "wget", "sudo", "kill",
   "pkill", "bash", "sh", "zsh", "make", "docker", "ssh", "scp", "rsync", "tar",
   "gzip", "gunzip", "zip", "unzip", "diff", "patch", "pwd", "tee", "sort", "uniq",
-  "head", "tail", "wc", "tr", "cut", "true", "false",
+  "head", "tail", "wc", "tr", "cut", "true", "false", ":",
 ] as const;
 
 /** Shell control-flow / compound-command keywords that start shell syntax. */

--- a/skills/orchestration/final-merge.md
+++ b/skills/orchestration/final-merge.md
@@ -10,8 +10,8 @@ if gh pr merge "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--
 else
   # gh exits non-zero when local-side cleanup (worktree remove / branch -D)
   # fails even though the server-side merge landed. Re-check via gh pr view.
-  state=$(gh pr view "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--json state -q .state)
-  [ "$state" = "MERGED" ] || exit 1
+  STATE=$(gh pr view "$PR_URL" {{#IF PROJECT_REPO}}--repo "{{PROJECT_REPO}}" {{/IF}}--json state -q .state)
+  [ "$STATE" = "MERGED" ] || exit 1
 fi
 printf 'merged\n' > "{{MERGED_MARKER_FILE}}"
 printf '%s|%s|final merge complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -373,7 +373,7 @@ describe("skills", () => {
     expect(rendered).toContain('gh pr view "$PR_URL" --repo "owner/my-staging" --json state');
     // Wrapper treats only state == "MERGED" as success, otherwise exits non-zero
     // so the runner's verifyPhaseOutcome retry/escalation takes over.
-    expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
+    expect(rendered).toContain('[ "$STATE" = "MERGED" ] || exit 1');
     // Success path (primary merge OR rescue) reaches both MERGED_MARKER_FILE
     // write and STATUS_FILE write — the marker line must sit AFTER `fi` so
     // both branches reach it, and BEFORE the STATUS_FILE printf so a missing
@@ -392,7 +392,7 @@ describe("skills", () => {
     expect(rendered).not.toContain("--repo");
     // Post-merge view fallback present without --repo when PROJECT_REPO is empty.
     expect(rendered).toContain('gh pr view "$PR_URL" --json state');
-    expect(rendered).toContain('[ "$state" = "MERGED" ] || exit 1');
+    expect(rendered).toContain('[ "$STATE" = "MERGED" ] || exit 1');
     // Marker + STATUS_FILE sequence pinned: rescue path reaches both writes.
     // Marker payload must be non-empty (readMarker rejects empty files).
     expect(rendered).toMatch(/fi\nprintf 'merged\\n' > "\/tmp\/merged"\nprintf '%s\|%s\|final merge complete\\n' 'review-done'/);


### PR DESCRIPTION
## Summary

- Restore green `Ludics` test suite by resolving the `SHELL_COMMANDS drift` meta-test failure introduced after PR #414 hardened `final-merge.md`'s rescue path.
- Add `:` (POSIX no-op) and `exit` (shell builtin) to the `SHELL_COMMANDS` allowlist in `scripts/lint-template-safety.ts` — both are first-class commands worth recognizing on principle.
- Rename lowercase `state` → `STATE` in `skills/orchestration/final-merge.md` so the existing strict `^[A-Z_][A-Z0-9_]*=` regex in `stripLeadingEnvAssignments` peels the assignment off naturally; aligns with the uppercase shell-var convention already used elsewhere in the file (`PR_URL`) and across other orchestration skills (`suggest-refactor.md`, `pr-conflict-resolve.md`, `pr-comments.md`).
- Update the two byte-identity assertions in `src/orchestration/skills.test.ts:376,395` that pinned the old lowercase name — same template, same rename, same batch.

Rescue-path semantics preserved: `if gh pr merge ...; then :; else STATE=$(gh pr view ... --json state -q .state); [ "$STATE" = "MERGED" ] || exit 1; fi`.

No parser change, no per-file exemption, no semantics drift. See `docs/proposals/task-f4ac6ff0.md` for the full rationale.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun test scripts/lint-template-safety.test.ts` — 60 pass, 0 fail (including the targeted `every fenced shell block in skills/orchestration/* uses a known first-token` case at `:861` and the synthetic-unknown-token sanity check at `:867`).
- [x] Full `bun test` — 1590 pass, 0 fail across 78 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)