### PR TITLE
container tasks: exclude from queues + auto-completion-check on subtask resolve

### DIFF
--- a/docs/task-frontmatter-reference.md
+++ b/docs/task-frontmatter-reference.md
@@ -74,3 +74,25 @@ The `skip_plan: true` frontmatter flag is only consulted at `medium` effort:
 ### Notes on extension
 
 The four levels above describe today's scale. Nothing in the model precludes a future `huge` or `epic` level if a class of work emerges that genuinely needs a different orchestration shape; the framing here is descriptive rather than normative. New levels would need corresponding entries in the dashboard validation allowlist, the `selectOrchestrationFlags` mapping, and this section.
+
+## `leaf` (container marker)
+
+Type: `boolean | undefined`. Default: `undefined` (treated as a leaf task).
+
+Set to `false` by `/ludics-split-task` when a task is decomposed into children via `subtask_of`. Indicates the task is a **container** — its work has been split and the parent itself has no actionable deliverable.
+
+**Effect on automation**:
+
+- `getSortedReadyCandidates` in `src/mag.ts` skips `leaf: false` entries, which automatically suppresses container tasks from `maybeFillEmptySlots`, `maybeQueueProposals`, and dashboard-generation consumers.
+- `tasksNeedsElaborationList` and `tasksQueuePreemptions` in `src/tasks/sync.ts` apply symmetric filters, so containers are never auto-queued for elaboration or preemption.
+- `slotAssign` in `src/slots/index.ts` throws before any slot mutation when the resolved task has `leaf: false` — assign a child instead.
+- `/ludics-elaborate` and `/ludics-draft-proposal` short-circuit on `leaf: false`: append a single deduped Notes line `Skipped: container task — work split into children` and exit without worker delegation.
+- Flow views and dashboard surfaces are intentionally **not** filtered, so containers remain visible for orphan-detection.
+
+**Container completion trigger**: the sweep in `tasksReconcileBlockedStatus` watches every `leaf: false` parent. When all children (via `subtask_of`) reach `done`/`abandoned`, it enqueues `/ludics-verify-container-completion <parent-id>`. Debounce details:
+
+- A 6-hour freshness sentinel under `mag/container-completion-checked/<parent-id>.epoch` suppresses re-fire while the child set is unchanged.
+- A `.children` sidecar records the sorted child-id+status fingerprint at last enqueue. The sweep clears the sentinel whenever the current fingerprint differs — covering both child reopen and newly-added child cases (including newly-added but already-terminal children).
+- `queueHasPendingActionForTask("verify-container-completion", parentId)` is the secondary dedupe while a request is unprocessed.
+
+The verify skill summarizes children, files `needs-confirmation` follow-ups for residual ambiguity (the dashboard's existing surface picks them up via `/api/tasks/<id>/confirm` and `/dismiss`), and notifies the user via `ludics notify outgoing`. **The parent's status transition stays user-driven** — the harness never auto-closes a container.

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -66,6 +66,20 @@ questions from elaboration — skip the proposal:
 - Write result JSON with `"status": "blocked"` and `"unanswered questions"`.
 - Don't delegate to the worker; Mag's nag loop reminds the user to answer.
 
+### Container short-circuit
+
+If the task's frontmatter has `leaf: false`, the work has already been split
+into subtasks and drafting a proposal for the parent is a no-op. Before any
+worker delegation:
+
+1. Use the `Edit` tool to append a single line to the task's `## Notes`
+   section: `Skipped: container task — work split into children`. The shared
+   `appendToSection` helper dedupes — repeated stale queue items do not stack.
+2. Write a result JSON with `"status": "skipped-container"` and the parent's
+   id, then exit. **Do not invoke the worker, and do not write a proposal
+   file.**
+3. The queue-pop layer drops this request rather than re-queueing.
+
 <!-- section:status-routing -->
 ## Status routing
 

--- a/skills/ludics-elaborate.md
+++ b/skills/ludics-elaborate.md
@@ -36,6 +36,20 @@ Follow [orchestrator-conventions.md](orchestrator-conventions.md):
 - **E** (Result JSON): write the result with the request ID.
 - **F** (Error Handling): standard patterns.
 
+### Container short-circuit (before Step D)
+
+If the task's frontmatter has `leaf: false`, the work has already been split
+into subtasks and elaborating the parent is a no-op. After Step A, before
+worker delegation:
+
+1. Use the `Edit` tool to append a single line to the task's `## Notes`
+   section: `Skipped: container task — work split into children`.
+   The shared `appendToSection` helper dedupes (skips if the exact line is
+   already present), so repeated stale queue items do not stack.
+2. Write a result JSON with `"status": "skipped-container"` and the parent's
+   id, then exit. **Do not invoke the worker.**
+3. The queue-pop layer drops this request rather than re-queueing.
+
 Worker: `/ludics-elaborate-worker <task_id> <project_path> <context_brief>`
 
 ## Status routing

--- a/skills/ludics-verify-container-completion.md
+++ b/skills/ludics-verify-container-completion.md
@@ -51,13 +51,12 @@ inline.
    - Capture the parent's `title` and `project` for the notify summary.
 
 2. **Enumerate children** by scanning every `*.md` file under
-   `$LUDICS_STATE_PATH/tasks/` whose frontmatter has
-   `dependencies.subtask_of == <parent_id>`. Use `parseTaskFrontmatter` via
-   the harness CLI (`ludics tasks list --json` exists; otherwise read files
-   directly with the standard `Read` tool — keep the work in this orchestrator
-   turn). For each child, record `id`, `status`, and a one-line outcome
-   summary by reading the child's `## Notes` section and trimming to a single
-   line (or fall back to `(no notes)`).
+   `$LUDICS_STATE_PATH/tasks/` with the standard `Read` / `Glob` tools.
+   Inspect each file's YAML frontmatter and keep the ones whose
+   `dependencies.subtask_of` equals `<parent_id>`. For each match, record
+   the `id`, `status`, and a one-line outcome summary taken from the
+   child's `## Notes` section (trim to a single line; fall back to
+   `(no notes)`). All work stays in this orchestrator turn — no worker.
 
 3. **Identify residual ambiguity.** Read the parent's body (everything after
    the frontmatter `---` and the `# Title` heading). Compare its scoped

