### PR TITLE
task-b6bca25c: resolveBaseRef helper + fold detectDefaultBranchesAuthoritative

### DIFF
--- a/src/git-runner.test.ts
+++ b/src/git-runner.test.ts
@@ -2,9 +2,9 @@ import { describe, test, expect } from "bun:test";
 import { resolve } from "path";
 import {
   detectDefaultBranches,
-  detectDefaultBranchesAuthoritative,
   expandHome,
   hasRemote,
+  resolveBaseRef,
   withCheckout,
   type RunGit,
 } from "./git-runner.ts";
@@ -83,7 +83,7 @@ describe("git-runner helpers", () => {
     expect(b.upstream).toBeNull();
   });
 
-  test("detectDefaultBranchesAuthoritative: prefers local symbolic-ref when present", () => {
+  test("detectDefaultBranches({ authoritative: true }): prefers local symbolic-ref when present", () => {
     // If symbolic-ref succeeds we should NOT call ls-remote (no network).
     const calls: string[][] = [];
     const rg: RunGit = (args) => {
@@ -96,13 +96,13 @@ describe("git-runner helpers", () => {
       }
       return { stdout: "", exitCode: 0 };
     };
-    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    const b = detectDefaultBranches("/x", rg, { authoritative: true });
     expect(b.origin).toBe("main");
     expect(b.upstream).toBe("main");
     expect(calls.some((c) => c[0] === "ls-remote")).toBe(false);
   });
 
-  test("detectDefaultBranchesAuthoritative: falls back to ls-remote --symref when symbolic-ref fails", () => {
+  test("detectDefaultBranches({ authoritative: true }): falls back to ls-remote --symref when symbolic-ref fails", () => {
     const rg = fakeGit([
       { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
       {
@@ -114,24 +114,24 @@ describe("git-runner helpers", () => {
         stdout: "ref: refs/heads/trunk\tHEAD\n0123abc\tHEAD\n",
       },
     ]);
-    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    const b = detectDefaultBranches("/x", rg, { authoritative: true });
     expect(b.origin).toBe("trunk");
     expect(b.upstream).toBe("develop");
   });
 
-  test("detectDefaultBranchesAuthoritative: ls-remote failure falls through to main/master probe", () => {
+  test("detectDefaultBranches({ authoritative: true }): ls-remote failure falls through to main/master probe", () => {
     const rg = fakeGit([
       { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
       { match: ["ls-remote"], stdout: "", exitCode: 128 },
       { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/main"], stdout: "feedface\n" },
       { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"], stdout: "deadbeef\n" },
     ]);
-    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    const b = detectDefaultBranches("/x", rg, { authoritative: true });
     expect(b.origin).toBe("main");
     expect(b.upstream).toBe("main");
   });
 
-  test("detectDefaultBranchesAuthoritative: ls-remote without `ref:` line falls through", () => {
+  test("detectDefaultBranches({ authoritative: true }): ls-remote without `ref:` line falls through", () => {
     const rg = fakeGit([
       { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
       // exit 0 but stdout lacks "ref: refs/heads/..." — treat as unknown and fall through.
@@ -139,9 +139,105 @@ describe("git-runner helpers", () => {
       { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"], stdout: "x\n" },
       { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/master"], stdout: "x\n" },
     ]);
-    const b = detectDefaultBranchesAuthoritative("/x", rg);
+    const b = detectDefaultBranches("/x", rg, { authoritative: true });
     expect(b.origin).toBe("master");
     expect(b.upstream).toBe("master");
+  });
+
+  test("detectDefaultBranches: default (no opts) does not invoke ls-remote — guards the briefing-lag no-network contract", () => {
+    // Briefing-lag invokes detectDefaultBranches every keepalive tick on
+    // every project; an accidental network round-trip per tick would be a
+    // serious regression. This test pins the no-network default by failing
+    // if any ls-remote call leaks through.
+    const calls: string[][] = [];
+    const rg: RunGit = (args) => {
+      calls.push(args.slice());
+      // Force the cascade past the symref tier so the bug — ls-remote
+      // firing in non-authoritative mode — would be observable.
+      if (args[0] === "symbolic-ref") return { stdout: "", exitCode: 128 };
+      if (args[0] === "rev-parse" && args[3]?.endsWith("/main")) {
+        return { stdout: "deadbeef\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 128 };
+    };
+    detectDefaultBranches("/x", rg);
+    expect(calls.some((c) => c[0] === "ls-remote")).toBe(false);
+    // And for authoritative: false explicitly, same guarantee.
+    const calls2: string[][] = [];
+    const rg2: RunGit = (args) => {
+      calls2.push(args.slice());
+      if (args[0] === "symbolic-ref") return { stdout: "", exitCode: 128 };
+      if (args[0] === "rev-parse" && args[3]?.endsWith("/main")) {
+        return { stdout: "deadbeef\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 128 };
+    };
+    detectDefaultBranches("/x", rg2, { authoritative: false });
+    expect(calls2.some((c) => c[0] === "ls-remote")).toBe(false);
+  });
+});
+
+describe("resolveBaseRef", () => {
+  test("origin symref present → returns origin/<name>", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref", "refs/remotes/origin/HEAD"], stdout: "refs/remotes/origin/main\n" },
+      { match: ["symbolic-ref", "refs/remotes/upstream/HEAD"], stdout: "refs/remotes/upstream/develop\n" },
+    ]);
+    expect(resolveBaseRef("/x", rg)).toBe("origin/main");
+  });
+
+  test("origin absent + upstream symref present → returns upstream/<name>", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref", "refs/remotes/origin/HEAD"], stdout: "", exitCode: 128 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"], stdout: "", exitCode: 1 },
+      { match: ["symbolic-ref", "refs/remotes/upstream/HEAD"], stdout: "refs/remotes/upstream/develop\n" },
+    ]);
+    expect(resolveBaseRef("/x", rg)).toBe("upstream/develop");
+  });
+
+  test("both remote symrefs empty + refs/heads/main exists → returns 'main'", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
+      // No remote main/master.
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/master"], stdout: "", exitCode: 1 },
+      // Local main exists.
+      { match: ["rev-parse", "--verify", "--quiet", "refs/heads/main"], stdout: "abcdef\n" },
+    ]);
+    expect(resolveBaseRef("/x", rg)).toBe("main");
+  });
+
+  test("both remote symrefs empty + refs/heads/master only → returns 'master'", () => {
+    const rg = fakeGit([
+      { match: ["symbolic-ref"], stdout: "", exitCode: 128 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/origin/master"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/remotes/upstream/master"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/heads/main"], stdout: "", exitCode: 1 },
+      { match: ["rev-parse", "--verify", "--quiet", "refs/heads/master"], stdout: "fedcba\n" },
+    ]);
+    expect(resolveBaseRef("/x", rg)).toBe("master");
+  });
+
+  test("all probes fail → returns null", () => {
+    const rg = fakeGit([]);
+    expect(resolveBaseRef("/x", rg)).toBeNull();
+  });
+
+  test("no network round-trip — ls-remote is never invoked", () => {
+    // Pins the local-only contract: resolveBaseRef must not call
+    // ls-remote even on a fully-empty repo where every probe fails.
+    const calls: string[][] = [];
+    const rg: RunGit = (args) => {
+      calls.push(args.slice());
+      return { stdout: "", exitCode: 128 };
+    };
+    resolveBaseRef("/x", rg);
+    expect(calls.some((c) => c[0] === "ls-remote")).toBe(false);
   });
 });
 

--- a/src/git-runner.ts
+++ b/src/git-runner.ts
@@ -41,25 +41,55 @@ export function hasRemote(cwd: string, name: string, runGit: RunGit): boolean {
   return r.stdout.split(/\r?\n/).map((s) => s.trim()).includes(name);
 }
 
+/** Options for {@link detectDefaultBranches}. */
+export interface DetectDefaultBranchesOptions {
+  /**
+   * When true, insert an `ls-remote --symref <remote> HEAD` network tier
+   * between the local symbolic-ref tier and the `main`/`master` probe tier.
+   * Intended for callers that have just warmed network connectivity (e.g.
+   * after `git fetch <remote>`), so the round-trip is cheap. Default
+   * `false` — fully local, no network.
+   */
+  authoritative?: boolean;
+}
+
 /**
- * Detect the default branch name for each of origin and upstream.
+ * Detect the default branch *name* for each of origin and upstream.
  *
- * Local-only: no network round-trip. Used by the briefing path where any
- * added latency would compound on every tick.
+ * **Returns names, not refs.** A bare `"main"` is the branch name; using
+ * it as `git log main..HEAD` compares against the *local* `main`, which in
+ * worktrees already contains the branch's commits and silently yields zero
+ * output. For a ready-to-use comparison base, prefer
+ * {@link resolveBaseRef}.
  *
- * Primary path: `git symbolic-ref refs/remotes/<remote>/HEAD`. This ref
- * exists when the repo was cloned (git creates it automatically) or when
- * the user has explicitly run `git remote set-head <remote> -a`.
+ * @example
+ * // WRONG — `main` is interpreted as the local branch:
+ * //   git log main..HEAD            // silently empty in worktrees
+ * // RIGHT — qualify with the remote:
+ * //   const { origin } = detectDefaultBranches(cwd, runGit);
+ * //   if (origin) runGit(["log", `origin/${origin}..HEAD`], cwd);
+ * // BETTER — use the helper that returns a ready-to-use ref:
+ * //   const base = resolveBaseRef(cwd, runGit);
+ * //   if (base) runGit(["log", `${base}..HEAD`], cwd);
  *
- * Fallback: for manually-added remotes (`git remote add upstream … && git
- * fetch upstream`), git does NOT create `refs/remotes/upstream/HEAD`, so
- * the primary path returns null. Probe the two overwhelmingly common
- * default branches — `main` then `master` — via `git rev-parse --verify`.
- *
- * If neither the symbolic ref nor a `main`/`master` ref is present, return
- * null.
+ * Tier ordering per remote (each tier short-circuits on success):
+ *  1. `git symbolic-ref refs/remotes/<remote>/HEAD` — present when the repo
+ *     was cloned or `git remote set-head <remote> -a` has been run.
+ *  2. (only when `opts.authoritative === true`) `git ls-remote --symref
+ *     <remote> HEAD` — network round-trip; parses `ref: refs/heads/<n>
+ *     HEAD` from stdout. Used by callers that already warmed the network
+ *     (e.g. immediately after `git fetch`) to detect non-`main`/`master`
+ *     defaults like `develop` or `trunk`.
+ *  3. `git rev-parse --verify --quiet refs/remotes/<remote>/{main,master}`
+ *     — covers manually-added remotes that lack `refs/remotes/<r>/HEAD`.
+ *  4. `null`.
  */
-export function detectDefaultBranches(cwd: string, runGit: RunGit): DetectedBranches {
+export function detectDefaultBranches(
+  cwd: string,
+  runGit: RunGit,
+  opts: DetectDefaultBranchesOptions = {},
+): DetectedBranches {
+  const authoritative = opts.authoritative === true;
   const read = (remote: string): string | null => {
     const primary = runGit(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
     if (primary.exitCode === 0) {
@@ -68,6 +98,15 @@ export function detectDefaultBranches(cwd: string, runGit: RunGit): DetectedBran
       if (line.startsWith(prefix)) {
         const name = line.slice(prefix.length);
         if (name) return name;
+      }
+    }
+    if (authoritative) {
+      const symref = runGit(["ls-remote", "--symref", remote, "HEAD"], cwd);
+      if (symref.exitCode === 0) {
+        // Expected line: `ref: refs/heads/<branch>\tHEAD` (whitespace may
+        // be a tab or spaces depending on git version).
+        const m = symref.stdout.match(/^ref:\s+refs\/heads\/(.+?)\s+HEAD\b/m);
+        if (m && m[1]) return m[1];
       }
     }
     for (const candidate of ["main", "master"]) {
@@ -83,46 +122,41 @@ export function detectDefaultBranches(cwd: string, runGit: RunGit): DetectedBran
 }
 
 /**
- * Detect the default branch name with an authoritative `ls-remote --symref`
- * tier that queries the remote directly. Intended for paths that have
- * already established network connectivity (e.g. `git fetch <remote>` moments
- * earlier), so the ls-remote round-trip is cheap.
+ * Resolve a ready-to-use comparison base (a git ref) for `git log
+ * <base>..HEAD`, `git diff <base>...HEAD`, and similar invocations.
  *
- * Tier ordering per remote: symbolic-ref (local) → ls-remote --symref
- * (network) → main/master probe (local) → null. Each tier short-circuits
- * on success.
+ * Cascade (first non-null wins):
+ *  1. If `detectDefaultBranches(cwd, runGit).origin` is non-null, return
+ *     `origin/<that-name>`.
+ *  2. Else if `.upstream` is non-null, return `upstream/<that-name>`.
+ *  3. Else, for each candidate in `["main", "master"]`, probe
+ *     `git rev-parse --verify --quiet refs/heads/<candidate>`; on the
+ *     first non-empty success return the bare name.
+ *  4. Else `null`.
+ *
+ * Prefer this over {@link detectDefaultBranches} when a single comparison
+ * base is wanted. `detectDefaultBranches` returns branch *names*, so
+ * passing them straight into `git log <name>..HEAD` compares against the
+ * *local* branch — which in worktrees already contains the branch's
+ * commits and silently yields zero output. `resolveBaseRef`'s return value
+ * is always remote-qualified (or a verified local fallback), so this
+ * footgun cannot fire.
+ *
+ * Local-only: no network round-trip. Each call performs at most a small
+ * handful of `git` invocations; no caching is performed.
  */
-export function detectDefaultBranchesAuthoritative(
-  cwd: string,
-  runGit: RunGit,
-): DetectedBranches {
-  const read = (remote: string): string | null => {
-    const primary = runGit(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
-    if (primary.exitCode === 0) {
-      const line = primary.stdout.trim();
-      const prefix = `refs/remotes/${remote}/`;
-      if (line.startsWith(prefix)) {
-        const name = line.slice(prefix.length);
-        if (name) return name;
-      }
-    }
-    const symref = runGit(["ls-remote", "--symref", remote, "HEAD"], cwd);
-    if (symref.exitCode === 0) {
-      // Expected line: `ref: refs/heads/<branch>\tHEAD` (whitespace may be
-      // a tab or spaces depending on git version).
-      const m = symref.stdout.match(/^ref:\s+refs\/heads\/(.+?)\s+HEAD\b/m);
-      if (m && m[1]) return m[1];
-    }
-    for (const candidate of ["main", "master"]) {
-      const verify = runGit(
-        ["rev-parse", "--verify", "--quiet", `refs/remotes/${remote}/${candidate}`],
-        cwd,
-      );
-      if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
-    }
-    return null;
-  };
-  return { origin: read("origin"), upstream: read("upstream") };
+export function resolveBaseRef(cwd: string, runGit: RunGit): string | null {
+  const detected = detectDefaultBranches(cwd, runGit);
+  if (detected.origin) return `origin/${detected.origin}`;
+  if (detected.upstream) return `upstream/${detected.upstream}`;
+  for (const candidate of ["main", "master"]) {
+    const verify = runGit(
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${candidate}`],
+      cwd,
+    );
+    if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
+  }
+  return null;
 }
 
 /**

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { harnessDir } from "../config.ts";
-import { defaultRunGit, detectDefaultBranches, type RunGit } from "../git-runner.ts";
+import { defaultRunGit, resolveBaseRef, type RunGit } from "../git-runner.ts";
 import type { Phase } from "./phases.ts";
 import { readAgentMarkerFile, readAgentStatus, readPhaseToken, resolvePeerSyncDir, writeStopHookRecord } from "./peer-sync.ts";
 import { confirmPhase, interruptCurrentPhase, runOrchestrationForSlot, skipToPhase } from "./runner.ts";
@@ -41,37 +41,15 @@ function orchStatus(slot: number): void {
 }
 
 /**
- * Resolve the comparison base for `orch diff` inside a worktree. Cascade:
- * `origin/<detected>` → `upstream/<detected>` → local `main` or `master`
- * (whichever exists) → literal `"main"` as a last-resort fallback. The
- * cascade never produces a standalone error; any remaining problem
- * (e.g. a repo with none of these refs) surfaces as the downstream
- * `git log` non-zero exit so the user sees git's own diagnostic.
- * Addresses the `master`-based repo case: without this cascade, the
- * literal `main` fallback would wedge on repos that use `master`.
- */
-function resolveDiffBase(wt: string, runGit: RunGit): string {
-  const detected = detectDefaultBranches(wt, runGit);
-  if (detected.origin) return `origin/${detected.origin}`;
-  if (detected.upstream) return `upstream/${detected.upstream}`;
-  for (const candidate of ["main", "master"]) {
-    const verify = runGit(
-      ["rev-parse", "--verify", "--quiet", `refs/heads/${candidate}`],
-      wt,
-    );
-    if (verify.exitCode === 0 && verify.stdout.trim() !== "") return candidate;
-  }
-  return "main";
-}
-
-/**
  * `ludics orch diff <slot>` — per-worktree commit summary for reviewer
  * stale-branch diagnosis. For each agent, runs
  * `git log <base>..HEAD --stat` inside the agent's worktree where
- * `<base>` comes from `resolveDiffBase` (cascade: origin → upstream →
- * local main/master → literal `"main"`). Per-agent failures print
- * under the agent's header and do not abort sibling agents; the
- * command exits non-zero overall if any agent block failed.
+ * `<base>` comes from `resolveBaseRef` (cascade: `origin/<n>` →
+ * `upstream/<n>` → local `main`/`master`), falling back to the literal
+ * `"main"` when the helper returns `null` so git's own diagnostic
+ * surfaces downstream. Per-agent failures print under the agent's
+ * header and do not abort sibling agents; the command exits non-zero
+ * overall if any agent block failed.
  */
 export function orchDiff(
   slot: number,
@@ -103,7 +81,7 @@ export function orchDiff(
       anyFailed = true;
       continue;
     }
-    const base = resolveDiffBase(wt, runGit);
+    const base = resolveBaseRef(wt, runGit) ?? "main";
     const res = Bun.spawnSync(
       ["git", "-C", wt, "log", `${base}..HEAD`, "--stat"],
       { stdout: "pipe", stderr: "pipe" },

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -868,31 +868,89 @@ describe("skills", () => {
     }
   });
 
-  test("PROPOSAL_FRESHNESS_WARNING: empty when origin has no detectable default branch", async () => {
+  test("PROPOSAL_FRESHNESS_WARNING: empty when no base ref can be resolved (no origin/upstream/main/master)", async () => {
     const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
     const { join: j } = await import("path");
-    const tmpDir = mkdtempSync("/tmp/ludics-freshness-noorigin-");
+    const tmpDir = mkdtempSync("/tmp/ludics-freshness-nobase-");
     const origHarness = process.env.LUDICS_HARNESS_DIR;
     try {
       const harnessTasks = j(tmpDir, "harness", "tasks");
       const projectDir = j(tmpDir, "project");
       mkdir2(harnessTasks, { recursive: true });
-      write2(j(harnessTasks, "task-noorigin.md"), [
-        "---", "id: task-noorigin", "proposal: docs/proposals/noorigin.md", "---",
+      write2(j(harnessTasks, "task-nobase.md"), [
+        "---", "id: task-nobase", "proposal: docs/proposals/nobase.md", "---",
         "", "## Acceptance Criteria", "- [ ] Do the thing",
       ].join("\n"));
-      // 15 commits would have triggered the warning under origin/main semantics —
-      // but with seedOrigin=false no refs/remotes/origin/* refs exist, so
-      // detectDefaultBranches returns origin=null and the helper returns "".
-      initGitRepoWithProposal(
-        projectDir, "docs/proposals/noorigin.md", "# No-origin proposal\n", 15,
-        { seedOrigin: false },
-      );
+      // Init on a non-main, non-master branch so resolveBaseRef's local
+      // refs/heads/{main,master} probes both fail. With no origin/upstream
+      // remotes seeded either, every cascade tier misses and the helper
+      // returns null — proposalFreshnessWarning must then no-op.
+      mkdirSync(projectDir, { recursive: true });
+      runGit(projectDir, ["init", "-q", "--initial-branch", "dev"]);
+      runGit(projectDir, ["config", "user.email", "test@example.com"]);
+      runGit(projectDir, ["config", "user.name", "test"]);
+      runGit(projectDir, ["config", "commit.gpgsign", "false"]);
+      const proposalRel = "docs/proposals/nobase.md";
+      const proposalAbs = j(projectDir, proposalRel);
+      mkdirSync(dirname(proposalAbs), { recursive: true });
+      writeFileSync(proposalAbs, "# No-base proposal\n");
+      runGit(projectDir, ["add", proposalRel]);
+      runGit(projectDir, ["commit", "-q", "-m", "init"]);
+      // 15 extra commits — would have triggered a warning if any base ref
+      // resolved.
+      for (let i = 0; i < 15; i++) {
+        runGit(projectDir, ["commit", "-q", "--allow-empty", "-m", `x${i}`]);
+      }
       process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
       const { buildSkillContext } = await import("./skills.ts");
-      const state = { ...makeState(), taskId: "task-noorigin", projectDir, round: 1 };
+      const state = { ...makeState(), taskId: "task-nobase", projectDir, round: 1 };
       const ctx = buildSkillContext(state, state.agents[0]!);
       expect(ctx["PROPOSAL_FRESHNESS_WARNING"]).toBe("");
+    } finally {
+      if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
+      else delete process.env.LUDICS_HARNESS_DIR;
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("PROPOSAL_FRESHNESS_WARNING: warns against local main when origin is absent (post-resolveBaseRef semantics)", async () => {
+    const { mkdtempSync, mkdirSync: mkdir2, writeFileSync: write2, rmSync } = await import("fs");
+    const { join: j } = await import("path");
+    const tmpDir = mkdtempSync("/tmp/ludics-freshness-localmain-");
+    const origHarness = process.env.LUDICS_HARNESS_DIR;
+    try {
+      const harnessTasks = j(tmpDir, "harness", "tasks");
+      const projectDir = j(tmpDir, "project");
+      mkdir2(harnessTasks, { recursive: true });
+      write2(j(harnessTasks, "task-localmain.md"), [
+        "---", "id: task-localmain", "proposal: docs/proposals/localmain.md", "---",
+        "", "## Acceptance Criteria", "- [ ] Do the thing",
+      ].join("\n"));
+      // No origin/upstream remotes, but the local default branch IS main.
+      // Post-migration resolveBaseRef cascade falls through to refs/heads/main
+      // and the freshness count runs against that. Confirms the user-acked
+      // semantics change in the proposal: origin-less repos with a local
+      // main now surface drift instead of silently returning "".
+      mkdirSync(projectDir, { recursive: true });
+      runGit(projectDir, ["init", "-q", "--initial-branch", "main"]);
+      runGit(projectDir, ["config", "user.email", "test@example.com"]);
+      runGit(projectDir, ["config", "user.name", "test"]);
+      runGit(projectDir, ["config", "commit.gpgsign", "false"]);
+      const proposalRel = "docs/proposals/localmain.md";
+      const proposalAbs = j(projectDir, proposalRel);
+      mkdirSync(dirname(proposalAbs), { recursive: true });
+      writeFileSync(proposalAbs, "# Local-main proposal\n");
+      runGit(projectDir, ["add", proposalRel]);
+      runGit(projectDir, ["commit", "-q", "-m", "init"]);
+      for (let i = 0; i < 15; i++) {
+        runGit(projectDir, ["commit", "-q", "--allow-empty", "-m", `m${i}`]);
+      }
+      process.env.LUDICS_HARNESS_DIR = j(tmpDir, "harness");
+      const { buildSkillContext } = await import("./skills.ts");
+      const state = { ...makeState(), taskId: "task-localmain", projectDir, round: 1 };
+      const ctx = buildSkillContext(state, state.agents[0]!);
+      expect(ctx["PROPOSAL_FRESHNESS_WARNING"]).toContain("Freshness warning");
+      expect(ctx["PROPOSAL_FRESHNESS_WARNING"]).toContain("15 commits");
     } finally {
       if (origHarness !== undefined) process.env.LUDICS_HARNESS_DIR = origHarness;
       else delete process.env.LUDICS_HARNESS_DIR;

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -5,7 +5,7 @@ import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { findProjectConfig, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
 import { taskFilePath } from "./paths.ts";
 import { safeSyncOutput } from "../spawn.ts";
-import { defaultRunGit, detectDefaultBranches } from "../git-runner.ts";
+import { defaultRunGit, resolveBaseRef } from "../git-runner.ts";
 import type { Phase } from "./phases.ts";
 import { planFilePath, mergedPlanFilePath } from "./plan-files.ts";
 import { parseReviewFilename, reviewFilePath } from "./review-files.ts";
@@ -42,15 +42,18 @@ function gitOutput(cwd: string, args: string[]): string | null {
 
 const PROPOSAL_FRESHNESS_THRESHOLD = 6;
 
-/** Count commits on the remote default branch (`origin/<default>`) since the
- *  proposal file was last modified, and return a warning when the count exceeds
- *  PROPOSAL_FRESHNESS_THRESHOLD. Returns "" on any failure (bad path, untracked
- *  file, non-git dir, no `origin` default branch, proposal commit not an
- *  ancestor of `origin/<default>`, parse failure) — must never block
- *  orchestration. The count reflects upstream drift on the default branch, not
- *  feature-branch churn, so orchestration worktrees checked out on
- *  `ludics/.../root` branches still report the intended signal. Freshness of
- *  `refs/remotes/origin/<default>` is delegated to callers that run
+/** Count commits on the resolved default branch ref since the proposal file
+ *  was last modified, and return a warning when the count exceeds
+ *  PROPOSAL_FRESHNESS_THRESHOLD. The base ref comes from `resolveBaseRef`
+ *  (cascade: `origin/<n>` → `upstream/<n>` → local `main`/`master`), so
+ *  origin-less projects (upstream-only or local-only) still surface drift
+ *  against whatever ref does exist. Returns "" on any failure (bad path,
+ *  untracked file, non-git dir, no resolvable base ref, proposal commit
+ *  not an ancestor of the base, parse failure) — must never block
+ *  orchestration. The count reflects upstream drift on the default branch,
+ *  not feature-branch churn, so orchestration worktrees checked out on
+ *  `ludics/.../root` branches still report the intended signal. Freshness
+ *  of `refs/remotes/origin/<default>` is delegated to callers that run
  *  `git fetch origin` ahead of orchestration rounds. */
 function proposalFreshnessWarning(projectDir: string, proposalPath: string): string {
   if (!proposalPath || proposalPath === "inline") return "";
@@ -61,9 +64,8 @@ function proposalFreshnessWarning(projectDir: string, proposalPath: string): str
   }
   const hash = gitOutput(projectDir, ["log", "-1", "--format=%H", "--", proposalPath]);
   if (!hash) return "";
-  const { origin } = detectDefaultBranches(projectDir, defaultRunGit);
-  if (!origin) return "";
-  const ref = `refs/remotes/origin/${origin}`;
+  const ref = resolveBaseRef(projectDir, defaultRunGit);
+  if (!ref) return "";
   const isAncestor = safeSyncOutput(["git", "merge-base", "--is-ancestor", hash, ref], { cwd: projectDir });
   if (isAncestor.exitCode !== 0) return "";
   const countStr = gitOutput(projectDir, ["rev-list", "--count", `${hash}..${ref}`]);

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -10,7 +10,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import {
-  detectDefaultBranchesAuthoritative,
+  detectDefaultBranches,
   expandHome,
   hasRemote,
   withCheckout,
@@ -113,7 +113,7 @@ export function syncStagingMainWithUpstream(
     // After `git fetch upstream` above, network connectivity + credentials
     // are warm — use the authoritative `ls-remote --symref` tier so non-
     // main/master defaults (e.g. `develop`, `trunk`) are detected correctly.
-    const branches = detectDefaultBranchesAuthoritative(path, opts.runGit);
+    const branches = detectDefaultBranches(path, opts.runGit, { authoritative: true });
     if (!branches.origin || !branches.upstream) {
       out.push({ project, outcome: "skipped-no-default-branch" });
       touchSentinel(sentinel, opts.now);


### PR DESCRIPTION
## Summary

Implements [docs/proposals/resolve-base-ref-helper.md](../blob/main/docs/proposals/resolve-base-ref-helper.md).

- **New `resolveBaseRef(cwd, runGit): string | null`** in `src/git-runner.ts` — returns a ready-to-use comparison base (`origin/<n>` → `upstream/<n>` → local `main`/`master` → `null`). Replaces hand-rolled cascades at every "compare against default" call site, eliminating the bare-`main` footgun where `git log main..HEAD` silently compares against the local branch in worktrees.
- **`detectDefaultBranchesAuthoritative` folded into `detectDefaultBranches`** via an `{ authoritative?: boolean }` options bag. Default behaviour unchanged. Sole caller (`src/staging-ff.ts`) migrated to opt in.
- **JSDoc-hardened `detectDefaultBranches`** with a name-vs-ref warning, a worked `git log main..HEAD` (wrong) vs `origin/main..HEAD` / `resolveBaseRef` (right) example, and a pointer to the new helper.
- **Migrated callers**: `orchDiff` (deletes private `resolveDiffBase`, becomes `resolveBaseRef(wt, runGit) ?? "main"` at the call site), `proposalFreshnessWarning` (now resolves drift against any base ref the cascade finds, not just `origin/<n>` — user-acked semantics change for origin-less repos).
- **Not migrated**: `src/briefing-lag.ts` — needs `origin` and `upstream` names *separately* for `upstream/${u}...origin/${o}`, doesn't fit the single-ref helper.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test` → 1732 pass / 1 fail (single failure pre-existing on base; threshold was reduced 10→6 in c0c929e but the boundary test wasn't updated — out of scope)
- [x] 6 new `resolveBaseRef` tests covering all 5 fixtures named in the AC (origin/upstream/local-main/local-master/null) plus a no-`ls-remote` guard pinning the local-only contract
- [x] 4 existing authoritative tests renamed and updated to `detectDefaultBranches(rg, { authoritative: true })`; new "default does not invoke ls-remote" guard pinning the briefing-lag no-network contract
- [x] `proposalFreshnessWarning` noorigin test rewritten to genuinely exercise the all-probes-fail null path (init on `--initial-branch dev`); new positive test asserts the user-acked semantics change (origin absent + local main present → warning fires)
- [x] `grep -rn detectDefaultBranchesAuthoritative src/` → zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)