### PR TITLE
test: factor setupOrchTestState helper for orch-CLI tests

### DIFF
--- a/src/orchestration/index.test.ts
+++ b/src/orchestration/index.test.ts
@@ -1,16 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { orchDiff, runOrchestrationCli } from "./index.ts";
-import {
-  defaultOrchestrationConfig,
-  initAgentRuntimeState,
-  orchestrationDir,
-  stateFilePath,
-  type AgentConfig,
-  type OrchestrationState,
-} from "./state.ts";
+import { makeTmpDir, setupOrchTestState } from "./runner.test-helpers.ts";
 
 function makeRepo(dir: string): void {
   mkdirSync(dir, { recursive: true });
@@ -31,98 +23,73 @@ function addCommits(dir: string, count: number): void {
   }
 }
 
-function makeState(slot: number, agents: AgentConfig[]): OrchestrationState {
-  return {
-    slot,
-    taskId: "gh-ludics-374-test",
-    mode: "pair",
-    phase: "review",
-    round: 1,
-    mergeRound: 0,
-    agents,
-    agentStates: initAgentRuntimeState(agents.map((a) => a.name)),
-    config: defaultOrchestrationConfig(),
-    phaseStartedAt: 0,
-    startedAt: "2026-04-25T00:00:00Z",
-    projectDir: "/tmp/project",
-    rootWorktree: "/tmp/project",
-    peerSyncDir: "/tmp/peer-sync",
-    threadIds: {},
-  };
-}
-
 describe("orchDiff / runOrchestrationCli diff", () => {
-  let harness: string;
-  let tmpRoot: string;
-  const prevHarness = process.env.LUDICS_HARNESS_DIR;
-  let captured: string[];
-  const capture = (msg: string): void => {
-    captured.push(msg);
-  };
-
-  beforeEach(() => {
-    tmpRoot = mkdtempSync(join(tmpdir(), "ludics-orch-diff-"));
-    harness = join(tmpRoot, "harness");
-    mkdirSync(orchestrationDir(harness), { recursive: true });
-    process.env.LUDICS_HARNESS_DIR = harness;
-    captured = [];
-  });
-
-  afterEach(() => {
-    if (prevHarness === undefined) delete process.env.LUDICS_HARNESS_DIR;
-    else process.env.LUDICS_HARNESS_DIR = prevHarness;
-    rmSync(tmpRoot, { recursive: true, force: true });
-  });
-
-  function writeState(state: OrchestrationState): void {
-    writeFileSync(stateFilePath(state.slot, harness), JSON.stringify(state));
-  }
-
   test("happy path: prints per-agent git log <base>..HEAD --stat output", () => {
     if (!Bun.which("git")) return;
+    const tmpRoot = makeTmpDir();
     const repo = join(tmpRoot, "wt-coder");
     makeRepo(repo);
     addCommits(repo, 2);
 
-    writeState(
-      makeState(7, [
+    const { cleanup } = setupOrchTestState({
+      slot: 7,
+      agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo },
-      ]),
-    );
-
-    orchDiff(7, undefined, capture);
-    const out = captured.join("\n");
-    expect(out).toContain("=== agent: coder (worktree: " + repo + ") ===");
-    expect(out).toContain("add f1");
-    expect(out).toContain("add f2");
-    expect(out).toContain("f1.txt");
+      ],
+      phase: "review",
+      taskId: "gh-ludics-374-test",
+      tmpRoot,
+    });
+    try {
+      const captured: string[] = [];
+      orchDiff(7, undefined, (msg) => captured.push(msg));
+      const out = captured.join("\n");
+      expect(out).toContain("=== agent: coder (worktree: " + repo + ") ===");
+      expect(out).toContain("add f1");
+      expect(out).toContain("add f2");
+      expect(out).toContain("f1.txt");
+    } finally {
+      cleanup();
+    }
   });
 
   test("mixed-result: valid agent prints, invalid agent reports, partial-failure error thrown", () => {
     if (!Bun.which("git")) return;
+    const tmpRoot = makeTmpDir();
     const repo = join(tmpRoot, "wt-valid");
     makeRepo(repo);
     addCommits(repo, 1);
+    const missing = join(tmpRoot, "does-not-exist");
 
-    writeState(
-      makeState(8, [
+    const { cleanup } = setupOrchTestState({
+      slot: 8,
+      agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo },
-        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: join(tmpRoot, "does-not-exist") },
-      ]),
-    );
-
-    expect(() => orchDiff(8, undefined, capture)).toThrow(
-      /orch diff: one or more agents failed/,
-    );
-    const out = captured.join("\n");
-    expect(out).toContain("=== agent: coder (worktree: " + repo + ") ===");
-    expect(out).toContain("add f1");
-    expect(out).toContain("=== agent: reviewer (worktree: " + join(tmpRoot, "does-not-exist") + ") ===");
-    expect(out).toContain("(worktree missing on disk)");
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "main", worktreePath: missing },
+      ],
+      phase: "review",
+      taskId: "gh-ludics-374-test",
+      tmpRoot,
+    });
+    try {
+      const captured: string[] = [];
+      const capture = (msg: string): void => { captured.push(msg); };
+      expect(() => orchDiff(8, undefined, capture)).toThrow(
+        /orch diff: one or more agents failed/,
+      );
+      const out = captured.join("\n");
+      expect(out).toContain("=== agent: coder (worktree: " + repo + ") ===");
+      expect(out).toContain("add f1");
+      expect(out).toContain("=== agent: reviewer (worktree: " + missing + ") ===");
+      expect(out).toContain("(worktree missing on disk)");
+    } finally {
+      cleanup();
+    }
   });
 
   test("master-based repo without origin: resolves base via local refs/heads/master", () => {
     if (!Bun.which("git")) return;
+    const tmpRoot = makeTmpDir();
     const repo = join(tmpRoot, "wt-master");
     // Master-based repo, no origin remote at all.
     mkdirSync(repo, { recursive: true });
@@ -138,52 +105,79 @@ describe("orchDiff / runOrchestrationCli diff", () => {
     Bun.spawnSync(["git", "add", "feature.txt"], { cwd: repo, stdout: "pipe", stderr: "pipe" });
     Bun.spawnSync(["git", "commit", "-m", "add feature"], { cwd: repo, stdout: "pipe", stderr: "pipe" });
 
-    writeState(
-      makeState(11, [
+    const { cleanup } = setupOrchTestState({
+      slot: 11,
+      agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "feat", worktreePath: repo },
-      ]),
-    );
-
-    orchDiff(11, undefined, capture);
-    const out = captured.join("\n");
-    // Resolution cascaded past origin/upstream (both absent) to local master.
-    expect(out).toContain("add feature");
-    expect(out).toContain("feature.txt");
-    // Must NOT have silently tried `main..HEAD` and failed.
-    expect(out).not.toContain("git log failed");
+      ],
+      phase: "review",
+      taskId: "gh-ludics-374-test",
+      tmpRoot,
+    });
+    try {
+      const captured: string[] = [];
+      orchDiff(11, undefined, (msg) => captured.push(msg));
+      const out = captured.join("\n");
+      // Resolution cascaded past origin/upstream (both absent) to local master.
+      expect(out).toContain("add feature");
+      expect(out).toContain("feature.txt");
+      // Must NOT have silently tried `main..HEAD` and failed.
+      expect(out).not.toContain("git log failed");
+    } finally {
+      cleanup();
+    }
   });
 
   test("empty-ahead: HEAD equals origin/main renders as no-commits-ahead without throwing", () => {
     if (!Bun.which("git")) return;
+    const tmpRoot = makeTmpDir();
     const repo = join(tmpRoot, "wt-empty");
     makeRepo(repo);
     // No extra commits — HEAD == origin/main.
 
-    writeState(
-      makeState(9, [
+    const { cleanup } = setupOrchTestState({
+      slot: 9,
+      agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: repo },
-      ]),
-    );
-
-    orchDiff(9, undefined, capture);
-    const out = captured.join("\n");
-    expect(out).toContain("(no commits ahead of origin/main)");
+      ],
+      phase: "review",
+      taskId: "gh-ludics-374-test",
+      tmpRoot,
+    });
+    try {
+      const captured: string[] = [];
+      orchDiff(9, undefined, (msg) => captured.push(msg));
+      const out = captured.join("\n");
+      expect(out).toContain("(no commits ahead of origin/main)");
+    } finally {
+      cleanup();
+    }
   });
 
   test("not-a-git-repo: reports under the agent header and throws partial-failure", () => {
+    const tmpRoot = makeTmpDir();
     const plainDir = join(tmpRoot, "wt-plain");
     mkdirSync(plainDir, { recursive: true });
 
-    writeState(
-      makeState(10, [
+    const { cleanup } = setupOrchTestState({
+      slot: 10,
+      agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: plainDir },
-      ]),
-    );
-
-    expect(() => orchDiff(10, undefined, capture)).toThrow(
-      /orch diff: one or more agents failed/,
-    );
-    expect(captured.join("\n")).toContain("(not a git repository)");
+      ],
+      phase: "review",
+      taskId: "gh-ludics-374-test",
+      tmpRoot,
+    });
+    try {
+      const captured: string[] = [];
+      const capture = (msg: string): void => { captured.push(msg); };
+      expect(() => orchDiff(10, undefined, capture)).toThrow(
+        /orch diff: one or more agents failed/,
+      );
+      expect(captured.join("\n")).toContain("(not a git repository)");
+    } finally {
+      cleanup();
+    }
   });
 
   test("missing slot argument throws slot-number-required", async () => {

--- a/src/orchestration/runner.test-helpers.test.ts
+++ b/src/orchestration/runner.test-helpers.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { join } from "path";
+import { setupOrchTestState } from "./runner.test-helpers.ts";
+import { stateFilePath, type OrchestrationState } from "./state.ts";
+import { readJsonFile } from "../json.ts";
+
+describe("setupOrchTestState", () => {
+  test("returns harness === join(tmpRoot, 'harness') and persists state at stateFilePath(slot, harness)", () => {
+    const { harness, tmpRoot, state, cleanup } = setupOrchTestState({
+      slot: 42,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "feat", worktreePath: "/tmp/wt" },
+      ],
+      taskId: "helper-test",
+      phase: "review",
+    });
+    try {
+      // AC4: harness path structure (distinct from tmpRoot, predictable layout)
+      expect(harness).toBe(join(tmpRoot, "harness"));
+      // AC1: env is pointed at the new harness
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(harness);
+      // AC1: state is persisted at the right path with the helper-supplied slot
+      const persisted = readJsonFile<OrchestrationState>(stateFilePath(42, harness));
+      expect(persisted).not.toBeNull();
+      expect(persisted!.slot).toBe(42);
+      expect(persisted!.taskId).toBe("helper-test");
+      expect(persisted!.phase).toBe("review");
+      expect(persisted!.agents.map((a) => a.name)).toEqual(["coder"]);
+      // Returned state mirrors what was persisted
+      expect(state.slot).toBe(42);
+      expect(state.agents.map((a) => a.name)).toEqual(["coder"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("AC2/AC3: cleanup restores LUDICS_HARNESS_DIR to a prior set value (per-call snapshot)", () => {
+    const sentinel = "/tmp/sentinel-prior-harness";
+    const before = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = sentinel;
+    try {
+      const { harness, tmpRoot, cleanup } = setupOrchTestState({
+        slot: 1,
+        agents: [
+          { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/wt" },
+        ],
+      });
+      // Inside: env is the new harness, not the sentinel
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(harness);
+      cleanup();
+      // After cleanup: env is restored to the captured sentinel
+      expect(process.env.LUDICS_HARNESS_DIR).toBe(sentinel);
+      // tmpRoot is gone
+      expect(existsSync(tmpRoot)).toBe(false);
+    } finally {
+      if (before === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = before;
+    }
+  });
+
+  test("AC2/AC3: cleanup deletes LUDICS_HARNESS_DIR when prev was unset (per-call snapshot)", () => {
+    const before = process.env.LUDICS_HARNESS_DIR;
+    // Drop the env var to instantiate the "prev was unset" branch. Conditional
+    // form keeps `lint-test-isolation` Rule 1 happy (the linter rejects
+    // unconditional deletes anywhere in test files, including helper tests).
+    if (process.env.LUDICS_HARNESS_DIR !== undefined) delete process.env.LUDICS_HARNESS_DIR;
+    try {
+      const { harness, tmpRoot, cleanup } = setupOrchTestState({
+        slot: 2,
+        agents: [
+          { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/wt" },
+        ],
+      });
+      // Inside: env points at the new harness
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(harness);
+      cleanup();
+      // After cleanup: env is unset again (delete branch fired)
+      expect(process.env.LUDICS_HARNESS_DIR).toBeUndefined();
+      // Helper-owned tmpRoot was removed
+      expect(existsSync(tmpRoot)).toBe(false);
+    } finally {
+      if (before === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = before;
+    }
+  });
+
+  test("AC4: cleanup of one call does not affect another call's tmpRoot", () => {
+    const before = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const a = setupOrchTestState({
+        slot: 3,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/a" }],
+      });
+      const b = setupOrchTestState({
+        slot: 4,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/b" }],
+      });
+      expect(a.tmpRoot).not.toBe(b.tmpRoot);
+      a.cleanup();
+      expect(existsSync(a.tmpRoot)).toBe(false);
+      // b's tmpRoot is still alive (and its state file still exists)
+      expect(existsSync(b.tmpRoot)).toBe(true);
+      expect(existsSync(stateFilePath(4, b.harness))).toBe(true);
+      b.cleanup();
+      expect(existsSync(b.tmpRoot)).toBe(false);
+    } finally {
+      if (before === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = before;
+    }
+  });
+
+  test("AC1/AC7: overrides cannot clobber helper-controlled slot", () => {
+    expect(() =>
+      setupOrchTestState({
+        slot: 7,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/wt" }],
+        // Cast through unknown so the runtime guard (not just the compile-time type) is exercised.
+        overrides: { slot: 99 } as unknown as Parameters<typeof setupOrchTestState>[0]["overrides"],
+      }),
+    ).toThrow(/'overrides\.slot' is reserved/);
+  });
+
+  test("AC1/AC7: overrides cannot clobber helper-controlled agents", () => {
+    expect(() =>
+      setupOrchTestState({
+        slot: 8,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/wt" }],
+        overrides: {
+          agents: [{ name: "evil", provider: "claude-code", role: "coder", model: "opus-4", branch: "x", worktreePath: "/tmp/x" }],
+        } as unknown as Parameters<typeof setupOrchTestState>[0]["overrides"],
+      }),
+    ).toThrow(/'overrides\.agents' is reserved/);
+  });
+
+  test("AC7: non-reserved overrides flow through (e.g. round, mergeRound)", () => {
+    const { harness, cleanup } = setupOrchTestState({
+      slot: 5,
+      agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/wt" }],
+      overrides: { round: 42, mergeRound: 7 },
+    });
+    try {
+      const persisted = readJsonFile<OrchestrationState>(stateFilePath(5, harness));
+      expect(persisted!.round).toBe(42);
+      expect(persisted!.mergeRound).toBe(7);
+      // helper-owned slot is still authoritative
+      expect(persisted!.slot).toBe(5);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/orchestration/runner.test-helpers.test.ts
+++ b/src/orchestration/runner.test-helpers.test.ts
@@ -110,6 +110,73 @@ describe("setupOrchTestState", () => {
     }
   });
 
+  test("LIFO cleanup (b then a) keeps env pointing at a live harness throughout", () => {
+    const sentinel = "/tmp/sentinel-lifo";
+    const before = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = sentinel;
+    try {
+      const a = setupOrchTestState({
+        slot: 21,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/a" }],
+      });
+      const b = setupOrchTestState({
+        slot: 22,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/b" }],
+      });
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(b.harness);
+      b.cleanup();
+      // After b cleanup, env must point at a's still-live harness, not at the
+      // pre-sequence sentinel and not at a deleted path.
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(a.harness);
+      expect(existsSync(a.tmpRoot)).toBe(true);
+      a.cleanup();
+      // After final cleanup, env restores to the pre-sequence sentinel.
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(sentinel);
+    } finally {
+      if (before === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = before;
+    }
+  });
+
+  test("FIFO cleanup (a then b) does not redirect env to a deleted harness (codex P2)", () => {
+    // Regression for codex review on PR #453: under FIFO cleanup the prior
+    // unconditional restore set LUDICS_HARNESS_DIR back to a's harness path
+    // (already deleted by a.cleanup()) when b cleaned up. The fix uses a
+    // module-level stack so the *final* cleanup restores the pre-sequence
+    // value rather than any sibling's prev.
+    const sentinel = "/tmp/sentinel-fifo";
+    const before = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = sentinel;
+    try {
+      const a = setupOrchTestState({
+        slot: 31,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/a" }],
+      });
+      const b = setupOrchTestState({
+        slot: 32,
+        agents: [{ name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "main", worktreePath: "/tmp/b" }],
+      });
+      // FIFO order: a first, b still active.
+      a.cleanup();
+      expect(existsSync(a.tmpRoot)).toBe(false);
+      // env must still point at b's live harness (a was inactive, so its
+      // cleanup must not stomp on the active sibling).
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(b.harness);
+      // b is still readable.
+      expect(existsSync(b.tmpRoot)).toBe(true);
+      expect(existsSync(stateFilePath(32, b.harness))).toBe(true);
+
+      b.cleanup();
+      // Critical: env must NOT be set to a.harness (deleted). It must restore
+      // to the pre-sequence sentinel.
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).toBe(sentinel);
+      expect(process.env.LUDICS_HARNESS_DIR as string | undefined).not.toBe(a.harness);
+    } finally {
+      if (before === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = before;
+    }
+  });
+
   test("AC1/AC7: overrides cannot clobber helper-controlled slot", () => {
     expect(() =>
       setupOrchTestState({

--- a/src/orchestration/runner.test-helpers.ts
+++ b/src/orchestration/runner.test-helpers.ts
@@ -201,6 +201,26 @@ export interface SetupOrchTestStateResult {
  *  `stateFilePath(opts.slot, harness)`. */
 const SETUP_ORCH_RESERVED_OVERRIDE_KEYS = ["slot", "agents"] as const;
 
+/**
+ * Stack of `LUDICS_HARNESS_DIR` values currently owned by live
+ * `setupOrchTestState` calls. Lets `cleanup` restore correctly under both
+ * LIFO and out-of-order cleanup sequences:
+ *
+ *   - When `cleanup` runs while sibling calls are still active, it never
+ *     redirects `process.env.LUDICS_HARNESS_DIR` to its own captured `prev`
+ *     (which may already point at a sibling's now-deleted tmpRoot).
+ *   - Only the *final* cleanup (stack empties) restores the
+ *     `harnessAtSequenceStart` value that was captured before any helper-call
+ *     ran in this Bun process — i.e. what `LUDICS_HARNESS_DIR` had been
+ *     before the chain began.
+ *
+ * Module-level state is safe here because Bun runs tests serially within a
+ * file and per-file processes are isolated; a leaked stack entry would
+ * indicate a missing `cleanup()` in the test, which is a test bug.
+ */
+const activeHarnessStack: string[] = [];
+let harnessAtSequenceStart: string | undefined;
+
 /** Overrides accepted by `setupOrchTestState`: any `OrchestrationState` field
  *  except those the helper owns authoritatively. */
 export type SetupOrchTestStateOverrides = Omit<
@@ -232,10 +252,17 @@ export function setupOrchTestState(opts: {
     }
   }
 
-  const prevHarness = process.env.LUDICS_HARNESS_DIR;
   const tmpRoot = opts.tmpRoot ?? mkdtempSync(join(tmpdir(), "ludics-orch-test-"));
   const harness = join(tmpRoot, "harness");
   mkdirSync(orchestrationDir(harness), { recursive: true });
+
+  // Capture the pre-sequence env once (when the stack was empty); subsequent
+  // pushes don't overwrite it, so out-of-order cleanups can still recover the
+  // original value. Cleared when the stack drains.
+  if (activeHarnessStack.length === 0) {
+    harnessAtSequenceStart = process.env.LUDICS_HARNESS_DIR;
+  }
+  activeHarnessStack.push(harness);
   process.env.LUDICS_HARNESS_DIR = harness;
 
   const state = makeState({
@@ -251,8 +278,26 @@ export function setupOrchTestState(opts: {
   writeJsonFile(stateFilePath(state.slot, harness), state);
 
   const cleanup = (): void => {
-    if (prevHarness === undefined) delete process.env.LUDICS_HARNESS_DIR;
-    else process.env.LUDICS_HARNESS_DIR = prevHarness;
+    const idx = activeHarnessStack.lastIndexOf(harness);
+    if (idx !== -1) activeHarnessStack.splice(idx, 1);
+
+    if (activeHarnessStack.length > 0) {
+      // Sibling calls are still active. Only redirect the env var if it
+      // currently points at *us*; otherwise a sibling already retargeted it
+      // and we must not stomp on their state. When we own it, point at the
+      // most-recently-pushed sibling so the active CLI calls keep working.
+      if (process.env.LUDICS_HARNESS_DIR === harness) {
+        process.env.LUDICS_HARNESS_DIR = activeHarnessStack[activeHarnessStack.length - 1]!;
+      }
+    } else {
+      // Final cleanup: restore the pre-sequence value (which is the env value
+      // before *any* setupOrchTestState ran in this chain — never a sibling's
+      // tmpRoot that could already be deleted).
+      const original = harnessAtSequenceStart;
+      harnessAtSequenceStart = undefined;
+      if (original === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = original;
+    }
     rmSync(tmpRoot, { recursive: true, force: true });
   };
 

--- a/src/orchestration/runner.test-helpers.ts
+++ b/src/orchestration/runner.test-helpers.ts
@@ -7,13 +7,17 @@
 // import whatever they need from this module; production imports remain in
 // each cluster file alongside the describe blocks that use them.
 
-import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { writeJsonFile } from "../json.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
 import {
   defaultOrchestrationConfig,
   initAgentRuntimeState,
+  orchestrationDir,
+  stateFilePath,
+  type AgentConfig,
   type AgentTurnLifecycle,
   type OrchestrationState,
 } from "./state.ts";
@@ -60,34 +64,173 @@ export function makeLifecycle(overrides: Partial<AgentTurnLifecycle> = {}): Agen
   };
 }
 
+/**
+ * Options for the unified `makeState` factory.
+ *
+ * `setupOrchTestState` and the orch-CLI tests (`index.test.ts`) construct
+ * states via this options-object form. Pre-existing positional callers
+ * (`makeState({...overrides}, peerSyncDir?)`) keep working because the
+ * implementation accepts unknown top-level fields as `Partial<OrchestrationState>`
+ * overrides — so legacy `makeState({ phase: "plan", planMergeRound: 0 }, dir)`
+ * continues to set `state.phase = "plan"` and `state.planMergeRound = 0`.
+ */
+export interface MakeStateOpts {
+  slot?: number;
+  agents?: AgentConfig[];
+  phase?: OrchestrationState["phase"];
+  taskId?: string;
+  /**
+   * If true (default), creates the peer-sync dir + `plans/` + `reviews/`
+   * sub-dirs on disk. Set false for orch-CLI tests that don't exercise the
+   * peer-sync pipeline.
+   */
+  preparePeerSync?: boolean;
+  peerSyncDir?: string;
+  overrides?: Partial<OrchestrationState>;
+}
+
+const MAKE_STATE_KNOWN_KEYS = new Set([
+  "slot",
+  "agents",
+  "phase",
+  "taskId",
+  "preparePeerSync",
+  "peerSyncDir",
+  "overrides",
+]);
+
+/**
+ * Unified `makeState` factory. Two call shapes:
+ *
+ *   - Unified (preferred): `makeState({ slot, agents, phase, taskId, preparePeerSync, peerSyncDir, overrides })`
+ *   - Legacy positional:    `makeState(overrides, peerSyncDir?)` — kept for back-compat
+ *     with ~70 existing callers in `runner.*.test.ts` / `phases.test.ts` / `skills.test.ts` /
+ *     `wrong-filename-recovery.test.ts`. The implementation extracts unified-shape keys via
+ *     destructuring; any remaining top-level fields are treated as `Partial<OrchestrationState>`
+ *     overrides, preserving legacy semantics.
+ */
 export function makeState(
-  overrides: Partial<OrchestrationState> = {},
-  peerSyncDir?: string,
+  opts: MakeStateOpts | Partial<OrchestrationState> = {},
+  peerSyncDirArg?: string,
 ): OrchestrationState {
-  const dir = peerSyncDir ?? makeTmpDir();
-  mkdirSync(join(dir, "plans"), { recursive: true });
-  mkdirSync(join(dir, "reviews"), { recursive: true });
+  const optsRecord = opts as Record<string, unknown>;
+  const slot = (optsRecord.slot as number | undefined) ?? 1;
+  const agents = (optsRecord.agents as AgentConfig[] | undefined) ?? [
+    { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
+    { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
+  ];
+  const phase = (optsRecord.phase as OrchestrationState["phase"] | undefined) ?? "work";
+  const taskId = (optsRecord.taskId as string | undefined) ?? "feat";
+  const preparePeerSync = (optsRecord.preparePeerSync as boolean | undefined) ?? true;
+  const explicitPeerSyncDir =
+    peerSyncDirArg ?? (optsRecord.peerSyncDir as string | undefined);
+  const explicitOverrides =
+    (optsRecord.overrides as Partial<OrchestrationState> | undefined) ?? {};
+
+  // Any top-level keys not in MAKE_STATE_KNOWN_KEYS are treated as legacy-style
+  // Partial<OrchestrationState> overrides, applied before explicit `overrides`.
+  const legacyOverrides: Partial<OrchestrationState> = {};
+  for (const k of Object.keys(optsRecord)) {
+    if (!MAKE_STATE_KNOWN_KEYS.has(k)) {
+      (legacyOverrides as Record<string, unknown>)[k] = optsRecord[k];
+    }
+  }
+
+  let dir: string;
+  if (preparePeerSync) {
+    dir = explicitPeerSyncDir ?? makeTmpDir();
+    mkdirSync(join(dir, "plans"), { recursive: true });
+    mkdirSync(join(dir, "reviews"), { recursive: true });
+  } else {
+    dir = explicitPeerSyncDir ?? "/tmp/peer-sync";
+  }
+
+  const agentNames = agents.map((a) => a.name);
+
   return {
-    slot: 1,
-    taskId: "feat",
+    slot,
+    taskId,
     mode: "pair",
-    phase: "work",
+    phase,
     round: 1,
     mergeRound: 0,
-    agents: [
-      { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
-      { name: "reviewer", provider: "claude-code", role: "reviewer", model: "opus-4", branch: "b", worktreePath: "/tmp/b" },
-    ],
-    agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+    agents,
+    agentStates: initAgentRuntimeState(agentNames),
     config: defaultOrchestrationConfig(),
     phaseStartedAt: Math.floor(Date.now() / 1000),
     startedAt: new Date().toISOString(),
     projectDir: "/tmp/project",
     rootWorktree: "/tmp/project-feat",
     peerSyncDir: dir,
-    threadIds: { coder: "t1", reviewer: "t2" },
-    ...overrides,
+    threadIds: agentNames.length === 2 && agentNames[0] === "coder" && agentNames[1] === "reviewer"
+      ? { coder: "t1", reviewer: "t2" }
+      : {},
+    ...legacyOverrides,
+    ...explicitOverrides,
   };
+}
+
+export interface SetupOrchTestStateResult {
+  /** Tmp harness dir; also assigned to `process.env.LUDICS_HARNESS_DIR`. */
+  harness: string;
+  /** Parent of `harness`; available for test-side fixtures (e.g. worktrees). */
+  tmpRoot: string;
+  /** The state that was persisted to `stateFilePath(slot, harness)`. */
+  state: OrchestrationState;
+  /** Restores `LUDICS_HARNESS_DIR` (conditionally — never unconditional `delete`,
+   *  per `lint-test-isolation` Rule 1) and `rmSync`'s only this call's `tmpRoot`. */
+  cleanup: () => void;
+}
+
+/**
+ * Set up scratch orch state for `runOrchestrationCli` / `orchDiff` /
+ * `orchStatus` / `orchLog` tests: creates a tmp harness dir, sets
+ * `LUDICS_HARNESS_DIR`, persists a minimal `OrchestrationState` to
+ * `stateFilePath(slot, harness)`, and returns paths + a cleanup callback.
+ *
+ * Env capture happens at call time (not at module load), so multiple calls per
+ * test stay independent.
+ *
+ * If the test needs `tmpRoot` to construct agent worktree paths *before* the
+ * state is built, pre-create one with `makeTmpDir()` and pass it in via
+ * `tmpRoot`; otherwise the helper allocates its own.
+ */
+export function setupOrchTestState(opts: {
+  slot: number;
+  agents: AgentConfig[];
+  taskId?: string;
+  phase?: OrchestrationState["phase"];
+  preparePeerSync?: boolean;
+  peerSyncDir?: string;
+  overrides?: Partial<OrchestrationState>;
+  /** Optional pre-existing root; if omitted the helper allocates via `mkdtempSync`. */
+  tmpRoot?: string;
+}): SetupOrchTestStateResult {
+  const prevHarness = process.env.LUDICS_HARNESS_DIR;
+  const tmpRoot = opts.tmpRoot ?? mkdtempSync(join(tmpdir(), "ludics-orch-test-"));
+  const harness = join(tmpRoot, "harness");
+  mkdirSync(orchestrationDir(harness), { recursive: true });
+  process.env.LUDICS_HARNESS_DIR = harness;
+
+  const state = makeState({
+    slot: opts.slot,
+    agents: opts.agents,
+    taskId: opts.taskId,
+    phase: opts.phase,
+    preparePeerSync: opts.preparePeerSync ?? false,
+    peerSyncDir: opts.peerSyncDir,
+    overrides: opts.overrides,
+  });
+
+  writeJsonFile(stateFilePath(state.slot, harness), state);
+
+  const cleanup = (): void => {
+    if (prevHarness === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = prevHarness;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  };
+
+  return { harness, tmpRoot, state, cleanup };
 }
 
 /**

--- a/src/orchestration/runner.test-helpers.ts
+++ b/src/orchestration/runner.test-helpers.ts
@@ -195,6 +195,19 @@ export interface SetupOrchTestStateResult {
  * state is built, pre-create one with `makeTmpDir()` and pass it in via
  * `tmpRoot`; otherwise the helper allocates its own.
  */
+/** Fields that `setupOrchTestState` owns authoritatively — callers cannot
+ *  redirect them via `overrides`, since doing so would silently decouple the
+ *  persisted state from the helper's required arguments and from
+ *  `stateFilePath(opts.slot, harness)`. */
+const SETUP_ORCH_RESERVED_OVERRIDE_KEYS = ["slot", "agents"] as const;
+
+/** Overrides accepted by `setupOrchTestState`: any `OrchestrationState` field
+ *  except those the helper owns authoritatively. */
+export type SetupOrchTestStateOverrides = Omit<
+  Partial<OrchestrationState>,
+  (typeof SETUP_ORCH_RESERVED_OVERRIDE_KEYS)[number]
+>;
+
 export function setupOrchTestState(opts: {
   slot: number;
   agents: AgentConfig[];
@@ -202,10 +215,23 @@ export function setupOrchTestState(opts: {
   phase?: OrchestrationState["phase"];
   preparePeerSync?: boolean;
   peerSyncDir?: string;
-  overrides?: Partial<OrchestrationState>;
+  overrides?: SetupOrchTestStateOverrides;
   /** Optional pre-existing root; if omitted the helper allocates via `mkdtempSync`. */
   tmpRoot?: string;
 }): SetupOrchTestStateResult {
+  // Defense-in-depth: fence reserved keys at runtime even when callers pass an
+  // un-typed object (e.g. a `Partial<OrchestrationState>` cast). The compile-time
+  // `Omit` above blocks the typed path; this check blocks the untyped one.
+  if (opts.overrides) {
+    for (const k of SETUP_ORCH_RESERVED_OVERRIDE_KEYS) {
+      if (k in opts.overrides) {
+        throw new Error(
+          `setupOrchTestState: 'overrides.${k}' is reserved; pass it via the top-level 'opts.${k}' argument instead`,
+        );
+      }
+    }
+  }
+
   const prevHarness = process.env.LUDICS_HARNESS_DIR;
   const tmpRoot = opts.tmpRoot ?? mkdtempSync(join(tmpdir(), "ludics-orch-test-"));
   const harness = join(tmpRoot, "harness");


### PR DESCRIPTION
## Summary

- Adds `setupOrchTestState({slot, agents, …})` to `src/orchestration/runner.test-helpers.ts`: creates tmp harness, sets `LUDICS_HARNESS_DIR`, persists `OrchestrationState` via `writeJsonFile` to `stateFilePath(slot, harness)`, returns `{harness, tmpRoot, state, cleanup}`.
- Unifies `makeState` to an options-object form (`MakeStateOpts`) while keeping the legacy positional shape working — unknown top-level fields route via `legacyOverrides` so ~70 existing callers in `runner.*.test.ts` / `phases.test.ts` / `wrong-filename-recovery.test.ts` keep passing without migration.
- Migrates the 6 behavior tests in `src/orchestration/index.test.ts` to call the helper; removes the file's hand-rolled `beforeEach`, `afterEach`, `writeState` closure, and inline `makeState`.
- **Round 2 (`0cbb6bc`):** Fences `overrides.slot` / `overrides.agents` (compile-time `Omit` + runtime guard); adds `src/orchestration/runner.test-helpers.test.ts` with direct AC2/AC3/AC4 assertions (env-restore branches, `harness === join(tmpRoot, "harness")` path structure, `tmpRoot` cleanup, per-call independence, reserved-override regressions).
- **Round 3 (`64ce837`):** Addresses codex P2 inline review on out-of-order cleanup. Replaces per-call `prevHarness` with a module-level `activeHarnessStack` + `harnessAtSequenceStart` capture, so under FIFO cleanup (`a.cleanup(); b.cleanup()`) the env var is never restored to a deleted harness path. Adds LIFO + FIFO regression tests.

Implements `docs/proposals/setup-orch-test-state-helper.md`. `cleanup` is `lint-test-isolation` Rule 1 compliant. No `withTaskFile?` option (deferred per Q3).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run lint:test-isolation` — no anti-patterns
- [x] `bun run build`
- [x] `bun test src/orchestration/runner.test-helpers.test.ts` → 9 pass (incl. LIFO + FIFO regression tests)
- [x] `bun test src/orchestration/index.test.ts` → 7 pass
- [x] `bun test src/orchestration/runner.*.test.ts src/orchestration/phases.test.ts src/orchestration/wrong-filename-recovery.test.ts` (positional `makeState` callers) → 386 pass / 0 fail
- [x] Full `bun test src/orchestration/` → 691 pass / 1 fail (the failure is pre-existing `skills.test.ts PROPOSAL_FRESHNESS_WARNING boundary`, reproduces on `origin/main` for that file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)