### PR TITLE
Defense-in-depth recovery for wrong-filename phase artifacts

### DIFF
--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -102,6 +102,27 @@ describe("parseOrchestrationAdapterArgs", () => {
     expect(parsed.orchestration?.agents[1]?.name).toBe("reviewer");
     expect(parsed.orchestration?.agents[1]?.provider).toBe("claude-code");
   });
+
+  test("--auto-recover-wrong-filename sets autoRecoverWrongFilename to true", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pair --auto-recover-wrong-filename");
+    expect(parsed.orchestration?.config.autoRecoverWrongFilename).toBe(true);
+  });
+
+  test("--no-auto-recover-wrong-filename sets autoRecoverWrongFilename to false", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pair --no-auto-recover-wrong-filename");
+    expect(parsed.orchestration?.config.autoRecoverWrongFilename).toBe(false);
+  });
+
+  test("default autoRecoverWrongFilename is true when no flag is passed", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pair");
+    // Adapter parser writes a partial config; the absence of an explicit
+    // toggle leaves the field unset, and defaultOrchestrationConfig() (used
+    // when the partial is plumbed through tmux/t3code start paths) supplies
+    // the default. The runtime-effective default is asserted in
+    // wrong-filename-recovery.test.ts; this assertion locks in that the
+    // adapter parser does NOT silently force the field to false.
+    expect(parsed.orchestration?.config.autoRecoverWrongFilename).not.toBe(false);
+  });
 });
 
 describe("orchestratedThreadTitle", () => {

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -340,6 +340,12 @@ export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
       case "--auto-finish":
         orchestrationConfig.autoFinish = true;
         break;
+      case "--auto-recover-wrong-filename":
+        orchestrationConfig.autoRecoverWrongFilename = true;
+        break;
+      case "--no-auto-recover-wrong-filename":
+        orchestrationConfig.autoRecoverWrongFilename = false;
+        break;
       case "--mag-tailoring":
         orchestrationConfig.useMagTailoring = true;
         break;

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -5,6 +5,40 @@ import { join } from "path";
 import type { AdapterContext } from "./types.ts";
 import { defaultOrchestrationConfig, initAgentRuntimeState, persistState, type OrchestrationState } from "../orchestration/state.ts";
 
+describe("tmux adapter — wrong-filename recovery flag pass-through", () => {
+  // tmux-adapter.ts imports `parseOrchestrationAdapterArgs` from t3code
+  // (`tmux-adapter.ts:37`) and threads the resulting orchestration.config
+  // through `defaultOrchestrationConfig(orchestration.config)` at the start
+  // path's persistState call (`tmux-adapter.ts:525`). This test locks in
+  // that --no-auto-recover-wrong-filename actually arrives at the persisted
+  // OrchestrationState.config without being overridden by the default.
+  test("--no-auto-recover-wrong-filename round-trips through defaultOrchestrationConfig as false", async () => {
+    const { parseOrchestrationAdapterArgs } = await import("./t3code.ts");
+    const { defaultOrchestrationConfig } = await import("../orchestration/state.ts");
+    const parsed = parseOrchestrationAdapterArgs("--pair --no-auto-recover-wrong-filename");
+    expect(parsed.orchestration?.config.autoRecoverWrongFilename).toBe(false);
+    // Mirrors the call at tmux-adapter.ts:525.
+    const persisted = defaultOrchestrationConfig(parsed.orchestration!.config);
+    expect(persisted.autoRecoverWrongFilename).toBe(false);
+  });
+
+  test("--auto-recover-wrong-filename round-trips as true", async () => {
+    const { parseOrchestrationAdapterArgs } = await import("./t3code.ts");
+    const { defaultOrchestrationConfig } = await import("../orchestration/state.ts");
+    const parsed = parseOrchestrationAdapterArgs("--pair --auto-recover-wrong-filename");
+    const persisted = defaultOrchestrationConfig(parsed.orchestration!.config);
+    expect(persisted.autoRecoverWrongFilename).toBe(true);
+  });
+
+  test("default (no flag) → defaultOrchestrationConfig produces true", async () => {
+    const { parseOrchestrationAdapterArgs } = await import("./t3code.ts");
+    const { defaultOrchestrationConfig } = await import("../orchestration/state.ts");
+    const parsed = parseOrchestrationAdapterArgs("--pair");
+    const persisted = defaultOrchestrationConfig(parsed.orchestration!.config);
+    expect(persisted.autoRecoverWrongFilename).toBe(true);
+  });
+});
+
 describe("tmux adapter exports", () => {
   test("adapter module is importable", async () => {
     const mod = await import("./tmux-adapter.ts");

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -1326,3 +1326,85 @@ describe("harness isolation regression", () => {
     expect(existsSync(harness!)).toBe(true);
   });
 });
+
+describe("validateDoneStatus suppression for wrong-filename recovery", () => {
+  // The artifact gate's 10s `orchestration_warning` is suppressed for one tick
+  // when the wrong-filename recovery driver has already nudged this
+  // (round, planMergeRound) tuple — the driver's own diagnostic event
+  // covers visibility.
+
+  function makeMissingArtifactState(opts: {
+    nudgeRound?: number;
+    nudgeMergeRound?: number | null;
+    planMergeRound?: number;
+  } = {}): OrchestrationState {
+    const peerSyncDir = mkdtempSync(join(tmpdir(), "phases-supp-"));
+    mkdirSync(join(peerSyncDir, "plans"), { recursive: true });
+    const state = makeState({
+      phase: "plan-merge",
+      planMergeRound: opts.planMergeRound ?? 0,
+      peerSyncDir,
+    });
+    // Status that triggers the artifact gate; lifecycle settled with a fresh
+    // fingerprint so isAgentDone reaches validateDoneStatus.
+    state.agentStates["coder"].status = "plan-merge-done";
+    state.agentStates["coder"].turnLifecycle = {
+      dispatchCommandId: "cmd",
+      dispatchedAt: "2026-04-30T00:00:00Z",
+      phaseToken: "tok",
+      observedTurnId: "turn",
+      state: "settled",
+      turnStartedAt: "2026-04-30T00:00:00Z",
+      turnCompletedAt: "2026-04-30T00:00:01Z",
+      completionSource: "snapshot",
+      statusFileFingerprint: "fp-old",
+      lastStopHookAt: null,
+      wrongFilenameNudgeRound: opts.nudgeRound,
+      wrongFilenameNudgePlanMergeRound: opts.nudgeMergeRound,
+    };
+    // Ensure fingerprint differs from baseline (no dispatchStatusFingerprint set
+    // means isStatusFresh returns true).
+    return state;
+  }
+
+  test("suppresses orchestration_warning when sentinels match this tuple", async () => {
+    const state = makeMissingArtifactState({ nudgeRound: 1, nudgeMergeRound: 0, planMergeRound: 0 });
+    const eventsMod = await import("../events.ts");
+    const events: Array<Record<string, unknown>> = [];
+    const spy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const done = isAgentDone(state, state.agents[0]);
+      expect(done).toBe(false);
+      expect(events.find((e) => e.event_type === "orchestration_warning")).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("emits orchestration_warning when sentinel round mismatches", async () => {
+    const state = makeMissingArtifactState({ nudgeRound: 99, nudgeMergeRound: 0, planMergeRound: 0 });
+    const eventsMod = await import("../events.ts");
+    const events: Array<Record<string, unknown>> = [];
+    const spy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const done = isAgentDone(state, state.agents[0]);
+      expect(done).toBe(false);
+      expect(events.some((e) => e.event_type === "orchestration_warning")).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("emits orchestration_warning when sentinel planMergeRound mismatches", async () => {
+    const state = makeMissingArtifactState({ nudgeRound: 1, nudgeMergeRound: 99, planMergeRound: 0 });
+    const eventsMod = await import("../events.ts");
+    const events: Array<Record<string, unknown>> = [];
+    const spy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      isAgentDone(state, state.agents[0]);
+      expect(events.some((e) => e.event_type === "orchestration_warning")).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -8,6 +8,7 @@ import { reviewFilePath } from "./review-files.ts";
 import type { AgentConfig, AgentRuntimeState, OrchestrationState } from "./state.ts";
 import { readDuoPeerState, bothSlotsReadyForMerge, isMergeCoordinator } from "./cross-slot.ts";
 import { nowEpoch } from "./util.ts";
+import { recoveryRecentlyActed } from "./wrong-filename-recovery.ts";
 
 export type Phase =
   | "setup"
@@ -195,6 +196,13 @@ function validateDoneStatus(state: OrchestrationState, agent: AgentConfig, runti
   // bail-out-confirmed without the coder side must not skip artifact checks.
   if ((runtime.status === "bail-out" || runtime.status === "bail-out-confirmed") && isBailedOut(state)) return true;
   if (!hasRequiredArtifact(state, agent)) {
+    // Suppress the 10s warning when the wrong-filename recovery driver
+    // already nudged this (round, planMergeRound) tuple — its own
+    // diagnostic event covers visibility, and we don't want to spam
+    // both event types on every poll. The driver lives in
+    // wrong-filename-recovery.ts and runs from runner.ts before this
+    // gate is consulted.
+    if (recoveryRecentlyActed(state, agent, runtime)) return false;
     emitEvent({
       event_type: "orchestration_warning",
       source: "orchestration",

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -3,7 +3,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { isAgentDone } from "./phases.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
-import { refreshAgentStatuses, runOrchestration } from "./runner.ts";
+import { refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery } from "./runner.ts";
+import * as wfr from "./wrong-filename-recovery.ts";
 import * as peerSync from "./peer-sync.ts";
 import * as events from "../events.ts";
 import { orchOnStop } from "./index.ts";
@@ -1288,6 +1289,51 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       expect(msgs.some((m: string) => m.includes("PID mismatch"))).toBe(true);
     } finally {
       errSpy.mockRestore();
+    }
+  });
+});
+
+describe("runWrongFilenameRecovery — runner integration", () => {
+  test("invokes recoverWrongFilename only for participating agents whose status is in DONE_STATUSES", async () => {
+    const state = makeState({ phase: "plan-merge", planMergeRound: 0 });
+    state.agentStates["coder"].status = "plan-merge-done";
+    state.agentStates["reviewer"].status = "running"; // not a done status
+    const transport: OrchestrationTransport = {
+      async sendTurn() { return "cmd"; },
+      async sendEnter() {},
+      async refreshAgentTransportState() {},
+      async interruptAgent() {},
+    };
+    const calls: string[] = [];
+    const spy = spyOn(wfr, "recoverWrongFilename").mockImplementation(async (_s, agent) => {
+      calls.push(agent.name);
+      return "none";
+    });
+    try {
+      await runWrongFilenameRecovery(state, transport);
+      // Only coder participates in plan-merge AND has a done-status. Reviewer
+      // doesn't participate in plan-merge at all, and isn't in DONE_STATUSES.
+      expect(calls).toEqual(["coder"]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("skips agents whose status is not in DONE_STATUSES even if they participate", async () => {
+    const state = makeState({ phase: "plan-merge" });
+    state.agentStates["coder"].status = "running";
+    const transport: OrchestrationTransport = {
+      async sendTurn() { return "cmd"; },
+      async sendEnter() {},
+      async refreshAgentTransportState() {},
+      async interruptAgent() {},
+    };
+    const spy = spyOn(wfr, "recoverWrongFilename").mockImplementation(async () => "none");
+    try {
+      await runWrongFilenameRecovery(state, transport);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
     }
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -30,6 +30,7 @@ import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } 
 import type { OrchestrationTransport } from "./transport.ts";
 import { agentPortRole, readTmuxSlotState, startTtyd, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { readSlotState, processAlive } from "../t3code/server.ts";
+import { recoverWrongFilename } from "./wrong-filename-recovery.ts";
 
 // --- Hung agent detection constants ---
 // A "hung agent" appears to be working (lifecycle running/dispatched) but the
@@ -1392,6 +1393,23 @@ export function autoCommitAllAgents(
   }
 }
 
+/** Drive the wrong-filename recovery branch once per poll cycle.
+ *  Invokes `recoverWrongFilename` for each phase-participating agent that
+ *  has self-reported phase completion (status in DONE_STATUSES) — exactly
+ *  the precondition for the artifact gate's 10s warning to fire. */
+export async function runWrongFilenameRecovery(
+  state: OrchestrationState,
+  transport: OrchestrationTransport,
+): Promise<void> {
+  for (const agent of state.agents) {
+    if (!agentParticipatesInPhase(state, agent)) continue;
+    const runtime = state.agentStates[agent.name];
+    if (!runtime) continue;
+    if (!DONE_STATUSES.has(runtime.status)) continue;
+    await recoverWrongFilename(state, agent, runtime, transport);
+  }
+}
+
 async function pollUntilDone(state: OrchestrationState, transport: OrchestrationTransport): Promise<void> {
   const timeout = state.config.timeouts[state.phase] ?? 600;
   const deadline = state.phaseStartedAt + timeout;
@@ -1426,6 +1444,13 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
 
       // Detect hung agents (static terminal) and send nudges / force-settle.
       await detectAndNudgeHungAgents(state, transport);
+
+      // Wrong-filename recovery: auto-cp safe alternatives onto the
+      // canonical artifact path, or send a targeted nudge listing
+      // recently-modified candidates. Runs after status refresh so
+      // `runtime.status` is fresh, and before `evaluateTransition` so an
+      // auto-cp becomes visible to this same tick's done-check.
+      await runWrongFilenameRecovery(state, transport);
 
       // Restart dead ttyd processes so dashboard terminals stay live.
       await ensureTtydAlive(state);

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -68,6 +68,12 @@ export interface AgentTurnLifecycle {
   lastPaneHash?: string | null;
   /** ISO timestamp when pane output last changed. */
   lastPaneChangeAt?: string | null;
+  // --- Wrong-filename recovery dedup (per-(round, planMergeRound) tuple) ---
+  /** state.round at which the most recent wrong-filename nudge fired. */
+  wrongFilenameNudgeRound?: number;
+  /** state.planMergeRound (??-1) at which the most recent wrong-filename nudge fired.
+   *  Distinguishes plan-merge / plan-review iterations within a single outer round. */
+  wrongFilenameNudgePlanMergeRound?: number | null;
 }
 
 export interface AgentRuntimeState {
@@ -117,6 +123,9 @@ export interface OrchestrationConfig {
   prCommentsTimeout: number;
   /** How often (seconds) to poll GitHub for new PR comments during pr-comments phase. */
   prCommentsCheckInterval: number;
+  /** Gates the wrong-filename auto-cp branch only. When false, whitelisted suspects
+   *  fall through to the targeted-nudge branch instead of being auto-copied. */
+  autoRecoverWrongFilename: boolean;
 }
 
 export interface OrchestrationState {
@@ -250,6 +259,7 @@ export function defaultOrchestrationConfig(
     prCommentsTimeout: overrides.prCommentsTimeout ?? DEFAULT_PR_COMMENTS_TIMEOUT,
     prCommentsCheckInterval:
       overrides.prCommentsCheckInterval ?? DEFAULT_PR_COMMENTS_CHECK_INTERVAL,
+    autoRecoverWrongFilename: overrides.autoRecoverWrongFilename ?? true,
   };
 }
 
@@ -294,6 +304,11 @@ export function migrateState(state: OrchestrationState, slot: number): Orchestra
     if (state.agents && state.agents.length !== 1) {
       console.error(`ludics: slot ${slot} has mode="solo" with ${state.agents.length} agents — invariant violation (solo must have exactly one agent)`);
     }
+  }
+  // Fill in fields added after the on-disk schema was first written so reads
+  // of legacy slot-N.json don't surface `undefined` to downstream consumers.
+  if (state.config && state.config.autoRecoverWrongFilename === undefined) {
+    state.config.autoRecoverWrongFilename = true;
   }
   return state;
 }

--- a/src/orchestration/wrong-filename-recovery.test.ts
+++ b/src/orchestration/wrong-filename-recovery.test.ts
@@ -548,6 +548,110 @@ describe("recoverWrongFilename — driver outcomes", () => {
     }
   });
 
+  test("(P1 regression) lc === null → returns none, no nudge spam, sentinels not consulted", async () => {
+    // Codex review: when runtime.turnLifecycle is null (legacy / resume /
+    // setup paths), we have nowhere to persist the nudge sentinel, so
+    // sending a nudge would re-fire on every poll forever and
+    // `recoveryRecentlyActed` would NOT suppress the existing warning.
+    // The driver bails out of the nudge branch in that state — auto-cp
+    // still runs above, but the nudge path is skipped so we don't get
+    // double-spam (warning + nudge every 10s).
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    state.agentStates["coder"].turnLifecycle = null;
+    const junk = join(dir, "plans", "scratch.md");
+    writeFile(junk, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const events: Array<Record<string, unknown>> = [];
+    const eventSpy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      // First poll
+      let outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("none");
+      expect(calls).toEqual([]);
+      expect(events.find((e) => e.event_type === "orchestration_wrong_filename_nudge")).toBeUndefined();
+      // Second poll (would have re-fired before the fix)
+      outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("none");
+      expect(calls).toEqual([]);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(P1 regression) lc === null still allows auto-cp (FS-only, idempotent)", async () => {
+    // Auto-cp doesn't need lifecycle state — it's pure FS, idempotent
+    // (next tick sees canonical and returns "none"). Confirm the lc=null
+    // bail-out is on the nudge branch only, not auto-cp.
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    state.agentStates["coder"].turnLifecycle = null;
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    writeFile(suspect, "merged-content", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("cp");
+      expect(calls).toEqual([]);
+      expect(readFileSync(mergedPlanFilePath(dir, 1, 0), "utf8")).toBe("merged-content");
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(P2 regression) auto-cp uses strict > on phaseStartedAt boundary", async () => {
+    // Codex review: mtime and phaseStartedAt are both floored to seconds.
+    // A file written in the same wall-clock second as the phase
+    // transition is ambiguous between "last write of previous phase" and
+    // "first write of new phase". Auto-cp is destructive so it uses
+    // strict `>` (not `>=`) — boundary-second files are excluded.
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    // mtime exactly at phaseStartedAt → must NOT auto-cp.
+    writeFile(suspect, "boundary", state.phaseStartedAt);
+
+    const { transport, calls } = makeMockTransport();
+    const events: Array<Record<string, unknown>> = [];
+    const eventSpy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      // Falls through to nudge branch (the suspect IS recent enough for
+      // the informational scan, which keeps `>=`), so outcome is
+      // "nudge", not "cp".
+      expect(outcome).toBe("nudge");
+      expect(events.find((e) => e.event_type === "orchestration_artifact_recovered")).toBeUndefined();
+      expect(existsSync(mergedPlanFilePath(dir, 1, 0))).toBe(false);
+      expect(calls.length).toBe(1);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(P2 regression) auto-cp fires for mtime = phaseStartedAt + 1 second", async () => {
+    // Sanity check: just one second past the boundary auto-cp's normally.
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    writeFile(suspect, "in-phase", state.phaseStartedAt + 1);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("cp");
+      expect(calls).toEqual([]);
+      expect(readFileSync(mergedPlanFilePath(dir, 1, 0), "utf8")).toBe("in-phase");
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
   test("non-eligible phase → none (work, merge-amend)", async () => {
     const dir = makePeerSync();
     for (const phase of ["work", "merge-amend"] as const) {

--- a/src/orchestration/wrong-filename-recovery.test.ts
+++ b/src/orchestration/wrong-filename-recovery.test.ts
@@ -1,0 +1,667 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as eventsMod from "../events.ts";
+import { mergedPlanFilePath } from "./plan-files.ts";
+import { defaultOrchestrationConfig, initAgentRuntimeState, type OrchestrationState } from "./state.ts";
+import type { OrchestrationTransport } from "./transport.ts";
+import {
+  attemptAutoCp,
+  isRecoveryEligiblePhase,
+  recoverWrongFilename,
+  recoveryRecentlyActed,
+  scanRecentlyModified,
+  whitelistSuspects,
+} from "./wrong-filename-recovery.ts";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+let TEST_TMP = "";
+
+beforeEach(() => {
+  TEST_TMP = mkdtempSync(join(tmpdir(), "ludics-wfr-test-"));
+  process.env.HOME = TEST_TMP;
+  const configDir = join(TEST_TMP, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "config.yaml"), `state_repo: test/ludics-state\nstate_path: harness\n`);
+  process.env.LUDICS_CONFIG = join(configDir, "config.yaml");
+  process.env.LUDICS_HARNESS_DIR = join(TEST_TMP, "harness");
+  mkdirSync(join(TEST_TMP, "harness"), { recursive: true });
+});
+
+afterEach(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+});
+
+function makePeerSync(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ludics-wfr-peer-"));
+  mkdirSync(join(dir, "plans"), { recursive: true });
+  mkdirSync(join(dir, "reviews"), { recursive: true });
+  return dir;
+}
+
+function makeState(peerSyncDir: string, overrides: Partial<OrchestrationState> = {}): OrchestrationState {
+  const phaseStartedAt = Math.floor(Date.now() / 1000) - 60;
+  return {
+    slot: 1,
+    taskId: "task-3a29f3fb",
+    mode: "pair",
+    phase: "plan-merge",
+    round: 1,
+    mergeRound: 0,
+    planMergeRound: 0,
+    agents: [
+      { name: "coder", provider: "claude-code", role: "coder", model: "opus", branch: "a", worktreePath: "/tmp/a" },
+      { name: "reviewer", provider: "codex", role: "reviewer", model: "gpt-5", branch: "b", worktreePath: "/tmp/b" },
+    ],
+    agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+    config: defaultOrchestrationConfig(),
+    phaseStartedAt,
+    startedAt: "2026-04-30T00:00:00Z",
+    projectDir: "/tmp/project",
+    rootWorktree: "/tmp/project-feat",
+    peerSyncDir,
+    threadIds: { coder: "t1", reviewer: "t2" },
+    ...overrides,
+  };
+}
+
+function makeMockTransport(): { transport: OrchestrationTransport; calls: Array<{ agent: string; message: string }> } {
+  const calls: Array<{ agent: string; message: string }> = [];
+  const transport: OrchestrationTransport = {
+    async sendTurn(_state, agent, message) { calls.push({ agent: agent.name, message }); return "cmd-mock"; },
+    async sendEnter() {},
+    async refreshAgentTransportState() {},
+    async interruptAgent() {},
+  };
+  return { transport, calls };
+}
+
+function writeFile(path: string, content: string, mtimeSec?: number) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  if (mtimeSec !== undefined) {
+    const t = new Date(mtimeSec * 1000);
+    utimesSync(path, t, t);
+  }
+}
+
+function setSettledLifecycle(state: OrchestrationState, agent: string) {
+  state.agentStates[agent].turnLifecycle = {
+    dispatchCommandId: "cmd-test",
+    dispatchedAt: new Date().toISOString(),
+    phaseToken: "phase-test",
+    observedTurnId: "turn-1",
+    state: "settled",
+    turnStartedAt: new Date().toISOString(),
+    turnCompletedAt: new Date().toISOString(),
+    completionSource: "snapshot",
+    statusFileFingerprint: null,
+    lastStopHookAt: null,
+    nudgeAttempts: 0,
+    lastNudgeAt: null,
+  };
+}
+
+describe("isRecoveryEligiblePhase", () => {
+  test("eligible: plan, plan-merge, plan-review, review", () => {
+    expect(isRecoveryEligiblePhase("plan")).toBe(true);
+    expect(isRecoveryEligiblePhase("plan-merge")).toBe(true);
+    expect(isRecoveryEligiblePhase("plan-review")).toBe(true);
+    expect(isRecoveryEligiblePhase("review")).toBe(true);
+  });
+  test("ineligible: work, pr-create, merge-amend, etc.", () => {
+    expect(isRecoveryEligiblePhase("work")).toBe(false);
+    expect(isRecoveryEligiblePhase("pr-create")).toBe(false);
+    expect(isRecoveryEligiblePhase("merge-amend")).toBe(false);
+    expect(isRecoveryEligiblePhase("merge-execute")).toBe(false);
+    expect(isRecoveryEligiblePhase("setup")).toBe(false);
+    expect(isRecoveryEligiblePhase("done")).toBe(false);
+  });
+});
+
+describe("whitelistSuspects (plan-merge)", () => {
+  test("includes round-R-coder.md (clobber smell)", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    writeFile(join(dir, "plans", "round-1-coder.md"), "x");
+    const out = whitelistSuspects(state, state.agents[0]);
+    expect(out).toContain(join(dir, "plans", "round-1-coder.md"));
+  });
+
+  test("includes round-R-merge.md and round-R-merged.md (singular-name fallthrough via PLAN_RE)", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    writeFile(join(dir, "plans", "round-1-merge.md"), "x");
+    writeFile(join(dir, "plans", "round-1-merged.md"), "y");
+    const out = whitelistSuspects(state, state.agents[0]);
+    expect(out).toContain(join(dir, "plans", "round-1-merge.md"));
+    expect(out).toContain(join(dir, "plans", "round-1-merged.md"));
+  });
+
+  test("includes round-R-merged-(K-1).md and round-R-merged-(K+1).md (off-by-one / skip-counter)", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { planMergeRound: 1 });
+    writeFile(join(dir, "plans", "round-1-merged-0.md"), "x");
+    writeFile(join(dir, "plans", "round-1-merged-2.md"), "y");
+    const out = whitelistSuspects(state, state.agents[0]);
+    expect(out).toContain(join(dir, "plans", "round-1-merged-0.md"));
+    expect(out).toContain(join(dir, "plans", "round-1-merged-2.md"));
+  });
+
+  test("excludes the canonical merged-K.md", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    const canonical = mergedPlanFilePath(dir, 1, 0);
+    writeFile(canonical, "x");
+    const out = whitelistSuspects(state, state.agents[0]);
+    expect(out).not.toContain(canonical);
+  });
+
+  test("excludes cross-round files", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { round: 2, planMergeRound: 0 });
+    writeFile(join(dir, "plans", "round-1-coder.md"), "x");
+    const out = whitelistSuspects(state, state.agents[0]);
+    expect(out).not.toContain(join(dir, "plans", "round-1-coder.md"));
+  });
+
+  test("excludes files in reviews/", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    writeFile(join(dir, "reviews", "round-1-reviewer.md"), "x");
+    const out = whitelistSuspects(state, state.agents[0]);
+    // Whitelist scans plans/ only — the reviews/ directory is the nudge
+    // branch's territory.
+    expect(out.find((p) => p.includes("/reviews/"))).toBeUndefined();
+  });
+
+  test("returns [] for non-plan-merge phases", () => {
+    const dir = makePeerSync();
+    for (const phase of ["plan", "plan-review", "review"] as const) {
+      const state = makeState(dir, { phase });
+      expect(whitelistSuspects(state, state.agents[0])).toEqual([]);
+    }
+  });
+});
+
+describe("scanRecentlyModified", () => {
+  test("filters by mtime threshold and excludes canonical", () => {
+    const dir = makePeerSync();
+    const phaseStartedAt = 1_000_000;
+    const canonical = join(dir, "plans", "round-1-merged-0.md");
+    writeFile(join(dir, "plans", "fresh.md"), "x", phaseStartedAt + 10);
+    writeFile(join(dir, "plans", "stale.md"), "x", phaseStartedAt - 10);
+    writeFile(canonical, "x", phaseStartedAt + 5);
+    const out = scanRecentlyModified(dir, phaseStartedAt, canonical);
+    const paths = out.map((c) => c.path);
+    expect(paths).toContain(join(dir, "plans", "fresh.md"));
+    expect(paths).not.toContain(join(dir, "plans", "stale.md"));
+    expect(paths).not.toContain(canonical);
+  });
+
+  test("unions plans/ and reviews/", () => {
+    const dir = makePeerSync();
+    const phaseStartedAt = 1_000_000;
+    writeFile(join(dir, "plans", "p.md"), "x", phaseStartedAt + 10);
+    writeFile(join(dir, "reviews", "r.md"), "x", phaseStartedAt + 20);
+    const out = scanRecentlyModified(dir, phaseStartedAt, "/nonexistent");
+    const paths = out.map((c) => c.path);
+    expect(paths).toContain(join(dir, "plans", "p.md"));
+    expect(paths).toContain(join(dir, "reviews", "r.md"));
+  });
+
+  test("sorts descending by mtime, caps at 5", () => {
+    const dir = makePeerSync();
+    const phaseStartedAt = 1_000_000;
+    for (let i = 0; i < 7; i++) {
+      writeFile(join(dir, "plans", `f${i}.md`), "x", phaseStartedAt + i * 10);
+    }
+    const out = scanRecentlyModified(dir, phaseStartedAt, "/none");
+    expect(out.length).toBe(5);
+    for (let i = 0; i < out.length - 1; i++) {
+      expect(out[i].mtime).toBeGreaterThanOrEqual(out[i + 1].mtime);
+    }
+  });
+
+  test("missing directories treated as empty", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ludics-wfr-empty-"));
+    const out = scanRecentlyModified(dir, 0, "/none");
+    expect(out).toEqual([]);
+  });
+});
+
+describe("attemptAutoCp", () => {
+  test("preserves source mtime and copies content atomically", () => {
+    const dir = makePeerSync();
+    const src = join(dir, "plans", "src.md");
+    const dst = join(dir, "plans", "dst.md");
+    const fixedMtime = 1_700_000_000;
+    writeFile(src, "hello", fixedMtime);
+    expect(attemptAutoCp(src, dst)).toBe(true);
+    expect(readFileSync(dst, "utf8")).toBe("hello");
+    expect(Math.floor(statSync(dst).mtimeMs / 1000)).toBe(fixedMtime);
+  });
+
+  test("returns false on missing source", () => {
+    const dir = makePeerSync();
+    const dst = join(dir, "plans", "dst.md");
+    expect(attemptAutoCp(join(dir, "plans", "missing.md"), dst)).toBe(false);
+  });
+});
+
+describe("recoverWrongFilename — driver outcomes", () => {
+  test("(a) canonical present → none, no events, no sendTurn, nudgeAttempts unchanged", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    writeFile(mergedPlanFilePath(dir, 1, 0), "merged");
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("none");
+      expect(calls).toEqual([]);
+      expect(eventSpy).not.toHaveBeenCalled();
+      expect(state.agentStates["coder"].turnLifecycle?.nudgeAttempts).toBe(0);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(b) canonical missing + no in-phase mods → none", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("none");
+      expect(calls).toEqual([]);
+      expect(eventSpy).not.toHaveBeenCalled();
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(c) whitelisted suspect in-phase → cp, recovered event, no sendTurn, mtime preserved", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    const fixedMtime = state.phaseStartedAt + 30;
+    writeFile(suspect, "merged-content", fixedMtime);
+
+    const { transport, calls } = makeMockTransport();
+    const events: Array<Record<string, unknown>> = [];
+    const eventSpy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("cp");
+      expect(calls).toEqual([]);
+      const canonical = mergedPlanFilePath(dir, 1, 0);
+      expect(existsSync(canonical)).toBe(true);
+      expect(readFileSync(canonical, "utf8")).toBe("merged-content");
+      expect(Math.floor(statSync(canonical).mtimeMs / 1000)).toBe(fixedMtime);
+      expect(events.find((e) => e.event_type === "orchestration_artifact_recovered")).toBeTruthy();
+      expect(state.agentStates["coder"].turnLifecycle?.nudgeAttempts).toBe(0);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(d) non-whitelisted in-phase mod in plans/ → nudge, sendTurn called, sentinels set", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    // A non-parsing junk-named file (whitespace makes it non-canonical)
+    const junk = join(dir, "plans", "scratch.md");
+    writeFile(junk, "scratch", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const events: Array<Record<string, unknown>> = [];
+    const eventSpy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("nudge");
+      expect(calls.length).toBe(1);
+      expect(calls[0].agent).toBe("coder");
+      expect(calls[0].message).toContain(junk);
+      expect(calls[0].message).toContain(mergedPlanFilePath(dir, 1, 0));
+      const nudgeEv = events.find((e) => e.event_type === "orchestration_wrong_filename_nudge");
+      expect(nudgeEv).toBeTruthy();
+      expect((nudgeEv as { candidatePaths: string[] }).candidatePaths).toContain(junk);
+      const lc = state.agentStates["coder"].turnLifecycle!;
+      expect(lc.nudgeAttempts).toBe(1);
+      expect(lc.wrongFilenameNudgeRound).toBe(1);
+      expect(lc.wrongFilenameNudgePlanMergeRound).toBe(0);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(e) cross-directory mod in reviews/ → nudge body lists the cross-dir file", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const crossDir = join(dir, "reviews", "stray.md");
+    writeFile(crossDir, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("nudge");
+      expect(calls.length).toBe(1);
+      expect(calls[0].message).toContain(crossDir);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(f) whitelisted suspect with mtime < phaseStartedAt → none, no copy, no nudge", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    writeFile(suspect, "stale", state.phaseStartedAt - 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("none");
+      expect(calls).toEqual([]);
+      expect(existsSync(mergedPlanFilePath(dir, 1, 0))).toBe(false);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(g) autoRecoverWrongFilename:false + whitelisted suspect in-phase → nudge instead of cp", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, {
+      config: defaultOrchestrationConfig({ autoRecoverWrongFilename: false }),
+    });
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-coder.md");
+    writeFile(suspect, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("nudge");
+      expect(calls.length).toBe(1);
+      expect(existsSync(mergedPlanFilePath(dir, 1, 0))).toBe(false);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(h) round R nudge already sent, R+1 missing canonical → nudge fires again", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const lc = state.agentStates["coder"].turnLifecycle!;
+    lc.wrongFilenameNudgeRound = 1;
+    lc.wrongFilenameNudgePlanMergeRound = 0;
+    lc.nudgeAttempts = 1;
+
+    state.round = 2;
+    // Non-parsing filename so the auto-cp branch finds nothing and we
+    // genuinely exercise the nudge path.
+    const junk = join(dir, "plans", "scratch.md");
+    writeFile(junk, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("nudge");
+      expect(calls.length).toBe(1);
+      expect(lc.wrongFilenameNudgeRound).toBe(2);
+      expect(lc.nudgeAttempts).toBe(2);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(i) deferred when lc.state === running; nudge fires after flipping to settled", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const lc = state.agentStates["coder"].turnLifecycle!;
+    lc.state = "running";
+
+    const junk = join(dir, "plans", "scratch.md");
+    writeFile(junk, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      let outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("deferred");
+      expect(calls).toEqual([]);
+      expect(lc.nudgeAttempts).toBe(0);
+      expect(lc.wrongFilenameNudgeRound).toBeUndefined();
+
+      lc.state = "settled";
+      outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("nudge");
+      expect(calls.length).toBe(1);
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(j) singular-name auto-cp: round-R-merged.md in-phase → cp", async () => {
+    for (const fname of ["round-1-merged.md", "round-1-merge.md"]) {
+      const dir = makePeerSync();
+      const state = makeState(dir);
+      setSettledLifecycle(state, "coder");
+      const suspect = join(dir, "plans", fname);
+      writeFile(suspect, `body-of-${fname}`, state.phaseStartedAt + 30);
+      const { transport, calls } = makeMockTransport();
+      const eventSpy = spyOn(eventsMod, "emitEvent");
+      try {
+        const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+        expect(outcome).toBe("cp");
+        expect(calls).toEqual([]);
+        const canonical = mergedPlanFilePath(dir, 1, 0);
+        expect(readFileSync(canonical, "utf8")).toBe(`body-of-${fname}`);
+      } finally {
+        eventSpy.mockRestore();
+      }
+    }
+  });
+
+  test("(k) skip-counter: canonical merged-K missing, suspect merged-(K+1) present → cp", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { planMergeRound: 0 });
+    setSettledLifecycle(state, "coder");
+    const suspect = join(dir, "plans", "round-1-merged-1.md");
+    writeFile(suspect, "skip-counter-body", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("cp");
+      expect(calls).toEqual([]);
+      expect(readFileSync(mergedPlanFilePath(dir, 1, 0), "utf8")).toBe("skip-counter-body");
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(l) two qualifying whitelisted suspects → most-recently-modified wins", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const older = join(dir, "plans", "round-1-coder.md");
+    const newer = join(dir, "plans", "round-1-merge.md");
+    writeFile(older, "older-body", state.phaseStartedAt + 10);
+    writeFile(newer, "newer-body", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const eventSpy = spyOn(eventsMod, "emitEvent");
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("cp");
+      expect(calls).toEqual([]);
+      expect(readFileSync(mergedPlanFilePath(dir, 1, 0), "utf8")).toBe("newer-body");
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("(m) lc.state === error → diagnostic-only, no sendTurn, sentinels untouched", async () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const lc = state.agentStates["coder"].turnLifecycle!;
+    lc.state = "error";
+
+    const junk = join(dir, "plans", "scratch.md");
+    writeFile(junk, "x", state.phaseStartedAt + 30);
+
+    const { transport, calls } = makeMockTransport();
+    const events: Array<Record<string, unknown>> = [];
+    const eventSpy = spyOn(eventsMod, "emitEvent").mockImplementation((e) => { events.push(e as Record<string, unknown>); });
+    try {
+      const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+      expect(outcome).toBe("diagnostic-only");
+      expect(calls).toEqual([]);
+      expect(events.find((e) => e.event_type === "orchestration_artifact_recovery_skipped")).toBeTruthy();
+      expect(lc.nudgeAttempts).toBe(0);
+      expect(lc.wrongFilenameNudgeRound).toBeUndefined();
+    } finally {
+      eventSpy.mockRestore();
+    }
+  });
+
+  test("non-eligible phase → none (work, merge-amend)", async () => {
+    const dir = makePeerSync();
+    for (const phase of ["work", "merge-amend"] as const) {
+      const state = makeState(dir, { phase });
+      setSettledLifecycle(state, "coder");
+      const { transport, calls } = makeMockTransport();
+      const eventSpy = spyOn(eventsMod, "emitEvent");
+      try {
+        const outcome = await recoverWrongFilename(state, state.agents[0], state.agentStates["coder"], transport);
+        expect(outcome).toBe("none");
+        expect(calls).toEqual([]);
+      } finally {
+        eventSpy.mockRestore();
+      }
+    }
+  });
+});
+
+describe("recoveryRecentlyActed", () => {
+  test("false when turnLifecycle is undefined", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    const runtime = state.agentStates["coder"];
+    runtime.turnLifecycle = null;
+    expect(recoveryRecentlyActed(state, state.agents[0], runtime)).toBe(false);
+  });
+
+  test("true when sentinels match state.round and planMergeRound", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { planMergeRound: 0 });
+    setSettledLifecycle(state, "coder");
+    const runtime = state.agentStates["coder"];
+    runtime.turnLifecycle!.wrongFilenameNudgeRound = 1;
+    runtime.turnLifecycle!.wrongFilenameNudgePlanMergeRound = 0;
+    expect(recoveryRecentlyActed(state, state.agents[0], runtime)).toBe(true);
+  });
+
+  test("false when round mismatches", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir);
+    setSettledLifecycle(state, "coder");
+    const runtime = state.agentStates["coder"];
+    runtime.turnLifecycle!.wrongFilenameNudgeRound = 99;
+    runtime.turnLifecycle!.wrongFilenameNudgePlanMergeRound = 0;
+    expect(recoveryRecentlyActed(state, state.agents[0], runtime)).toBe(false);
+  });
+
+  test("false when planMergeRound mismatches", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { planMergeRound: 1 });
+    setSettledLifecycle(state, "coder");
+    const runtime = state.agentStates["coder"];
+    runtime.turnLifecycle!.wrongFilenameNudgeRound = 1;
+    runtime.turnLifecycle!.wrongFilenameNudgePlanMergeRound = 0;
+    expect(recoveryRecentlyActed(state, state.agents[0], runtime)).toBe(false);
+  });
+
+  test("normalizes state.planMergeRound undefined to -1 (matches sentinel -1)", () => {
+    const dir = makePeerSync();
+    const state = makeState(dir, { planMergeRound: undefined });
+    setSettledLifecycle(state, "coder");
+    const runtime = state.agentStates["coder"];
+    runtime.turnLifecycle!.wrongFilenameNudgeRound = 1;
+    runtime.turnLifecycle!.wrongFilenameNudgePlanMergeRound = -1;
+    expect(recoveryRecentlyActed(state, state.agents[0], runtime)).toBe(true);
+  });
+});
+
+describe("OrchestrationConfig + AgentTurnLifecycle round-trip", () => {
+  test("defaultOrchestrationConfig has autoRecoverWrongFilename = true", () => {
+    expect(defaultOrchestrationConfig().autoRecoverWrongFilename).toBe(true);
+  });
+
+  test("override flips the default", () => {
+    expect(defaultOrchestrationConfig({ autoRecoverWrongFilename: false })
+      .autoRecoverWrongFilename).toBe(false);
+  });
+
+  test("migrateState fills autoRecoverWrongFilename for legacy persisted state (true default)", async () => {
+    const { migrateState } = await import("./state.ts");
+    const legacy = {
+      slot: 1,
+      taskId: "t",
+      mode: "pair",
+      phase: "work",
+      round: 1,
+      mergeRound: 0,
+      agents: [],
+      agentStates: {},
+      // Legacy config: no autoRecoverWrongFilename field.
+      config: { ...defaultOrchestrationConfig() } as unknown as Record<string, unknown>,
+      phaseStartedAt: 0,
+      startedAt: "x",
+      projectDir: "/",
+      rootWorktree: "/",
+      peerSyncDir: "/",
+      threadIds: {},
+    } as unknown as OrchestrationState;
+    delete (legacy.config as unknown as Record<string, unknown>).autoRecoverWrongFilename;
+    const migrated = migrateState(legacy, 1);
+    expect(migrated.config.autoRecoverWrongFilename).toBe(true);
+  });
+
+  test("AgentTurnLifecycle round-trips wrongFilename* fields through JSON", () => {
+    const lc = {
+      dispatchCommandId: "x", dispatchedAt: "x", phaseToken: "x",
+      observedTurnId: null, state: "settled" as const,
+      turnStartedAt: null, turnCompletedAt: null, completionSource: null,
+      statusFileFingerprint: null, lastStopHookAt: null,
+      wrongFilenameNudgeRound: 3,
+      wrongFilenameNudgePlanMergeRound: 1,
+    };
+    const parsed = JSON.parse(JSON.stringify(lc));
+    expect(parsed.wrongFilenameNudgeRound).toBe(3);
+    expect(parsed.wrongFilenameNudgePlanMergeRound).toBe(1);
+  });
+});

--- a/src/orchestration/wrong-filename-recovery.ts
+++ b/src/orchestration/wrong-filename-recovery.ts
@@ -1,0 +1,330 @@
+// Defense-in-depth recovery for wrong-filename phase artifacts.
+//
+// When the artifact gate fires for `plan` / `plan-merge` / `plan-review` /
+// `review` and the agent's canonical artifact is missing, this module:
+//   1. Auto-cp's a small whitelisted set of safe alternatives onto the
+//      canonical path (currently `plan-merge` only).
+//   2. Failing that, sends a targeted nudge naming the canonical path and
+//      listing recently-modified candidate files from `plans/` ∪ `reviews/`.
+//
+// The async driver (`recoverWrongFilename`) is called from runner.ts; the
+// pure suppression predicate (`recoveryRecentlyActed`) is read by
+// `phases.ts:validateDoneStatus` to suppress its 10s warning when a nudge
+// already fired this (round, planMergeRound) tuple.
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync, utimesSync } from "fs";
+import { basename, dirname, join } from "path";
+import { emitEvent } from "../events.ts";
+import { mergedPlanFilePath, parsePlanFilename } from "./plan-files.ts";
+import { reviewFilePath } from "./review-files.ts";
+import type {
+  AgentConfig,
+  AgentRuntimeState,
+  OrchestrationState,
+} from "./state.ts";
+import type { OrchestrationTransport } from "./transport.ts";
+import { isoNow } from "./util.ts";
+import type { Phase } from "./phases.ts";
+
+/** Phases that participate in wrong-filename recovery. Outside this set the
+ *  driver is a no-op so git-artifact phases (work, pr-create, merge-execute)
+ *  and `merge-amend` (no canonical) keep their existing fall-through. */
+export function isRecoveryEligiblePhase(phase: Phase): boolean {
+  return phase === "plan-merge" || phase === "plan"
+    || phase === "plan-review" || phase === "review";
+}
+
+/** Build the canonical artifact path for the current phase. Mirrors
+ *  `phases.requiredArtifactPath` for the eligible phases only — kept local
+ *  to avoid a circular import with phases.ts. */
+function canonicalPath(state: OrchestrationState, agent: AgentConfig): string | null {
+  const dir = state.peerSyncDir;
+  switch (state.phase) {
+    case "plan":
+      return join(dir, "plans", `round-${state.round}-${agent.name}.md`);
+    case "plan-merge":
+      return mergedPlanFilePath(dir, state.round, state.planMergeRound ?? 0);
+    case "plan-review":
+      return reviewFilePath(dir, "plan-review", state.planMergeRound ?? 0, agent.name);
+    case "review":
+      return reviewFilePath(dir, "review", state.round, agent.name);
+    default:
+      return null;
+  }
+}
+
+/** Return absolute paths of files that, when found in-phase, are safe to
+ *  auto-cp onto the canonical path. The whitelist is intentionally narrow
+ *  and grows by code edit only. v1: plan-merge only. */
+export function whitelistSuspects(state: OrchestrationState, _agent: AgentConfig): string[] {
+  if (state.phase !== "plan-merge") return [];
+
+  const plansDir = join(state.peerSyncDir, "plans");
+  const round = state.round;
+  const k = state.planMergeRound ?? 0;
+  const canonical = mergedPlanFilePath(state.peerSyncDir, round, k);
+  const out: string[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(plansDir);
+  } catch {
+    return out;
+  }
+
+  for (const f of entries) {
+    const full = join(plansDir, f);
+    if (full === canonical) continue;
+    const parsed = parsePlanFilename(f);
+    if (!parsed) continue;
+    if (parsed.type === "plan" && parsed.round === round) {
+      // Covers `round-R-coder.md` clobber, `round-R-merge.md`,
+      // `round-R-merged.md` — PLAN_RE's `[\w-]+` accepts those literals
+      // as agent names, so the parse-based rule subsumes the singular-name
+      // fallthrough described in the proposal text.
+      out.push(full);
+      continue;
+    }
+    if (parsed.type === "merged"
+        && parsed.round === round
+        && parsed.planMergeRound !== undefined
+        && parsed.planMergeRound !== k) {
+      // off-by-one (K-1) and skip-counter (K+1)
+      out.push(full);
+    }
+  }
+
+  return out;
+}
+
+/** Scan plans/ ∪ reviews/ for `.md` files modified at or after phaseStartedAt,
+ *  excluding the canonical. Returns up to 5 entries, sorted by mtime
+ *  descending. Missing directories are treated as empty. */
+export function scanRecentlyModified(
+  peerSyncDir: string,
+  phaseStartedAt: number,
+  excludePath: string,
+): { path: string; mtime: number }[] {
+  const candidates: { path: string; mtime: number }[] = [];
+  for (const sub of ["plans", "reviews"]) {
+    const subDir = join(peerSyncDir, sub);
+    let entries: string[];
+    try {
+      entries = readdirSync(subDir);
+    } catch {
+      continue;
+    }
+    for (const f of entries) {
+      if (!f.endsWith(".md")) continue;
+      const full = join(subDir, f);
+      if (full === excludePath) continue;
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      const mtimeSec = Math.floor(st.mtimeMs / 1000);
+      if (mtimeSec < phaseStartedAt) continue;
+      candidates.push({ path: full, mtime: mtimeSec });
+    }
+  }
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  return candidates.slice(0, 5);
+}
+
+/** `cp -p` semantics: copy contents and preserve source mtime/atime.
+ *  Atomic via `.tmp` + rename. Returns false on any IO error (caller falls
+ *  through to nudge-or-warning). */
+export function attemptAutoCp(suspectPath: string, canonicalPath: string): boolean {
+  try {
+    mkdirSync(dirname(canonicalPath), { recursive: true });
+    const tmp = `${canonicalPath}.tmp.${process.pid}.${Date.now()}`;
+    copyFileSync(suspectPath, tmp);
+    renameSync(tmp, canonicalPath);
+    const srcStat = statSync(suspectPath);
+    utimesSync(canonicalPath, srcStat.atime, srcStat.mtime);
+    return true;
+  } catch {
+    // Best-effort cleanup of the .tmp file on failure (rare path).
+    try {
+      const stale = `${canonicalPath}.tmp.${process.pid}`;
+      if (existsSync(stale)) unlinkSync(stale);
+    } catch { /* swallow */ }
+    return false;
+  }
+}
+
+export type RecoveryOutcome = "cp" | "nudge" | "deferred" | "diagnostic-only" | "none";
+
+function formatHmsUtc(epochSec: number): string {
+  const d = new Date(epochSec * 1000);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+}
+
+function buildNudgeBody(state: OrchestrationState, canonical: string, candidates: { path: string; mtime: number }[]): string {
+  const lines: string[] = [];
+  lines.push(`The canonical artifact for the ${state.phase} phase was not produced.`);
+  lines.push("");
+  lines.push(`Expected path: ${canonical}`);
+  lines.push("Recently-modified candidates (did you mean to write here?):");
+  for (const c of candidates) {
+    lines.push(`  - ${c.path}  (mtime ${formatHmsUtc(c.mtime)} UTC)`);
+  }
+  lines.push("");
+  lines.push(`Please ensure your output is written to the canonical path exactly: ${canonical}`);
+  return lines.join("\n");
+}
+
+/** Suppression predicate read by `phases.ts:validateDoneStatus`.
+ *
+ *  Note: `validateDoneStatus` is reached only when (a) `runtime.turnLifecycle`
+ *  is undefined (legacy / resume) or (b) `lc.state === "settled"` —
+ *  `isAgentDone` short-circuits non-settled lifecycle states earlier. So
+ *  this predicate intentionally does NOT branch on `lc.state`; it asks only
+ *  "did a wrong-filename nudge already fire for this (round,
+ *  planMergeRound) tuple in the settled path?" When yes, suppress the
+ *  10s warning so we don't double-log. */
+export function recoveryRecentlyActed(
+  state: OrchestrationState,
+  _agent: AgentConfig,
+  runtime: AgentRuntimeState,
+): boolean {
+  const lc = runtime.turnLifecycle;
+  if (!lc) return false;
+  return lc.wrongFilenameNudgeRound === state.round
+    && (lc.wrongFilenameNudgePlanMergeRound ?? null) === (state.planMergeRound ?? -1);
+}
+
+/** Driver: auto-cp → nudge → diagnostic-only → none.
+ *  Called from runner.ts each poll cycle for each participating done-status
+ *  agent. */
+export async function recoverWrongFilename(
+  state: OrchestrationState,
+  agent: AgentConfig,
+  runtime: AgentRuntimeState,
+  transport: OrchestrationTransport,
+): Promise<RecoveryOutcome> {
+  if (!isRecoveryEligiblePhase(state.phase)) return "none";
+  const canonical = canonicalPath(state, agent);
+  if (!canonical) return "none";
+  if (existsSync(canonical)) return "none";
+
+  // --- Auto-cp branch ---
+  if (state.config.autoRecoverWrongFilename) {
+    const suspects = whitelistSuspects(state, agent);
+    let best: { path: string; mtime: number } | null = null;
+    for (const sp of suspects) {
+      let st;
+      try {
+        st = statSync(sp);
+      } catch {
+        continue;
+      }
+      const mtimeSec = Math.floor(st.mtimeMs / 1000);
+      if (mtimeSec < state.phaseStartedAt) continue;
+      if (!best || mtimeSec > best.mtime) {
+        best = { path: sp, mtime: mtimeSec };
+      }
+    }
+    if (best) {
+      if (attemptAutoCp(best.path, canonical)) {
+        emitEvent({
+          event_type: "orchestration_artifact_recovered",
+          source: "orchestration",
+          scope: "slot",
+          slot: state.slot,
+          task: state.taskId,
+          agent: agent.name,
+          phase: state.phase,
+          round: state.round,
+          planMergeRound: state.planMergeRound,
+          suspectPath: best.path,
+          canonicalPath: canonical,
+          message: `${agent.name}: auto-cp'd ${basename(best.path)} → ${basename(canonical)} (phase=${state.phase} round=${state.round})`,
+        });
+        return "cp";
+      }
+      // Fall through to the nudge branch on copy failure.
+    }
+  }
+
+  // --- Nudge dedup ---
+  const lc = runtime.turnLifecycle;
+  if (lc
+      && lc.wrongFilenameNudgeRound === state.round
+      && (lc.wrongFilenameNudgePlanMergeRound ?? null) === (state.planMergeRound ?? -1)) {
+    return "none";
+  }
+
+  // --- TUI gating (proposal-aligned) ---
+  // - dispatched | starting | running → defer
+  // - error → diagnostic-only (no nudge)
+  // - settled or no lifecycle → proceed
+  if (lc) {
+    if (lc.state === "dispatched" || lc.state === "starting" || lc.state === "running") {
+      return "deferred";
+    }
+    if (lc.state === "error") {
+      emitEvent({
+        event_type: "orchestration_artifact_recovery_skipped",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.taskId,
+        agent: agent.name,
+        phase: state.phase,
+        round: state.round,
+        planMergeRound: state.planMergeRound,
+        reason: "lifecycle-error",
+        message: `${agent.name}: skipping wrong-filename nudge (lifecycle.state=error)`,
+      });
+      return "diagnostic-only";
+    }
+  }
+
+  // --- Recently-modified scan ---
+  const candidates = scanRecentlyModified(state.peerSyncDir, state.phaseStartedAt, canonical);
+  if (candidates.length === 0) return "none";
+
+  // --- Send nudge ---
+  const body = buildNudgeBody(state, canonical, candidates);
+  try {
+    await transport.sendTurn(state, agent, body);
+    if (lc) {
+      lc.nudgeAttempts = (lc.nudgeAttempts ?? 0) + 1;
+      lc.lastNudgeAt = isoNow();
+      lc.wrongFilenameNudgeRound = state.round;
+      lc.wrongFilenameNudgePlanMergeRound = state.planMergeRound ?? -1;
+    }
+    emitEvent({
+      event_type: "orchestration_wrong_filename_nudge",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.taskId,
+      agent: agent.name,
+      phase: state.phase,
+      round: state.round,
+      planMergeRound: state.planMergeRound,
+      candidatePaths: candidates.map((c) => c.path),
+      canonicalPath: canonical,
+      message: `${agent.name}: wrong-filename nudge sent (canonical missing, ${candidates.length} candidates)`,
+    });
+    return "nudge";
+  } catch (err) {
+    emitEvent({
+      event_type: "orchestration_nudge_failed",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.taskId,
+      agent: agent.name,
+      phase: state.phase,
+      message: `${agent.name}: wrong-filename nudge dispatch failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    // Do NOT bump counters or sentinels — next poll retries.
+    return "none";
+  }
+}

--- a/src/orchestration/wrong-filename-recovery.ts
+++ b/src/orchestration/wrong-filename-recovery.ts
@@ -223,7 +223,14 @@ export async function recoverWrongFilename(
         continue;
       }
       const mtimeSec = Math.floor(st.mtimeMs / 1000);
-      if (mtimeSec < state.phaseStartedAt) continue;
+      // Strict `>` (not `>=`): mtime and phaseStartedAt are both floored to
+      // seconds, so a file written in the same wall-clock second as the
+      // phase transition is ambiguous between "last write of previous
+      // phase" and "first write of new phase". Auto-cp is destructive
+      // (overwrites the canonical), so we exclude that boundary second.
+      // The proposal text's `>=` is preserved for the informational nudge
+      // scan via `scanRecentlyModified`.
+      if (mtimeSec <= state.phaseStartedAt) continue;
       if (!best || mtimeSec > best.mtime) {
         best = { path: sp, mtime: mtimeSec };
       }
@@ -252,8 +259,17 @@ export async function recoverWrongFilename(
 
   // --- Nudge dedup ---
   const lc = runtime.turnLifecycle;
-  if (lc
-      && lc.wrongFilenameNudgeRound === state.round
+  // No-lifecycle bail-out: when `runtime.turnLifecycle` is null (legacy /
+  // resume / setup paths), we have nowhere to persist the nudge sentinel
+  // — sending the nudge would re-fire on every poll forever, AND
+  // `recoveryRecentlyActed` would still return false so the existing
+  // 10s warning would also keep spamming. Skip the nudge branch
+  // entirely; auto-cp above already handled the recoverable case, and
+  // `validateDoneStatus`'s existing warning matches today's behaviour
+  // for legacy state. Once the runner re-dispatches the agent and
+  // installs a turnLifecycle, the full recovery path engages.
+  if (!lc) return "none";
+  if (lc.wrongFilenameNudgeRound === state.round
       && (lc.wrongFilenameNudgePlanMergeRound ?? null) === (state.planMergeRound ?? -1)) {
     return "none";
   }
@@ -261,8 +277,8 @@ export async function recoverWrongFilename(
   // --- TUI gating (proposal-aligned) ---
   // - dispatched | starting | running → defer
   // - error → diagnostic-only (no nudge)
-  // - settled or no lifecycle → proceed
-  if (lc) {
+  // - settled → proceed
+  {
     if (lc.state === "dispatched" || lc.state === "starting" || lc.state === "running") {
       return "deferred";
     }
@@ -292,12 +308,11 @@ export async function recoverWrongFilename(
   const body = buildNudgeBody(state, canonical, candidates);
   try {
     await transport.sendTurn(state, agent, body);
-    if (lc) {
-      lc.nudgeAttempts = (lc.nudgeAttempts ?? 0) + 1;
-      lc.lastNudgeAt = isoNow();
-      lc.wrongFilenameNudgeRound = state.round;
-      lc.wrongFilenameNudgePlanMergeRound = state.planMergeRound ?? -1;
-    }
+    // `lc` is guaranteed non-null here by the no-lifecycle bail-out above.
+    lc.nudgeAttempts = (lc.nudgeAttempts ?? 0) + 1;
+    lc.lastNudgeAt = isoNow();
+    lc.wrongFilenameNudgeRound = state.round;
+    lc.wrongFilenameNudgePlanMergeRound = state.planMergeRound ?? -1;
     emitEvent({
       event_type: "orchestration_wrong_filename_nudge",
       source: "orchestration",


### PR DESCRIPTION
## Summary

When a coder/reviewer agent self-reports phase completion (`<phase>-done`) but the canonical artifact is missing — typically because the agent wrote into a wrong filename — the orchestrator now recovers automatically for a small whitelisted set of safe alternatives, and otherwise emits a sharp targeted nudge naming the canonical path and listing recently-modified candidate files.

Previously the only signal was a `required artifact missing: <path>` warning that repeated every 10s until the phase timeout fired and force-promoted. Observed twice on 2026-04-29 (slot 2 / task-7ae99643): coder wrote merged plan into `round-1-coder.md` (clobbering pre-merge plan) instead of `round-1-merged-0.md`, then on the next plan-merge round skipped `merged-0` and wrote `merged-1.md`. Both required manual `cp` to unstick.

## Implementation (4 commits)

1. `a1ffb6a` — `state.ts` (config flag `autoRecoverWrongFilename` + lifecycle dedup fields `wrongFilenameNudgeRound` / `wrongFilenameNudgePlanMergeRound` + `migrateState` legacy fill-in) + new `src/orchestration/wrong-filename-recovery.ts` driver module + 38 unit tests covering AC cases (a)–(m).
2. `a85f400` — `phases.ts:validateDoneStatus` warning suppression via `recoveryRecentlyActed` + `runner.ts:pollUntilDone` poll-cycle hook (`runWrongFilenameRecovery`) + 3 phases.test suppression cases + 2 runner.lifecycle.test integration cases.
3. `fc00fca` — `--auto-recover-wrong-filename` / `--no-auto-recover-wrong-filename` flag in shared `parseOrchestrationAdapterArgs` (t3code + tmux inherit via import) + 3 t3code.test parser cases + 3 tmux-adapter.test pass-through cases.
4. `ae041f9` — Codex review fixes: P1 no-lifecycle nudge spam (bail out of nudge branch when `lc === null`; auto-cp still runs since it's lifecycle-agnostic and idempotent) + P2 second-precision boundary (auto-cp uses strict `>` on `phaseStartedAt` to exclude the ambiguous transition second; nudge scan keeps `>=`) + 4 regression tests.

## Behaviour

The driver runs from the runner's main poll loop after `refreshAgentStatuses` + `detectAndNudgeHungAgents` and before `evaluateTransition`. For each phase-participating agent with a status in `DONE_STATUSES`:

1. **Auto-cp branch** (gated by `autoRecoverWrongFilename`, default true): for `plan-merge` only, if a whitelisted suspect (`round-R-<agent>.md`, `round-R-merged-<j>.md` with `j !== K`) has `mtime > phaseStartedAt`, copy it to the canonical path with `cp -p` semantics (atomic via `.tmp + rename`, then `utimesSync` to preserve source mtime). Most-recently-modified wins on tie. Emits `orchestration_artifact_recovered`. Does NOT increment `nudgeAttempts`. Lifecycle-agnostic.
2. **Nudge branch**: if no auto-cp acted and the canonical is still missing, scan `plans/*.md ∪ reviews/*.md` for files with `mtime >= phaseStartedAt` (canonical excluded, top-5 by mtime). If at least one exists AND `runtime.turnLifecycle` is non-null, send a targeted nudge via `transport.sendTurn` naming the canonical path. Increments `nudgeAttempts`. Emits `orchestration_wrong_filename_nudge`. Dedups per `(round, planMergeRound ?? -1)` tuple via lifecycle sentinels — re-fires when the round/mergeRound advances.
3. **No-lifecycle bail-out**: when `runtime.turnLifecycle === null` (legacy / resume / setup), the nudge branch is skipped entirely so we don't re-fire on every poll without a sentinel to deduplicate against. Auto-cp still runs. Existing 10s warning continues to fire — matching today's behaviour for legacy state.
4. **TUI gating**: deferred when `lc.state` is `dispatched | starting | running` (no action this tick). Emits `orchestration_artifact_recovery_skipped` (no nudge) when `lc.state === "error"` per the proposal's error-state contract.
5. **No suspects**: returns `"none"` and the existing 10s `orchestration_warning` continues to fire — fallback path unchanged.

## Out of scope

- `merge-amend` (no canonical artifact today)
- `work` / `pr-create` / `merge-execute` / `merge-review` (git artifacts, not standalone files)
- Cross-directory auto-cp (nudge handles cross-directory hints)
- Header-content matching / skill-template edits

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` + `lint:cli-readme` + `lint:config-reference` — clean
- [x] `bun run build` — `bin/ludics` compiles
- [x] `bun test` — 1717 pass / 1 fail. The single failure (`skills > PROPOSAL_FRESHNESS_WARNING: boundary — exactly 10 commits does NOT trigger`) is the pre-existing baseline from `main` and is unrelated. New tests: +53 (38 in `wrong-filename-recovery.test.ts` covering AC cases (a)–(m) + helpers + suppression-predicate matrix; 4 in `wrong-filename-recovery.test.ts` for Codex P1+P2 regression coverage; 3 in `phases.test.ts` for warning suppression; 2 in `runner.lifecycle.test.ts` for the runner hook; 3 in `t3code.test.ts` for the parser flag; 3 in `tmux-adapter.test.ts` for the shared-parser pass-through).
- [ ] Manual sanity (post-merge): stage a peer-sync tree with a `plans/round-1-coder.md` clobber; observe the next poll auto-cp's it onto `plans/round-1-merged-0.md` with `orchestration_artifact_recovered` in `events.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)