### PR TITLE
refactor(pid-probes): route remaining 6 aliveness probes through processAlive

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1172,7 +1172,7 @@ export function dashboardStop(): void {
     // Wait for processes to die, escalate to SIGKILL
     const deadline = Date.now() + 3000;
     while (Date.now() < deadline) {
-      const alive = targetPids.filter((p) => { try { process.kill(p, 0); return true; } catch { return false; } });
+      const alive = targetPids.filter(processAlive);
       if (alive.length === 0) break;
       Bun.sleepSync(100);
     }

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -29,7 +29,7 @@ import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 import { agentPortRole, readTmuxSlotState, startTtyd, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
-import { readSlotState } from "../t3code/server.ts";
+import { readSlotState, processAlive } from "../t3code/server.ts";
 
 // --- Hung agent detection constants ---
 // A "hung agent" appears to be working (lifecycle running/dispatched) but the
@@ -673,10 +673,7 @@ async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
     const pid = tmuxState.ttydPids[agent.name];
 
     // Check if PID is alive
-    let alive = false;
-    if (pid) {
-      try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
-    }
+    const alive = pid ? processAlive(pid) : false;
     if (alive) continue;
 
     // Dead or missing — restart

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1172,13 +1172,13 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
 
     if (tmuxState?.orchestration?.pid) {
       const pid = tmuxState.orchestration.pid;
-      let alive = false;
-      try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
-      if (alive) {
+      if (processAlive(pid)) {
         console.error(`ludics: terminating stale orchestration runner (pid ${pid}) before resume`);
         try { process.kill(pid, "SIGTERM"); } catch { /* ignore */ }
         await new Promise((resolve) => setTimeout(resolve, 500));
-        try { process.kill(pid, 0); process.kill(pid, "SIGKILL"); } catch { /* dead */ }
+        if (processAlive(pid)) {
+          try { process.kill(pid, "SIGKILL"); } catch { /* race: died between check and kill */ }
+        }
       }
     }
 
@@ -1251,13 +1251,13 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
     const slotState = readSlotState(slotNum, ctx.harnessDir)!;
     if (slotState.orchestration?.pid) {
       const pid = slotState.orchestration.pid;
-      let alive = false;
-      try { process.kill(pid, 0); alive = true; } catch { /* dead */ }
-      if (alive) {
+      if (processAlive(pid)) {
         console.error(`ludics: terminating stale orchestration runner (pid ${pid}) before resume`);
         try { process.kill(pid, "SIGTERM"); } catch { /* ignore */ }
         await new Promise((resolve) => setTimeout(resolve, 500));
-        try { process.kill(pid, 0); process.kill(pid, "SIGKILL"); } catch { /* dead */ }
+        if (processAlive(pid)) {
+          try { process.kill(pid, "SIGKILL"); } catch { /* race: died between check and kill */ }
+        }
       }
     }
   }

--- a/src/t3code/server.test.ts
+++ b/src/t3code/server.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { spawnSync } from "child_process";
 import { commandLineMatchesServerRecord, processAlive, readServerRecord } from "./server.ts";
 import type { T3CodeServerRecord } from "./types.ts";
 
@@ -141,14 +140,11 @@ describe("processAlive", () => {
     expect(processAlive(Number.NaN)).toBe(false);
   });
 
-  test("returns false for a pid whose process has exited", () => {
-    // Spawn a short-lived child and wait for it to exit synchronously.
-    const r = spawnSync("/bin/sh", ["-c", "echo $$"], { encoding: "utf8" });
-    expect(r.status).toBe(0);
-    const deadPid = Number((r.stdout ?? "").trim());
-    expect(Number.isInteger(deadPid)).toBe(true);
-    expect(deadPid).toBeGreaterThan(0);
-    // The shell has already exited by the time spawnSync returns.
-    expect(processAlive(deadPid)).toBe(false);
+  test("returns false for a pid that cannot exist on any reasonable kernel", () => {
+    // INT32_MAX is far above Linux's pid_max (~2^22) and macOS's kern.maxproc
+    // (~10^5), so kill(2) returns ESRCH (or EINVAL on some kernels) and
+    // processAlive catches it. Using a sentinel pid avoids the PID-reuse race
+    // a freshly-exited spawnSync child would have on busy CI hosts.
+    expect(processAlive(2147483647)).toBe(false);
   });
 });

--- a/src/t3code/server.test.ts
+++ b/src/t3code/server.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { commandLineMatchesServerRecord, readServerRecord } from "./server.ts";
+import { spawnSync } from "child_process";
+import { commandLineMatchesServerRecord, processAlive, readServerRecord } from "./server.ts";
 import type { T3CodeServerRecord } from "./types.ts";
 
 function makeRecord(overrides: Partial<T3CodeServerRecord> = {}): T3CodeServerRecord {
@@ -125,5 +126,29 @@ describe("readServerRecord", () => {
     expect(readServerRecord(tmpDir)).toBeNull();
 
     rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("processAlive", () => {
+  test("returns true for the current process", () => {
+    expect(processAlive(process.pid)).toBe(true);
+  });
+
+  test("returns false for invalid pids without throwing", () => {
+    expect(processAlive(0)).toBe(false);
+    expect(processAlive(-1)).toBe(false);
+    expect(processAlive(1.5)).toBe(false);
+    expect(processAlive(Number.NaN)).toBe(false);
+  });
+
+  test("returns false for a pid whose process has exited", () => {
+    // Spawn a short-lived child and wait for it to exit synchronously.
+    const r = spawnSync("/bin/sh", ["-c", "echo $$"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    const deadPid = Number((r.stdout ?? "").trim());
+    expect(Number.isInteger(deadPid)).toBe(true);
+    expect(deadPid).toBeGreaterThan(0);
+    // The shell has already exited by the time spawnSync returns.
+    expect(processAlive(deadPid)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Migrates the six documented `try { process.kill(pid, 0) } catch` aliveness probes in `src/slots/index.ts` (4 sites), `src/orchestration/runner.ts` (1 site), and `src/dashboard.ts` (1 site) to the existing `processAlive` helper from `src/t3code/server.ts` — completing the cleanup begun in task-d55e5398.
- Preserves the two paired-SIGKILL guard sites' swallow-if-already-dead semantics by wrapping the SIGKILL in its own `try { … } catch { /* race */ }` after `if (processAlive(pid))`. All actual `SIGTERM`/`SIGKILL` signal sends remain `process.kill`.
- Adds three unit tests for `processAlive` itself (current pid, invalid pids, INT32_MAX sentinel for the unreachable-pid case) so the helper's semantics are pinned for future refactors.

Out-of-scope aliveness probes in `mag.ts`, `queue.ts`, and the adapters remain untouched per the proposal.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` — 1601 pass / 0 fail (3 new processAlive tests)
- [x] `grep -rn 'process.kill(.*\b0\b' src/` — only `processAlive` body and explicitly out-of-scope files remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)