### PR TITLE
patterns: pattern+count enumeration for bulk migrations

### DIFF
--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -65,7 +65,26 @@ If a new pattern needs to be added, it should pass the same bar the templates ho
 
 **The grep itself can lie.** Leading-anchor patterns like `^export function` or `^export const` miss `export { ... }` re-export blocks — a symbol can be publicly exposed without ever appearing as the head of a declaration line. `src/adapters/tmux-adapter.ts`'s trailing `export { ... }` block is the worked example: it re-exports `readTmuxSlotState`, `writeTmuxSlotState`, `removeTmuxSlotState`, and `agentPortRole` alongside the adapter object's own members, none of which a `^export function` grep would surface. Use a broader pattern — `grep -nE 'export[[:space:]]*\{'` (or `rg 'export\s*\{'`) — alongside the leading-anchor patterns when the question is "is this name publicly exposed?" rather than "where is it declared?". The leading `\{` only works in extended-regex mode; default `grep` is BRE and errors with `Unmatched \{`. See also gh-ludics-406 (the consumer-side sibling: lint scripts that regex-extract symbol references break silently on DRY refactors) — same family of regex-shape blind spot, opposite end of the import chain.
 
-See also [post-edit-occurrence-recheck](#post-edit-occurrence-recheck) for running the same sweep *after* the edit, and in both directions (forward and inverse).
+See also [post-edit-occurrence-recheck](#post-edit-occurrence-recheck) for running the same sweep *after* the edit, and in both directions (forward and inverse). See also [patterncount-enumeration-for-bulk-migrations](#patterncount-enumeration-for-bulk-migrations) for the durable form of the site enumeration this entry advocates.
+
+### Pattern+count enumeration for bulk migrations
+
+**Principle.** When a bulk migration touches more than a handful of sites, express the site set in the proposal as `grep -c '<exact-pattern>' <path> = N`, not as a line range. The same exact-pattern grep that *enumerates* the cohort is the one that *qualifies* it for `replace_all`.
+
+**Why.** Pattern+count is rebase-stable — exact-string counts survive unrelated commits the way line ranges don't — and mechanically verifiable: a reviewer or worker can re-run the same grep and compare to the proposal's stated count without a visual scan. A line-range proposal can match the stated bound and still miss sites that fall outside it; pattern+count cannot.
+
+**Recipe.**
+
+1. Pick the exact pattern that defines a site (the inline call shape, the regex, the string literal — whatever is character-identical across the cohort).
+2. Record `grep -c '<pattern>' <path> = N` in the proposal, not a line range. If the migration spans multiple files, list one `grep -c` per file with its expected count.
+3. At edit time, re-run the grep and confirm the count matches the proposal before starting. If it doesn't, the pattern set has drifted since the proposal — pause and reconcile.
+4. If the pattern is character-identical across the cohort (verified by step 3's count matching), a single `Edit { replace_all: true }` collapses N edits into one operation; iterate site-by-site only on the residue.
+
+**Worked example.** `task-95310454`'s dashboard console-silence migration. The original proposal said "12 sites in lines 241–565". The actual count was 13: a 13th site at the `startDashboardServer` wrapper (~line 615) sat outside the proposed line range and was caught only on a thorough sweep. A pattern+count enumeration — `grep -c 'originalConsoleX(\.\.\.args)' src/dashboard.ts = 13` — would have surfaced the 13th site at proposal-write time, before any edit was attempted. 12 of the 13 sites then collapsed in one `Edit { replace_all: true }` because the inline pattern was character-identical; the 13th, with different surrounding context, iterated as a single follow-up edit.
+
+**Boundary.** Pattern+count earns its keep on bulk migrations (≥3 sites). For 1–2 site changes, line refs (or symbol-name references — see [symbol-name-references](#symbol-name-references)) are still fine and shorter. `replace_all` is only safe under exact-pattern identity verified by `grep -c`: whitespace or indentation drift defeats the match, and subtle context differences (a different surrounding helper, an alternative cast) usually mean the cohort needs splitting into `grep -c` sub-counts before any `replace_all` is attempted.
+
+See also [exhaustive-occurrence-search](#exhaustive-occurrence-search), [post-edit-occurrence-recheck](#post-edit-occurrence-recheck).
 
 ### Data-shape consumer sweep
 
@@ -546,4 +565,4 @@ See also [negative-case-regression-testing](#negative-case-regression-testing) (
 
 **Example.** `task-c5937037`'s `task-files/` → `task.html?task=` migration touched three `dashboard.js` patterns and one `dashboard.ts` line. The inverse grep for `task.html?task=` caught an encoding inconsistency where one site used `encodeURIComponent` while the others used `escapeHtml` — the kind of half-migration the forward-direction grep doesn't see.
 
-See also [exhaustive-occurrence-search](#exhaustive-occurrence-search).
+See also [exhaustive-occurrence-search](#exhaustive-occurrence-search). See also [patterncount-enumeration-for-bulk-migrations](#patterncount-enumeration-for-bulk-migrations) for the proposal-time enumeration that drives the post-edit recheck.

--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -69,20 +69,22 @@ See also [post-edit-occurrence-recheck](#post-edit-occurrence-recheck) for runni
 
 ### Pattern+count enumeration for bulk migrations
 
-**Principle.** When a bulk migration touches more than a handful of sites, express the site set in the proposal as `grep -c '<exact-pattern>' <path> = N`, not as a line range. The same exact-pattern grep that *enumerates* the cohort is the one that *qualifies* it for `replace_all`.
+**Principle.** When a bulk migration touches more than a handful of sites, express the site set in the proposal as `grep -oF '<exact-pattern>' <path> | wc -l = N`, not as a line range. The same exact-pattern grep that *enumerates* the cohort is the one that *qualifies* it for `replace_all`.
+
+Why `-oF | wc -l` rather than `grep -c`: `grep -c` counts *lines* containing a match (under-counting when two call sites share a line — minified code, chained calls, compressed fixtures), and treats the pattern as a regex by default (regex metacharacters like `.`, `(`, `[`, `?` would inflate or deflate the count). `-o` prints each match on its own line; `-F` reads the pattern as a fixed string. The pair `grep -oF | wc -l` therefore counts *occurrences* of a *literal* pattern — exactly the semantics this entry's "exact-pattern, character-identical" framing requires.
 
 **Why.** Pattern+count is rebase-stable — exact-string counts survive unrelated commits the way line ranges don't — and mechanically verifiable: a reviewer or worker can re-run the same grep and compare to the proposal's stated count without a visual scan. A line-range proposal can match the stated bound and still miss sites that fall outside it; pattern+count cannot.
 
 **Recipe.**
 
 1. Pick the exact pattern that defines a site (the inline call shape, the regex, the string literal — whatever is character-identical across the cohort).
-2. Record `grep -c '<pattern>' <path> = N` in the proposal, not a line range. If the migration spans multiple files, list one `grep -c` per file with its expected count.
-3. At edit time, re-run the grep and confirm the count matches the proposal before starting. If it doesn't, the pattern set has drifted since the proposal — pause and reconcile.
+2. Record `grep -oF '<pattern>' <path> | wc -l = N` in the proposal, not a line range. If the migration spans multiple files, list one `grep -oF | wc -l` per file with its expected count.
+3. At edit time, re-run the same `grep -oF | wc -l` invocation and confirm the count matches the proposal before starting. If it doesn't, the pattern set has drifted since the proposal — pause and reconcile.
 4. If the pattern is character-identical across the cohort (verified by step 3's count matching), a single `Edit { replace_all: true }` collapses N edits into one operation; iterate site-by-site only on the residue.
 
-**Worked example.** `task-95310454`'s dashboard console-silence migration. The original proposal said "12 sites in lines 241–565". The actual count was 13: a 13th site at the `startDashboardServer` wrapper (~line 615) sat outside the proposed line range and was caught only on a thorough sweep. A pattern+count enumeration — `grep -c 'originalConsoleX(\.\.\.args)' src/dashboard.ts = 13` — would have surfaced the 13th site at proposal-write time, before any edit was attempted. 12 of the 13 sites then collapsed in one `Edit { replace_all: true }` because the inline pattern was character-identical; the 13th, with different surrounding context, iterated as a single follow-up edit.
+**Worked example.** `task-95310454`'s dashboard console-silence migration. The original proposal said "12 sites in lines 241–565". The actual count was 13: a 13th site at the `startDashboardServer` wrapper (~line 615) sat outside the proposed line range and was caught only on a thorough sweep. A pattern+count enumeration — `grep -oF 'originalConsoleX(...args)' src/dashboard.ts | wc -l = 13` — would have surfaced the 13th site at proposal-write time, before any edit was attempted. 12 of the 13 sites then collapsed in one `Edit { replace_all: true }` because the inline pattern was character-identical; the 13th, with different surrounding context, iterated as a single follow-up edit.
 
-**Boundary.** Pattern+count earns its keep on bulk migrations (≥3 sites). For 1–2 site changes, line refs (or symbol-name references — see [symbol-name-references](#symbol-name-references)) are still fine and shorter. `replace_all` is only safe under exact-pattern identity verified by `grep -c`: whitespace or indentation drift defeats the match, and subtle context differences (a different surrounding helper, an alternative cast) usually mean the cohort needs splitting into `grep -c` sub-counts before any `replace_all` is attempted.
+**Boundary.** Pattern+count earns its keep on bulk migrations (≥3 sites). For 1–2 site changes, line refs (or symbol-name references — see [symbol-name-references](#symbol-name-references)) are still fine and shorter. `replace_all` is only safe under exact-pattern identity verified by `grep -oF | wc -l`: whitespace or indentation drift defeats the match, and subtle context differences (a different surrounding helper, an alternative cast) usually mean the cohort needs splitting into per-pattern sub-counts before any `replace_all` is attempted.
 
 See also [exhaustive-occurrence-search](#exhaustive-occurrence-search), [post-edit-occurrence-recheck](#post-edit-occurrence-recheck).
 


### PR DESCRIPTION
## Summary

- Adds `### Pattern+count enumeration for bulk migrations` to `docs/orchestration-patterns.md` under `## Planning`, immediately after `### Exhaustive occurrence search`. Single combined entry; the `replace_all` opportunity heuristic is folded into `**Recipe.**` step 4 and `**Boundary.**` rather than carrying its own `###` heading.
- Worked example cites `task-95310454`'s dashboard console-silence migration: 12-of-13 sites collapsed under one `Edit { replace_all: true }`, the 13th at `startDashboardServer` (~line 615) sat outside the originally-proposed 241–565 line range, and `grep -oF 'originalConsoleX(...args)' src/dashboard.ts | wc -l = 13` would have surfaced the missing site at proposal-write time.
- Reciprocal `See also` back-links added to `### Exhaustive occurrence search` and `### Post-edit occurrence recheck`. Per the proposal's AC6 fallback, the rendered slug is `#patterncount-enumeration-for-bulk-migrations` — GitHub's renderer (verified at PR HEAD via `gh api -H "Accept: application/vnd.github.html"`) drops `+` rather than collapsing it to `-`.

Closes task-2c5bd512.

Proposal: `docs/proposals/pattern-count-enumeration-bulk-migrations.md`.

## Codex review follow-ups

Commit `50408b6` addresses two P2 comments from `chatgpt-codex-connector` on the original commit `d3c3470c`:

1. **`grep -c` counts lines, not matches.** Switched recipe and worked example to `grep -oF '<exact-pattern>' <path> | wc -l = N`. Verified on a synthetic fixture (3 matches across 2 lines): `grep -c` reports 2; `grep -oF | wc -l` reports 3.
2. **`grep -c` interprets the pattern as a regex.** `-F` makes it a fixed-string literal match — exactly what the entry's "character-identical, exact-pattern" framing requires. Worked-example pattern drops the regex escape (`\.\.\.` → `...`) because `-F` reads it literally.

Added a short paragraph after `**Principle.**` explaining the `-oF | wc -l` choice so future readers don't reach for `grep -c` from muscle memory.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test src/orchestration/skills.test.ts -t "orchestration templates link only to existing anchors"` — pass (the slug-resolution lint, both before and after the codex fix commit).
- [x] Probe over `docs/orchestration-patterns.md` confirms 0 unresolved internal `(#slug)` anchors after the edit.
- [x] Synthetic-fixture demonstration of the `grep -c` failure mode the codex comments cited: `grep -c = 2` vs `grep -oF | wc -l = 3` on a file with three matches across two lines.
- [x] One pre-existing failure observed (`PROPOSAL_FRESHNESS_WARNING: boundary — exactly 10 commits does NOT trigger`); reproduces on the base branch (stash + re-run), unrelated to this doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)