### PR TITLE
fix(orchestration): auto-recover orphan worktree dirs in addWorktree + deferred cleanup

### DIFF
--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -311,6 +311,52 @@ describe("processDeferredCleanups orphan-dir hardening (task-d2a16a60)", () => {
     expect(loadDeferredCleanups()).toHaveLength(0);
   });
 
+  // Regression for P1 reviewer comment on PR #435: a corrupted cleanup manifest
+  // could list a path whose basename is NOT the canonical orchestration shape but
+  // whose contents happen to be allow-list-only (e.g. a stray
+  // ~/Code/some-project/node_modules left in a manifest). Both `removeWorktreeByPath`
+  // and `purgeOrphanDirIfRecoverable` apply the same orchestration-name guard, so
+  // neither path can wipe the directory.
+  test("refuses to purge a manifest path whose basename does not match orchestration naming", async () => {
+    if (!Bun.which("git")) return;
+    const projectDir = join(tmpDir, "proj-orphan-corrupt");
+    initBareRepo(projectDir);
+    // Sibling path with allow-list-only contents but basename "user-data" — not a
+    // canonical {repoName}-{taskSlug}(-s{N})? shape.
+    const strayPath = join(dirname(projectDir), "user-data");
+    mkdirSync(join(strayPath, ".peer-sync"), { recursive: true });
+    writeFileSync(join(strayPath, ".peer-sync", "x"), "user content\n");
+    writeFileSync(join(strayPath, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
+
+    recordDeferredCleanup(makeEntry({
+      timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+      projectDir,
+      taskId: "task-corrupt",
+      slot: 1,
+      worktreePaths: [strayPath],
+      branches: [],
+      tmuxSessionNames: [],
+      peerSyncLink: null,
+    }));
+
+    const origErr = console.error;
+    const captured: string[] = [];
+    console.error = (...args: unknown[]) => { captured.push(args.map((a) => String(a)).join(" ")); };
+    try {
+      await processDeferredCleanups(25);
+    } finally {
+      console.error = origErr;
+    }
+
+    // Stray dir contents preserved — neither removal path touched them.
+    expect(existsSync(join(strayPath, ".peer-sync", "x"))).toBe(true);
+    expect(existsSync(join(strayPath, ".ludics-orchestration.json"))).toBe(true);
+    // Both guard layers logged a refusal: removeWorktreeByPath ("refusing to remove worktree")
+    // and purgeOrphanDirIfRecoverable ("refusing to purge orphan dir").
+    expect(captured.some((w) => w.includes("refusing to remove worktree") && w.includes("user-data"))).toBe(true);
+    expect(captured.some((w) => w.includes("refusing to purge orphan dir") && w.includes("user-data"))).toBe(true);
+  });
+
   test("leaves dir intact and logs when contents are unrecognised; does NOT keep entry in manifest (best-effort)", async () => {
     if (!Bun.which("git")) return;
     const projectDir = join(tmpDir, "proj-orphan-stray");

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { cleanupDelayHours } from "../config.ts";
 import * as t3codeServer from "../t3code/server.ts";
 
@@ -254,6 +254,98 @@ describe("buildCleanupEntry", () => {
     const entry = buildCleanupEntry(orchState, 1);
     // Convention-derived root branch
     expect(entry.branches).toContain("ludics/test-task-1-s1/root");
+  });
+});
+
+// task-d2a16a60: cleanup-side hardening — when the worktree path still exists
+// after `removeWorktreeByPath` (because git lost the registration but the
+// scaffolding sat on disk), processDeferredCleanups must purge the allow-list
+// entries directly so the next slot start does not need the addWorktree
+// recovery branch.
+describe("processDeferredCleanups orphan-dir hardening (task-d2a16a60)", () => {
+  function initBareRepo(repo: string): void {
+    mkdirSync(repo, { recursive: true });
+    Bun.spawnSync(["git", "init", "-b", "main"], { cwd: repo });
+    Bun.spawnSync(["git", "config", "user.email", "test@example.com"], { cwd: repo });
+    Bun.spawnSync(["git", "config", "user.name", "Test User"], { cwd: repo });
+    writeFileSync(join(repo, "README.md"), "init\n");
+    Bun.spawnSync(["git", "add", "README.md"], { cwd: repo });
+    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repo });
+  }
+
+  test("purges an orphan worktree directory whose contents match the allow-list", async () => {
+    if (!Bun.which("git")) return;
+    // Real project + an orphan worktree dir at the canonical orchestration name.
+    // The dir contains allow-list scaffolding only, with no git registration.
+    const projectDir = join(tmpDir, "proj-orphan-cleanup");
+    initBareRepo(projectDir);
+    const repoName = "proj-orphan-cleanup";
+    const slug = "task-orphan-cleanup";
+    const orphanPath = join(dirname(projectDir), `${repoName}-${slug}-s1`);
+    mkdirSync(join(orphanPath, ".peer-sync"), { recursive: true });
+    writeFileSync(join(orphanPath, ".peer-sync", "coder.status"), "stale\n");
+    mkdirSync(join(orphanPath, ".claude"), { recursive: true });
+    writeFileSync(join(orphanPath, ".claude", "settings.local.json"), "{}\n");
+    writeFileSync(join(orphanPath, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
+
+    // Sanity: git does NOT know this path as a worktree (orphan condition).
+    const list = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], { cwd: projectDir }).stdout.toString();
+    expect(list).not.toContain(`worktree ${orphanPath}`);
+
+    recordDeferredCleanup(makeEntry({
+      timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+      projectDir,
+      taskId: slug,
+      slot: 1,
+      worktreePaths: [orphanPath],
+      branches: [],
+      tmuxSessionNames: [],
+      peerSyncLink: null,
+    }));
+
+    await processDeferredCleanups(25);
+
+    // Orphan dir is gone — the next slot start does not need addWorktree's recovery branch.
+    expect(existsSync(orphanPath)).toBe(false);
+    // Manifest was cleared (cleanup succeeded).
+    expect(loadDeferredCleanups()).toHaveLength(0);
+  });
+
+  test("leaves dir intact and logs when contents are unrecognised; does NOT keep entry in manifest (best-effort)", async () => {
+    if (!Bun.which("git")) return;
+    const projectDir = join(tmpDir, "proj-orphan-stray");
+    initBareRepo(projectDir);
+    const repoName = "proj-orphan-stray";
+    const slug = "task-orphan-stray";
+    const orphanPath = join(dirname(projectDir), `${repoName}-${slug}-s1`);
+    mkdirSync(orphanPath, { recursive: true });
+    writeFileSync(join(orphanPath, "user-WIP.txt"), "important\n");
+
+    recordDeferredCleanup(makeEntry({
+      timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+      projectDir,
+      taskId: slug,
+      slot: 1,
+      worktreePaths: [orphanPath],
+      branches: [],
+      tmuxSessionNames: [],
+      peerSyncLink: null,
+    }));
+
+    // Silence expected console.error about the deferred cleanup completing.
+    const origErr = console.error;
+    console.error = () => {};
+    try {
+      await processDeferredCleanups(25);
+    } finally {
+      console.error = origErr;
+    }
+
+    // Stray file is preserved — the purge fallback declined to touch it.
+    expect(existsSync(join(orphanPath, "user-WIP.txt"))).toBe(true);
+    // Best-effort: the entry is NOT pushed back into `remaining` because the
+    // purge fallback's classify-only failure does not flip `failed`.
+    expect(loadDeferredCleanups()).toHaveLength(0);
   });
 });
 

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -168,7 +168,7 @@ export async function processDeferredCleanups(
       // Best-effort: failures are logged inside `purgeOrphanDirIfRecoverable` and
       // do NOT push the entry back into `remaining`.
       try {
-        purgeOrphanDirIfRecoverable(path);
+        purgeOrphanDirIfRecoverable(entry.projectDir, path);
       } catch (err) {
         console.error(`ludics: orphan-dir purge fallback failed for ${path}:`, err);
       }

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -6,7 +6,7 @@ import { join } from "path";
 import { harnessDir as defaultHarnessDir, cleanupDelayHours } from "../config.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
-import { removeWorktreeByPath, deleteBranches, orchBranchName } from "./worktrees.ts";
+import { removeWorktreeByPath, deleteBranches, orchBranchName, purgeOrphanDirIfRecoverable } from "./worktrees.ts";
 import { removePeerSyncLink } from "./peer-sync.ts";
 
 export interface CleanupEntry {
@@ -160,6 +160,17 @@ export async function processDeferredCleanups(
       } catch (err) {
         console.error(`ludics: deferred worktree removal failed for ${path}:`, err);
         failed = true;
+      }
+      // Defense-in-depth: if `removeWorktreeByPath` no-op'd because git no longer
+      // registered the path (e.g. a prior `git worktree prune` swept the admin
+      // record but left scaffolding on disk), fall back to purging the orchestration
+      // entries so the next slot start does not need the inline recovery branch.
+      // Best-effort: failures are logged inside `purgeOrphanDirIfRecoverable` and
+      // do NOT push the entry back into `remaining`.
+      try {
+        purgeOrphanDirIfRecoverable(path);
+      } catch (err) {
+        console.error(`ludics: orphan-dir purge fallback failed for ${path}:`, err);
       }
     }
 

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1004,20 +1004,24 @@ describe("addWorktree orphan recovery", () => {
 describe("purgeOrphanDirIfRecoverable", () => {
   test("returns true and removes allow-list entries", () => {
     mkdirSync(TMP, { recursive: true });
-    const path = join(TMP, "purge-recoverable");
+    const projectDir = join(TMP, "myrepo");
+    mkdirSync(projectDir, { recursive: true });
+    const path = join(TMP, "myrepo-task-purge-s1");
     seedOrphanLayout(path);
 
-    expect(purgeOrphanDirIfRecoverable(path)).toBe(true);
+    expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(true);
     expect(existsSync(path)).toBe(false);
   });
 
   test("returns false and leaves dir intact when contents are unrecognised", () => {
     mkdirSync(TMP, { recursive: true });
-    const path = join(TMP, "purge-unrecognised");
+    const projectDir = join(TMP, "myrepo");
+    mkdirSync(projectDir, { recursive: true });
+    const path = join(TMP, "myrepo-task-unrec-s1");
     seedOrphanLayout(path, { withStray: { name: "user-notes.md", contents: "keep me\n" } });
 
     const warnings = captureConsoleError(() => {
-      expect(purgeOrphanDirIfRecoverable(path)).toBe(false);
+      expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
     });
     // No console.error from the purge itself — classify-only path is silent.
     expect(warnings).toHaveLength(0);
@@ -1025,7 +1029,50 @@ describe("purgeOrphanDirIfRecoverable", () => {
     expect(existsSync(join(path, ".peer-sync"))).toBe(true);
   });
 
-  test("returns true when path does not exist", () => {
-    expect(purgeOrphanDirIfRecoverable("/nonexistent/orphan-purge-xxxxx")).toBe(true);
+  test("returns true when path does not exist (and matches orchestration naming)", () => {
+    mkdirSync(TMP, { recursive: true });
+    const projectDir = join(TMP, "myrepo");
+    mkdirSync(projectDir, { recursive: true });
+    expect(purgeOrphanDirIfRecoverable(projectDir, join(TMP, "myrepo-task-noexist-s1"))).toBe(true);
+  });
+
+  // Regression for P1 reviewer comment: a corrupted cleanup manifest could list
+  // a path whose contents happen to be a subset of the allow-list (e.g. a user's
+  // ~/Code/myproject/node_modules) but whose basename is NOT the canonical
+  // orchestration worktree shape. The orchestration-name guard inside
+  // purgeOrphanDirIfRecoverable must refuse such paths even though their
+  // contents would otherwise classify as "recoverable".
+  test("refuses path whose basename does not match orchestration naming, even if contents are allow-list-only", () => {
+    mkdirSync(TMP, { recursive: true });
+    const projectDir = join(TMP, "myrepo");
+    mkdirSync(projectDir, { recursive: true });
+    // Path basename is "user-data" — not "{repoName}-{taskSlug}(-s{N})?(-{agent})?"
+    const path = join(TMP, "user-data");
+    seedOrphanLayout(path); // pure allow-list content
+
+    const warnings = captureConsoleError(() => {
+      expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
+    });
+    expect(warnings.some((w) => w.includes("refusing to purge") && w.includes("user-data"))).toBe(true);
+    // Contents preserved.
+    expect(existsSync(join(path, ".peer-sync", "coder.status"))).toBe(true);
+    expect(existsSync(join(path, ".claude"))).toBe(true);
+    expect(existsSync(join(path, ".ludics-orchestration.json"))).toBe(true);
+  });
+
+  test("refuses repo-prefixed non-task paths like backup or scratch (matches removeWorktreeByPath guard)", () => {
+    mkdirSync(TMP, { recursive: true });
+    const projectDir = join(TMP, "myrepo");
+    mkdirSync(projectDir, { recursive: true });
+    // "myrepo-backup" shares the prefix but the suffix "backup" is a single
+    // segment without a slot marker — same shape rejected by isOrchWorktreeSuffix.
+    const path = join(TMP, "myrepo-backup");
+    seedOrphanLayout(path);
+
+    const warnings = captureConsoleError(() => {
+      expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
+    });
+    expect(warnings.some((w) => w.includes("refusing to purge"))).toBe(true);
+    expect(existsSync(join(path, ".peer-sync"))).toBe(true);
   });
 });

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { autoCommitWorktree, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, orchBranchName, orchWorktreeStem, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, purgeOrphanDirIfRecoverable, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -839,5 +839,193 @@ describe("deleteBranches prefix guard", () => {
     expect(warnings.some((w) => w.includes("main") && w.includes("refusing"))).toBe(true);
     expect(warnings.some((w) => w.includes("feature-safe") && w.includes("refusing"))).toBe(true);
     expect(warnings.some((w) => w.includes("master") && w.includes("refusing"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphan-worktree recovery (task-d2a16a60)
+// ---------------------------------------------------------------------------
+
+/** Seed the parent dir of the orchestration root worktree with allow-list scaffolding,
+ *  simulating the state where a prior `git worktree prune` (or partial removal) left
+ *  the directory on disk while git no longer knows it as a registered worktree. */
+function seedOrphanLayout(orphanPath: string, options: {
+  withDsStore?: boolean;
+  withStray?: { name: string; contents: string };
+} = {}): void {
+  mkdirSync(orphanPath, { recursive: true });
+  mkdirSync(join(orphanPath, ".peer-sync"), { recursive: true });
+  writeFileSync(join(orphanPath, ".peer-sync", "coder.status"), "pending|0|seed\n");
+  mkdirSync(join(orphanPath, ".claude"), { recursive: true });
+  writeFileSync(join(orphanPath, ".claude", "settings.local.json"), '{"hooks":{}}\n');
+  writeFileSync(join(orphanPath, ".ludics-orchestration.json"), '{"agentName":"coder"}\n');
+  if (options.withDsStore) writeFileSync(join(orphanPath, ".DS_Store"), "macos-finder-noise\n");
+  if (options.withStray) writeFileSync(join(orphanPath, options.withStray.name), options.withStray.contents);
+}
+
+describe("classifyOrphanDir", () => {
+  test("recognises pure allow-list contents as recoverable", () => {
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "classify-recoverable");
+    seedOrphanLayout(path);
+
+    const result = classifyOrphanDir(path);
+    expect(result.kind).toBe("recoverable");
+    if (result.kind !== "recoverable") return;
+    expect(result.preserve.sort()).toEqual([".claude", ".ludics-orchestration.json", ".peer-sync"].sort());
+  });
+
+  test("flags any unrecognised entry, naming the offender", () => {
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "classify-unrecognised");
+    seedOrphanLayout(path, { withStray: { name: "user-notes.md", contents: "do not lose\n" } });
+
+    const result = classifyOrphanDir(path);
+    expect(result.kind).toBe("unrecognized");
+    if (result.kind !== "unrecognized") return;
+    expect(result.offending).toContain("user-notes.md");
+    // Stray file MUST remain on disk — the throw path is non-destructive.
+    expect(existsSync(join(path, "user-notes.md"))).toBe(true);
+  });
+
+  test("silently drops .DS_Store and still classifies as recoverable", () => {
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "classify-ds-store");
+    seedOrphanLayout(path, { withDsStore: true });
+
+    const result = classifyOrphanDir(path);
+    expect(result.kind).toBe("recoverable");
+    expect(existsSync(join(path, ".DS_Store"))).toBe(false);
+    // Allow-list entries unchanged
+    expect(existsSync(join(path, ".peer-sync", "coder.status"))).toBe(true);
+  });
+
+  test("does NOT include .DS_Store in the preserve list (allow-list constant carve-out)", () => {
+    expect(ORPHAN_RECOVERY_ALLOWLIST).not.toContain(".DS_Store");
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "classify-ds-only-no-recovery");
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, ".DS_Store"), "noise\n");
+
+    const result = classifyOrphanDir(path);
+    expect(result.kind).toBe("recoverable");
+    if (result.kind !== "recoverable") return;
+    // .DS_Store is silently dropped, never preserved
+    expect(result.preserve).toEqual([]);
+  });
+});
+
+describe("addWorktree orphan recovery", () => {
+  test("recovers an orphan dir whose contents match the allow-list", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "orphan-recover-ok");
+    initRepo(repo);
+
+    // Pre-seed the canonical root-worktree path with allow-list scaffolding.
+    const stem = orchWorktreeStem("orphan-recover-ok", "task-orphan", 1);
+    const orphanPath = join(dirname(repo), stem);
+    seedOrphanLayout(orphanPath);
+    // Assert pre-condition: dir exists, no git registration.
+    expect(existsSync(orphanPath)).toBe(true);
+    const preList = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(preList).not.toContain(`worktree ${orphanPath}`);
+
+    // createWorktrees calls addWorktree(repo, orphanPath, ...) under the hood.
+    const setup = createWorktrees(repo, "task-orphan", [{ name: "coder" }], "main", 1, "pair");
+
+    // Worktree is now registered with git.
+    expect(setup.rootWorktree).toBe(orphanPath);
+    const postList = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(postList).toContain(`worktree ${orphanPath}`);
+
+    // Orchestration entries restored with original contents.
+    expect(readFileSync(join(orphanPath, ".peer-sync", "coder.status"), "utf-8")).toBe("pending|0|seed\n");
+    expect(readFileSync(join(orphanPath, ".ludics-orchestration.json"), "utf-8")).toBe('{"agentName":"coder"}\n');
+    expect(readFileSync(join(orphanPath, ".claude", "settings.local.json"), "utf-8")).toBe('{"hooks":{}}\n');
+
+    // Recovery temp dir cleaned up.
+    expect(existsSync(`${orphanPath}.orphan-recover`)).toBe(false);
+
+    cleanupWorktrees(repo, "task-orphan", [{ name: "coder" }], 1, "pair");
+  });
+
+  test("throws clearer error and leaves dir untouched when stray content is present", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "orphan-recover-stray");
+    initRepo(repo);
+
+    const stem = orchWorktreeStem("orphan-recover-stray", "task-stray", 1);
+    const orphanPath = join(dirname(repo), stem);
+    seedOrphanLayout(orphanPath, { withStray: { name: "user-WIP.txt", contents: "important work\n" } });
+
+    expect(() =>
+      createWorktrees(repo, "task-stray", [{ name: "coder" }], "main", 1, "pair"),
+    ).toThrow(/orphan worktree-directory detected at .* with non-orchestration content \(.*user-WIP\.txt.*\); manual recovery needed/);
+
+    // Stray file must be untouched on disk and the worktree remains unregistered.
+    expect(existsSync(join(orphanPath, "user-WIP.txt"))).toBe(true);
+    expect(readFileSync(join(orphanPath, "user-WIP.txt"), "utf-8")).toBe("important work\n");
+    const postList = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(postList).not.toContain(`worktree ${orphanPath}`);
+    // Recovery temp dir was never created.
+    expect(existsSync(`${orphanPath}.orphan-recover`)).toBe(false);
+  });
+
+  test("recovery silently drops .DS_Store and still registers the worktree", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "orphan-recover-ds-store");
+    initRepo(repo);
+
+    const stem = orchWorktreeStem("orphan-recover-ds-store", "task-ds", 2);
+    const orphanPath = join(dirname(repo), stem);
+    seedOrphanLayout(orphanPath, { withDsStore: true });
+
+    const setup = createWorktrees(repo, "task-ds", [{ name: "coder" }], "main", 2, "pair");
+    expect(setup.rootWorktree).toBe(orphanPath);
+    expect(existsSync(join(orphanPath, ".DS_Store"))).toBe(false);
+    expect(existsSync(join(orphanPath, ".peer-sync", "coder.status"))).toBe(true);
+
+    cleanupWorktrees(repo, "task-ds", [{ name: "coder" }], 2, "pair");
+  });
+});
+
+describe("purgeOrphanDirIfRecoverable", () => {
+  test("returns true and removes allow-list entries", () => {
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "purge-recoverable");
+    seedOrphanLayout(path);
+
+    expect(purgeOrphanDirIfRecoverable(path)).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("returns false and leaves dir intact when contents are unrecognised", () => {
+    mkdirSync(TMP, { recursive: true });
+    const path = join(TMP, "purge-unrecognised");
+    seedOrphanLayout(path, { withStray: { name: "user-notes.md", contents: "keep me\n" } });
+
+    const warnings = captureConsoleError(() => {
+      expect(purgeOrphanDirIfRecoverable(path)).toBe(false);
+    });
+    // No console.error from the purge itself — classify-only path is silent.
+    expect(warnings).toHaveLength(0);
+    expect(existsSync(join(path, "user-notes.md"))).toBe(true);
+    expect(existsSync(join(path, ".peer-sync"))).toBe(true);
+  });
+
+  test("returns true when path does not exist", () => {
+    expect(purgeOrphanDirIfRecoverable("/nonexistent/orphan-purge-xxxxx")).toBe(true);
   });
 });

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -70,13 +70,32 @@ export function classifyOrphanDir(
   return { kind: "recoverable", preserve };
 }
 
-/** Best-effort cleanup of an orphan worktree directory: if `path` exists and its
- *  contents match {@link ORPHAN_RECOVERY_ALLOWLIST}, remove the orchestration
- *  entries and `rmdir` the parent so the next `addWorktree(path, ...)` does not
- *  need to enter the inline recovery branch. Returns `true` on successful purge
- *  (or if `path` did not exist), `false` if contents were unrecognized or any
- *  removal step failed. Does not throw — failures are logged via `console.error`. */
-export function purgeOrphanDirIfRecoverable(path: string): boolean {
+/** Best-effort cleanup of an orphan worktree directory: if `path` exists, its
+ *  basename matches the orchestration worktree naming pattern relative to
+ *  `projectDir`, AND its contents match {@link ORPHAN_RECOVERY_ALLOWLIST},
+ *  remove the orchestration entries and `rmdir` the parent so the next
+ *  `addWorktree(path, ...)` does not need to enter the inline recovery branch.
+ *
+ *  Returns `true` on successful purge (or if `path` did not exist), `false` if
+ *  the path failed the orchestration-name guard, contents were unrecognized,
+ *  or any removal step failed. Does not throw — failures are logged via
+ *  `console.error`.
+ *
+ *  The orchestration-name guard mirrors {@link removeWorktreeByPath}'s safety
+ *  constraint: this is a destructive operation, and a corrupted or malicious
+ *  cleanup manifest could otherwise list arbitrary paths whose contents
+ *  happen to be a subset of the allow-list (e.g. a user's `node_modules` or
+ *  `.claude` directory) and have them silently wiped. The guard is enforced
+ *  inside the function rather than at the call site so it cannot be bypassed
+ *  by future callers. */
+export function purgeOrphanDirIfRecoverable(projectDir: string, path: string): boolean {
+  const repoName = basename(resolve(projectDir));
+  const base = basename(path);
+  const prefix = repoName + "-";
+  if (!base.startsWith(prefix) || !isOrchWorktreeSuffix(base.slice(prefix.length))) {
+    console.error(`ludics: refusing to purge orphan dir "${path}" — does not match orchestration naming`);
+    return false;
+  }
   if (!existsSync(path)) return true;
   let classification: ReturnType<typeof classifyOrphanDir>;
   try {

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, rmSync, rmdirSync, symlinkSync, writeFileSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { PEER_SYNC_DIRNAME, peerSyncPath } from "./peer-sync.ts";
 import { slugify } from "./util.ts";
@@ -31,6 +31,72 @@ export const GIT_EXCLUDE_ENTRIES = [
   "node_modules",
   "_build_review*",
 ];
+
+/** Entries the orchestrator may write into a worktree root before any agent commits.
+ *  Used by the orphan-recovery path in {@link addWorktree} and the cleanup-hardening
+ *  path in `processDeferredCleanups`. Narrower than {@link GIT_EXCLUDE_ENTRIES} —
+ *  excludes `.agents`, `.agent-sessions`, and `_build_review*` (agent work-product
+ *  or sibling targets), so the presence of any of those means the dir contains
+ *  real work and recovery must NOT proceed silently. */
+export const ORPHAN_RECOVERY_ALLOWLIST = [
+  PEER_SYNC_DIRNAME,
+  ".claude",
+  ".ludics-orchestration.json",
+  "node_modules",
+] as const;
+
+/** Classify the contents of a directory at `path` for orphan-recovery purposes.
+ *  Returns `recoverable` with the entries to preserve when contents are a subset
+ *  of {@link ORPHAN_RECOVERY_ALLOWLIST} (after silently dropping `.DS_Store` noise),
+ *  or `unrecognized` with the offending entries otherwise. `.DS_Store` is treated
+ *  as silently-removable noise but does NOT count toward `preserve`. */
+export function classifyOrphanDir(
+  path: string,
+): { kind: "recoverable"; preserve: string[] } | { kind: "unrecognized"; offending: string[] } {
+  const entries = readdirSync(path);
+  const allowlist = new Set<string>(ORPHAN_RECOVERY_ALLOWLIST);
+  const preserve: string[] = [];
+  const offending: string[] = [];
+  let dropDsStore = false;
+  for (const entry of entries) {
+    if (entry === ".DS_Store") { dropDsStore = true; continue; }
+    if (allowlist.has(entry)) preserve.push(entry);
+    else offending.push(entry);
+  }
+  if (offending.length > 0) return { kind: "unrecognized", offending };
+  if (dropDsStore) {
+    try { rmSync(join(path, ".DS_Store"), { force: true }); } catch { /* best-effort */ }
+  }
+  return { kind: "recoverable", preserve };
+}
+
+/** Best-effort cleanup of an orphan worktree directory: if `path` exists and its
+ *  contents match {@link ORPHAN_RECOVERY_ALLOWLIST}, remove the orchestration
+ *  entries and `rmdir` the parent so the next `addWorktree(path, ...)` does not
+ *  need to enter the inline recovery branch. Returns `true` on successful purge
+ *  (or if `path` did not exist), `false` if contents were unrecognized or any
+ *  removal step failed. Does not throw — failures are logged via `console.error`. */
+export function purgeOrphanDirIfRecoverable(path: string): boolean {
+  if (!existsSync(path)) return true;
+  let classification: ReturnType<typeof classifyOrphanDir>;
+  try {
+    classification = classifyOrphanDir(path);
+  } catch (err) {
+    console.error(`ludics: orphan-dir purge failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+  if (classification.kind === "unrecognized") return false;
+  try {
+    for (const entry of classification.preserve) {
+      rmSync(join(path, entry), { recursive: true, force: true });
+    }
+    rmdirSync(path);
+    return true;
+  } catch (err) {
+    console.error(`ludics: orphan-dir purge failed at ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
 
 /** Subset of {@link GIT_EXCLUDE_ENTRIES} that is unambiguously orchestration-internal —
  *  safe to proactively `git rm --cached` from the index so these paths do not enter
@@ -205,18 +271,66 @@ export function deleteBranches(projectDir: string, branches: string[]): void {
 
 function addWorktree(projectDir: string, path: string, branch: string, base: string): void {
   removeIfRegistered(projectDir, path);
+
+  // Orphan recovery: directory exists but git no longer registers it as a worktree
+  // (typically because `git worktree prune` swept the admin record while the
+  // scaffolding remained on disk). Move the orchestration entries aside, recreate
+  // the worktree via `git worktree add`, then move the entries back into place.
+  let recoveredEntries: string[] | null = null;
+  let tempDir: string | null = null;
   if (existsSync(path)) {
-    throw new Error(`refusing to reuse non-worktree path: ${path}`);
+    const c = classifyOrphanDir(path);
+    if (c.kind === "unrecognized") {
+      throw new Error(
+        `orphan worktree-directory detected at ${path} with non-orchestration content (${c.offending.join(", ")}); manual recovery needed`,
+      );
+    }
+    tempDir = `${path}.orphan-recover`;
+    if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+    mkdirSync(tempDir, { recursive: true });
+    for (const entry of c.preserve) {
+      renameSync(join(path, entry), join(tempDir, entry));
+    }
+    rmdirSync(path);
+    recoveredEntries = c.preserve;
   }
+
   const branchExists = safeSyncOutput(
     ["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
     { cwd: projectDir },
   ).ok;
-  if (branchExists) {
-    runGit(projectDir, ["worktree", "add", path, branch]);
-  } else {
-    runGit(projectDir, ["worktree", "add", "-b", branch, path, base]);
+  try {
+    if (branchExists) {
+      runGit(projectDir, ["worktree", "add", path, branch]);
+    } else {
+      runGit(projectDir, ["worktree", "add", "-b", branch, path, base]);
+    }
+  } catch (err) {
+    if (tempDir && existsSync(tempDir)) {
+      console.error(
+        `ludics: orphan recovery aborted for ${path}; preserved orchestration entries remain at ${tempDir}`,
+      );
+    }
+    throw err;
   }
+
+  if (recoveredEntries && tempDir) {
+    for (const entry of recoveredEntries) {
+      const target = join(path, entry);
+      if (existsSync(target) || lstatExistsLink(target)) {
+        rmSync(target, { recursive: true, force: true });
+      }
+      renameSync(join(tempDir, entry), target);
+    }
+    try { rmdirSync(tempDir); } catch { /* leftover noise — leave for operator */ }
+  }
+}
+
+/** `existsSync` follows symlinks, so a dangling symlink at `target` reports false
+ *  and a subsequent `renameSync(...)` would fail with EEXIST. Detect link presence
+ *  via `lstatSync` so we can pre-remove dangling links before moving entries back. */
+function lstatExistsLink(target: string): boolean {
+  try { return lstatSync(target).isSymbolicLink(); } catch { return false; }
 }
 
 export function defaultMainBranch(projectDir: string): string {


### PR DESCRIPTION
## Summary

Closes the recurring "orphan worktree directory" failure mode where `<repo>-<task>(-s<slot>)/` exists on disk but git no longer registers it as a worktree, blocking the next `slot start` with `fatal: refusing to reuse non-worktree path: ...` and forcing manual recovery.

- **`addWorktree` orphan recovery** (`src/orchestration/worktrees.ts`): when the path exists but `worktreeExists` is false, classify contents against `ORPHAN_RECOVERY_ALLOWLIST` (`.peer-sync`, `.claude`, `.ludics-orchestration.json`, `node_modules`). If the dir is allow-list-only (with optional silent-`rm` of `.DS_Store`), move entries to `${path}.orphan-recover`, run `git worktree add`, then move them back. Otherwise throw a clearer error naming the offending entries: `orphan worktree-directory detected at ${path} with non-orchestration content (${list}); manual recovery needed`.
- **Deferred-cleanup hardening** (`src/orchestration/deferred-cleanup.ts`): after each `removeWorktreeByPath`, call `purgeOrphanDirIfRecoverable(projectDir, path)` so a directory left behind by `git worktree remove --force` (when git already lost the registration) is wiped before the next slot start needs the inline recovery branch. Best-effort: failures log via `console.error` and do not push the entry back into the manifest.
- **Orchestration-name guard inside the purge** (`347cfe6`, addressing P1 reviewer comment): `purgeOrphanDirIfRecoverable` itself enforces the same `{repoName}-{taskSlug}(-s{N})?(-{agentSlug})?` shape that `removeWorktreeByPath` requires, so a corrupted or malicious `cleanup-pending.json` listing an arbitrary directory whose contents happen to match the allow-list (e.g. a user's `~/Code/myproject/node_modules`) cannot be wiped. Defense-in-depth — the guard cannot be bypassed by future callers.
- Allow-list constant and helpers (`classifyOrphanDir`, `purgeOrphanDirIfRecoverable`) live once in `worktrees.ts` and are imported by `deferred-cleanup.ts`.

## Commits

- `19e7030` — `fix(orchestration): auto-recover orphan worktree dirs in addWorktree + deferred cleanup`
- `347cfe6` — `fix(orchestration): apply orchestration-name guard inside purgeOrphanDirIfRecoverable` (P1 reviewer follow-up)

## Test plan

- [x] `bun test src/orchestration/worktrees.test.ts` — 56 pass (covers recoverable / unrecognised / `.DS_Store` branches in `addWorktree`, plus `classifyOrphanDir` and `purgeOrphanDirIfRecoverable` direct coverage including the orchestration-name guard refusal cases)
- [x] `bun test src/orchestration/deferred-cleanup.test.ts` — 27 pass (covers the hardening path + corrupted-manifest regression where both guards refuse a non-canonical basename)
- [x] `bun test` — 1629 pass / 0 fail
- [x] `bun run build` — compiles cleanly
- [x] `bun run lint` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)