--- a/skills/ludics-verify-container-completion.md
+++ b/skills/ludics-verify-container-completion.md
@@ -1,0 +1,117 @@
+---
+name: ludics-verify-container-completion
+description: Surface a decision on a container task whose subtasks have all resolved
+queue-action: verify-container-completion
+queue-args: [task]
+queue-required-args: [task]
+---
+
+# /ludics-verify-container-completion - Container Completion Review (Orchestrator)
+
+A lightweight orchestrator that reads a `leaf: false` parent and its children,
+summarizes outcomes, files `needs-confirmation` follow-ups for residual
+ambiguity, and notifies the user. **Does not transition the parent's status —
+that decision stays with the user.**
+
+## Trigger
+
+This skill is invoked when:
+- The container-completion sweep in `tasksReconcileBlockedStatus` detects that
+  every child of a `leaf: false` parent (via `subtask_of`) has reached a
+  terminal status (`done` or `abandoned`), and queues
+  `ludics mag verify-container-completion <parent-id>`.
+- The user runs `ludics mag verify-container-completion <parent-id>` manually.
+
+The sweep uses a fingerprint-aware sentinel under
+`mag/container-completion-checked/<parent-id>.{epoch,children}` to debounce
+repeated firings while the child set is unchanged, and to re-fire when a
+child reopens or a new child appears.
+
+## Arguments
+
+- `$ARGUMENTS`: `<parent_id>` — Container task identifier.
+
+## Inputs
+
+- `$LUDICS_STATE_PATH`: Path to the harness directory (environment variable).
+- `$LUDICS_RESULTS_DIR`: Directory for writing result JSON (environment variable).
+- **Request ID**: Read from file `$LUDICS_STATE_PATH/mag/current-request-id`.
+
+## Steps
+
+This skill is materially lighter than `/ludics-verify-completion` — no
+codebase inspection, no worker delegation. The orchestrator does all the work
+inline.
+
+1. **Read the parent task file** at `$LUDICS_STATE_PATH/tasks/<parent_id>.md`.
+   - Confirm `leaf: false` is set. If not, write a result JSON with
+     `"status": "error"` and `"reason": "not a container task"` and stop.
+   - Confirm `status` is not in `done`/`abandoned`/`merged` already. If it is,
+     write a result JSON with `"status": "skipped"` and stop.
+   - Capture the parent's `title` and `project` for the notify summary.
+
+2. **Enumerate children** by scanning every `*.md` file under
+   `$LUDICS_STATE_PATH/tasks/` whose frontmatter has
+   `dependencies.subtask_of == <parent_id>`. Use `parseTaskFrontmatter` via
+   the harness CLI (`ludics tasks list --json` exists; otherwise read files
+   directly with the standard `Read` tool — keep the work in this orchestrator
+   turn). For each child, record `id`, `status`, and a one-line outcome
+   summary by reading the child's `## Notes` section and trimming to a single
+   line (or fall back to `(no notes)`).
+
+3. **Identify residual ambiguity.** Read the parent's body (everything after
+   the frontmatter `---` and the `# Title` heading). Compare its scoped
+   semantic claims (the AC bullets in the proposal it points to via
+   `proposal:` if present, or its own `## Acceptance Criteria` block) against
+   the children's outcomes. For each unmet semantic — work the children did
+   not cover — file a follow-up:
+
+   ```bash
+   ludics tasks create "<short residual description>" <project> C
+   ```
+
+   Then edit the new file's frontmatter to set `status: needs-confirmation`
+   (the `ludics tasks create` CLI does not accept a status flag) and, under
+   the existing `dependencies:` block, replace `relates_to: []` with
+   `relates_to: [<parent_id>]`. Use `needs-confirmation`, **not** `deferred`
+   — the dashboard's needs-confirmation surface (with confirm/dismiss API
+   endpoints) is the correct UI routing for "user must take an action".
+
+4. **Notify the user.** Send a single outgoing notification summarizing:
+   - which children were `done`, which were `abandoned`,
+   - any follow-ups created in step 3,
+   - the three options the user has: mark the container `done`, mark it
+     `abandoned` with rationale, or act on the follow-ups first.
+
+   ```bash
+   ludics notify outgoing "Container <parent_id> ready for review: <K> child(ren) resolved, <M> follow-up(s) filed. Decide: mark done / abandoned / process follow-ups." 3 "Container Completion"
+   ```
+
+5. **Write result JSON** at `$LUDICS_RESULTS_DIR/<request_id>.json` with:
+   ```json
+   {
+     "status": "completed",
+     "task_id": "<parent_id>",
+     "children": [{"id": "...", "status": "...", "summary": "..."}],
+     "followups_filed": <count>
+   }
+   ```
+
+6. **Exit.** Do **not** transition the parent's status. The user decides.
+
+## Bounded re-fire
+
+When a `needs-confirmation` follow-up itself transitions to
+`done` / `abandoned`, the all-children-resolved sweep re-fires this skill on
+the parent — provided the debounce sentinel was cleared at the previous
+resolution. Each iteration either resolves an ambiguity (closer to the user
+deciding `done`) or files another concise follow-up. Bounded because each
+resolution narrows the residual space.
+
+## Errors
+
+- Parent file missing → `"status": "error"`, `"reason": "task not found"`.
+- Parent missing `leaf: false` → `"status": "error"`, see step 1.
+- No children found via `subtask_of` → write `"status": "skipped"`,
+  `"reason": "vacuous container"` (the sweep should not have queued this; if
+  it did, dedupe via `queueHasPendingActionForTask` was bypassed manually).

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ Commands:
   mag draft-proposal <id>     Generate proposal document for task
   mag split-task <id>          Split multi-concern task into subtasks
   mag verify-completion <id>   Deep-inspect task completion, create follow-ups
+  mag verify-container-completion <id>  Review container task once all subtasks resolve
   mag health-check             Check for deadlines, issues
   mag adopt-sessions [--force] Discover sessions and queue adoption for Mag
   mag process-suggestions <id> Queue suggestion processing for completed task

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -88,4 +88,23 @@ describe("auto-compact does not fire for unrelated actions", () => {
     expect(items).toHaveLength(1);
     expect(items[0]!.action).toBe("elaborate");
   });
+
+  test("verify-container-completion <id> enqueues a single matching request", async () => {
+    // Harness condition: the CLI sub-command exists and the dispatcher routes
+    // to queueRequest with the right action+task. If the case were missing
+    // (the round-1 reviewer's first remediation point), runMag would throw
+    // and the queue would stay empty — both assertions would fail.
+    const { runMag } = await import("./mag.ts");
+    await runMag(["verify-container-completion", "task-parent"]);
+
+    const items = readQueue();
+    expect(items).toHaveLength(1);
+    expect(items[0]!.action).toBe("verify-container-completion");
+    expect(items[0]!.task).toBe("task-parent");
+  });
+
+  test("verify-container-completion without an id throws", async () => {
+    const { runMag } = await import("./mag.ts");
+    await expect(runMag(["verify-container-completion"])).rejects.toThrow("task id required");
+  });
 });

