### PR TITLE
slots: drop "null" string sentinels from frontmatter writers (task-138eb60b)

### DIFF
--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -200,6 +200,55 @@ source: local
     expect(data.task).toBeNull();
   });
 
+  test("journal entry omits (task=...) parenthetical when no task resolves (task-138eb60b AC3)", () => {
+    // Harness condition: pass a taskId-shaped string that does NOT resolve to
+    // any task file ("null"). slotAssign normalizes the local taskId to JS
+    // `null` (the existsSync(tf) branch is false), exercising the *absent*
+    // arm of the journal-format conditional. This is the only branch the AC
+    // guards; a regression that re-introduced a `task=null` placeholder, or
+    // dropped the conditional entirely (`(task=undefined)`, etc.), would
+    // surface here.
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(harness, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+
+    void slotAssign(1, "null", "t3code");
+
+    const today = new Date().toISOString().slice(0, 10);
+    const journalPath = join(harness, "journal", `${today}.md`);
+    const journal = readFileSync(journalPath, "utf-8");
+    const assignLine = journal.split("\n").find((l) => l.includes("Slot 1 assigned"));
+    expect(assignLine).toBeDefined();
+    // Invariant: no `(task=...)` parenthetical at all when taskId is absent.
+    expect(assignLine!).not.toMatch(/\(task=/);
+    // Adapter parenthetical and processDesc are still present.
+    expect(assignLine!).toContain("(adapter=t3code)");
+  });
+
+  test("journal entry includes (task=<id>) when a task resolves (task-138eb60b AC3 sibling)", () => {
+    // Sibling/positive control for the AC3 conditional: when a task file
+    // exists, `taskId` is set and the parenthetical must reappear with the
+    // resolved id. Pins that the writer didn't drop the parenthetical
+    // unconditionally.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-journal-id", "Journal id present");
+
+    void slotAssign(1, "task-journal-id", "manual");
+
+    const today = new Date().toISOString().slice(0, 10);
+    const journalPath = join(harness, "journal", `${today}.md`);
+    const journal = readFileSync(journalPath, "utf-8");
+    const assignLine = journal.split("\n").find((l) => l.includes("Slot 1 assigned"));
+    expect(assignLine).toBeDefined();
+    expect(assignLine!).toContain("(task=task-journal-id)");
+    expect(assignLine!).toContain("(adapter=manual)");
+  });
+
   test("batches the three frontmatter field updates into a single atomic write (task-29bea074)", async () => {
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -198,7 +198,7 @@ function readRawEffortField(content: string): string | null {
  * the (slot, adapter, started) write transactional — a crash mid-sequence would
  * otherwise leave the task with partial assignment (e.g. slot but no adapter).
  */
-function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, string>): void {
+function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, string | null>): void {
   const file = taskFilePath(taskId);
   if (!existsSync(file)) return;
 
@@ -223,7 +223,9 @@ function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, str
       let matched = false;
       for (const field of remaining) {
         if (line.startsWith(`${field}:`)) {
-          output.push(`${field}: ${updates[field]}`);
+          const raw = updates[field]!;
+          const rendered = (raw === null || raw === "") ? "null" : raw;
+          output.push(`${field}: ${rendered}`);
           remaining.delete(field);
           matched = true;
           break;
@@ -237,7 +239,7 @@ function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, str
   atomicWriteFileSync(file, output.join("\n"));
 }
 
-function taskUpdateFrontmatter(taskId: string, field: string, value: string): void {
+function taskUpdateFrontmatter(taskId: string, field: string, value: string | null): void {
   taskUpdateFrontmatterFields(taskId, { [field]: value });
 }
 
@@ -283,7 +285,7 @@ function taskUpdateForSlotClear(taskId: string, finalStatus: string): void {
     console.error(`ludics: skipping slot clear for ${taskId}: status is '${actual}', expected one of [${expectedFrom.join(", ")}]`);
     return;
   }
-  taskUpdateFrontmatter(taskId, "slot", "null");
+  taskUpdateFrontmatter(taskId, "slot", null);
 
   if (finalStatus === "done" || finalStatus === "abandoned") {
     const completed = new Date().toISOString().replace(/\.\d{3}Z$/, "Z").replace(/:\d{2}Z$/, "Z");
@@ -396,7 +398,7 @@ export async function slotAssign(
   if (oldData.task && oldData.task !== taskId) {
     const oldTaskFile = taskFilePath(oldData.task);
     if (existsSync(oldTaskFile)) {
-      updateFrontmatterField(oldTaskFile, "slot", "null");
+      updateFrontmatterField(oldTaskFile, "slot", null);
       const oldContent = readFileSync(oldTaskFile, "utf-8");
       const oldStatus = parseTaskFrontmatter(oldContent).status;
       if (oldStatus === "in-progress" || oldStatus === "deferred") {
@@ -434,7 +436,10 @@ export async function slotAssign(
     taskUpdateForSlotAssign(taskId, slotNum, adapter, started);
   }
 
-  journalAppend("slot", `Slot ${slotNum} assigned: ${processDesc} (task=${taskId ?? "null"}, adapter=${adapter})`);
+  journalAppend(
+    "slot",
+    `Slot ${slotNum} assigned: ${processDesc}${taskId ? ` (task=${taskId})` : ""} (adapter=${adapter})`,
+  );
   emitEvent({ event_type: "slot_assign", source: "cli", scope: "slot", slot: slotNum, task: taskId ?? undefined, adapter, message: processDesc });
   stateMarkDirty();
 }
@@ -605,7 +610,7 @@ export function taskCompleteDirectly(taskId: string): void {
     console.error(`ludics: skipping direct completion for ${taskId}: status is '${actual}', expected one of [in-progress, deferred]`);
     return;
   }
-  taskUpdateFrontmatter(taskId, "slot", "null");
+  taskUpdateFrontmatter(taskId, "slot", null);
   const completed = new Date().toISOString().replace(/\.\d{3}Z$/, "Z").replace(/:\d{2}Z$/, "Z");
   taskUpdateFrontmatter(taskId, "completed", completed);
   pruneBlockedBy(taskId);

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -14,7 +14,7 @@ import { journalAppend } from "../journal.ts";
 import { emitEvent } from "../events.ts";
 import { runAdapterAction, readAdapterState, readAdapterLastActivity } from "../adapters/index.ts";
 import type { AdapterContext } from "../adapters/index.ts";
-import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus } from "../tasks/markdown.ts";
+import { addFrontmatterField, updateFrontmatterField, updateDependencyArray, parseTaskFrontmatter, transitionStatus, renderFrontmatterValue } from "../tasks/markdown.ts";
 import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
@@ -223,9 +223,7 @@ function taskUpdateFrontmatterFields(taskId: string, updates: Record<string, str
       let matched = false;
       for (const field of remaining) {
         if (line.startsWith(`${field}:`)) {
-          const raw = updates[field]!;
-          const rendered = (raw === null || raw === "") ? "null" : raw;
-          output.push(`${field}: ${rendered}`);
+          output.push(`${field}: ${renderFrontmatterValue(updates[field]!)}`);
           remaining.delete(field);
           matched = true;
           break;

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -270,7 +270,7 @@ function tasksMerge(targetId: string, sourceIds: string[]): void {
       continue;
     }
     addFrontmatterField(srcFile, "merged_into", targetId);
-    updateFrontmatterField(srcFile, "slot", "null");
+    updateFrontmatterField(srcFile, "slot", null);
     mergedIds.push(srcId);
     console.log(`Merged: ${srcId} -> ${targetId}`);
   }

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -192,6 +192,96 @@ describe("addFrontmatterField", () => {
   });
 });
 
+describe("updateFrontmatterField null/empty normalization", () => {
+  // Invariant: when callers pass JS `null` or `""`, the writer emits the
+  // canonical YAML null token `null` on disk — never the JS-literal string
+  // `"null"` and never an empty value. Replaces the legacy
+  // `updateFrontmatterField(file, "slot", "null")` write idiom.
+  test("null value renders as canonical YAML null on existing field", () => {
+    const f = tmpFile("null-update.md", [
+      "---",
+      "id: task-1",
+      "slot: 3",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "slot", null);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("slot: null");
+    // Round-trip: parser sees the field as absent (null/undefined-y).
+    const fm = parseTaskFrontmatter(result);
+    expect(fm.slot ?? null).toBeNull();
+  });
+
+  test("empty string value normalizes to YAML null on existing field", () => {
+    const f = tmpFile("empty-update.md", [
+      "---",
+      "id: task-1",
+      "slot: 3",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "slot", "");
+    const result = readFileSync(f, "utf-8");
+    // Must be the canonical `null` token, not a dangling `slot: ` line.
+    expect(result).toContain("slot: null");
+    expect(result).not.toMatch(/^slot:\s*$/m);
+  });
+
+  test("null value renders as YAML null when upserting a missing field", () => {
+    const f = tmpFile("null-upsert.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "slot", null);
+    const result = readFileSync(f, "utf-8");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch).not.toBeNull();
+    expect(fmMatch![1]).toContain("slot: null");
+  });
+
+  test("non-empty string value passes through verbatim (regression guard)", () => {
+    // Harness condition: value is a real, non-empty, non-null string —
+    // the only branch where the normalization rule must NOT fire.
+    const f = tmpFile("passthrough.md", [
+      "---",
+      "id: task-1",
+      "slot: null",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    updateFrontmatterField(f, "slot", "3");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("slot: 3");
+    expect(result).not.toContain("slot: null");
+  });
+
+  test("addFrontmatterField inherits the same null/empty normalization", () => {
+    const f = tmpFile("add-null.md", [
+      "---",
+      "id: task-1",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+
+    addFrontmatterField(f, "slot", null);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("slot: null");
+  });
+});
+
 describe("parseTaskFrontmatter field reads", () => {
   test("reads basic scalar value (proposal)", () => {
     const content = "---\nproposal: docs/proposals/foo.md\n---\n\n# Title";

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -209,19 +209,22 @@ export function frontmatterBounds(lines: string[]): { openLine: number; closeLin
   return null;
 }
 
-export function updateFrontmatterField(filePath: string, field: string, value: string): void {
+export function updateFrontmatterField(filePath: string, field: string, value: string | null): void {
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
   const bounds = frontmatterBounds(lines);
   if (!bounds) return;
 
+  // Normalize JS null and empty string to the canonical YAML null token.
+  const rendered = (value === null || value === "") ? "null" : value;
+
   let done = false;
   const output: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
     if (i > bounds.openLine && i < bounds.closeLine && !done && lines[i]!.startsWith(`${field}:`)) {
-      output.push(`${field}: ${value}`);
+      output.push(`${field}: ${rendered}`);
       done = true;
       continue;
     }
@@ -230,13 +233,13 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
 
   if (!done) {
     // Upsert: insert before the frontmatter closing ---
-    output.splice(bounds.closeLine, 0, `${field}: ${value}`);
+    output.splice(bounds.closeLine, 0, `${field}: ${rendered}`);
   }
 
   atomicWriteFileSync(filePath, output.join("\n"));
 }
 
-export function addFrontmatterField(filePath: string, field: string, value: string): void {
+export function addFrontmatterField(filePath: string, field: string, value: string | null): void {
   updateFrontmatterField(filePath, field, value);
 }
 

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -209,6 +209,16 @@ export function frontmatterBounds(lines: string[]): { openLine: number; closeLin
   return null;
 }
 
+/** Normalize a frontmatter scalar to its on-disk YAML form. JS `null` and
+ *  the empty string both render as the canonical YAML null token, so any
+ *  "absent" sentinel a caller passes ends up as a single shape on disk
+ *  (`<field>: null`). Non-empty strings pass through verbatim. Exported so
+ *  other writers in the repo can share the rule without re-stating the
+ *  literal — keeps `grep '"null"'` from re-finding the legacy sentinel. */
+export function renderFrontmatterValue(value: string | null): string {
+  return (value === null || value === "") ? "null" : value;
+}
+
 export function updateFrontmatterField(filePath: string, field: string, value: string | null): void {
   if (!existsSync(filePath)) return;
   const content = readFileSync(filePath, "utf-8");
@@ -216,8 +226,7 @@ export function updateFrontmatterField(filePath: string, field: string, value: s
   const bounds = frontmatterBounds(lines);
   if (!bounds) return;
 
-  // Normalize JS null and empty string to the canonical YAML null token.
-  const rendered = (value === null || value === "") ? "null" : value;
+  const rendered = renderFrontmatterValue(value);
 
   let done = false;
   const output: string[] = [];


### PR DESCRIPTION
## Summary

Eliminates the legacy `"null"` JS-literal sentinel from `src/slots/index.ts` frontmatter writes — the last reason to keep that branch alive after reader-side normalization (`normalizeOptionalString`, `parseTaskFrontmatterLineFallback`) was already centralized. On-disk byte shape stays exactly `<field>: null`; only the JS-literal smell goes away.

- **Writer signatures widened** to `string | null` — `updateFrontmatterField`, `addFrontmatterField` (`src/tasks/markdown.ts`); `taskUpdateFrontmatterFields`, `taskUpdateFrontmatter` (`src/slots/index.ts`).
- **Shared helper**: `renderFrontmatterValue(value)` exported from `src/tasks/markdown.ts` collapses `null` and `""` to the canonical YAML `null` token. Both writers route through it, so the literal `"null"` no longer appears in `src/slots/index.ts` at all.
- **Four call sites flipped** in `src/slots/index.ts`: `taskUpdateForSlotClear` (slotClear), `slotAssign` reassign cleanup, `taskCompleteDirectly`, plus the `slotAssign` journal-format line — which now drops the `(task=...)` parenthetical entirely when `taskId` is absent (instead of emitting `task=null`).
- **scope-expansion**: same idiom in `src/tasks/index.ts:273` (`tasksMerge` clears `slot:` on a merged-source task) — declared in commit `0a29959`'s trailer; reviewer accepted.
- **Regression tests** alongside both behavior changes:
  - `src/tasks/markdown.test.ts` — 5 new normalization tests (null/"" → YAML null on update + upsert; non-empty passthrough negative control; `addFrontmatterField` inheritance).
  - `src/slots/index.test.ts` — 2 new journal-file tests for the `slotAssign` parenthetical AC: absent-taskId omits `(task=...)`; positive control asserts it reappears for a real task.

## Verification

- `bun run lint`, `bun run typecheck`, `bun run build` — clean.
- `bun test src/tasks/markdown.test.ts src/slots/index.test.ts` — **154 pass / 0 fail**.
- `grep -n '"null"' src/slots/index.ts` — only the out-of-scope reader helper (line 190) and the `slotPreemptStash`/`slotPreemptUnstash` cluster (lines 688–743) remain, exactly as the proposal carves out.
- One unrelated preexisting failure in `src/orchestration/skills.test.ts` ("PROPOSAL_FRESHNESS_WARNING boundary") confirmed to fail on the base branch via `git stash` — out of scope (relates to the freshness-threshold change in `c0c929e`).

## Test plan

- [ ] `bun run lint && bun run typecheck && bun run build` exit clean
- [ ] `bun test src/tasks/markdown.test.ts src/slots/index.test.ts` is green
- [ ] `grep -n '"null"' src/slots/index.ts` returns only the reader helper and preempt-stash hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)