### PR TITLE
Audit string→union widenings for missing boundary validators

### DIFF
--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -260,14 +260,17 @@ import { existsSync, readFileSync } from "fs";
 describe("atomic writes for intent/heartbeat/orchestration-state", () => {
   test("recordIntent writes a round-trippable file with no .tmp leftover", async () => {
     const mod = await import("./cluster-http.ts");
-    const intent = {
+    const intent: import("./cluster-http.ts").PendingIntent = {
+      action: "start",
+      epoch: Math.floor(Date.now() / 1000),
+      machine: "host-a",
       taskId: "task-abc",
-      kind: "assign",
-      recordedAt: "2026-04-24T00:00:00Z",
-    } as unknown as import("./cluster-http.ts").PendingIntent;
+    };
     mod.recordIntent(2, intent);
     const round = mod.getIntentForDashboard(2);
     expect(round).not.toBeNull();
+    expect(round?.action).toBe("start");
+    expect(round?.taskId).toBe("task-abc");
   });
 
   test("POST /api/cluster/orchestration-state writes pretty JSON atomically", async () => {
@@ -289,5 +292,97 @@ describe("atomic writes for intent/heartbeat/orchestration-state", () => {
     // so we assert no .tmp sibling appears in the harness directory (atomicity holds
     // across the runtime dir too, verified indirectly by the 200 response).
     expect(existsSync(join(harnessDir, ".tmp"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePendingIntent — boundary validator (gh-ludics-411 AC 1)
+// ---------------------------------------------------------------------------
+
+describe("parsePendingIntent", () => {
+  const NOW = 1_750_000_000;
+  const valid = { action: "start" as const, epoch: NOW, machine: "host-a" };
+
+  test("accepts each of the three valid action values", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, action: "start" })).toEqual({ action: "start", epoch: NOW, machine: "host-a" });
+    expect(parsePendingIntent({ ...valid, action: "stop" })).toEqual({ action: "stop", epoch: NOW, machine: "host-a" });
+    expect(parsePendingIntent({ ...valid, action: "resume" })).toEqual({ action: "resume", epoch: NOW, machine: "host-a" });
+  });
+
+  test("rejects whitespace-padded action (no trim — JSON-on-disk shouldn't gain whitespace)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, action: "  start  " })).toBeNull();
+    expect(parsePendingIntent({ ...valid, action: "start\n" })).toBeNull();
+  });
+
+  test("rejects unknown action strings", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, action: "unknown" })).toBeNull();
+    expect(parsePendingIntent({ ...valid, action: "" })).toBeNull();
+    expect(parsePendingIntent({ ...valid, action: "START" })).toBeNull();
+  });
+
+  test("rejects non-integer / non-finite epoch", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, epoch: "1750000000" })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: NaN })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: Infinity })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: 1.5 })).toBeNull();
+  });
+
+  test("rejects empty / missing / non-string machine", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, machine: "" })).toBeNull();
+    const noMachine: Record<string, unknown> = { action: "start", epoch: NOW };
+    expect(parsePendingIntent(noMachine)).toBeNull();
+    expect(parsePendingIntent({ ...valid, machine: 42 })).toBeNull();
+  });
+
+  test("preserves optional taskId and preserveState when valid", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    const out = parsePendingIntent({ ...valid, taskId: "task-99", preserveState: true });
+    expect(out).toEqual({ action: "start", epoch: NOW, machine: "host-a", taskId: "task-99", preserveState: true });
+  });
+
+  test("rejects optional fields with wrong type", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, taskId: 42 })).toBeNull();
+    expect(parsePendingIntent({ ...valid, preserveState: "yes" })).toBeNull();
+  });
+
+  test("rejects null, undefined, and non-objects", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent(null)).toBeNull();
+    expect(parsePendingIntent(undefined)).toBeNull();
+    expect(parsePendingIntent("start")).toBeNull();
+    expect(parsePendingIntent(42)).toBeNull();
+    expect(parsePendingIntent([])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File-read boundary regression: getIntentForDashboard skips malformed files
+// ---------------------------------------------------------------------------
+
+describe("intent file-read boundary (parsePendingIntent at JSON.parse seams)", () => {
+  test("getIntentForDashboard returns null for a malformed intent file but works for a valid sibling", async () => {
+    const mod = await import("./cluster-http.ts");
+    const valid: import("./cluster-http.ts").PendingIntent = {
+      action: "resume",
+      epoch: Math.floor(Date.now() / 1000),
+      machine: "host-b",
+    };
+    mod.recordIntent(3, valid);
+
+    // Hand-corrupt slot 4's intent by writing a malformed JSON file directly.
+    // Reuse intentsDir() shape — `${HOME}/.ludics-intents-<md5(stateRepoDir)>`.
+    // Easier: write an invalid action through the same recordIntent helper by
+    // first coercing the type, simulating a foreign-machine JSON write.
+    const corrupt = { action: "danse-macabre", epoch: 0, machine: "" } as unknown as import("./cluster-http.ts").PendingIntent;
+    mod.recordIntent(4, corrupt);
+
+    expect(mod.getIntentForDashboard(3)?.action).toBe("resume");
+    expect(mod.getIntentForDashboard(4)).toBeNull(); // malformed → skipped
   });
 });

--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -323,20 +323,43 @@ describe("parsePendingIntent", () => {
     expect(parsePendingIntent({ ...valid, action: "START" })).toBeNull();
   });
 
-  test("rejects non-integer / non-finite epoch", async () => {
+  test("parseInt-coerces string-encoded epoch (proposal AC 1 contract)", async () => {
     const { parsePendingIntent } = await import("./cluster-http.ts");
-    expect(parsePendingIntent({ ...valid, epoch: "1750000000" })).toBeNull();
-    expect(parsePendingIntent({ ...valid, epoch: NaN })).toBeNull();
-    expect(parsePendingIntent({ ...valid, epoch: Infinity })).toBeNull();
-    expect(parsePendingIntent({ ...valid, epoch: 1.5 })).toBeNull();
+    // String integers must round-trip — JSON writers from other processes
+    // sometimes emit numeric fields as strings.
+    expect(parsePendingIntent({ ...valid, epoch: "1750000000" })).toEqual({
+      action: "start", epoch: 1_750_000_000, machine: "host-a",
+    });
+    // parseInt truncates floats and tolerates trailing garbage.
+    expect(parsePendingIntent({ ...valid, epoch: "1750000000.9" })?.epoch).toBe(1_750_000_000);
   });
 
-  test("rejects empty / missing / non-string machine", async () => {
+  test("rejects non-finite / unparseable epoch", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, epoch: NaN })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: Infinity })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: -Infinity })).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: "not-a-number" })).toBeNull();
+    const noEpoch: Record<string, unknown> = { action: "start", machine: "host-a" };
+    expect(parsePendingIntent(noEpoch)).toBeNull();
+    expect(parsePendingIntent({ ...valid, epoch: {} })).toBeNull();
+  });
+
+  test("string-coerces non-string machine (proposal AC 1 contract)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    // Per proposal AC 1: "machine/taskId string-coerce so a single function
+    // returns either a fully-validated PendingIntent or null."
+    expect(parsePendingIntent({ ...valid, machine: 42 })).toEqual({
+      action: "start", epoch: NOW, machine: "42",
+    });
+  });
+
+  test("rejects empty / missing machine even after coercion", async () => {
     const { parsePendingIntent } = await import("./cluster-http.ts");
     expect(parsePendingIntent({ ...valid, machine: "" })).toBeNull();
     const noMachine: Record<string, unknown> = { action: "start", epoch: NOW };
     expect(parsePendingIntent(noMachine)).toBeNull();
-    expect(parsePendingIntent({ ...valid, machine: 42 })).toBeNull();
+    expect(parsePendingIntent({ ...valid, machine: null })).toBeNull();
   });
 
   test("preserves optional taskId and preserveState when valid", async () => {
@@ -345,10 +368,20 @@ describe("parsePendingIntent", () => {
     expect(out).toEqual({ action: "start", epoch: NOW, machine: "host-a", taskId: "task-99", preserveState: true });
   });
 
-  test("rejects optional fields with wrong type", async () => {
+  test("string-coerces non-string taskId; drops empty after coercion", async () => {
     const { parsePendingIntent } = await import("./cluster-http.ts");
-    expect(parsePendingIntent({ ...valid, taskId: 42 })).toBeNull();
+    // Proposal AC 1: taskId is also string-coerce.
+    expect(parsePendingIntent({ ...valid, taskId: 42 })?.taskId).toBe("42");
+    // Empty after coercion is dropped (taskId is optional).
+    expect(parsePendingIntent({ ...valid, taskId: "" })?.taskId).toBeUndefined();
+    // Explicit null on optional field is treated as absent.
+    expect(parsePendingIntent({ ...valid, taskId: null })?.taskId).toBeUndefined();
+  });
+
+  test("rejects non-bool preserveState (no sensible coercion target)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
     expect(parsePendingIntent({ ...valid, preserveState: "yes" })).toBeNull();
+    expect(parsePendingIntent({ ...valid, preserveState: 1 })).toBeNull();
   });
 
   test("rejects null, undefined, and non-objects", async () => {
@@ -384,5 +417,90 @@ describe("intent file-read boundary (parsePendingIntent at JSON.parse seams)", (
 
     expect(mod.getIntentForDashboard(3)?.action).toBe("resume");
     expect(mod.getIntentForDashboard(4)).toBeNull(); // malformed → skipped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateIntentsPayload — HTTP-client boundary (gh-ludics-411 AC 1, the
+// `clusterGetIntents()` cast that was previously unchecked). Tested as a
+// pure function plus an integration test that drives clusterGetIntents()
+// through a stubbed fetch so the worker keepalive path is exercised
+// end-to-end.
+// ---------------------------------------------------------------------------
+
+describe("validateIntentsPayload", () => {
+  const NOW = 1_750_000_000;
+  const validIntent = { action: "start", epoch: NOW, machine: "host-a" };
+
+  test("filters out malformed intent entries while preserving valid siblings", async () => {
+    const { validateIntentsPayload } = await import("./cluster-http.ts");
+    const payload = {
+      intents: {
+        "1": validIntent,
+        "2": { action: "danse-macabre", epoch: 0, machine: "" }, // bad action
+        "3": { action: "stop", epoch: NaN, machine: "host-b" },   // bad epoch
+        "4": { action: "resume", epoch: NOW, machine: "" },       // empty machine
+        "5": { action: "resume", epoch: "1750000099", machine: 42 }, // coerced
+      },
+    };
+    const out = validateIntentsPayload(payload);
+    expect(Object.keys(out).sort()).toEqual(["1", "5"]);
+    expect(out[1]).toEqual({ action: "start", epoch: NOW, machine: "host-a" });
+    expect(out[5]).toEqual({ action: "resume", epoch: 1_750_000_099, machine: "42" });
+  });
+
+  test("returns {} on missing/non-object intents field", async () => {
+    const { validateIntentsPayload } = await import("./cluster-http.ts");
+    expect(validateIntentsPayload(undefined)).toEqual({});
+    expect(validateIntentsPayload(null)).toEqual({});
+    expect(validateIntentsPayload({})).toEqual({});
+    expect(validateIntentsPayload({ intents: null })).toEqual({});
+    expect(validateIntentsPayload({ intents: "string" })).toEqual({});
+  });
+
+  test("skips entries whose slot key is non-numeric", async () => {
+    const { validateIntentsPayload } = await import("./cluster-http.ts");
+    const payload = { intents: { "abc": validIntent, "1": validIntent } };
+    const out = validateIntentsPayload(payload);
+    expect(Object.keys(out)).toEqual(["1"]);
+  });
+});
+
+describe("clusterGetIntents — HTTP-client boundary integration (gh-ludics-411 AC 1)", () => {
+  test("stubbed GET response with one valid + one malformed entry: malformed is dropped", async () => {
+    // Spy on the cluster-side resolver so resolveAndGet succeeds with a
+    // synthetic ClusterMachine, then stub fetch to return our mock payload.
+    const cluster = await import("./cluster.ts");
+    const NOW = 1_750_000_000;
+    const fakeMachine = {
+      name: "controller",
+      ip: "127.0.0.1",
+      port: 1,
+      seniority: 0,
+      role: "controller" as const,
+    } as unknown as import("./cluster.ts").ClusterMachine;
+
+    const resolveSpy = spyOn(cluster, "resolveController").mockReturnValue(fakeMachine);
+    const stubFetch = (async () => new Response(JSON.stringify({
+      intents: {
+        "1": { action: "start", epoch: NOW, machine: "host-a" },
+        "2": { action: "danse-macabre", epoch: 0, machine: "" }, // malformed
+      },
+    }), { status: 200, headers: { "Content-Type": "application/json" } })) as unknown as typeof fetch;
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation(stubFetch);
+
+    try {
+      const mod = await import("./cluster-http.ts");
+      const result = await mod.clusterGetIntents();
+      expect(result.ok).toBe(true);
+      expect(result.data).toBeDefined();
+      // Only slot 1 (the valid intent) survives the boundary; slot 2 is
+      // dropped before mag.ts::workerKeepalive sees it.
+      expect(Object.keys(result.data!).sort()).toEqual(["1"]);
+      expect(result.data![1].action).toBe("start");
+    } finally {
+      fetchSpy.mockRestore();
+      resolveSpy.mockRestore();
+    }
   });
 });

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -142,31 +142,72 @@ export interface PendingIntent {
 }
 
 /** Validate an untrusted intent payload (file-on-disk read, HTTP body) into
- *  a typed {@link PendingIntent}. Returns `null` on any malformed field —
- *  callers skip the intent and rely on the existing 15-min TTL sweep to
- *  clean up the file. The whole struct is validated, not only `action`,
- *  because a corrupt epoch breaks the `now - intent.epoch` arithmetic
- *  downstream. Action match is exact (no trim) — JSON-on-disk shouldn't
- *  gain whitespace, and trimming would mask real corruption. */
+ *  a typed {@link PendingIntent}. Returns `null` on any unrecoverable field —
+ *  callers skip the intent and rely on the existing 15-min TTL sweep to clean
+ *  up the file. Per gh-ludics-411 AC 1, the contract is:
+ *  - `action`: exact whitelist match (no trim — JSON-on-disk shouldn't gain
+ *    whitespace, and trimming would mask real corruption).
+ *  - `epoch`: `parseInt`-coerce — accept either a number or a string-encoded
+ *    integer; reject `NaN`/`Infinity`. Cross-process JSON writers may emit
+ *    epochs as strings.
+ *  - `machine` and `taskId`: string-coerce non-string values with `String(…)`
+ *    so a single function returns either a fully-validated intent or `null`.
+ *  - `preserveState`: optional bool, no coercion (no sensible target). */
 export function parsePendingIntent(raw: unknown): PendingIntent | null {
   if (!raw || typeof raw !== "object") return null;
   const r = raw as Record<string, unknown>;
+
   const action = r.action;
   if (action !== "start" && action !== "stop" && action !== "resume") return null;
-  const epoch = r.epoch;
-  if (typeof epoch !== "number" || !Number.isFinite(epoch) || !Number.isInteger(epoch)) return null;
-  const machine = r.machine;
-  if (typeof machine !== "string" || machine === "") return null;
-  const out: PendingIntent = { action, epoch, machine };
-  if (r.taskId !== undefined) {
-    if (typeof r.taskId !== "string") return null;
-    out.taskId = r.taskId;
+
+  let epoch: number;
+  if (typeof r.epoch === "number") {
+    if (!Number.isFinite(r.epoch)) return null;
+    epoch = Math.trunc(r.epoch); // mirror parseInt's float-truncation
+  } else if (typeof r.epoch === "string") {
+    epoch = parseInt(r.epoch, 10);
+    if (Number.isNaN(epoch)) return null;
+  } else {
+    return null;
   }
+
+  if (r.machine === undefined || r.machine === null) return null;
+  const machine = typeof r.machine === "string" ? r.machine : String(r.machine);
+  if (machine === "") return null;
+
+  const out: PendingIntent = { action, epoch, machine };
+
+  if (r.taskId !== undefined && r.taskId !== null) {
+    const taskId = typeof r.taskId === "string" ? r.taskId : String(r.taskId);
+    if (taskId !== "") out.taskId = taskId;
+  }
+
   if (r.preserveState !== undefined) {
     if (typeof r.preserveState !== "boolean") return null;
     out.preserveState = r.preserveState;
   }
+
   return out;
+}
+
+/** Validate the `/api/cluster/intents` GET response body. Server shape is
+ *  `{ intents: Record<number, PendingIntent> }` (set by `handleGetIntents`).
+ *  Walks each entry through {@link parsePendingIntent} so the worker-side
+ *  HTTP-client boundary never returns a payload whose `action`/`epoch` is
+ *  unvalidated. Exported for direct testing of the boundary contract. */
+export function validateIntentsPayload(rawData: unknown): Record<number, PendingIntent> {
+  const payload = rawData as { intents?: unknown } | null | undefined;
+  const rawIntents = (payload && typeof payload === "object" ? payload.intents : undefined);
+  if (!rawIntents || typeof rawIntents !== "object") return {};
+  const validated: Record<number, PendingIntent> = {};
+  for (const [slotStr, rawIntent] of Object.entries(rawIntents as Record<string, unknown>)) {
+    const slotNum = Number(slotStr);
+    if (!Number.isFinite(slotNum)) continue;
+    const intent = parsePendingIntent(rawIntent);
+    if (!intent) continue;
+    validated[slotNum] = intent;
+  }
+  return validated;
 }
 
 const INTENT_TTL = 900; // seconds
@@ -310,21 +351,7 @@ export async function clusterPostSlotUpdate(slot: number, sections: Record<strin
 export async function clusterGetIntents(): Promise<{ ok: boolean; data?: Record<number, PendingIntent> }> {
   const result = await resolveAndGet("/api/cluster/intents");
   if (!result.ok) return { ok: false };
-  // Server shape: { intents: Record<number, PendingIntent> } (handleGetIntents).
-  // Validate every entry through parsePendingIntent so callers (mag.ts
-  // workerKeepalive) can switch on intent.action without a re-cast.
-  const payload = result.data as { intents?: unknown } | null | undefined;
-  const rawIntents = (payload && typeof payload === "object" ? payload.intents : undefined);
-  if (!rawIntents || typeof rawIntents !== "object") return { ok: true, data: {} };
-  const validated: Record<number, PendingIntent> = {};
-  for (const [slotStr, rawIntent] of Object.entries(rawIntents as Record<string, unknown>)) {
-    const slotNum = Number(slotStr);
-    if (!Number.isFinite(slotNum)) continue;
-    const intent = parsePendingIntent(rawIntent);
-    if (!intent) continue;
-    validated[slotNum] = intent;
-  }
-  return { ok: true, data: validated };
+  return { ok: true, data: validateIntentsPayload(result.data) };
 }
 
 export async function clusterDeleteIntent(slot: number): Promise<{ ok: boolean }> {

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -141,6 +141,34 @@ export interface PendingIntent {
   preserveState?: boolean;
 }
 
+/** Validate an untrusted intent payload (file-on-disk read, HTTP body) into
+ *  a typed {@link PendingIntent}. Returns `null` on any malformed field —
+ *  callers skip the intent and rely on the existing 15-min TTL sweep to
+ *  clean up the file. The whole struct is validated, not only `action`,
+ *  because a corrupt epoch breaks the `now - intent.epoch` arithmetic
+ *  downstream. Action match is exact (no trim) — JSON-on-disk shouldn't
+ *  gain whitespace, and trimming would mask real corruption. */
+export function parsePendingIntent(raw: unknown): PendingIntent | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const action = r.action;
+  if (action !== "start" && action !== "stop" && action !== "resume") return null;
+  const epoch = r.epoch;
+  if (typeof epoch !== "number" || !Number.isFinite(epoch) || !Number.isInteger(epoch)) return null;
+  const machine = r.machine;
+  if (typeof machine !== "string" || machine === "") return null;
+  const out: PendingIntent = { action, epoch, machine };
+  if (r.taskId !== undefined) {
+    if (typeof r.taskId !== "string") return null;
+    out.taskId = r.taskId;
+  }
+  if (r.preserveState !== undefined) {
+    if (typeof r.preserveState !== "boolean") return null;
+    out.preserveState = r.preserveState;
+  }
+  return out;
+}
+
 const INTENT_TTL = 900; // seconds
 
 function intentsDir(): string {
@@ -169,7 +197,8 @@ export function getIntentForDashboard(slot: number): PendingIntent | null {
   const file = intentFilePath(slot);
   if (!existsSync(file)) return null;
   try {
-    const intent = JSON.parse(readFileSync(file, "utf-8")) as PendingIntent;
+    const intent = parsePendingIntent(JSON.parse(readFileSync(file, "utf-8")));
+    if (!intent) return null;
     if ((Math.floor(Date.now() / 1000) - intent.epoch) >= INTENT_TTL) {
       clearIntent(slot);
       return null;
@@ -189,7 +218,8 @@ function getIntentsForMachine(machine: string): Record<number, PendingIntent> {
       if (!match) continue;
       const slot = Number(match[1]);
       try {
-        const intent = JSON.parse(readFileSync(join(dir, file), "utf-8")) as PendingIntent;
+        const intent = parsePendingIntent(JSON.parse(readFileSync(join(dir, file), "utf-8")));
+        if (!intent) continue;
         if (intent.machine === machine && (now - intent.epoch) < INTENT_TTL) {
           result[slot] = intent;
         } else if ((now - intent.epoch) >= INTENT_TTL) {
@@ -210,7 +240,8 @@ function expireStaleIntents(): void {
       const match = file.match(/^slot-(\d+)\.json$/);
       if (!match) continue;
       try {
-        const intent = JSON.parse(readFileSync(join(dir, file), "utf-8")) as PendingIntent;
+        const intent = parsePendingIntent(JSON.parse(readFileSync(join(dir, file), "utf-8")));
+        if (!intent) continue;
         if ((now - intent.epoch) >= INTENT_TTL) clearIntent(Number(match[1]));
       } catch { /* skip */ }
     }
@@ -278,7 +309,22 @@ export async function clusterPostSlotUpdate(slot: number, sections: Record<strin
 
 export async function clusterGetIntents(): Promise<{ ok: boolean; data?: Record<number, PendingIntent> }> {
   const result = await resolveAndGet("/api/cluster/intents");
-  return { ok: result.ok, data: result.data as Record<number, PendingIntent> | undefined };
+  if (!result.ok) return { ok: false };
+  // Server shape: { intents: Record<number, PendingIntent> } (handleGetIntents).
+  // Validate every entry through parsePendingIntent so callers (mag.ts
+  // workerKeepalive) can switch on intent.action without a re-cast.
+  const payload = result.data as { intents?: unknown } | null | undefined;
+  const rawIntents = (payload && typeof payload === "object" ? payload.intents : undefined);
+  if (!rawIntents || typeof rawIntents !== "object") return { ok: true, data: {} };
+  const validated: Record<number, PendingIntent> = {};
+  for (const [slotStr, rawIntent] of Object.entries(rawIntents as Record<string, unknown>)) {
+    const slotNum = Number(slotStr);
+    if (!Number.isFinite(slotNum)) continue;
+    const intent = parsePendingIntent(rawIntent);
+    if (!intent) continue;
+    validated[slotNum] = intent;
+  }
+  return { ok: true, data: validated };
 }
 
 export async function clusterDeleteIntent(slot: number): Promise<{ ok: boolean }> {
@@ -529,7 +575,8 @@ function handleGetIntents(req: Request): Response {
         const match = file.match(/^slot-(\d+)\.json$/);
         if (!match) continue;
         try {
-          const intent = JSON.parse(readFileSync(join(dir, file), "utf-8")) as PendingIntent;
+          const intent = parsePendingIntent(JSON.parse(readFileSync(join(dir, file), "utf-8")));
+          if (!intent) continue;
           if ((now - intent.epoch) < INTENT_TTL) all[Number(match[1])] = intent;
         } catch { /* skip */ }
       }

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2752,10 +2752,12 @@ async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Pro
       const { setWorkerSlotsOverride } = await import("./slots/index.ts");
       const result = await clusterGetIntents();
       if (!result.ok || !result.data) return;
-      const intents = (result.data as { intents?: Record<string, unknown> })?.intents ?? result.data;
-      for (const [slotStr, rawIntent] of Object.entries(intents as Record<string, unknown>)) {
+      // result.data is Record<number, PendingIntent> validated by
+      // parsePendingIntent at the HTTP-client boundary — every entry's
+      // action is "start" | "stop" | "resume", epoch is a finite integer,
+      // and machine is a non-empty string. No re-cast needed.
+      for (const [slotStr, intent] of Object.entries(result.data)) {
         const slotNum = Number(slotStr);
-        const intent = rawIntent as { action: string; machine: string; epoch: number; preserveState?: boolean };
         if (intent.machine !== currentMachine) continue;
         if ((Math.floor(Date.now() / 1000) - intent.epoch) > 900) {
           await clusterDeleteIntent(slotNum).catch(() => {});

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -1317,6 +1317,195 @@ describe("migrateState — solo invariants", () => {
   });
 });
 
+// gh-ludics-411 AC 3: per-field policy for boundary validators on
+// `OrchestrationState` string unions. Helper-level tests; the
+// read-boundary regression lives in state.harnessdir.test.ts.
+describe("migrateState — boundary validators (gh-ludics-411 AC 3)", () => {
+  test("throws on invalid mode (\"throw\" policy — invariant)", () => {
+    const state = makeSoloState();
+    (state as { mode: string }).mode = "weird";
+    expect(() => migrateState(state, 1)).toThrow(/mode.*weird/);
+  });
+
+  test("coerces invalid backend to globalAdapter() default and logs once (\"coerce\" policy)", async () => {
+    const { globalAdapter } = await import("../config.ts");
+    const expectedFallback = globalAdapter();
+    const state = makeSoloState({ backend: "junk" as "tmux" });
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 5);
+      // Capture .mock.calls BEFORE mockRestore (per memory feedback).
+      calls = [...spy.mock.calls];
+      expect(result.backend).toBe(expectedFallback);
+      const backendLogs = calls.filter((c) => String(c[0] ?? "").includes("backend"));
+      expect(backendLogs.length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("legacy state with backend === undefined passes through unchanged (no log)", () => {
+    const state = makeSoloState();
+    delete (state as { backend?: string }).backend;
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 6);
+      calls = [...spy.mock.calls];
+      expect(result.backend).toBeUndefined();
+      const backendLogs = calls.filter((c) => String(c[0] ?? "").includes("backend"));
+      expect(backendLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("throws on invalid agents[].provider (\"throw\" policy — wire-protocol-bound)", () => {
+    const state = makeSoloState();
+    (state.agents[0] as { provider: string }).provider = "rogue-llm";
+    expect(() => migrateState(state, 7)).toThrow(/provider.*rogue-llm/);
+  });
+
+  test("drops invalid agents[].role and logs (\"drop\" policy)", () => {
+    const state = makeSoloState();
+    (state.agents[0] as { role?: string }).role = "narrator";
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 8);
+      calls = [...spy.mock.calls];
+      expect(result.agents[0].role).toBeUndefined();
+      const roleLogs = calls.filter((c) => String(c[0] ?? "").includes("agents[].role"));
+      expect(roleLogs.length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("coerces invalid turnLifecycle.state to \"error\" (\"coerce\" policy)", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.turnLifecycle = {
+      dispatchCommandId: "c1",
+      dispatchedAt: "2026-04-22T00:00:00Z",
+      phaseToken: "p1",
+      observedTurnId: null,
+      state: "galaxy-brain" as "settled",
+      turnStartedAt: null,
+      turnCompletedAt: null,
+      completionSource: null,
+      statusFileFingerprint: null,
+      lastStopHookAt: null,
+    };
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 9);
+      calls = [...spy.mock.calls];
+      expect(result.agentStates.coder.turnLifecycle?.state).toBe("error");
+      const stateLogs = calls.filter((c) => String(c[0] ?? "").includes("turnLifecycle.state"));
+      expect(stateLogs.length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("coerces invalid turnLifecycle.completionSource to null (\"coerce\" policy)", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.turnLifecycle = {
+      dispatchCommandId: "c1",
+      dispatchedAt: "2026-04-22T00:00:00Z",
+      phaseToken: "p1",
+      observedTurnId: null,
+      state: "settled",
+      turnStartedAt: null,
+      turnCompletedAt: null,
+      completionSource: "plot-twist" as "snapshot",
+      statusFileFingerprint: null,
+      lastStopHookAt: null,
+    };
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 10);
+      calls = [...spy.mock.calls];
+      expect(result.agentStates.coder.turnLifecycle?.completionSource).toBeNull();
+      const csLogs = calls.filter((c) => String(c[0] ?? "").includes("completionSource"));
+      expect(csLogs.length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // Sentinel-null fast-path: `null` is the documented "completion source
+  // unknown" value. The validator must NOT log on null/undefined or
+  // healthy state-file reads will spam stderr.
+  test("preserves turnLifecycle.completionSource === null without logging", () => {
+    const state = makeSoloState();
+    state.agentStates.coder.turnLifecycle = {
+      dispatchCommandId: "c1",
+      dispatchedAt: "2026-04-22T00:00:00Z",
+      phaseToken: "p1",
+      observedTurnId: null,
+      state: "settled",
+      turnStartedAt: null,
+      turnCompletedAt: null,
+      completionSource: null,
+      statusFileFingerprint: null,
+      lastStopHookAt: null,
+    };
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 11);
+      calls = [...spy.mock.calls];
+      expect(result.agentStates.coder.turnLifecycle?.completionSource).toBeNull();
+      const csLogs = calls.filter((c) => String(c[0] ?? "").includes("completionSource"));
+      expect(csLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // Positive-control sibling — happy-path through every validator with
+  // legal values flows through silently (no console.error). Required by
+  // the AC self-check format from prior memory feedback.
+  test("happy path: legal values pass through without coercion or logging", () => {
+    const state = makeSoloState();
+    state.backend = "tmux";
+    state.agentStates.coder.turnLifecycle = {
+      dispatchCommandId: "c1",
+      dispatchedAt: "2026-04-22T00:00:00Z",
+      phaseToken: "p1",
+      observedTurnId: null,
+      state: "running",
+      turnStartedAt: null,
+      turnCompletedAt: null,
+      completionSource: "snapshot",
+      statusFileFingerprint: null,
+      lastStopHookAt: null,
+    };
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const result = migrateState(state, 12);
+      calls = [...spy.mock.calls];
+      expect(result.mode).toBe("solo");
+      expect(result.backend).toBe("tmux");
+      expect(result.agents[0].role).toBe("coder");
+      expect(result.agentStates.coder.turnLifecycle?.state).toBe("running");
+      expect(result.agentStates.coder.turnLifecycle?.completionSource).toBe("snapshot");
+      const validatorLogs = calls.filter((c) => {
+        const msg = String(c[0] ?? "");
+        return msg.includes("OrchestrationState.") || msg.includes("invalid");
+      });
+      expect(validatorLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe("harness isolation regression", () => {
   test("LUDICS_HARNESS_DIR is set to the explicit path under TEST_TMP", () => {
     const harness = process.env.LUDICS_HARNESS_DIR;

--- a/src/orchestration/state.harnessdir.test.ts
+++ b/src/orchestration/state.harnessdir.test.ts
@@ -1,11 +1,13 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
   defaultOrchestrationConfig,
+  initAgentRuntimeState,
   persistState,
   readOrchestrationState,
+  type AgentTurnLifecycle,
   type OrchestrationState,
 } from "./state.ts";
 
@@ -127,5 +129,127 @@ describe("OrchestrationState.harnessDir", () => {
     // Fallback writes to DECOY (defaultHarnessDir() target) — this is the
     // behaviour the top-of-runOrchestration seed prevents for real runs.
     expect(existsSync(join(DECOY, "orchestration", "slot-5.json"))).toBe(true);
+  });
+});
+
+// gh-ludics-411 AC 3 read-boundary regression: writing a corrupted slot
+// state file to disk and asserting readOrchestrationState() applies the
+// per-field policy (throw / coerce / drop). This proves the validator
+// is wired through the read path, not just the migrateState() helper —
+// the helper-level cases live in phases.test.ts.
+describe("readOrchestrationState — boundary validators (gh-ludics-411 AC 3)", () => {
+  function writeSlot(slot: number, mutate: (s: OrchestrationState) => void): void {
+    const state = baseState(slot, REAL);
+    state.agents = [
+      { name: "coder", provider: "claude-code", role: "coder", model: "claude-sonnet-4-6", branch: "a", worktreePath: "/tmp/a" },
+    ];
+    state.agentStates = initAgentRuntimeState(["coder"]);
+    mutate(state);
+    const path = join(REAL, "orchestration", `slot-${slot}.json`);
+    writeFileSync(path, JSON.stringify(state, null, 2));
+  }
+
+  function lifecycle(overrides: Partial<AgentTurnLifecycle> = {}): AgentTurnLifecycle {
+    return {
+      dispatchCommandId: "c1",
+      dispatchedAt: "2026-04-22T00:00:00Z",
+      phaseToken: "p1",
+      observedTurnId: null,
+      state: "settled",
+      turnStartedAt: null,
+      turnCompletedAt: null,
+      completionSource: null,
+      statusFileFingerprint: null,
+      lastStopHookAt: null,
+      ...overrides,
+    };
+  }
+
+  test("throws when slot JSON has corrupt mode (\"throw\" policy at read boundary)", () => {
+    writeSlot(7, (s) => { (s as { mode: string }).mode = "weird"; });
+    expect(() => readOrchestrationState(7, REAL)).toThrow(/mode.*weird/);
+  });
+
+  test("coerces invalid backend to globalAdapter() and logs once at read boundary", async () => {
+    const { globalAdapter } = await import("../config.ts");
+    const expectedFallback = globalAdapter();
+    writeSlot(8, (s) => { (s as { backend: string }).backend = "junk"; });
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const loaded = readOrchestrationState(8, REAL);
+      calls = [...spy.mock.calls];
+      expect(loaded).not.toBeNull();
+      expect(loaded!.backend).toBe(expectedFallback);
+      const backendLogs = calls.filter((c) => String(c[0] ?? "").includes("backend"));
+      expect(backendLogs.length).toBe(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("drops invalid agents[].role at read boundary (\"drop\" policy)", () => {
+    writeSlot(9, (s) => { (s.agents[0] as { role?: string }).role = "narrator"; });
+    const loaded = readOrchestrationState(9, REAL);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.agents[0].role).toBeUndefined();
+  });
+
+  test("coerces invalid turnLifecycle.state and PRESERVES sentinel-null completionSource without logging", () => {
+    writeSlot(10, (s) => {
+      s.agentStates.coder.turnLifecycle = lifecycle({
+        state: "galaxy-brain" as "settled",
+        completionSource: null,
+      });
+    });
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const loaded = readOrchestrationState(10, REAL);
+      calls = [...spy.mock.calls];
+      expect(loaded).not.toBeNull();
+      const lc = loaded!.agentStates.coder.turnLifecycle;
+      expect(lc?.state).toBe("error");
+      expect(lc?.completionSource).toBeNull();
+      // turnLifecycle.state coerced once; completionSource:null fast-path = no log.
+      const stateLogs = calls.filter((c) => String(c[0] ?? "").includes("turnLifecycle.state"));
+      const csLogs = calls.filter((c) => String(c[0] ?? "").includes("completionSource"));
+      expect(stateLogs.length).toBe(1);
+      expect(csLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // Positive control: a fully-valid slot state file flows through the read
+  // boundary without any validator-driven console.error or mutation.
+  // Required by the AC self-check format (positive-control sibling fixture).
+  test("happy path: legal slot JSON round-trips silently through readOrchestrationState", () => {
+    writeSlot(11, (s) => {
+      s.backend = "tmux";
+      s.agentStates.coder.turnLifecycle = lifecycle({
+        state: "running",
+        completionSource: "snapshot",
+      });
+    });
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const loaded = readOrchestrationState(11, REAL);
+      calls = [...spy.mock.calls];
+      expect(loaded).not.toBeNull();
+      expect(loaded!.mode).toBe("pair");
+      expect(loaded!.backend).toBe("tmux");
+      expect(loaded!.agents[0].role).toBe("coder");
+      expect(loaded!.agentStates.coder.turnLifecycle?.state).toBe("running");
+      expect(loaded!.agentStates.coder.turnLifecycle?.completionSource).toBe("snapshot");
+      const validatorLogs = calls.filter((c) => {
+        const msg = String(c[0] ?? "");
+        return msg.includes("OrchestrationState.") || msg.includes("invalid");
+      });
+      expect(validatorLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync, mkdirSync } from "fs";
 import { join } from "path";
-import { harnessDir as defaultHarnessDir } from "../config.ts";
+import { harnessDir as defaultHarnessDir, globalAdapter } from "../config.ts";
 import type { T3ProviderKind } from "../t3code/types.ts";
 import { nowEpoch, readJsonFile, writeJsonFile } from "./util.ts";
 import type { Phase } from "./phases.ts";
@@ -296,10 +296,104 @@ function isWorkerContext(): boolean {
   }
 }
 
+/**
+ * File-local validator for narrow string unions read off disk
+ * (gh-ludics-411 AC 3). `migrateState` is the single read-boundary for every
+ * `OrchestrationState` deserialization, so per-field whitelist checks here
+ * cover both the controller `readJsonFile<OrchestrationState>` site and the
+ * worker cache equivalent. Policy is per-field, per the proposal:
+ *  - "throw" — invariant fields whose corruption should halt the read
+ *    (caller has its own catch-and-fall-through path).
+ *  - "coerce" — fields with a meaningful safe default; emit a console.error
+ *    and substitute `fallback`.
+ *  - "drop" — optional fields whose absence is already a documented state;
+ *    invalid values are removed by the caller (`delete state.foo`).
+ */
+function validateAndCoerce<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  policy: "throw" | "coerce" | "drop",
+  fallback: T | null,
+  fieldPath: string,
+  slot: number,
+): T | null {
+  if (typeof value === "string" && (allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  if (policy === "throw") {
+    throw new Error(`ludics: slot ${slot} corrupt OrchestrationState.${fieldPath}: ${JSON.stringify(value)}`);
+  }
+  if (policy === "drop") {
+    console.error(`ludics: slot ${slot} dropping invalid OrchestrationState.${fieldPath}: ${JSON.stringify(value)}`);
+    return null;
+  }
+  // policy === "coerce"
+  console.error(`ludics: slot ${slot} coercing invalid OrchestrationState.${fieldPath}: ${JSON.stringify(value)} → ${JSON.stringify(fallback)}`);
+  return fallback;
+}
+
 export function migrateState(state: OrchestrationState, slot: number): OrchestrationState {
   if (!state.taskId && (state as unknown as Record<string, unknown>).feature) {
     state.taskId = String((state as unknown as Record<string, unknown>).feature);
   }
+
+  // --- AC 3 boundary validators (string unions read from disk JSON) -------
+  state.mode = validateAndCoerce(
+    state.mode, ["duo", "pair", "solo"] as const, "throw", null, "mode", slot,
+  ) as "duo" | "pair" | "solo";
+
+  if (state.backend !== undefined) {
+    const validated = validateAndCoerce(
+      state.backend, ["t3code", "tmux"] as const, "coerce", globalAdapter(), "backend", slot,
+    );
+    state.backend = validated as "t3code" | "tmux";
+  }
+
+  if (state.agents) {
+    for (const agent of state.agents) {
+      agent.provider = validateAndCoerce(
+        agent.provider, ["codex", "claude-code"] as const, "throw", null,
+        "agents[].provider", slot,
+      ) as T3ProviderKind;
+
+      if (agent.role !== undefined) {
+        const validated = validateAndCoerce(
+          agent.role, ["coder", "reviewer"] as const, "drop", null,
+          "agents[].role", slot,
+        );
+        if (validated === null) delete agent.role;
+        else agent.role = validated;
+      }
+    }
+  }
+
+  if (state.agentStates) {
+    for (const runtime of Object.values(state.agentStates)) {
+      const lc = runtime.turnLifecycle;
+      if (lc != null) {
+        lc.state = validateAndCoerce(
+          lc.state,
+          ["dispatched", "starting", "running", "settled", "error"] as const,
+          "coerce", "error", "turnLifecycle.state", slot,
+        ) as "dispatched" | "starting" | "running" | "settled" | "error";
+
+        // Sentinel-null fast-path: `null` is a valid value here (means
+        // "completion source unknown"), not an "absent" marker. Skip the
+        // validator on null/undefined to avoid spurious console.error logs
+        // on every healthy state-file read.
+        if (lc.completionSource !== null && lc.completionSource !== undefined) {
+          const validated = validateAndCoerce(
+            lc.completionSource,
+            ["snapshot", "stop-hook", "timeout"] as const,
+            "coerce", null, "turnLifecycle.completionSource", slot,
+          );
+          lc.completionSource = validated as "snapshot" | "stop-hook" | "timeout" | null;
+        }
+      }
+    }
+  }
+  // ------------------------------------------------------------------------
+
   if (state.mode === "duo" && state.duoPeerSlot == null) {
     console.error(`ludics: slot ${slot} has legacy mode="duo" without duoPeerSlot — should be cleared and re-assigned`);
   }

--- a/src/sessions/discover-codex.ts
+++ b/src/sessions/discover-codex.ts
@@ -4,7 +4,8 @@
 
 import { readdirSync, statSync, existsSync } from "fs";
 import { join, basename } from "path";
-import type { DiscoveredSession, SourceKind } from "../types.ts";
+import type { DiscoveredSession } from "../types.ts";
+import { parseSourceKind } from "../types.ts";
 import { readFirstLines } from "./read-lines.ts";
 
 const MAX_SCAN_LINES = 20;
@@ -172,7 +173,7 @@ export async function discoverCodex(
       cwd: normalizeCwd(cwd),
       cwdNormalized: normalizeCwd(cwd),
       sessionId,
-      source: source as SourceKind,
+      source: parseSourceKind(source),
       lastActivityEpoch: mtimeEpoch,
       meta,
     });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { parseSourceKind } from "./types.ts";
+
+describe("parseSourceKind", () => {
+  test("accepts all 7 valid SourceKind values unchanged", () => {
+    expect(parseSourceKind("cli")).toBe("cli");
+    expect(parseSourceKind("vscode")).toBe("vscode");
+    expect(parseSourceKind("exec")).toBe("exec");
+    expect(parseSourceKind("appServer")).toBe("appServer");
+    expect(parseSourceKind("app")).toBe("app");
+    expect(parseSourceKind("web")).toBe("web");
+    expect(parseSourceKind("unknown")).toBe("unknown");
+  });
+
+  test("trims surrounding whitespace before whitelist match", () => {
+    expect(parseSourceKind("  vscode  ")).toBe("vscode");
+    expect(parseSourceKind("\tcli\n")).toBe("cli");
+  });
+
+  test("collapses null/undefined/empty inputs to \"unknown\"", () => {
+    expect(parseSourceKind(null)).toBe("unknown");
+    expect(parseSourceKind(undefined)).toBe("unknown");
+    expect(parseSourceKind("")).toBe("unknown");
+    expect(parseSourceKind("   ")).toBe("unknown");
+  });
+
+  test("collapses unrecognized strings to \"unknown\"", () => {
+    expect(parseSourceKind("bogus")).toBe("unknown");
+    expect(parseSourceKind("CLI")).toBe("unknown"); // case-sensitive whitelist
+    expect(parseSourceKind("complete")).toBe("unknown"); // typo case
+  });
+
+  test("collapses non-string inputs to \"unknown\"", () => {
+    expect(parseSourceKind(42)).toBe("unknown");
+    expect(parseSourceKind(true)).toBe("unknown");
+    expect(parseSourceKind({})).toBe("unknown");
+    expect(parseSourceKind([])).toBe("unknown");
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,22 @@
 export type AgentType = "t3code" | "codex" | "claude-code";
 export type SourceKind = "cli" | "vscode" | "exec" | "appServer" | "app" | "web" | "unknown";
 
+/** Narrow an untrusted string (Codex `session_meta.source` JSONL field, etc.)
+ *  to a valid {@link SourceKind}. Unknown / non-string values collapse to
+ *  `"unknown"` — the existing fallback used elsewhere in session discovery
+ *  (e.g. `discover-codex.ts:144` and `discover-claude.ts:153`). Default-to-
+ *  safe is the right policy here: an unknown source kind shouldn't crash
+ *  session discovery on a single malformed log. */
+export function parseSourceKind(raw: unknown): SourceKind {
+  if (typeof raw !== "string") return "unknown";
+  const s = raw.trim();
+  if (
+    s === "cli" || s === "vscode" || s === "exec" || s === "appServer" ||
+    s === "app" || s === "web" || s === "unknown"
+  ) return s;
+  return "unknown";
+}
+
 export interface DiscoveredSession {
   agentType: AgentType;
   cwd: string;


### PR DESCRIPTION
## Summary

Closes gh-ludics-411. Extends the `parseSlotLiveness` worked example
to every other string→union widening with an external read boundary,
per the proposal at `docs/proposals/audit-string-union-boundary-validators.md`.

Before this PR, only `SlotData.liveness` had a runtime validator
co-located with its type. Three other unions were silently casting
external input (HTTP body, JSONL, on-disk JSON) into typed fields:
`PendingIntent`, `SourceKind`, and six fields of `OrchestrationState`.
Each union now has a parser at every external-read seam.

## Audit summary (per AC 6)

| Union | External read site | Status before | This PR |
|---|---|---|---|
| `SlotLiveness` | HTTP body, markdown migration | `parseSlotLiveness` (worked example) | Unchanged |
| `PendingIntent` (`action` + `epoch` + `machine` + …) | 4 file reads + 1 HTTP-client cast in `cluster-http.ts`; consumer in `mag.ts::workerKeepalive` | Unchecked `as PendingIntent` cast | `parsePendingIntent` validates whole struct (parseInt-coerces epoch, string-coerces machine/taskId per AC 1); tightened `clusterGetIntents()` so worker keepalive never sees an unvalidated payload |
| `SourceKind` | `discover-codex.ts:175` (Codex `session_meta` JSONL) | `source as SourceKind` | `parseSourceKind` collapses unknowns to `"unknown"` |
| `OrchestrationState.mode` | `migrateState()` | Unvalidated | Whitelist + **throw** (invariant) |
| `OrchestrationState.backend` | `migrateState()` | Unvalidated | Whitelist + **coerce to `globalAdapter()`** |
| `OrchestrationState.agents[].provider` | `migrateState()` | Unvalidated | Whitelist + **throw** (wire-protocol-bound) |
| `OrchestrationState.agents[].role` | `migrateState()` | Unvalidated | Whitelist + **drop** (downstream handles `undefined`) |
| `turnLifecycle.state` | `migrateState()` | Unvalidated | Whitelist + **coerce to `"error"`** |
| `turnLifecycle.completionSource` | `migrateState()` | Unvalidated | Whitelist + **coerce to `null`** (sentinel-null fast-path so valid `null` flows silently) |
| `GlobalAdapterMode` | `config.yaml` | Already validated at `config.ts:236-242` | Skipped (proposal AC 4) |
| `SweepMode` | `known-sessions.json` | Already validated via `SWEEP_TARGET_MODES.has` | Skipped |
| `UnifiedEffort` | task frontmatter / config | Already validated via `normaliseEffortLevel` | Skipped |
| Verdict | review markdown | Already validated via `parseVerdictFromContent` | Skipped |

Out-of-scope per the proposal:
- Task-frontmatter `status`/`priority`/`effort`/`adapter` are still
  typed as plain `string` in `tasks/types.ts`, so they aren't
  string→union *widenings* yet — narrowing them is a separate task.
- No internal-constructor validators (the gh-ludics-410 anti-pattern).

## Per-field policy rationale

- **Throw** — `mode` and `agents[].provider` are invariants whose
  corruption should halt the read; callers (`slotResume`, `slotStart`)
  already have catch-and-fall-through paths.
- **Coerce** — `backend`, `turnLifecycle.state`,
  `turnLifecycle.completionSource` have meaningful safe defaults
  (the existing fallbacks elsewhere in the codebase). Validator
  emits one `console.error` so corruption is visible without
  blocking the read.
- **Drop** — `agents[].role` is already optional; an invalid value
  is removed and downstream `role === undefined` handling kicks in.
- **Default-to-null / "unknown"** — `parsePendingIntent` and
  `parseSourceKind` collapse unrecoverable input because malformed
  intents are TTL-expired anyway, and a malformed source kind
  shouldn't crash session discovery.

`parsePendingIntent` follows the proposal AC 1 contract literally:
`parseInt(epoch)` accepts string-encoded integers, and
`String(machine)` / `String(taskId)` coerce non-string values.
The function returns either a fully-validated intent or `null`.

The sentinel-null fast-path on `turnLifecycle.completionSource` is
worth calling out: `null` is a valid value (means "completion source
unknown"), not an "absent" marker. Without the explicit guard,
every healthy state-file read would log a spurious validator warning.

## Tests

35 new tests across 4 files, all landed in this PR:

1. `src/types.test.ts` (NEW) — 5 cases for `parseSourceKind`.
2. `src/cluster-http.test.ts` — 11 cases for `parsePendingIntent`
   (including the parseInt/string-coerce contract from AC 1), 3 for
   `validateIntentsPayload` (the HTTP-client boundary helper), a
   file-read boundary regression that writes one valid + one
   malformed intent, and a `clusterGetIntents()` integration test
   that stubs `globalThis.fetch` end-to-end so the malformed entry
   is filtered before `mag.ts::workerKeepalive` sees it.
3. `src/orchestration/phases.test.ts` — 9 helper-level cases for
   `migrateState` covering every policy branch (throw / coerce /
   drop), the sentinel-null fast-path, and a positive-control
   happy path that asserts no validator log fires on legal data.
4. `src/orchestration/state.harnessdir.test.ts` — 5 read-boundary
   regression tests that write corrupted slot JSON to a temp
   `LUDICS_HARNESS_DIR` and exercise `readOrchestrationState()`
   end-to-end, proving the validator is wired through the read path.

Pre-existing baseline: `1724 pass / 1 fail` (the unrelated
`PROPOSAL_FRESHNESS_WARNING` boundary test). After this PR:
`1759 pass / 1 fail` — all 35 new tests pass, no regressions.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — only the pre-existing freshness-sentinel failure
- [x] `bun run build` produces a working binary
- [x] No internal-constructor validators added (gh-ludics-410 negative check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)