### PR TITLE
refactor(slots): normalize taskId to undefined in makeAdapterContext

### DIFF
--- a/src/adapters/agent-session.ts
+++ b/src/adapters/agent-session.ts
@@ -59,7 +59,7 @@ function readLaunchFeature(
   ctx: AdapterContext,
   projectDir: string,
 ): string | null {
-  if (!ctx.taskId || ctx.taskId === "null") return null;
+  if (!ctx.taskId) return null;
   return readProposalLaunchMetadata(cfg.command, ctx.harnessDir, ctx.taskId, projectDir)?.launchFeature ?? null;
 }
 
@@ -147,7 +147,7 @@ export function createAgentSessionAdapter(cfg: AgentSessionConfig): Adapter {
     const knownName = (
       sessionInfo?.task
       || launchFeature
-      || (ctx.taskId && ctx.taskId !== "null" ? ctx.taskId : "")
+      || ctx.taskId
       || (ctx.session && ctx.session !== "null" && !/^\d+$/.test(ctx.session) ? ctx.session : "")
     ).trim();
     if (knownName) {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -23,7 +23,7 @@ import type { AgentStatus } from "./types.ts";
  * Suffix is taskId when present, otherwise the provided fallback (or role).
  */
 export function slotSessionName(slot: number, role?: string, taskId?: string, fallback?: string): string {
-  const suffix = taskId && taskId !== "null" ? taskId : (fallback ?? role ?? "unknown");
+  const suffix = taskId || (fallback ?? role ?? "unknown");
   return role ? `s${slot}_${role}_${suffix}` : `s${slot}_${suffix}`;
 }
 

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -123,12 +123,6 @@ describe("orchestratedThreadTitle", () => {
     );
   });
 
-  test("falls back to role when taskId is 'null' string", () => {
-    expect(orchestratedThreadTitle(1, "coder", "null")).toBe(
-      "s1_coder_coder",
-    );
-  });
-
   test("uses agent name as role in duo mode", () => {
     expect(orchestratedThreadTitle(4, "agent-b", "task-abc")).toBe(
       "s4_agent-b_task-abc",

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -860,7 +860,7 @@ async function startOrchestratedThreads(
   workspaceRoot: string,
 ): Promise<string> {
   const orchestration = options.orchestration!;
-  const taskId = ctx.taskId && ctx.taskId !== "null" ? ctx.taskId : undefined;
+  const taskId = ctx.taskId;
   if (!taskId) {
     throw new Error(`slot ${ctx.slot}: taskId is required for orchestration. Assign a task first.`);
   }

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -448,7 +448,7 @@ async function start(ctx: AdapterContext): Promise<string> {
   }
 
   const orchestration = options.orchestration;
-  const taskId = ctx.taskId && ctx.taskId !== "null" ? ctx.taskId : undefined;
+  const taskId = ctx.taskId;
   if (!taskId) {
     throw new Error(`slot ${ctx.slot}: taskId is required for orchestration. Assign a task first.`);
   }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -5,7 +5,7 @@ export interface AdapterContext {
   mode: string;
   session: string;
   path: string;
-  taskId: string;
+  taskId: string | undefined;
   adapterArgs: string;
   started?: string;
   process: string;

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -8,7 +8,7 @@ import { resolve, extname, join } from "path";
 import YAML from "yaml";
 import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
-import { readSlotJson } from "./slots/json.ts";
+import { readSlotJson, normalizeTaskId } from "./slots/json.ts";
 import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
 import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
@@ -250,8 +250,8 @@ export function startDashboardServer(
           let pendingPriorityWrite: (() => void) | null = null;
           {
             const slotData = readSlotJson(slotNum);
-            const taskId = slotData.task;
-            if (taskId && taskId !== "null" && TASK_ID_RE.test(taskId)) {
+            const taskId = normalizeTaskId(slotData.task);
+            if (taskId && TASK_ID_RE.test(taskId)) {
               const taskResolved = resolveTaskFile(taskId);
               if (!("error" in taskResolved)) {
                 const taskFile = taskResolved.path;

--- a/src/sessions/sweep.ts
+++ b/src/sessions/sweep.ts
@@ -9,7 +9,7 @@ import { existsSync, readdirSync } from "fs";
 import { basename, join } from "path";
 import { slotsCount } from "../config.ts";
 import { safeSyncOutput } from "../spawn.ts";
-import { readAllSlotJson } from "../slots/json.ts";
+import { readAllSlotJson, normalizeTaskId } from "../slots/json.ts";
 import { resolveProjectDir } from "../adapters/base.ts";
 import { findSessionByPrefixOrTask } from "../adapters/peer-sync.ts";
 import { readSlotState, serverStatus } from "../t3code/server.ts";
@@ -49,8 +49,8 @@ function resolveProjectDirForSlot(mode: SweepMode, slotPath: string, slotSession
   return unique[0] ?? process.cwd();
 }
 
-function providerCleanupName(taskId: string, session: string): string | null {
-  if (taskId && taskId !== "null") return taskId;
+function providerCleanupName(taskId: string | undefined, session: string): string | null {
+  if (taskId) return taskId;
   if (session && session !== "null" && !/^\d+$/.test(session)) return session;
   return null;
 }
@@ -63,7 +63,7 @@ function collectAttachedKeys(): Set<string> {
     const modeRaw = (data.mode ?? "").trim();
     if (!SWEEP_TARGET_MODES.has(modeRaw as SweepMode)) continue;
     const mode = modeRaw as SweepMode;
-    const taskId = (data.task ?? "").trim();
+    const taskId = normalizeTaskId(data.task);
     const slotSession = (data.session ?? "").trim();
     const slotPath = (data.path ?? "").trim();
 

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -519,7 +519,7 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     writeSlotJson(1, emptySlotData(1), harness);
     writeSlotJson(2, emptySlotData(2), harness);
     writeTask(tasksDir, "task-empty-args-1", "Empty args test");
-    // slotAssign with no adapterArgs stores "null" which makeAdapterContext converts to ""
+    // slotAssign with no adapterArgs stores "null" which makeAdapterContext normalizes to undefined
     void slotAssign(1, "task-empty-args-1", "t3code");
     const data = readSlotJson(1, harness);
     const ctx = makeAdapterContext(1, data);
@@ -704,6 +704,53 @@ describe("slotStart — t3code empty-args auto-fill", () => {
     expect(args).toContain("--pair");
     expect(args).toContain("--coder");
     expect(args).toContain("--reviewer");
+  });
+});
+
+describe("makeAdapterContext taskId normalization", () => {
+  // These tests are the contract that lets every downstream `ctx.taskId`
+  // consumer drop the legacy `taskId && taskId !== "null"` guard. If any of
+  // these break, the scattered guards we removed need to come back.
+  function buildSlotData(task: string | null): import("./types.ts").SlotData {
+    return {
+      slot: 1,
+      process: "running",
+      task,
+      mode: "t3code",
+      session: null,
+      path: "/tmp/proj",
+      started: null,
+      adapterArgs: null,
+      machine: null,
+      sessionStarted: null,
+      liveness: null,
+      terminals: "",
+      runtime: "",
+      git: "",
+    };
+  }
+
+  test("normalizes null SlotData.task to undefined", () => {
+    const ctx = makeAdapterContext(1, buildSlotData(null));
+    expect(ctx.taskId).toBeUndefined();
+  });
+
+  test("normalizes the legacy 'null' string sentinel to undefined", () => {
+    // SlotData.task is typed `string | null` but the markdown/migration layer
+    // can still surface the literal string "null" — normalization must catch
+    // it at the single ingestion point.
+    const ctx = makeAdapterContext(1, buildSlotData("null"));
+    expect(ctx.taskId).toBeUndefined();
+  });
+
+  test("normalizes empty string to undefined", () => {
+    const ctx = makeAdapterContext(1, buildSlotData(""));
+    expect(ctx.taskId).toBeUndefined();
+  });
+
+  test("preserves a real task id", () => {
+    const ctx = makeAdapterContext(1, buildSlotData("task-abc123"));
+    expect(ctx.taskId).toBe("task-abc123");
   });
 });
 

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { globalAdapter, harnessDir, slotsCount, stateRepoDir, resolveProjectPath } from "../config.ts";
 import { atomicWriteFileSync } from "../json.ts";
 import { mergeAdapterState, addNoteToSlotData } from "./markdown.ts";
-import { readSlotJson, writeSlotJson, readAllSlotJson, emptySlotData, slotJsonDir, slotDataToMarkdown } from "./json.ts";
+import { readSlotJson, writeSlotJson, readAllSlotJson, emptySlotData, slotJsonDir, slotDataToMarkdown, normalizeTaskId } from "./json.ts";
 import { migrateMarkdownToSlotData } from "./migration.ts";
 import { cleanupStaleItems } from "../t3code/index.ts";
 import type { SlotData, SlotLiveness } from "./types.ts";
@@ -786,10 +786,11 @@ export async function slotSetMode(slotNum: number, mode: string): Promise<void> 
 
 export function makeAdapterContext(slotNum: number, data: SlotData): AdapterContext {
   let resolvedPath = data.path ?? "";
+  const taskId = normalizeTaskId(data.task);
 
   // If path is empty, try to resolve from the task's project config
-  if (!resolvedPath && data.task) {
-    const taskFile = join(harnessDir(), "tasks", `${data.task}.md`);
+  if (!resolvedPath && taskId) {
+    const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
     if (existsSync(taskFile)) {
       const content = readFileSync(taskFile, "utf-8");
       const project = parseTaskFrontmatter(content).project;
@@ -805,7 +806,7 @@ export function makeAdapterContext(slotNum: number, data: SlotData): AdapterCont
     session: data.session ?? "",
     path: resolvedPath,
     started: data.started ?? "",
-    taskId: data.task ?? "",
+    taskId,
     adapterArgs: data.adapterArgs ?? "",
     process: data.process === "(empty)" ? "" : data.process,
     machine: data.machine ?? "",

--- a/src/slots/json.test.ts
+++ b/src/slots/json.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { slotDataToMarkdown } from "./json.ts";
+import { slotDataToMarkdown, normalizeTaskId } from "./json.ts";
 import { migrateMarkdownToSlotData } from "./migration.ts";
 import type { SlotData } from "./types.ts";
 
@@ -226,6 +226,23 @@ describe("slotDataToMarkdown round-trip fidelity", () => {
     } finally {
       rmSync(tmp, { recursive: true });
     }
+  });
+
+  test("normalizeTaskId returns undefined for absent/legacy-null inputs and trims real ids", () => {
+    // Absent forms — every shape that callers used to gate with
+    // `taskId && taskId !== "null"` must collapse to undefined here so guards
+    // upstream can be a single truthiness check.
+    expect(normalizeTaskId(null)).toBeUndefined();
+    expect(normalizeTaskId(undefined)).toBeUndefined();
+    expect(normalizeTaskId("")).toBeUndefined();
+    expect(normalizeTaskId("   ")).toBeUndefined();
+    expect(normalizeTaskId("null")).toBeUndefined();
+    expect(normalizeTaskId("NULL")).toBeUndefined();
+    expect(normalizeTaskId("  null  ")).toBeUndefined();
+
+    // Real task ids pass through (with trim).
+    expect(normalizeTaskId("task-abc123")).toBe("task-abc123");
+    expect(normalizeTaskId("  task-abc123  ")).toBe("task-abc123");
   });
 
   test("every SlotData key is represented in the output", () => {

--- a/src/slots/json.ts
+++ b/src/slots/json.ts
@@ -6,6 +6,22 @@ import { harnessDir } from "../config.ts";
 import { isPlainObject } from "../json.ts";
 import type { SlotData } from "./types.ts";
 
+/**
+ * Normalize a raw `task` field (from slot JSON, markdown migration, or
+ * frontmatter) into a real task identifier or `undefined`. Treats `null`,
+ * `undefined`, the empty/whitespace string, and the legacy `"null"` sentinel
+ * (case-insensitive) as absent.
+ *
+ * Single source of truth for the normalization that callers used to do inline
+ * with `taskId && taskId !== "null"` checks.
+ */
+export function normalizeTaskId(raw: string | null | undefined): string | undefined {
+  if (raw === null || raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.toLowerCase() === "null") return undefined;
+  return trimmed;
+}
+
 export function slotJsonDir(harness?: string): string {
   const h = harness ?? harnessDir();
   return join(h, "slots");


### PR DESCRIPTION
## Summary

- Centralize the `taskId && taskId !== "null"` guard pattern at the single ingestion point: `makeAdapterContext()` now routes `data.task` through a new `normalizeTaskId()` helper that collapses `null`, `undefined`, empty/whitespace strings, and the legacy `"null"` sentinel (case-insensitive) to `undefined`.
- Widen `AdapterContext.taskId` from `string` to `string | undefined` so the type system enforces consumers handle the absent case.
- Simplify scattered guards in `src/adapters/base.ts` (`slotSessionName`), `t3code.ts`, `tmux-adapter.ts`, `agent-session.ts` — all now use plain truthiness on `ctx.taskId`. The two raw-slot-field readers (`sessions/sweep.ts:providerCleanupName`, `dashboard-server.ts` slot-postpone) route through `normalizeTaskId` for the same effect.

Persistence layer is untouched per the proposal: `slotDataToMarkdown` still emits `"null"` for the legacy markdown view, and `slotAssign("null", ...)` continues to mean "clear task".

Closes task-ab90fcb7. See `docs/proposals/task-ab90fcb7-normalize-taskid-undefined.md`.

## Test plan

- [x] `bun test` — 1594 pass / 0 fail (added 4 cases in `src/slots/index.test.ts` for `makeAdapterContext` against `null`/`""`/`"null"`/real id, plus 1 case in `src/slots/json.test.ts` for the helper directly)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean (the wider type forced every `ctx.taskId` consumer to either guard or accept `undefined`)
- [x] `bun run build` — clean
- [x] `grep -rn 'taskId.*"null"' src/` — only the three persistence-layer *write* sites in `src/slots/index.ts` remain (out of scope per proposal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)