### PR TITLE
gh-ludics-441: Manual-Smoke Evidence playbook + dashboard mirror helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Simplified upstream workflow: for projects declaring `upstream_repo`, orchestrat
 ### Documentation / contracts
 
 - **Small-effort tasks are now explicitly documented to skip the plan phase.** `skip_plan` remains a manual override applying only to medium effort. No behavior change; the rule is now asserted by tests (`selectOrchestrationFlags` / `selectOrchestrationFlagsForTask`).
+- **Manual-smoke evidence playbook.** New `## Manual-Smoke Evidence` section in `skills/worker-conventions.md` documents two probe patterns (wrapper-pipeline + live HTTP via `startDashboardServer`) for ACs that require runtime verification of deterministically-rendered, statically-served surfaces. Cross-linked from `ludics-elaborate`, `ludics-draft-proposal`, `ludics-verify-completion`. New helper: `bun run scripts/dev-dashboard-mirror.ts` boots the dashboard against a temp-dir mirror.
 
 ### Breaking changes
 

--- a/scripts/dev-dashboard-mirror.test.ts
+++ b/scripts/dev-dashboard-mirror.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const SOURCE_PATH = join(import.meta.dir, "dev-dashboard-mirror.ts");
+const SCRIPT_PATH = SOURCE_PATH;
 const SOURCE = readFileSync(SOURCE_PATH, "utf-8");
 
 describe("dev-dashboard-mirror.ts /tmp prefix invariant", () => {
@@ -17,5 +18,65 @@ describe("dev-dashboard-mirror.ts /tmp prefix invariant", () => {
   test("does not import tmpdir from node:os", () => {
     expect(SOURCE).not.toMatch(/from\s+["']node:os["']/);
     expect(SOURCE).not.toMatch(/\btmpdir\s*\(/);
+  });
+});
+
+describe("dev-dashboard-mirror.ts CLI argument validation", () => {
+  // Codex P2 review (PR #452): parseArg used to accept any next token as
+  // the value, so `--port --keep` made Number("--keep") = NaN and the
+  // server started with garbage inputs. Each variant below would have
+  // started the server with NaN under the round-2 implementation; the
+  // new parseNumberArg exits non-zero before reaching startDashboardServer.
+
+  function runScript(args: string[]): { exitCode: number; stderr: string } {
+    const proc = Bun.spawnSync(["bun", "run", SCRIPT_PATH, ...args], {
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    return {
+      exitCode: proc.exitCode ?? -1,
+      stderr: new TextDecoder().decode(proc.stderr),
+    };
+  }
+
+  test("rejects --port followed by another flag", () => {
+    const { exitCode, stderr } = runScript(["--port", "--keep"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--port requires a numeric value");
+  });
+
+  test("rejects --ttl with non-numeric value", () => {
+    const { exitCode, stderr } = runScript(["--ttl", "soon"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--ttl");
+    expect(stderr).toContain("not a finite number");
+  });
+
+  test("rejects --port at end of argv", () => {
+    const { exitCode, stderr } = runScript(["--port"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("--port requires a numeric value");
+  });
+});
+
+describe("dev-dashboard-mirror.ts startup-failure cleanup", () => {
+  // Codex P3 review (PR #452): if startDashboardServer throws before
+  // SIGINT/SIGTERM handlers are registered/run, the mirror dir leaks.
+  // We force a startup failure by invoking the script with an invalid
+  // numeric port literal that Bun.serve rejects ("99999" is out of range
+  // for TCP). The argv validator above only catches non-finite Number();
+  // 99999 is finite, so it reaches startDashboardServer and throws.
+  test("removes mirror dir when server start throws", () => {
+    const before = existsSync("/tmp")
+      ? new Set(readdirSync("/tmp").filter((n) => n.startsWith("ludics-dash-mirror-")))
+      : new Set();
+    const proc = Bun.spawnSync(["bun", "run", SCRIPT_PATH, "--port", "99999"], {
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(proc.exitCode).not.toBe(0);
+    const after = readdirSync("/tmp").filter((n) => n.startsWith("ludics-dash-mirror-"));
+    const leaked = after.filter((n) => !before.has(n));
+    expect(leaked).toEqual([]);
   });
 });

--- a/scripts/dev-dashboard-mirror.test.ts
+++ b/scripts/dev-dashboard-mirror.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SOURCE_PATH = join(import.meta.dir, "dev-dashboard-mirror.ts");
+const SOURCE = readFileSync(SOURCE_PATH, "utf-8");
+
+describe("dev-dashboard-mirror.ts /tmp prefix invariant", () => {
+  // AC7 of gh-ludics-441 requires the mirror to land at
+  // /tmp/ludics-dash-mirror-<random>/, not the platform tmpdir, which on
+  // macOS resolves to /var/folders/.../T. The playbook example transcript
+  // and reviewer probes both depend on this prefix.
+  test("mkdtempSync uses the literal /tmp/ludics-dash-mirror- prefix", () => {
+    expect(SOURCE).toContain('mkdtempSync("/tmp/ludics-dash-mirror-")');
+  });
+
+  test("does not import tmpdir from node:os", () => {
+    expect(SOURCE).not.toMatch(/from\s+["']node:os["']/);
+    expect(SOURCE).not.toMatch(/\btmpdir\s*\(/);
+  });
+});

--- a/scripts/dev-dashboard-mirror.ts
+++ b/scripts/dev-dashboard-mirror.ts
@@ -9,7 +9,6 @@
 // Usage: bun run scripts/dev-dashboard-mirror.ts [--port N] [--ttl SEC] [--keep]
 
 import { mkdtempSync, mkdirSync, cpSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { startDashboardServer } from "../src/dashboard-server.ts";
 
@@ -22,7 +21,10 @@ const port = Number(parseArg("--port", "0"));
 const ttl = Number(parseArg("--ttl", "3600"));
 const keep = process.argv.includes("--keep");
 
-const root = mkdtempSync(join(tmpdir(), "ludics-dash-mirror-"));
+// AC7 requires the mirror to live under /tmp/ literally — not the platform
+// tmpdir, which on macOS resolves to /var/folders/.../T. The playbook's
+// example transcript and reviewer probe both expect a /tmp/ path.
+const root = mkdtempSync("/tmp/ludics-dash-mirror-");
 const dashboardDir = join(root, "dashboard");
 const tasksDir = join(root, "tasks");
 mkdirSync(tasksDir, { recursive: true });

--- a/scripts/dev-dashboard-mirror.ts
+++ b/scripts/dev-dashboard-mirror.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+// Boot the dashboard against a temp-dir mirror of templates/dashboard/.
+//
+// Citable shorthand for pattern (b) of the Manual-Smoke Evidence playbook
+// in skills/worker-conventions.md. Mirrors the asset tree so the live HTTP
+// probe runs against the real `startDashboardServer` entrypoint without
+// touching the in-repo templates directory.
+//
+// Usage: bun run scripts/dev-dashboard-mirror.ts [--port N] [--ttl SEC] [--keep]
+
+import { mkdtempSync, mkdirSync, cpSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { startDashboardServer } from "../src/dashboard-server.ts";
+
+function parseArg(name: string, fallback: string): string {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback;
+}
+
+const port = Number(parseArg("--port", "0"));
+const ttl = Number(parseArg("--ttl", "3600"));
+const keep = process.argv.includes("--keep");
+
+const root = mkdtempSync(join(tmpdir(), "ludics-dash-mirror-"));
+const dashboardDir = join(root, "dashboard");
+const tasksDir = join(root, "tasks");
+mkdirSync(tasksDir, { recursive: true });
+cpSync(
+  resolve(import.meta.dir, "..", "templates", "dashboard"),
+  dashboardDir,
+  { recursive: true },
+);
+
+const server = startDashboardServer(port, dashboardDir, ttl);
+console.log(
+  `dashboard listening on http://localhost:${server.port} (mirror=${root}${keep ? ", kept" : ""})`,
+);
+
+let stopping = false;
+function shutdown(): void {
+  if (stopping) return;
+  stopping = true;
+  void server.stop(true);
+  if (!keep) rmSync(root, { recursive: true, force: true });
+  process.exit(0);
+}
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);

--- a/scripts/dev-dashboard-mirror.ts
+++ b/scripts/dev-dashboard-mirror.ts
@@ -12,13 +12,24 @@ import { mkdtempSync, mkdirSync, cpSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { startDashboardServer } from "../src/dashboard-server.ts";
 
-function parseArg(name: string, fallback: string): string {
+function parseNumberArg(name: string, fallback: number): number {
   const i = process.argv.indexOf(name);
-  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : fallback;
+  if (i < 0) return fallback;
+  const raw = process.argv[i + 1];
+  if (raw === undefined || raw.startsWith("--")) {
+    console.error(`error: ${name} requires a numeric value`);
+    process.exit(2);
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    console.error(`error: ${name} value ${JSON.stringify(raw)} is not a finite number`);
+    process.exit(2);
+  }
+  return n;
 }
 
-const port = Number(parseArg("--port", "0"));
-const ttl = Number(parseArg("--ttl", "3600"));
+const port = parseNumberArg("--port", 0);
+const ttl = parseNumberArg("--ttl", 3600);
 const keep = process.argv.includes("--keep");
 
 // AC7 requires the mirror to live under /tmp/ literally — not the platform
@@ -27,14 +38,23 @@ const keep = process.argv.includes("--keep");
 const root = mkdtempSync("/tmp/ludics-dash-mirror-");
 const dashboardDir = join(root, "dashboard");
 const tasksDir = join(root, "tasks");
-mkdirSync(tasksDir, { recursive: true });
-cpSync(
-  resolve(import.meta.dir, "..", "templates", "dashboard"),
-  dashboardDir,
-  { recursive: true },
-);
 
-const server = startDashboardServer(port, dashboardDir, ttl);
+let server: ReturnType<typeof startDashboardServer>;
+try {
+  mkdirSync(tasksDir, { recursive: true });
+  cpSync(
+    resolve(import.meta.dir, "..", "templates", "dashboard"),
+    dashboardDir,
+    { recursive: true },
+  );
+  server = startDashboardServer(port, dashboardDir, ttl);
+} catch (err) {
+  // Server start (or mirror copy) threw before signal handlers were
+  // registered — clean up the temp directory so we don't leak it.
+  rmSync(root, { recursive: true, force: true });
+  throw err;
+}
+
 console.log(
   `dashboard listening on http://localhost:${server.port} (mirror=${root}${keep ? ", kept" : ""})`,
 );

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -58,6 +58,13 @@ The worker creates the directory; this step just resolves the path.
 
 Worker: `/ludics-draft-proposal-worker <task_id> <project_path> <proposals_path> <context_brief>`
 
+- **Manual-smoke ACs.** When drafting an AC that requires manual visual or
+  runtime verification, see
+  [Manual-Smoke Evidence](worker-conventions.md#manual-smoke-evidence) in
+  worker-conventions for the two probe shapes (wrapper-pipeline + live
+  HTTP) the harness can deliver. Phrase the AC so its evidence layer is
+  one of those, not "open the dashboard in a browser."
+
 <!-- section:precondition-check -->
 ## Precondition check
 

--- a/skills/ludics-elaborate.md
+++ b/skills/ludics-elaborate.md
@@ -36,6 +36,12 @@ Follow [orchestrator-conventions.md](orchestrator-conventions.md):
 - **E** (Result JSON): write the result with the request ID.
 - **F** (Error Handling): standard patterns.
 
+- **Manual-smoke ACs.** When elaboration surfaces an AC that implies visual
+  or runtime verification, point the worker at
+  [Manual-Smoke Evidence](worker-conventions.md#manual-smoke-evidence) in
+  worker-conventions rather than inlining guidance. Two probe shapes
+  (wrapper-pipeline + live HTTP) cover the harness-deliverable cases.
+
 ### Container short-circuit (before Step D)
 
 If the task's frontmatter has `leaf: false`, the work has already been split

--- a/skills/ludics-verify-completion.md
+++ b/skills/ludics-verify-completion.md
@@ -39,6 +39,13 @@ Follow [orchestrator-conventions.md](orchestrator-conventions.md):
 
 Worker: `/ludics-verify-completion-worker <task_id> <project_path> <context_brief>`
 
+- **Manual-smoke ACs require evidence, not argument.** Do not accept
+  "unit tests exercise the same library combination" as evidence for an
+  AC that names a route, an asset, or a rendered surface. See
+  [Manual-Smoke Evidence](worker-conventions.md#manual-smoke-evidence) for
+  the two probe shapes (wrapper-pipeline + live HTTP) the harness can
+  deliver.
+
 ## Verdict routing
 
 Extract the final ` ```json ` block from the worker. Fields:

--- a/skills/worker-conventions.md
+++ b/skills/worker-conventions.md
@@ -26,6 +26,92 @@ Reach for declare/salvage/follow-up only when a fix exceeds the absorb
 boundary — a few lines, same file or sibling test, no new abstractions or
 imports, no new public surface.
 
+## Manual-Smoke Evidence
+
+When an AC requires "manual smoke verification," reviewers will not accept
+*substitution-by-argument* ("the unit tests exercise the same library
+combination, therefore manual smoke is covered") and will not accept
+deferral. The harness *can* produce real evidence for any deterministically-
+rendered, statically-served surface; "I can't open a browser" is not a valid
+limit when rendering is deterministic from MD source + library versions and
+the server is a static file server. Two patterns work, often used together:
+
+### (a) Wrapper-pipeline probe
+
+Run the wrapper's exact pipeline at the *vendored* library versions against
+real harness content. Capture the output (HTML, transformed text, whatever
+the wrapper produces) so the reviewer can read what a user would see.
+
+Recipe:
+
+1. Install the libraries from npm at the *exact* versions claimed by the
+   vendored bundles (e.g. `templates/dashboard/vendor/README.md` cites
+   versions for `marked` and `isomorphic-dompurify`).
+2. Write a small `.ts` file under `/tmp/` that imports those libraries and
+   replays the wrapper's pipeline (including any pre/post-processing such
+   as `task.html`'s frontmatter strip).
+3. Feed it 2–3 real harness files spanning the variation the AC cares
+   about (e.g. a task file with frontmatter, a proposal with code blocks,
+   a briefing with tables).
+4. Capture stdout/stderr into `/tmp/<probe-name>.transcript` and quote
+   key sections in the workflow-feedback or PR comment.
+
+> **Verify version alignment first.** If `package.json` and
+> `templates/dashboard/vendor/` drift, the probe silently tests the wrong
+> artifact. Cross-check the version string in the vendored bundle against
+> the npm-installed version before trusting the evidence. (See
+> task-d024e32c — `lint:vendor-sync`.)
+
+### (b) Live HTTP probe
+
+Instantiate the *real* server entrypoint against a temp-dir mirror of the
+asset tree, then `fetch` (or `curl`) the routes the AC names. The transcript
+becomes the evidence.
+
+Entrypoint signature:
+`startDashboardServer(port: number, dashboardDir: string, ttlSeconds: number): ReturnType<typeof Bun.serve>`
+exported from `src/dashboard-server.ts`. Pass `port = 0` to let Bun pick a
+free port; read the resolved port back from the returned server's `.port`.
+
+Worked example: `src/dashboard.test.ts` around line 545 shows the canonical
+shape (mirror under `harnessDir()/dashboard`, boot with port 0, `fetch`,
+`stop`). Lift it instead of writing your own.
+
+For the dashboard specifically,
+`bun run scripts/dev-dashboard-mirror.ts` performs the temp-dir mirror +
+boot dance and prints the URL; pipe its output into your evidence
+transcript. Example:
+
+```bash
+bun run scripts/dev-dashboard-mirror.ts
+# dashboard listening on http://localhost:54321 (mirror=/tmp/ludics-dash-mirror-XXXX)
+curl http://localhost:54321/index.html | head
+curl http://localhost:54321/task.html?task=<id> | head
+curl http://localhost:54321/vendor/marked.esm.js | head -1
+```
+
+### Patterns combined
+
+For ACs that exercise both rendering *and* serving (the markdown-renderer
+case from task-61aee08e), run (a) first to prove the pipeline is correct
+given the inputs, then (b) to prove the server actually delivers those
+inputs to the browser.
+
+### What this does *not* cover
+
+- Subjective visual judgement ("the layout looks right on mobile",
+  "typography feels balanced"). These ACs still need a human; the playbook
+  is for deterministic rendering only.
+- Stateful interaction flows (clicking through a multi-step UI). Out of
+  scope for static-content surfaces.
+
+### Hygiene
+
+- Probe scripts and transcripts live under `/tmp/`, never in the repo.
+- Name them with the task ID: `/tmp/<task-id>-<probe>.ts`,
+  `/tmp/<task-id>-<probe>.transcript`.
+- Cite paths in the PR comment so reviewers can rerun if needed.
+
 ## Broader Context
 
 Some workers receive a `<context_brief>` as a trailing argument — free-form


### PR DESCRIPTION
## Summary
- New `## Manual-Smoke Evidence` section in `skills/worker-conventions.md` codifying two probe shapes — (a) wrapper-pipeline at vendored library versions, (b) live HTTP via `startDashboardServer` against a temp-dir mirror — for ACs that require runtime verification of deterministically-rendered, statically-served surfaces. Names the entrypoint signature, cites `src/dashboard.test.ts:545` as the worked example, and lists three caveats (subjective visual review excluded, vendor-version drift, `/tmp/` hygiene).
- One-bullet cross-links into `ludics-elaborate`, `ludics-draft-proposal`, and `ludics-verify-completion` (reviewer-side framing in the last).
- New helper `scripts/dev-dashboard-mirror.ts` mirrors `templates/dashboard/` into `/tmp/ludics-dash-mirror-<random>/` (with empty sibling `tasks/` for production-equivalent task-endpoint behavior), boots `startDashboardServer`, prints the listening URL, and cleans up on SIGINT/SIGTERM unless `--keep`. Validates `--port`/`--ttl` numeric values and rmSyncs the mirror if startup throws (Codex P2/P3 review fixes).
- Sibling regression test `scripts/dev-dashboard-mirror.test.ts` pins the `/tmp/` literal, the argv-validator behavior (`--port --keep`, `--ttl soon`, bare `--port` all exit 2), and the startup-failure cleanup (`--port 99999` triggers EADDRINUSE; before/after `/tmp` snapshot confirms zero leaked dirs).
- `CHANGELOG.md` entry under Unreleased / Documentation.

Source: https://github.com/lukstafi/ludics/issues/441
Proposal: `docs/proposals/gh-ludics-441-manual-smoke-evidence-playbook.md`

## Commits
- `40bdafd` — round 1: playbook section, three skill cross-links, helper script, CHANGELOG
- `6d2e7ae` — round 2: pin mirror to literal `/tmp/`, drop `node:os` `tmpdir()`, add regression test
- `3b4b78c` — round 3: Codex P2/P3 — argv numeric validation + startup-throw cleanup, expand regression tests

## Test plan
- [x] `bun run typecheck` — passes (all rounds).
- [x] `bun run scripts/lint-template-safety.ts` — passes.
- [x] `bun run scripts/lint-cli-readme.ts` — passes.
- [x] `bun test scripts/dev-dashboard-mirror.test.ts` — 6/6 pass, 12 expect calls.
- [x] Live smoke of helper: `bun run scripts/dev-dashboard-mirror.ts --port 0 --ttl 60` served `/index.html` (real DOCTYPE), `/vendor/marked.esm.js` (`marked v18.0.2 - a markdown parser`); SIGINT cleanly removed `/tmp/ludics-dash-mirror-<random>/`.
- [x] Anchor `worker-conventions.md#manual-smoke-evidence` resolves: `## Manual-Smoke Evidence` is a level-2 heading; GitHub's slugger maps it to `manual-smoke-evidence` exactly.
- [x] Diff scope: 7 files — `CHANGELOG.md`, `scripts/dev-dashboard-mirror.ts`, `scripts/dev-dashboard-mirror.test.ts`, four `skills/*.md`. No `src/` or `templates/` paths; no pre-existing test files modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)