### PR TITLE
refactor(tasks/sync): drop dead try/catch wrappers around parseTaskFrontmatter

### DIFF
--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -424,12 +424,7 @@ export async function tasksUpdate(): Promise<void> {
   for (const file of files) {
     const filePath = join(tasksDir, file);
     const content = readFileSync(filePath, "utf-8");
-    let fm;
-    try {
-      fm = parseTaskFrontmatter(content);
-    } catch {
-      continue;
-    }
+    const fm = parseTaskFrontmatter(content);
     if (!fm.id) continue;
     records.set(fm.id, {
       id: fm.id,
@@ -674,8 +669,7 @@ function healBlockedByLinks(tasksDir: string): void {
   for (const f of files) {
     const filePath = join(tasksDir, f);
     const content = readFileSync(filePath, "utf-8");
-    let fm;
-    try { fm = parseTaskFrontmatter(content); } catch { continue; }
+    const fm = parseTaskFrontmatter(content);
     if (!fm.id) continue;
     // Malformed YAML falls through the line-regex recovery path, which can
     // salvage top-level fields but cannot reconstruct the nested dependencies
@@ -731,10 +725,7 @@ function tasksReconcileBlockedStatus(tasksDir: string): void {
   for (const f of files) {
     const filePath = join(tasksDir, f);
     const content = readFileSync(filePath, "utf-8");
-    let fm;
-    try {
-      fm = parseTaskFrontmatter(content);
-    } catch { continue; }
+    const fm = parseTaskFrontmatter(content);
 
     // Guard against the malformed-YAML line-regex fallback: it populates
     // top-level fields (e.g. status) but leaves nested `dependencies`
@@ -778,10 +769,7 @@ function tasksMilestoneWarnings(tasksDir: string): void {
 
   for (const f of files) {
     const content = readFileSync(join(tasksDir, f), "utf-8");
-    let fm;
-    try {
-      fm = parseTaskFrontmatter(content);
-    } catch { continue; }
+    const fm = parseTaskFrontmatter(content);
 
     // Only warn for active (non-terminal) tasks
     const status = fm.status ?? "ready";


### PR DESCRIPTION
## Summary

- `parseTaskFrontmatter` was made non-throwing in task-d68d485a (PR #396) — on malformed YAML it returns `{}` or a partial salvage object via the line-regex fallback. The four `try { fm = parseTaskFrontmatter(...) } catch { continue; }` wrappers in `src/tasks/sync.ts` are now unreachable defensive deadweight.
- Replaces each wrapper with a direct `const fm = parseTaskFrontmatter(content);` at the four proposal-named sites: `tasksUpdate`, `healBlockedByLinks`, `tasksReconcileBlockedStatus`, `tasksMilestoneWarnings`.
- Existing per-site guards (`!fm.id`, `!fm.dependencies`, the explanatory comment block at `tasksReconcileBlockedStatus`) are preserved byte-identical — they already cover the empty/partial-frontmatter case from the salvage path. The unrelated try blocks at sync.ts:54/232/322 (wrapping `JSON.parse` / `new URL`) are untouched.

Single-file diff: 4 insertions, 16 deletions.

See `docs/proposals/task-93e1fe1a.md` for full context (acceptance criteria, sweep verification, edge cases).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — `bin/ludics` compiled
- [x] `bun test src/tasks/sync.test.ts` — 8/8 pass, including the malformed-YAML regression at `sync.test.ts:259-291` (`malformed YAML with status: blocked is not silently rewritten to ready`)
- [x] `bun test` — 1589 pass, 1 pre-existing fail (`SHELL_COMMANDS drift` in `final-merge.md`, owned by task-f4ac6ff0; reproduces on base via `git stash && bun test scripts/lint-template-safety.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)