--- a/src/mag-ready-candidates.test.ts
+++ b/src/mag-ready-candidates.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { getSortedReadyCandidates } from "./mag.ts";
+
+let tmpDir: string;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_CLUSTER_NAME = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ludics-ready-candidates-"));
+  mkdirSync(join(tmpDir, "tasks"), { recursive: true });
+  mkdirSync(join(tmpDir, "slots"), { recursive: true });
+  process.env.LUDICS_HARNESS_DIR = tmpDir;
+  delete process.env.LUDICS_CONFIG;
+  delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_CLUSTER_NAME === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_CLUSTER_NAME;
+});
+
+function writeTask(id: string, fm: Record<string, string | boolean>): void {
+  const lines = ["---", `id: ${id}`, `title: ${id}`];
+  for (const [k, v] of Object.entries(fm)) {
+    lines.push(`${k}: ${v}`);
+  }
+  if (!("status" in fm)) lines.push("status: ready");
+  if (!("priority" in fm)) lines.push("priority: B");
+  if (!("project" in fm)) lines.push("project: ludics");
+  lines.push("dependencies:");
+  lines.push("  blocks: []");
+  lines.push("  blocked_by: []");
+  lines.push("  relates_to: []");
+  lines.push("  subtask_of: null");
+  lines.push("effort: small");
+  lines.push("context: ludics");
+  lines.push("uses_browser: false");
+  lines.push("created: 2026-04-29");
+  lines.push("source: manual");
+  lines.push("---", "", `# ${id}`, "");
+  writeFileSync(join(tmpDir, "tasks", `${id}.md`), lines.join("\n"));
+}
+
+describe("getSortedReadyCandidates leaf filter (AC2)", () => {
+  test("excludes leaf: false containers; retains plain leaf tasks and explicit leaf: true", () => {
+    // Harness condition: three ready tasks differing only in the `leaf` field.
+    // If any of the three were missing or the directory empty, the assertions
+    // below would not exercise the AC's "filter out containers" path.
+    writeTask("task-leaf-plain", {});
+    writeTask("task-container", { leaf: false });
+    writeTask("task-leaf-explicit", { leaf: true });
+
+    const ids = getSortedReadyCandidates().map((c) => c.id).sort();
+
+    // Invariant: leaf===false MUST be filtered (the AC2 rule). If the filter
+    // is removed, this assertion flips because the container would appear.
+    expect(ids).not.toContain("task-container");
+    // Invariant: legacy tasks (no leaf field) MUST remain — this is the
+    // "absent !== false" property the parser guard depends on.
+    expect(ids).toContain("task-leaf-plain");
+    // Invariant: leaf===true is unfiltered — confirms `=== false`, not falsy.
+    expect(ids).toContain("task-leaf-explicit");
+  });
+
+  test("a single-task harness containing only a container produces an empty candidate list", () => {
+    // Harness condition: only one task exists, and it is a container. If the
+    // filter were absent, the candidate list would have one element.
+    writeTask("task-only-container", { leaf: false });
+
+    expect(getSortedReadyCandidates()).toEqual([]);
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2277,11 +2277,14 @@ export function mergeRequirements(
   return merged;
 }
 
-interface ReadyCandidate { id: string; priority: string; project: string; milestone?: string; hasDeadline: boolean; deadline: string; effort: string; elaborated: boolean; requirements?: { os?: string; gpu?: string } }
+export interface ReadyCandidate { id: string; priority: string; project: string; milestone?: string; hasDeadline: boolean; deadline: string; effort: string; elaborated: boolean; requirements?: { os?: string; gpu?: string } }
 
 /** Compute the sorted ready queue — single source of truth for task ordering.
- *  Used by maybeFillEmptySlots, maybeQueueProposals, and dashboard generation. */
-function getSortedReadyCandidates(config?: LudicsFullConfig): ReadyCandidate[] {
+ *  Used by maybeFillEmptySlots, maybeQueueProposals, and dashboard generation.
+ *  Exported for direct testability (mirrors the mergeRequirements pattern in
+ *  this file). Container tasks (frontmatter `leaf: false`) are filtered out
+ *  here so every consumer inherits the exclusion. */
+export function getSortedReadyCandidates(config?: LudicsFullConfig): ReadyCandidate[] {
   const tasksDir = join(harnessDir(), "tasks");
   if (!existsSync(tasksDir)) return [];
   const cfg = config ?? loadConfigSync();
@@ -2325,6 +2328,11 @@ function getSortedReadyCandidates(config?: LudicsFullConfig): ReadyCandidate[] {
     });
 
     if (tasksInSlots.has(id)) continue;
+    // Container tasks (work split into subtasks) are not actionable. The check
+    // is `=== false` (not falsy) so legacy tasks without the field are kept.
+    // Defensive coercion handles a stringified "false" from malformed input.
+    const leafRaw = fm.leaf;
+    if (leafRaw === false || leafRaw === "false") continue;
     if (status !== "ready") continue;
     const blockedBy = deps.blocked_by;
     if (Array.isArray(blockedBy) && blockedBy.length > 0) continue;

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1,7 +1,7 @@
 // Mag session management — start/stop/status/attach/logs/doctor/briefing/queue
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, effectivePriorityValue, milestonesEnabledProjects, resolveProjectPath, postponedProjectSet, findProjectConfigByName, type LudicsFullConfig } from "./config.ts";
 import { formatUpstreamLagSection } from "./briefing-lag.ts";
 import { defaultRunGit, type RunGit } from "./git-runner.ts";
@@ -2024,6 +2024,53 @@ function autoProposalDebounced(taskId: string): boolean {
 
 function markAutoProposalQueued(taskId: string): void {
   touchSentinel(autoProposalDebounceFile(taskId));
+}
+
+// --- Container completion sweep debounce + child-set fingerprint ---
+//
+// Mirrors the auto-proposal-debounce shape but pairs the freshness sentinel
+// with a `.children` sidecar that records the parent's child-set state at
+// last enqueue. The sweep clears the sentinel whenever the current child
+// set differs (reopen, new child added — even one that is already terminal),
+// satisfying the AC7 reset rules without write-time hooks.
+
+const CONTAINER_COMPLETION_DEBOUNCE_SECONDS = 6 * 3600;
+
+function containerCompletionDir(): string {
+  return join(magStateDir(), "container-completion-checked");
+}
+
+export function containerCompletionDebounceFile(parentId: string): string {
+  return join(containerCompletionDir(), `${encodeURIComponent(parentId)}.epoch`);
+}
+
+export function containerCompletionChildrenFile(parentId: string): string {
+  return join(containerCompletionDir(), `${encodeURIComponent(parentId)}.children`);
+}
+
+export function containerCompletionDebounced(parentId: string): boolean {
+  return sentinelFresh(containerCompletionDebounceFile(parentId), new Date(), CONTAINER_COMPLETION_DEBOUNCE_SECONDS);
+}
+
+export function markContainerCompletionQueued(parentId: string): void {
+  touchSentinel(containerCompletionDebounceFile(parentId));
+}
+
+export function clearContainerCompletionSentinel(parentId: string): void {
+  clearSentinel(containerCompletionDebounceFile(parentId));
+  try { unlinkSync(containerCompletionChildrenFile(parentId)); } catch { /* best-effort */ }
+}
+
+export function readContainerCompletionFingerprint(parentId: string): string | null {
+  const f = containerCompletionChildrenFile(parentId);
+  if (!existsSync(f)) return null;
+  try { return readFileSync(f, "utf-8"); } catch { return null; }
+}
+
+export function writeContainerCompletionFingerprint(parentId: string, fp: string): void {
+  const f = containerCompletionChildrenFile(parentId);
+  mkdirSync(dirname(f), { recursive: true });
+  atomicWriteFileSync(f, fp);
 }
 
 /** Auto-start slots that have proposals but no active session. */

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3607,6 +3607,13 @@ export async function runMag(args: string[]): Promise<void> {
       console.log(`Queued verify-completion request for ${taskId}`);
       break;
     }
+    case "verify-container-completion": {
+      const taskId = args[1];
+      if (!taskId) throw new Error("task id required");
+      queueRequest({ action: "verify-container-completion", task: taskId });
+      console.log(`Queued verify-container-completion request for ${taskId}`);
+      break;
+    }
     case "feedback-digest": {
       const fdResult = tryQueueFeedbackDigest("ludics");
       if (fdResult.queued) {
@@ -3715,6 +3722,6 @@ export async function runMag(args: string[]): Promise<void> {
       break;
     }
     default:
-      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue pop one, queue pop all, queue-pop, on-stop, context, feedback-digest)`);
+      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, verify-container-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue pop one, queue pop all, queue-pop, on-stop, context, feedback-digest)`);
   }
 }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -131,7 +131,7 @@ function nextRequestId(): string {
 
 export type QueueAction =
   | { action: "briefing" | "suggest" | "health-check" | "adopt-sessions" }
-  | { action: "elaborate" | "draft-proposal" | "split-task" | "verify-completion" | "complete-task" | "process-suggestions"; task: string }
+  | { action: "elaborate" | "draft-proposal" | "split-task" | "verify-completion" | "verify-container-completion" | "complete-task" | "process-suggestions"; task: string }
   | { action: "revise-proposal"; task: string; feedback?: string }
   | { action: "preempt"; task: string; autonomy: string }
   | { action: "feedback-digest"; repo: string }

--- a/src/skill-queue-registry.test.ts
+++ b/src/skill-queue-registry.test.ts
@@ -9,12 +9,12 @@ beforeEach(() => {
 });
 
 describe("hasRegisteredAction", () => {
-  test("returns true for all 14 known queue actions", () => {
+  test("returns true for all 15 known queue actions", () => {
     const known = [
       "briefing", "suggest", "elaborate", "health-check", "learn",
       "sync-learnings", "feedback-digest", "draft-proposal", "revise-proposal",
-      "split-task", "preempt", "verify-completion", "adopt-sessions",
-      "process-suggestions",
+      "split-task", "preempt", "verify-completion", "verify-container-completion",
+      "adopt-sessions", "process-suggestions",
     ];
     for (const action of known) {
       expect(hasRegisteredAction(action), `expected "${action}" to be registered`).toBe(true);
@@ -74,6 +74,19 @@ describe("resolveSkillCommand — single-arg skills", () => {
 
   test("verify-completion with task", () => {
     expect(resolveSkillCommand("verify-completion", { task: "task-042" })).toBe("/ludics-verify-completion task-042");
+  });
+
+  test("verify-container-completion with task (AC8 — registry resolves new skill)", () => {
+    // Invariant: the queue-pop layer dispatches /ludics-verify-container-completion
+    // for the action emitted by containerCompletionSweep. If skill frontmatter
+    // (queue-action / queue-args) drifted, this assertion is the canary.
+    expect(resolveSkillCommand("verify-container-completion", { task: "task-parent" }))
+      .toBe("/ludics-verify-container-completion task-parent");
+  });
+
+  test("verify-container-completion without task returns null (queue-required-args)", () => {
+    expect(resolveSkillCommand("verify-container-completion", {})).toBeNull();
+    expect(resolveSkillCommand("verify-container-completion", { task: "" })).toBeNull();
   });
 
   test("feedback-digest with repo (no queue-args declared, repo ignored)", () => {

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -120,6 +120,73 @@ describe("slotAssign", () => {
     expect(task).toContain("adapter: manual");
   });
 
+  test("rejects leaf:false container tasks before any slot mutation (AC5)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+
+    // Harness condition: a real task file exists with `leaf: false`. The
+    // existsSync(tf) branch fires; if the guard isn't there, slot mutation
+    // proceeds and the byte-equality assertion below fails.
+    writeFileSync(join(tasksDir, "task-container.md"), `---
+id: task-container
+title: "Container parent"
+project: demo
+status: ready
+priority: B
+leaf: false
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+effort: medium
+context: demo
+uses_browser: false
+slot: null
+adapter: null
+created: 2026-04-29
+started: null
+completed: null
+modified: null
+source: local
+---
+`);
+
+    const slotPath = join(harness, "slots", "slot-1.json");
+    const slotBefore = readFileSync(slotPath, "utf-8");
+    const taskPath = join(tasksDir, "task-container.md");
+    const taskBefore = readFileSync(taskPath, "utf-8");
+
+    // Invariant: the throw must happen before any write. Asserting the
+    // error message also pins the actionable hint that names the parent.
+    await expect(slotAssign(1, "task-container", "manual"))
+      .rejects.toThrow(/container task task-container/);
+
+    // Atomic-failure invariant: slot JSON byte-identical post-throw.
+    expect(readFileSync(slotPath, "utf-8")).toBe(slotBefore);
+    // Atomic-failure invariant: task frontmatter untouched (slot/status/started
+    // would all change if the mutation path had been entered).
+    expect(readFileSync(taskPath, "utf-8")).toBe(taskBefore);
+  });
+
+  test("free-form description assignment bypasses the leaf guard (no task file resolves)", () => {
+    // Harness condition: NO task file at this path; existsSync(tf) is false,
+    // so the leaf-check branch never runs. This codifies the AC5 carve-out.
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+
+    void slotAssign(1, "task-container", "manual"); // looks like a task id but no file
+
+    const data = readSlotJson(1, harness);
+    expect(data.task).toBeNull(); // treated as free-form because no file
+    expect(data.process).toBe("task-container");
+  });
+
   test("keeps free-text descriptions as non-task assignments", () => {
     const harness = join(TMP, "ludics-state", "harness");
     mkdirSync(harness, { recursive: true });

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -342,7 +342,16 @@ export async function slotAssign(
   if (existsSync(tf)) {
     taskId = taskOrDesc;
     const content = readFileSync(tf, "utf-8");
-    processDesc = parseTaskFrontmatter(content).title || taskId;
+    const fm = parseTaskFrontmatter(content);
+    // Container tasks (work split into subtasks) cannot be assigned — the
+    // parent is non-actionable. Throw before any slot mutation so the call
+    // is atomic: no slot file write, no prior-slot cleanup, no status flip.
+    if (fm.leaf === false) {
+      throw new Error(
+        `Cannot assign container task ${taskId} to slot ${slotNum} — its work was split into subtasks. Assign a child instead.`,
+      );
+    }
+    processDesc = fm.title || taskId;
   } else {
     taskId = null;
     processDesc = taskOrDesc;

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -333,6 +333,59 @@ describe("parseTaskFrontmatter field reads", () => {
     expect(fm.title).toBe("quoted");
     expect(fm.status).toBeUndefined();
   });
+
+  test("leaf: false round-trips as boolean false (container marker)", () => {
+    const content = [
+      "---",
+      "id: task-container",
+      "title: parent",
+      "status: ready",
+      "leaf: false",
+      "---",
+    ].join("\n");
+    expect(parseTaskFrontmatter(content).leaf).toBe(false);
+  });
+
+  test("leaf absent stays undefined (legacy tasks must not be filtered)", () => {
+    const content = [
+      "---",
+      "id: task-leaf",
+      "title: leaf",
+      "status: ready",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.leaf).toBeUndefined();
+    // Critical: the consumer guard is `=== false`, so undefined must not coerce.
+    expect(fm.leaf === false).toBe(false);
+  });
+
+  test("leaf: true round-trips as boolean true (explicit non-container)", () => {
+    const content = [
+      "---",
+      "id: task-explicit",
+      "title: explicit leaf",
+      "status: ready",
+      "leaf: true",
+      "---",
+    ].join("\n");
+    expect(parseTaskFrontmatter(content).leaf).toBe(true);
+  });
+
+  test("leaf: false survives malformed-YAML line fallback path", () => {
+    // Trigger the fallback by leaving an unclosed array in dependencies.
+    const content = [
+      "---",
+      "id: task-fb",
+      "status: blocked",
+      "leaf: false",
+      "dependencies: [unclosed",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.leaf).toBe(false);
+    expect(fm.id).toBe("task-fb");
+  });
 });
 
 describe("appendToSection", () => {

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -112,6 +112,7 @@ function parseTaskFrontmatterUncached(content: string): ParsedTaskFrontmatter {
     },
     effort: String(d.effort ?? "medium"),
     skip_plan: asBoolean(d.skip_plan),
+    leaf: d.leaf !== undefined ? asBoolean(d.leaf) : undefined,
     requirements: d.requirements ? d.requirements as { os?: string; gpu?: string } : undefined,
     context: String(d.context ?? ""),
     uses_browser: asBoolean(d.uses_browser),
@@ -189,6 +190,7 @@ function parseTaskFrontmatterLineFallback(fmBlock: string): ParsedTaskFrontmatte
   if (out.elaborated !== undefined) fm.elaborated = out.elaborated;
   if (out.merged_into !== undefined) fm.merged_into = out.merged_into;
   if (out.skip_plan !== undefined) fm.skip_plan = asBoolean(out.skip_plan);
+  if (out.leaf !== undefined) fm.leaf = asBoolean(out.leaf);
   if (out.uses_browser !== undefined) fm.uses_browser = asBoolean(out.uses_browser);
   if (out.started !== undefined) fm.started = out.started;
   if (out.completed !== undefined) fm.completed = out.completed;

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -352,6 +352,201 @@ describe("tasksReconcileBlockedStatus", () => {
   });
 });
 
+describe("containerCompletionSweep", () => {
+  function readQueueActions(queueFile: string): Array<{ action?: string; task?: string }> {
+    if (!readFileSync) return [];
+    try {
+      return readFileSync(queueFile, "utf-8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { action?: string; task?: string });
+    } catch { return []; }
+  }
+
+  function setupContainerWithChildren(parent: string, children: Array<{ id: string; status: string }>): { harness: string; tasksDir: string; queueFile: string } {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+    writeContainerTask(tasksDir, parent, "ludics", "ready");
+    for (const c of children) {
+      writeChildTask(tasksDir, c.id, parent, c.status);
+    }
+    return { harness, tasksDir, queueFile: join(harness, "mag", "queue.jsonl") };
+  }
+
+  test("enqueues verify-container-completion exactly once when all children resolve (AC6)", () => {
+    // Harness condition: leaf:false parent, two terminal children (one done,
+    // one abandoned), parent itself still `ready`.
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent", [
+      { id: "task-child-a", status: "done" },
+      { id: "task-child-b", status: "abandoned" },
+    ]);
+
+    tasksReconcileBlockedStatus(tasksDir);
+    let entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.task).toBe("task-parent");
+
+    // Invariant: a second sweep with no state change does NOT re-enqueue
+    // (combined sentinel-fresh + fingerprint-match check). A regression here
+    // would cause notify-spam every sync tick.
+    tasksReconcileBlockedStatus(tasksDir);
+    entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion");
+    expect(entries).toHaveLength(1);
+  });
+
+  test("vacuous parent (no children with subtask_of) does not enqueue (AC6 edge case)", () => {
+    // Harness condition: leaf:false parent, NO child files referencing it.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+    writeContainerTask(tasksDir, "task-empty-parent", "ludics", "ready");
+
+    tasksReconcileBlockedStatus(tasksDir);
+    const entries = readQueueActions(join(harness, "mag", "queue.jsonl"));
+    expect(entries.filter(e => e.action === "verify-container-completion")).toHaveLength(0);
+  });
+
+  test("parent in TERMINAL_FOR_PARENT status is skipped (AC6 — already-decided guard)", () => {
+    // Harness condition: parent is `done` already; sweep must not re-enqueue.
+    // If the guard were missing, the queue would gain a stale entry.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+    writeContainerTask(tasksDir, "task-done-parent", "ludics", "done");
+    writeChildTask(tasksDir, "task-child-1", "task-done-parent", "done");
+
+    tasksReconcileBlockedStatus(tasksDir);
+    const entries = readQueueActions(join(harness, "mag", "queue.jsonl"));
+    expect(entries.filter(e => e.action === "verify-container-completion")).toHaveLength(0);
+  });
+
+  test("re-fires when a child reopens then re-completes (AC7 — reset on child status flip)", () => {
+    // Harness condition: two terminal children → enqueue, then flip A back to
+    // ready (sentinel cleared by fingerprint mismatch), then back to done →
+    // sweep re-enqueues. Without fingerprint comparison, the sentinel would
+    // stay fresh and the second valid completion would be silently dropped.
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent2", [
+      { id: "task-c2-a", status: "done" },
+      { id: "task-c2-b", status: "done" },
+    ]);
+
+    tasksReconcileBlockedStatus(tasksDir);
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent2"))
+      .toHaveLength(1);
+
+    // Flip child-a back to ready: fingerprint changes, sentinel cleared,
+    // but children no longer all terminal so no enqueue this tick.
+    writeChildTask(tasksDir, "task-c2-a", "task-parent2", "ready");
+    tasksReconcileBlockedStatus(tasksDir);
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent2"))
+      .toHaveLength(1);
+
+    // Flip back to done: fingerprint differs from prior sidecar (status `done`
+    // vs the prior sidecar's `done` — same; but sentinel was cleared above),
+    // so re-enqueue. We also need to drain the prior request from the queue
+    // because queueHasPendingActionForTask would otherwise dedupe. The
+    // intent is "after the user processes the first request, the second
+    // completion still re-fires" — drain to simulate that.
+    writeChildTask(tasksDir, "task-c2-a", "task-parent2", "done");
+    writeFileSync(queueFile, ""); // user/mag drained the prior request
+    tasksReconcileBlockedStatus(tasksDir);
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent2"))
+      .toHaveLength(1);
+  });
+
+  test("re-fires when a new terminal child appears even though every child is still terminal (AC7 — reset on child-set change)", () => {
+    // Harness condition: two children both done → enqueue, then a NEW child
+    // is added with status: done. The "any non-terminal child" heuristic
+    // would NOT detect this; only the child-set fingerprint comparison does.
+    // This is the regression the round-1 review pinned.
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent3", [
+      { id: "task-c3-a", status: "done" },
+      { id: "task-c3-b", status: "done" },
+    ]);
+
+    tasksReconcileBlockedStatus(tasksDir);
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent3"))
+      .toHaveLength(1);
+
+    // Add a new terminal child. Drain the queue (so `queueHasPendingActionForTask`
+    // doesn't suppress) — this models the user processing the first notify.
+    writeChildTask(tasksDir, "task-c3-c", "task-parent3", "done");
+    writeFileSync(queueFile, "");
+
+    tasksReconcileBlockedStatus(tasksDir);
+    // Invariant: a 3-child set differs from the 2-child set fingerprint, so
+    // the sentinel is cleared and a fresh request fires. Without fingerprint
+    // tracking, the sentinel would stay fresh (since 6h > test runtime) and
+    // the user would never be told the parent's situation changed.
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent3"))
+      .toHaveLength(1);
+  });
+
+  test("pending-request dedupe suppresses double-enqueue", () => {
+    // Harness condition: we pre-seed an unprocessed request, then the sweep
+    // must NOT add a second one for the same parent.
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent4", [
+      { id: "task-c4-a", status: "done" },
+    ]);
+    writeFileSync(queueFile, JSON.stringify({
+      id: "req-pre", action: "verify-container-completion", task: "task-parent4", timestamp: "2026-04-29T00:00:00Z",
+    }) + "\n");
+
+    tasksReconcileBlockedStatus(tasksDir);
+
+    expect(readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent4"))
+      .toHaveLength(1);
+  });
+
+  test("merged_from containment is NOT honored — only subtask_of", () => {
+    // Harness condition: parent has `merged_from` (irrelevant here) but no
+    // child references it via subtask_of. The sweep must treat it as vacuous.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+    writeFileSync(join(tasksDir, "task-merge-parent.md"), `---
+id: task-merge-parent
+title: "merge parent"
+project: ludics
+status: ready
+priority: B
+leaf: false
+merged_from:
+  - task-old
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+    writeFileSync(join(tasksDir, "task-old.md"), `---
+id: task-old
+title: "old"
+project: ludics
+status: done
+priority: B
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+
+    tasksReconcileBlockedStatus(tasksDir);
+
+    expect(readQueueActions(join(harness, "mag", "queue.jsonl")).filter(e => e.action === "verify-container-completion"))
+      .toHaveLength(0);
+  });
+});
+
 describe("tasksNeedsElaborationList", () => {
   test("skips leaf:false container tasks (AC3 — elaboration exclusion)", () => {
     const harness = join(TMP, "ludics-state", "harness");

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
+import { tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
 import { emptySlotData, writeSlotJson } from "../slots/json.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-sync");
@@ -45,6 +45,41 @@ dependencies:
   blocked_by: []
   relates_to: []
   subtask_of: null
+---
+`);
+}
+
+function writeContainerTask(tasksDir: string, id: string, project: string, status: string): void {
+  writeFileSync(join(tasksDir, `${id}.md`), `---
+id: ${id}
+title: "${id}"
+project: ${project}
+status: ${status}
+priority: A
+elaborated: true
+leaf: false
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+}
+
+function writeChildTask(tasksDir: string, id: string, parent: string, status: string): void {
+  writeFileSync(join(tasksDir, `${id}.md`), `---
+id: ${id}
+title: "${id}"
+project: ludics
+status: ${status}
+priority: B
+elaborated: true
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: ${parent}
 ---
 `);
 }
@@ -160,6 +195,32 @@ describe("tasksQueuePreemptions", () => {
     const newEntries = allLines.slice(lines.length); // entries added by tasksQueuePreemptions
     const newTasks = newEntries.map((l) => (JSON.parse(l) as { task?: string }).task ?? "");
     expect(newTasks).toEqual(["task-beta-ready"]);
+  });
+
+  test("skips leaf:false container tasks (AC4 — preempt exclusion)", () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+
+    // Harness condition: a priority-project ready container exists alongside
+    // a leaf sibling. Both slots full → preempt path runs. If the filter is
+    // absent, the container also gets queued and the assertion below fails.
+    writeTask(tasksDir, "task-alpha-active", "alpha", "in-progress");
+    writeTask(tasksDir, "task-beta-active", "beta", "in-progress");
+    writeContainerTask(tasksDir, "task-alpha-container", "alpha", "ready");
+    writeTask(tasksDir, "task-beta-leaf", "beta", "ready");
+
+    writeSlotJson(1, { ...emptySlotData(1), process: "alpha active", task: "task-alpha-active" }, harness);
+    writeSlotJson(2, { ...emptySlotData(2), process: "beta active", task: "task-beta-active" }, harness);
+
+    tasksQueuePreemptions();
+
+    const queuedTasks = readQueueTasks(join(harness, "mag", "queue.jsonl"));
+    // Invariant: leaf:false container is NEVER preempt-queued. If filter is
+    // removed, this changes to ["task-alpha-container", "task-beta-leaf"].
+    expect(queuedTasks).toEqual(["task-beta-leaf"]);
+    expect(readFileSync(join(tasksDir, "task-alpha-container.md"), "utf-8")).toContain("status: ready");
   });
 
   test("keeps the limit per project when one project already has a stashed preemption", () => {
@@ -288,5 +349,53 @@ describe("tasksReconcileBlockedStatus", () => {
     expect(after).toBe(before);
     expect(after).toContain("status: blocked");
     expect(after).not.toContain("status: ready");
+  });
+});
+
+describe("tasksNeedsElaborationList", () => {
+  test("skips leaf:false container tasks (AC3 — elaboration exclusion)", () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    // Harness condition: container task is `ready` AND not yet elaborated
+    // (no `elaborated:` line via writeUnElaboratedContainer below). Without
+    // the filter, the function would return its id.
+    writeFileSync(join(tasksDir, "task-container.md"), `---
+id: task-container
+title: "container"
+project: ludics
+status: ready
+priority: B
+leaf: false
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+    // Sibling leaf task in the same harness — proves the function is wired
+    // and would return the leaf if the container were not filtered.
+    writeFileSync(join(tasksDir, "task-leaf.md"), `---
+id: task-leaf
+title: "leaf"
+project: ludics
+status: ready
+priority: B
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+
+    const list = tasksNeedsElaborationList(tasksDir);
+
+    // Invariant: container is excluded from the elaboration list even when
+    // it is unelaborated and ready. Removing the filter flips this assertion.
+    expect(list).not.toContain("task-container");
+    expect(list).toContain("task-leaf");
   });
 });

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -839,6 +839,9 @@ function tasksNeedsElaborationList(tasksDir: string): string[] {
 
     const status = fm.status ?? "";
     if (["merged", "done", "abandoned", "needs-confirmation"].includes(status)) continue;
+    // Container tasks (work split into subtasks) are not actionable; never
+    // queue them for elaboration even if they happen to be unelaborated.
+    if (fm.leaf === false) continue;
 
     if (!isElaborated(content)) result.push(id);
   }
@@ -890,6 +893,8 @@ function tasksQueuePreemptions(): void {
     if (!id) continue;
 
     if (fm.status !== "ready") continue;
+    // Container tasks are non-actionable; preempting a slot for one is wrong.
+    if (fm.leaf === false) continue;
 
     const project = fm.project ?? "";
     if (!project) continue;

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -8,7 +8,14 @@ import { listStashes } from "../slots/preempt.ts";
 import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray } from "./markdown.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
-import { queueRequest, parseQueueLines } from "../queue.ts";
+import { queueRequest, queueHasPendingActionForTask, parseQueueLines } from "../queue.ts";
+import {
+  clearContainerCompletionSentinel,
+  containerCompletionDebounced,
+  markContainerCompletionQueued,
+  readContainerCompletionFingerprint,
+  writeContainerCompletionFingerprint,
+} from "../mag.ts";
 import { safeSyncOutput } from "../spawn.ts";
 
 function yamlEscape(value: string): string {
@@ -657,15 +664,20 @@ export async function tasksUpdate(): Promise<void> {
   );
 }
 
+type TaskMap = Map<string, { status: string; filePath: string; fm: ReturnType<typeof parseTaskFrontmatter> }>;
+
 /**
  * Heal blocked_by/blocks links: remove done/abandoned tasks from blocked_by,
  * and ensure each blocked_by reference has a matching blocks backlink.
+ *
+ * Returns the parsed taskMap so the container-completion sweep can reuse it
+ * without re-parsing every file.
  */
-function healBlockedByLinks(tasksDir: string): void {
+function healBlockedByLinks(tasksDir: string): TaskMap {
   const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
 
   // Build id -> { status, filePath, fm } map
-  const taskMap = new Map<string, { status: string; filePath: string; fm: ReturnType<typeof parseTaskFrontmatter> }>();
+  const taskMap: TaskMap = new Map();
   for (const f of files) {
     const filePath = join(tasksDir, f);
     const content = readFileSync(filePath, "utf-8");
@@ -713,11 +725,81 @@ function healBlockedByLinks(tasksDir: string): void {
   if (healed > 0) {
     console.error(`ludics: healed ${healed} blocked_by/blocks link(s)`);
   }
+
+  return taskMap;
+}
+
+/**
+ * Sweep `leaf: false` parents and queue `verify-container-completion` exactly
+ * once per (parent, child-set) state when every child is terminal. Reuses the
+ * `taskMap` from `healBlockedByLinks` so this is a single extra walk over
+ * an already-parsed structure.
+ *
+ * Debounce: a fresh `.epoch` sentinel suppresses re-fire within 6 hours.
+ * Reset rule: a `.children` sidecar records the child-set fingerprint at
+ * last enqueue. Whenever the current fingerprint differs, the sentinel is
+ * cleared — covering both child-status reopen AND new-child-added cases.
+ */
+function containerCompletionSweep(taskMap: TaskMap): void {
+  const TERMINAL_FOR_PARENT = new Set([
+    "done", "abandoned", "merged", "needs-confirmation",
+    "in-progress", "deferred", "preempt-queued", "preempted",
+  ]);
+  const TERMINAL_FOR_CHILD = new Set(["done", "abandoned"]);
+
+  // Single pass to index children by parent.
+  const childrenByParent = new Map<string, Array<{ id: string; status: string }>>();
+  for (const [childId, child] of taskMap) {
+    const parent = child.fm.dependencies?.subtask_of;
+    if (!parent) continue;
+    let arr = childrenByParent.get(parent);
+    if (!arr) { arr = []; childrenByParent.set(parent, arr); }
+    arr.push({ id: childId, status: child.status });
+  }
+
+  for (const [parentId, entry] of taskMap) {
+    if (entry.fm.leaf !== false) continue;
+    if (TERMINAL_FOR_PARENT.has(entry.status)) continue;
+
+    const children = childrenByParent.get(parentId) ?? [];
+    if (children.length === 0) continue; // vacuous — never enqueue
+
+    const sorted = children.slice().sort((a, b) => a.id.localeCompare(b.id));
+    const currentFingerprint = sorted.map(c => `${c.id}:${c.status}`).join("\n");
+
+    const prior = readContainerCompletionFingerprint(parentId);
+    if (prior !== null && prior !== currentFingerprint) {
+      // Child set changed (reopen, new child, status flip). Reset so the
+      // next all-terminal state re-fires the verify skill.
+      clearContainerCompletionSentinel(parentId);
+    }
+
+    const allTerminal = sorted.every(c => TERMINAL_FOR_CHILD.has(c.status));
+    if (!allTerminal) continue;
+
+    // All terminal: enqueue unless already debounced for this exact state.
+    const fpUnchanged = prior !== null && prior === currentFingerprint;
+    if (fpUnchanged && containerCompletionDebounced(parentId)) continue;
+    if (queueHasPendingActionForTask("verify-container-completion", parentId)) continue;
+
+    queueRequest({ action: "verify-container-completion", task: parentId });
+    markContainerCompletionQueued(parentId);
+    writeContainerCompletionFingerprint(parentId, currentFingerprint);
+    emitEvent({
+      event_type: "container_completion_queued",
+      source: "sync",
+      scope: "task",
+      task: parentId,
+      message: `${sorted.length} child(ren) all terminal`,
+    });
+  }
 }
 
 function tasksReconcileBlockedStatus(tasksDir: string): void {
-  // Heal stale blocked_by links before checking status
-  healBlockedByLinks(tasksDir);
+  // Heal stale blocked_by links before checking status, capturing the parsed
+  // taskMap so the container-completion sweep can reuse it.
+  const taskMap = healBlockedByLinks(tasksDir);
+  containerCompletionSweep(taskMap);
 
   const files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
   let reconciled = 0;
@@ -918,4 +1000,4 @@ function tasksQueuePreemptions(): void {
   }
 }
 
-export { tasksNeedsElaborationList, tasksQueueElaborations, tasksQueuePreemptions, tasksReconcileBlockedStatus, contentFingerprint };
+export { tasksNeedsElaborationList, tasksQueueElaborations, tasksQueuePreemptions, tasksReconcileBlockedStatus, containerCompletionSweep, contentFingerprint };

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -16,6 +16,10 @@ export interface TaskFrontmatter {
   /** tiny, small, medium, large — see docs/task-frontmatter-reference.md#effort-levels */
   effort: string;
   skip_plan?: boolean;
+  /** When `false`, this task is a container — its work is split across children
+   *  via `subtask_of`. Container tasks are excluded from auto-queue, preempt,
+   *  elaboration auto-queue, and slotAssign. Set by `/ludics-split-task`. */
+  leaf?: boolean;
   requirements?: { os?: string; gpu?: string };
   context: string;
   uses_browser: boolean;


### PR DESCRIPTION
## Summary

- Treat `leaf: false` as a first-class container-task signal across the typed frontmatter schema, every actionable queue path, and slot assignment.
- Add an "all-children-resolved" sweep that fires `/ludics-verify-container-completion <parent-id>` once per (parent, child-set) state — debounced 6h and reset via a child-set fingerprint sidecar.
- Container-aware short-circuits in `/ludics-elaborate` and `/ludics-draft-proposal` codify the manual gh-ocannl-293 pattern.
- Manual-trigger CLI (`ludics mag verify-container-completion <id>`) parallels the existing `verify-completion` sub-command.

Resolves task-7ae99643. Authoritative source: `docs/proposals/container-task-queue-exclusion-and-completion-check.md` (12 acceptance criteria).

## Changes by commit

1. `tasks: type and parse leaf?: boolean container marker` — schema + both parser paths, with the `undefined`-stays-undefined guard.
2. `mag: filter leaf:false containers from ready-candidate chokepoint` — single chokepoint filter; also exports `getSortedReadyCandidates` + `ReadyCandidate` for direct testing (mirrors the `mergeRequirements` precedent in the same file).
3. `sync: filter leaf:false from elaboration and preempt queues` — symmetric filters in `tasksNeedsElaborationList` and `tasksQueuePreemptions`.
4. `slots: guard slotAssign against leaf:false container tasks` — atomic-throw before any slot/task mutation; byte-equality regression test.
5. `sync: container-completion sweep + queue action` — extends the `QueueAction` union, refactors `healBlockedByLinks` to return its `taskMap`, and runs the new sweep with sentinel + `.children` fingerprint.
6. `skills: container short-circuits + new verify-container-completion skill` — orchestrator early-return + new lightweight orchestrator skill.
7. `docs: document leaf field semantics and container-completion trigger` — `## leaf (container marker)` section in `docs/task-frontmatter-reference.md`.
8. `mag: implement verify-container-completion CLI dispatch` — adds the runMag case + USAGE line (round-1 reviewer's blocking finding); also removes a bogus `tasks list --json` reference from the skill.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [x] `bun run lint:cli-readme`, `bun run lint:no-mock-module` — clean.
- [x] `bun run build` — clean compile.
- [x] `bun test` — **1635 pass / 0 fail** (1614 baseline + 21 new).
- [x] `./bin/ludics --help | grep verify-container` — confirms the new sub-command is wired in the compiled binary.
- [x] New tests cover all five AC11 cases plus the round-2 CLI dispatch: parser round-trip; ready-queue exclusion; preempt exclusion; slotAssign atomic-failure; sweep enqueue / vacuous-skip / terminal-parent-skip / debounce / re-fire on reopen / re-fire on new-terminal-child / pending dedupe / `merged_from` non-honoring; `mag verify-container-completion` dispatch (happy path + missing id).
- [ ] Manual smoke (caller to run): seed a `leaf: false` parent + 2 terminal children in a tmp harness, run `ludics tasks sync`, confirm one `verify-container-completion` queue line + matching `.children` sidecar; add a third terminal child + drain queue, re-run sync, confirm fingerprint mismatch re-fires; try `ludics slot 1 assign <container-id>` and confirm atomic rejection; try `ludics mag verify-container-completion <container-id>` manually and confirm a queued request appears.

## Out-of-tree follow-up

- `gh-ocannl-293`'s manual `status: blocked` workaround lives in your private state repo, not in this PR. After this lands, drop the override and let the new filter do the actual exclusion. The task body's Notes pointer to this fix can stay as historical context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)