### PR TITLE
test: pin warning counts in lint-test-isolation and lint-contracts integration tests

### DIFF
--- a/docs/proposals/pin-lint-warning-counts.md
+++ b/docs/proposals/pin-lint-warning-counts.md
@@ -44,9 +44,17 @@ PR #402).
   HEAD.
 - `bun run lint:test-isolation` and `bun run lint:contracts` continue to pass
   (no script changes — only test changes).
-- The assertion catches a regression: temporarily removing the side-effect-
-  import branch in `parseImports` (in `lint-test-isolation.ts`) makes the
-  pinned-count test fail. Worker verifies this manually and reverts.
+- The pinned-count assertion catches a real `parseImports` coverage
+  regression: worker temporarily breaks one of `parseImports`'s matcher
+  branches (the side-effect-import loop OR, if no real test file under `src/`
+  uses that shape, the multi-line `withFromRe` body — whichever flips the
+  HEAD count) and confirms the integration assertion fails, then reverts.
+  The proposal originally specified the side-effect branch; on HEAD that
+  probe is empirically a no-op (the proposal's own context flags side-effect
+  matching as "purely a coverage fix — no actual test file uses side-effect
+  imports of target modules"), so the multi-line probe is the live-tree
+  proxy that exercises the same invariant. Worker records which probe
+  produced the failing count and the observed delta in the AC verification.
 - Lints without a warning tier (`lint-template-safety`, `lint-config-helpers`,
   `lint-cli-readme`) are not modified — pinning warnings on a lint that emits
   none would be churn for no signal.

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "bun:test";
-import { spawnSync } from "bun";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -506,17 +505,18 @@ describe("runCli", () => {
 // ---------------------------------------------------------------------------
 
 describe("integration", () => {
-  test("lint-contracts exits 0 on current repo", () => {
-    const result = spawnSync({
-      cmd: ["bun", "run", join(import.meta.dir, "lint-contracts.ts")],
-      cwd: join(import.meta.dir, ".."),
-      stdout: "pipe",
-      stderr: "pipe",
+  test("lint-contracts: no errors, warning count pinned", () => {
+    const repo = join(import.meta.dir, "..");
+    const result = runCli({
+      skillsDir: join(repo, "skills"),
+      writeErr: () => {},
+      writeOut: () => {},
     });
-    if (result.exitCode !== 0) {
-      console.error(result.stderr.toString());
-      console.error(result.stdout.toString());
-    }
-    expect(result.exitCode).toBe(0);
+    expect(result.errorCount).toBe(0);
+    // When this fails: either a new skill pair introduced a worker/orchestrator
+    // field-contract drift (regression — fix the pair) OR a matcher improvement
+    // found new real-world hits (coverage upgrade — justify and update the
+    // count).
+    expect(result.warningCount).toBe(0);
   });
 });

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "bun:test";
-import { spawnSync } from "bun";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -767,17 +766,19 @@ describe("runCli", () => {
 // ---------------------------------------------------------------------------
 
 describe("integration", () => {
-  test("lint-test-isolation exits 0 on current repo", () => {
-    const result = spawnSync({
-      cmd: ["bun", "run", join(import.meta.dir, "lint-test-isolation.ts")],
-      cwd: join(import.meta.dir, ".."),
-      stdout: "pipe",
-      stderr: "pipe",
+  test("lint-test-isolation: no errors, warning count pinned", () => {
+    const repo = join(import.meta.dir, "..");
+    const result = runCli({
+      srcDir: join(repo, "src"),
+      repoRoot: repo,
+      writeErr: () => {},
+      writeOut: () => {},
     });
-    if (result.exitCode !== 0) {
-      console.error(result.stderr.toString());
-      console.error(result.stdout.toString());
-    }
-    expect(result.exitCode).toBe(0);
+    expect(result.errorCount).toBe(0);
+    // When this fails: either a new test introduced an unhandled isolation
+    // anti-pattern (regression — fix the test) OR a matcher improvement
+    // found new real-world hits (coverage upgrade — justify and update the
+    // count).
+    expect(result.warningCount).toBe(19);
   });
 });


### PR DESCRIPTION
## Summary

- Switch the `integration` blocks in `scripts/lint-test-isolation.test.ts` and `scripts/lint-contracts.test.ts` from a `bun run` `spawnSync` (which only checked `exitCode`) to an in-process `runCli` call that asserts both `errorCount === 0` and a pinned `warningCount` (19 and 0 respectively on HEAD).
- Both lints have a warning tier — rule hits don't change the exit code — so the prior tests stayed green for any matcher regression that silently changed warning coverage. PR #402 actually had this failure mode: a `parseImports` bug under-matched side-effect imports without affecting `exitCode`.
- Each pinned assertion is preceded by a comment explaining the dual interpretation reviewers should apply to a count diff: regression (fix the new test/skill pair) vs coverage upgrade (justify and update the count).

## Round 2: proposal AC revision

Round-1 review blocked on the literal text "removing the side-effect-import branch in `parseImports` makes the pinned-count test fail." On HEAD that probe is empirically a no-op — no test file under `src/` uses side-effect-style `import "./x.ts";` of a target module (verified with `grep -rEn '^\s*import\s+["'"'"']' src --include="*.ts"`, zero hits). The proposal's own context already flagged side-effect matching as "purely a coverage fix", so the literal AC self-contradicted.

Per the round-1 reviewer's offered second resolution ("the proposal / AC is revised through the normal process to match the enforceable invariant"), this round revises `docs/proposals/pin-lint-warning-counts.md` to require breaking *one of* `parseImports`'s matcher branches (side-effect-import loop OR multi-line `withFromRe` body, whichever flips the HEAD count) and confirming the integration assertion fails. The multi-line probe (`[^;]*?` → `[^;\n]*?`) mirrors the actual round-1 PR #402 bug shape (single-line-only parser missing multi-line imports). Re-ran this round: integration test failed with `Expected: 19 / Received: 18`. Reverted before commit.

Lints without a warning tier (`lint-template-safety`, `lint-config-helpers`, `lint-cli-readme`) are intentionally not modified per the proposal scope.

task: task-4f13a49b
proposal: docs/proposals/pin-lint-warning-counts.md

## Test plan

- [x] `bun test scripts/lint-test-isolation.test.ts scripts/lint-contracts.test.ts` — 71 pass, 0 fail
- [x] `bun run typecheck`
- [x] `bun run lint:test-isolation` — exits 0 (19 warnings)
- [x] `bun run lint:contracts` — exits 0 (0 warnings)
- [x] Regression probe: tighten `withFromRe` to forbid newlines in body → integration test fails with `Expected: 19 / Received: 18`. Reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)