### PR TITLE
fix(lint:cli-readme): use backtick-aware USAGE extractor

### DIFF
--- a/scripts/lint-cli-readme.test.ts
+++ b/scripts/lint-cli-readme.test.ts
@@ -43,6 +43,27 @@ describe("extractUsageBlock", () => {
     expect(block).toBe("body");
     expect(block).not.toContain("should not appear");
   });
+
+  test("escaped backticks inside the body do not truncate the block", () => {
+    // If a USAGE line is ever written with inline code style — for example
+    // `\`--flag\`` — the parser must skip the escaped backticks rather than
+    // treat them as the end of the template literal. Otherwise commands past
+    // that line silently disappear and the lint produces false stale-doc
+    // failures (the same class of bug the `;`-based parser had).
+    const src = [
+      "const USAGE = `",
+      "  alpha — first command",
+      "  beta — supports the \\`--quiet\\` flag",
+      "  gamma — third command",
+      "`;",
+    ].join("\n");
+    const block = extractUsageBlock(src);
+    expect(block).toContain("alpha");
+    expect(block).toContain("beta");
+    expect(block).toContain("gamma");
+    const cmds = extractUsageCommands(src);
+    expect(cmds.has("gamma")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lint-cli-readme.test.ts
+++ b/scripts/lint-cli-readme.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  extractUsageBlock,
+  extractUsageCommands,
+  extractReadmeCommands,
+  lintCliReadme,
+} from "./lint-cli-readme.ts";
+
+// ---------------------------------------------------------------------------
+// extractUsageBlock — backtick-aware extractor
+// ---------------------------------------------------------------------------
+
+describe("extractUsageBlock", () => {
+  test("captures full template literal even when body contains a semicolon", () => {
+    // Reproduces the original bug: a `;` inside the template literal body
+    // (here inside a parenthetical, mirroring `cluster.machines);` in the
+    // real source) used to truncate the parsed block.
+    const src = [
+      "const USAGE = `",
+      "  alpha — first command",
+      "  beta — host is not in cluster.machines); in single-machine",
+      "  gamma — third command",
+      "`;",
+      "",
+      "function other() {}",
+    ].join("\n");
+    const block = extractUsageBlock(src);
+    expect(block).toContain("alpha");
+    expect(block).toContain("beta");
+    // The critical assertion: content past the parenthetical `;` survives.
+    expect(block).toContain("gamma");
+  });
+
+  test("returns empty string when USAGE constant is absent", () => {
+    expect(extractUsageBlock("const FOO = `bar`;\n")).toBe("");
+  });
+
+  test("does not consume past the closing backtick", () => {
+    const src = "const USAGE = `body`;\nconst AFTER = `should not appear`;\n";
+    const block = extractUsageBlock(src);
+    expect(block).toBe("body");
+    expect(block).not.toContain("should not appear");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractUsageCommands — top-level command extraction
+// ---------------------------------------------------------------------------
+
+describe("extractUsageCommands", () => {
+  test("recognises every top-level command past a semicolon-bearing line", () => {
+    // The 12 names from the original failure must all be extracted, plus a
+    // couple of others, when an earlier line contains a `;` in its body.
+    const src = [
+      "const USAGE = `",
+      "  slot <n> — host is not in cluster.machines); in single-machine",
+      "  slots — list active slots",
+      "  tasks ls — list tasks",
+      "  flow ready — show ready tasks",
+      "  orch status — orchestration status",
+      "  notify outgoing — send notification",
+      "  mag start — start mag",
+      "  status — show status",
+      "  briefing — produce briefing",
+      "  init — initialize",
+      "  stop — stop",
+      "  triggers install — install triggers",
+      "  doctor — diagnose",
+      "  help — show help",
+      "`;",
+    ].join("\n");
+    const cmds = extractUsageCommands(src);
+    for (const name of [
+      "slot",
+      "slots",
+      "tasks",
+      "flow",
+      "orch",
+      "notify",
+      "mag",
+      "status",
+      "briefing",
+      "init",
+      "stop",
+      "triggers",
+      "doctor",
+      "help",
+    ]) {
+      expect(cmds.has(name)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractReadmeCommands — slice CLI Reference, then collect `ludics <cmd>`
+// ---------------------------------------------------------------------------
+
+describe("extractReadmeCommands", () => {
+  test("collects commands inside the CLI Reference section only", () => {
+    const md = [
+      "## Intro",
+      "",
+      "ludics outside-section",
+      "",
+      "## CLI Reference",
+      "",
+      "ludics tasks ls",
+      "ludics flow ready",
+      "",
+      "## Other",
+      "",
+      "ludics also-outside",
+    ].join("\n");
+    const cmds = extractReadmeCommands(md);
+    expect(cmds.has("tasks")).toBe(true);
+    expect(cmds.has("flow")).toBe(true);
+    expect(cmds.has("outside-section")).toBe(false);
+    expect(cmds.has("also-outside")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintCliReadme — drift detection still works after the fix
+// ---------------------------------------------------------------------------
+
+describe("lintCliReadme", () => {
+  test("reports a README command missing from USAGE as stale", () => {
+    const indexSrc = "const USAGE = `\n  alpha — first\n`;\n";
+    const readmeSrc = "## CLI Reference\n\nludics alpha\nludics ghost\n";
+    const { stale, undocumented } = lintCliReadme(indexSrc, readmeSrc);
+    expect(stale).toEqual(["ghost"]);
+    expect(undocumented).toEqual([]);
+  });
+
+  test("reports nothing stale when README ⊆ USAGE", () => {
+    const indexSrc = "const USAGE = `\n  alpha — first\n  beta — second\n`;\n";
+    const readmeSrc = "## CLI Reference\n\nludics alpha\n";
+    const { stale, undocumented } = lintCliReadme(indexSrc, readmeSrc);
+    expect(stale).toEqual([]);
+    expect(undocumented).toEqual(["beta"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end against the real repo: the gate currently passes
+// ---------------------------------------------------------------------------
+
+describe("real repository", () => {
+  const root = join(import.meta.dir, "..");
+
+  test("USAGE includes the 12 commands previously falsely flagged as stale", () => {
+    // Pre-assertion harness probe: confirm the world (real src/index.ts
+    // contents) actually instantiates the AC's case — i.e. these 12 commands
+    // really do appear in USAGE. If not, the test would pass vacuously.
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const cmds = extractUsageCommands(indexSrc);
+    const previouslyFlagged = [
+      "tasks",
+      "flow",
+      "orch",
+      "notify",
+      "mag",
+      "status",
+      "briefing",
+      "init",
+      "stop",
+      "triggers",
+      "doctor",
+      "help",
+    ];
+    for (const name of previouslyFlagged) {
+      expect(cmds.has(name)).toBe(true);
+    }
+  });
+
+  test("lintCliReadme returns no stale entries against the real README + USAGE", () => {
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const readmeSrc = readFileSync(join(root, "README.md"), "utf-8");
+    const { stale } = lintCliReadme(indexSrc, readmeSrc);
+    expect(stale).toEqual([]);
+  });
+});

--- a/scripts/lint-cli-readme.ts
+++ b/scripts/lint-cli-readme.ts
@@ -24,9 +24,11 @@ const root = join(import.meta.dir, "..");
 //
 // We use a backtick-aware match rather than scanning for the next `;` because
 // the template literal body contains parenthetical semicolons (e.g.
-// "cluster.machines);") that would otherwise truncate the block.
+// "cluster.machines);") that would otherwise truncate the block. The body
+// pattern `(?:\\[\s\S]|[^`])*` skips over escaped sequences (`\`` etc.) so an
+// inline `\`--flag\`` in USAGE doesn't truncate the block early.
 export function extractUsageBlock(source: string): string {
-  const match = source.match(/const USAGE = `([\s\S]*?)`/);
+  const match = source.match(/const USAGE = `((?:\\[\s\S]|[^`])*)`/);
   return match ? match[1]! : "";
 }
 

--- a/scripts/lint-cli-readme.ts
+++ b/scripts/lint-cli-readme.ts
@@ -16,89 +16,104 @@ import { join } from "path";
 const root = join(import.meta.dir, "..");
 
 // ---------------------------------------------------------------------------
-// Parse USAGE constant from src/index.ts
+// Pure helpers (exported for unit testing)
 // ---------------------------------------------------------------------------
 
-const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+// Extract the contents of `const USAGE = \`...\`` as opaque text. Returns the
+// string between the opening and closing backticks (or "" if not found).
+//
+// We use a backtick-aware match rather than scanning for the next `;` because
+// the template literal body contains parenthetical semicolons (e.g.
+// "cluster.machines);") that would otherwise truncate the block.
+export function extractUsageBlock(source: string): string {
+  const match = source.match(/const USAGE = `([\s\S]*?)`/);
+  return match ? match[1]! : "";
+}
 
-// Collect every top-level command word that appears at the start of a USAGE
-// line (after leading whitespace), before any space or end-of-line.
-// The USAGE block looks like:  "  slots ...", "  slot <n> ..."  etc.
-const usageStart = indexSrc.indexOf("const USAGE =");
-const usageEnd = indexSrc.indexOf(";", usageStart + "const USAGE =".length);
-const usageBlock = usageStart !== -1 && usageEnd !== -1
-  ? indexSrc.slice(usageStart, usageEnd)
-  : "";
-
-// Extract top-level command names: lines like "  word ..." or "  word\n"
+// Top-level command names: lines like "  word ..." or "  word\n".
 const usageCommandPattern = /^\s{1,4}([a-z][\w-]*)\b/gm;
-const usageCommands = new Set<string>();
-let m: RegExpExecArray | null;
-while ((m = usageCommandPattern.exec(usageBlock)) !== null) {
-  usageCommands.add(m[1]!);
+
+export function extractUsageCommands(source: string): Set<string> {
+  const block = extractUsageBlock(source);
+  const commands = new Set<string>();
+  let m: RegExpExecArray | null;
+  usageCommandPattern.lastIndex = 0;
+  while ((m = usageCommandPattern.exec(block)) !== null) {
+    commands.add(m[1]!);
+  }
+  return commands;
 }
 
-// ---------------------------------------------------------------------------
-// Parse README CLI Reference section
-// ---------------------------------------------------------------------------
+// Slice out the `## CLI Reference` section (up to the next `## ` heading).
+export function extractCliReferenceSection(readme: string): string {
+  const start = readme.indexOf("## CLI Reference");
+  if (start === -1) return "";
+  const next = readme.indexOf("\n## ", start + 1);
+  return readme.slice(start, next !== -1 ? next : undefined);
+}
 
-const readmeSrc = readFileSync(join(root, "README.md"), "utf-8");
-
-// Find the "## CLI Reference" section and collect until the next "## " heading.
-const cliRefStart = readmeSrc.indexOf("## CLI Reference");
-const nextSection = readmeSrc.indexOf("\n## ", cliRefStart + 1);
-const cliBlock = cliRefStart !== -1
-  ? readmeSrc.slice(cliRefStart, nextSection !== -1 ? nextSection : undefined)
-  : "";
-
-// Extract command names from code-fence lines: "ludics <command> ..."
+// Command names from code-fence lines: "ludics <command> ...".
 const readmeCommandPattern = /^ludics\s+([a-z][\w-]*)\b/gm;
-const readmeCommands = new Set<string>();
-while ((m = readmeCommandPattern.exec(cliBlock)) !== null) {
-  readmeCommands.add(m[1]!);
+
+export function extractReadmeCommands(readme: string): Set<string> {
+  const block = extractCliReferenceSection(readme);
+  const commands = new Set<string>();
+  let m: RegExpExecArray | null;
+  readmeCommandPattern.lastIndex = 0;
+  while ((m = readmeCommandPattern.exec(block)) !== null) {
+    commands.add(m[1]!);
+  }
+  return commands;
+}
+
+export interface LintResult {
+  stale: string[];
+  undocumented: string[];
+}
+
+export function lintCliReadme(indexSrc: string, readmeSrc: string): LintResult {
+  const usageCommands = extractUsageCommands(indexSrc);
+  const readmeCommands = extractReadmeCommands(readmeSrc);
+
+  const stale: string[] = [];
+  for (const cmd of readmeCommands) {
+    if (!usageCommands.has(cmd)) stale.push(cmd);
+  }
+  const undocumented: string[] = [];
+  for (const cmd of usageCommands) {
+    if (!readmeCommands.has(cmd)) undocumented.push(cmd);
+  }
+  return { stale, undocumented };
 }
 
 // ---------------------------------------------------------------------------
-// Report
+// CLI entry point
 // ---------------------------------------------------------------------------
 
-let errors = 0;
+if (import.meta.main) {
+  const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+  const readmeSrc = readFileSync(join(root, "README.md"), "utf-8");
+  const { stale, undocumented } = lintCliReadme(indexSrc, readmeSrc);
 
-// Stale docs: README mentions a command not in USAGE  (error — docs are wrong)
-const stale: string[] = [];
-for (const cmd of readmeCommands) {
-  if (!usageCommands.has(cmd)) {
-    stale.push(cmd);
-    errors++;
+  if (stale.length > 0) {
+    console.error(`\n❌  README CLI Reference contains commands not found in USAGE (stale docs):`);
+    for (const cmd of stale) {
+      console.error(`     - ${cmd}`);
+    }
   }
-}
 
-// Undocumented: USAGE has a command not in README  (warning — just FYI)
-const undocumented: string[] = [];
-for (const cmd of usageCommands) {
-  if (!readmeCommands.has(cmd)) {
-    undocumented.push(cmd);
+  if (undocumented.length > 0) {
+    console.warn(`\n⚠️   USAGE commands not documented in README (undocumented — warnings only):`);
+    for (const cmd of undocumented) {
+      console.warn(`     - ${cmd}`);
+    }
   }
-}
 
-if (stale.length > 0) {
-  console.error(`\n❌  README CLI Reference contains commands not found in USAGE (stale docs):`);
-  for (const cmd of stale) {
-    console.error(`     - ${cmd}`);
+  if (stale.length === 0 && undocumented.length === 0) {
+    console.log("✅  CLI Reference is in sync with USAGE.");
+  } else if (stale.length === 0) {
+    console.log("✅  No stale docs found (some commands are undocumented — see warnings above).");
   }
-}
 
-if (undocumented.length > 0) {
-  console.warn(`\n⚠️   USAGE commands not documented in README (undocumented — warnings only):`);
-  for (const cmd of undocumented) {
-    console.warn(`     - ${cmd}`);
-  }
+  process.exit(stale.length > 0 ? 1 : 0);
 }
-
-if (errors === 0 && undocumented.length === 0) {
-  console.log("✅  CLI Reference is in sync with USAGE.");
-} else if (errors === 0) {
-  console.log("✅  No stale docs found (some commands are undocumented — see warnings above).");
-}
-
-process.exit(errors > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Fixes `bun run lint:cli-readme` so it stops falsely flagging 12 commands (`tasks`, `flow`, `orch`, `notify`, `mag`, `status`, `briefing`, `init`, `stop`, `triggers`, `doctor`, `help`) as "stale docs" on every PR.
- Replaces the `;`-based template-literal end-delimiter lookup with a backtick-aware regex; factors parsing into pure exported helpers gated behind `if (import.meta.main)`.
- Adds `scripts/lint-cli-readme.test.ts` covering the regression (semicolon inside the USAGE body), drift detection, escaped-backtick handling, and the real repo's USAGE + README pair.

## Root cause

`USAGE` in `src/index.ts` is a backtick template literal. The extractor used `indexOf(";")` to find the end-of-block, but the body contains `cluster.machines);` inside a `slot <n>` description. That truncated the parsed block to ~7 lines, so only `slot` / `slots` were recognized; every other top-level command was silently dropped and falsely reported as stale.

## Commits

- `3c8995f` — backtick-aware extractor; factored helpers; initial regression tests.
- `1e09816` — extend the body pattern to skip escaped backticks (`\``), so a future inline `\`--flag\`` in USAGE can't truncate the block early. Codex review follow-up.

## Test plan

- [x] `bun run lint:cli-readme` exits 0
- [x] `bun test scripts/` (169 tests pass, including 10 new ones in `lint-cli-readme.test.ts`)
- [x] `bun run typecheck` clean
- [x] No edits to `README.md` or `src/index.ts` USAGE

Proposal: `docs/proposals/fix-lint-cli-readme-template-literal-parser.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)