### PR TITLE
lint-template-safety follow-ups: empty-default convention doc + env-stripper unification + drop dead fencedLines param

### DIFF
--- a/docs/proposals/task-fa409f49-lint-template-safety-followups.md
+++ b/docs/proposals/task-fa409f49-lint-template-safety-followups.md
@@ -60,9 +60,28 @@ The improvements:
   same input. When the helper returns a non-null remainder,
   `looksLikeShell` continues with that remainder through the existing
   `SHELL_COMMAND_PREFIX` / `$(/${` / `SHELL_CHAIN` checks.
-- After the lift, `looksLikeShell("PR_URL=$(cat \"x\" 2>/dev/null) gh pr view")`
-  returns `true` (today: `false`, because the regex halts mid-`$(...)`).
-  This gap-closure is exercised by at least one new unit test.
+- After the lift, `looksLikeShell` correctly classifies pure-assignment
+  lines whose RHS is `$(...)` as **not** shell. Concretely:
+  `looksLikeShell("PR_URL=$(cat \"x\" 2>/dev/null)")` returns `false`
+  (today: `true`, because `body.replace(ENV_ASSIGNMENT_PREFIX, "")` halts
+  mid-`$(...)` and leaves the residual `$(` to be picked up by the
+  independent `/\$\(|\$\{/` recognizer, falsely flagging the assignment as
+  a shell command). The same input with a real command appended —
+  `looksLikeShell("PR_URL=$(cat \"x\" 2>/dev/null) gh pr view")` — keeps
+  its existing `true` classification, but now via `SHELL_COMMAND_PREFIX`
+  matching the post-strip remainder rather than via the `$(` fallback;
+  i.e., the helper correctly identifies the *command* (`gh pr view`) as
+  the shell signal instead of relying on the `$(` artefact inside the
+  assignment value. Both directions of this gap-closure are exercised by
+  new unit tests.
+
+  > **AC drafting note (added during coder verification on 2026-04-30):**
+  > the original AC bullet claimed today's behavior on the
+  > "`PR_URL=$(...) gh pr view`" input is `false`. Empirical probe shows
+  > today's behavior is `true` (the `$(/${` recognizer fires). The AC has
+  > been revised to the actually-load-bearing case (pure-assignment
+  > `PR_URL=$(...)` without a trailing command, where today's `true`
+  > result is incorrect and the new helper produces the correct `false`).
 - `ENV_ASSIGNMENT_PREFIX` may be retained as an exported constant for the
   one residual fallback consumer (the per-segment stripper in the
   meta-test's `splitOnShellChain` segment loop) or removed entirely if

--- a/scripts/lint-template-safety.test.ts
+++ b/scripts/lint-template-safety.test.ts
@@ -16,6 +16,7 @@ import {
   parseIfRanges,
   lintTemplate,
   runLint,
+  stripLeadingEnvAssignments,
 } from "./lint-template-safety.ts";
 
 describe("findFencedShellBlocks", () => {
@@ -289,6 +290,65 @@ describe("looksLikeShell", () => {
 
   test("rejects assignment-without-command", () => {
     expect(looksLikeShell("FOO=bar")).toBe(false);
+  });
+
+  // Gap-closure: previously the brittle ENV_ASSIGNMENT_PREFIX regex's `\S*`
+  // alternative halted mid-`$(...)`, leaving residual `$(` characters that the
+  // independent `/\$\(|\$\{/` recognizer would then false-positive on. With
+  // stripLeadingEnvAssignments, pure-assignment lines whose RHS is `$(...)` are
+  // correctly classified as not-a-shell-command.
+  test("rejects pure-assignment lines whose RHS contains $(...) with whitespace", () => {
+    expect(looksLikeShell(`PR_URL=$(cat "x" 2>/dev/null)`)).toBe(false);
+    expect(looksLikeShell(`FOO=$(date +%s)`)).toBe(false);
+  });
+
+  test("accepts $(...)-valued assignment followed by a real command", () => {
+    // The post-strip remainder is `gh pr view`, matching SHELL_COMMAND_PREFIX.
+    // Verifies the helper consumed the full `$(...)` body (whitespace and
+    // nested redirection included) rather than halting mid-value.
+    expect(
+      looksLikeShell(`PR_URL=$(cat "x" 2>/dev/null) gh pr view`),
+    ).toBe(true);
+  });
+});
+
+describe("stripLeadingEnvAssignments", () => {
+  test("returns null for pure assignment with no command", () => {
+    expect(stripLeadingEnvAssignments("FOO=bar")).toBeNull();
+    expect(stripLeadingEnvAssignments(`FOO="bar baz"`)).toBeNull();
+    expect(stripLeadingEnvAssignments(`FOO='bar baz'`)).toBeNull();
+    expect(stripLeadingEnvAssignments(`FOO=$(date)`)).toBeNull();
+    expect(stripLeadingEnvAssignments(`PR_URL=$(cat "x" 2>/dev/null)`)).toBeNull();
+  });
+
+  test("returns null for multiple chained pure assignments", () => {
+    expect(stripLeadingEnvAssignments(`FOO=bar BAZ="qux"`)).toBeNull();
+    expect(stripLeadingEnvAssignments(`A=1 B=$(date) C="d e f"`)).toBeNull();
+  });
+
+  test("returns the command remainder when a command follows", () => {
+    expect(stripLeadingEnvAssignments("FOO=bar gh pr view")).toBe("gh pr view");
+    expect(stripLeadingEnvAssignments(`FOO="bar baz" gh pr view`)).toBe(
+      "gh pr view",
+    );
+    expect(
+      stripLeadingEnvAssignments(`PR_URL=$(cat "x" 2>/dev/null) gh pr view`),
+    ).toBe("gh pr view");
+  });
+
+  test("returns the input verbatim when no leading assignment is present", () => {
+    // Used by looksLikeShell to feed the SHELL_COMMAND_PREFIX recognizer.
+    expect(stripLeadingEnvAssignments("gh pr view")).toBe("gh pr view");
+    expect(stripLeadingEnvAssignments("APPROVE")).toBe("APPROVE");
+    expect(stripLeadingEnvAssignments("{{STATUS_FILE}}")).toBe(
+      "{{STATUS_FILE}}",
+    );
+  });
+
+  test("handles single-quoted values with embedded escapes and whitespace", () => {
+    expect(stripLeadingEnvAssignments(`FOO='it\\'s fine' gh pr view`)).toBe(
+      "gh pr view",
+    );
   });
 });
 
@@ -752,54 +812,6 @@ describe("SHELL_COMMANDS drift", () => {
     }
     parts.push(buf);
     return parts;
-  }
-
-  /** Strip leading env-var assignments, including those with `$(...)`,
-   *  `"..."`, `'...'` values that may contain whitespace. Returns null when
-   *  the entire line is a pure assignment statement (no command follows),
-   *  signalling "skip this line". Otherwise returns the remainder starting
-   *  at the first command token. Falls back to the simple
-   *  `ENV_ASSIGNMENT_PREFIX` regex when the leading text doesn't look like
-   *  an assignment, preserving the runtime lint's behavior. */
-  function stripLeadingEnvAssignments(line: string): string | null {
-    let i = 0;
-    while (true) {
-      // Skip leading whitespace at this iteration.
-      while (i < line.length && /\s/.test(line[i]!)) i++;
-      const m = line.slice(i).match(/^[A-Z_][A-Z0-9_]*=/);
-      if (!m) {
-        // No assignment here — return remainder (or empty if we consumed all).
-        return i >= line.length ? null : line.slice(i);
-      }
-      i += m[0].length;
-      if (i >= line.length) return null; // pure `NAME=` with no value
-      const ch = line[i]!;
-      if (ch === '"' || ch === "'") {
-        const quote = ch;
-        i++;
-        while (i < line.length && line[i] !== quote) {
-          if (line[i] === "\\" && i + 1 < line.length) i += 2;
-          else i++;
-        }
-        if (i < line.length) i++; // skip closing quote
-      } else if (ch === "$" && line[i + 1] === "(") {
-        i += 2;
-        let depth = 1;
-        while (i < line.length && depth > 0) {
-          const c = line[i]!;
-          if (c === "(") depth++;
-          else if (c === ")") depth--;
-          if (depth === 0) break;
-          i++;
-        }
-        if (i < line.length) i++; // skip closing )
-      } else {
-        // Bare value: consume until whitespace.
-        while (i < line.length && !/\s/.test(line[i]!)) i++;
-      }
-      if (i >= line.length) return null; // pure assignment, no command after
-      // Whitespace follows: there may be more assignments or a command. Loop.
-    }
   }
 
   /** Strip leading `{{#IF VAR}}` / `{{/IF}}` template tags (one or more,

--- a/scripts/lint-template-safety.test.ts
+++ b/scripts/lint-template-safety.test.ts
@@ -350,6 +350,26 @@ describe("stripLeadingEnvAssignments", () => {
       "gh pr view",
     );
   });
+
+  // Regression: the depth counter inside the `$(...)` walker incremented on
+  // every `(` / `)` regardless of quoting, so a quoted `(` inside the
+  // substitution body left depth unbalanced and the walker consumed past the
+  // real closing `)` into the trailing command — producing `null` (Codex
+  // review on PR #455). The walker now tracks quoted regions explicitly.
+  test("handles quoted parentheses inside $(...) without skewing depth", () => {
+    expect(
+      stripLeadingEnvAssignments(`FOO=$(printf '(') gh pr view`),
+    ).toBe("gh pr view");
+    expect(
+      stripLeadingEnvAssignments(`FOO=$(printf ')') gh pr view`),
+    ).toBe("gh pr view");
+    expect(
+      stripLeadingEnvAssignments(`FOO=$(printf "(") gh pr view`),
+    ).toBe("gh pr view");
+    expect(stripLeadingEnvAssignments(`FOO=$(printf '(')`)).toBeNull();
+    // looksLikeShell consumer must agree.
+    expect(looksLikeShell(`FOO=$(printf '(') gh pr view`)).toBe(true);
+  });
 });
 
 describe("parseIfRanges", () => {

--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -61,8 +61,69 @@ const SHELL_COMMAND_PREFIX = new RegExp(
   `^(?:${SHELL_COMMAND_ALT}|:|\\[|\\[\\[|\\{|\\(|\\$\\()\\b`,
 );
 
-/** A shell-style leading env-var assignment: `NAME=value ` (one or more). */
+/** A shell-style leading env-var assignment: `NAME=value ` (one or more).
+ *  Retained for the per-segment fallback consumer in
+ *  `scripts/lint-template-safety.test.ts`'s `splitOnShellChain` segment loop,
+ *  where post-`&&`/`;` segments rarely contain `$(...)` values with embedded
+ *  whitespace. The load-bearing `looksLikeShell` path now goes through
+ *  `stripLeadingEnvAssignments`, which correctly handles `$(...)` /
+ *  double-quoted / single-quoted values containing whitespace (the regex's
+ *  `\S*` alternative halts mid-`$(...)` on values like
+ *  `PR_URL=$(cat "..." 2>/dev/null)`). */
 export const ENV_ASSIGNMENT_PREFIX = /^(?:[A-Z_][A-Z0-9_]*=(?:"[^"]*"|'[^']*'|\S*)\s+)+/;
+
+/** Strip leading env-var assignments from a shell-line candidate, including
+ *  assignments whose values are `$(...)`, `"..."`, or `'...'` and may contain
+ *  whitespace. Returns `null` when the entire line is one or more pure
+ *  assignments with no command after (e.g. `FOO=bar`, `FOO="bar baz"`,
+ *  `FOO=$(date)`) — the caller should treat this as "not a shell command".
+ *  Returns the remainder starting at the first command token otherwise.
+ *
+ *  Used by `looksLikeShell` to close the gap where the simpler
+ *  `ENV_ASSIGNMENT_PREFIX` regex's `\S*` alternative halts at the first
+ *  whitespace inside a `$(...)` value, causing patterns like
+ *  `PR_URL=$(cat "..." 2>/dev/null) gh pr view` to be misclassified as prose.
+ *  The meta-test in `scripts/lint-template-safety.test.ts` consumes this
+ *  same helper so the runtime lint and the meta-test agree on env-prefix
+ *  semantics. */
+export function stripLeadingEnvAssignments(line: string): string | null {
+  let i = 0;
+  while (true) {
+    while (i < line.length && /\s/.test(line[i]!)) i++;
+    const m = line.slice(i).match(/^[A-Z_][A-Z0-9_]*=/);
+    if (!m) {
+      return i >= line.length ? null : line.slice(i);
+    }
+    i += m[0].length;
+    if (i >= line.length) return null; // pure `NAME=` with no value
+    const ch = line[i]!;
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++;
+      while (i < line.length && line[i] !== quote) {
+        if (line[i] === "\\" && i + 1 < line.length) i += 2;
+        else i++;
+      }
+      if (i < line.length) i++; // skip closing quote
+    } else if (ch === "$" && line[i + 1] === "(") {
+      i += 2;
+      let depth = 1;
+      while (i < line.length && depth > 0) {
+        const c = line[i]!;
+        if (c === "(") depth++;
+        else if (c === ")") depth--;
+        if (depth === 0) break;
+        i++;
+      }
+      if (i < line.length) i++; // skip closing )
+    } else {
+      // Bare value: consume until whitespace.
+      while (i < line.length && !/\s/.test(line[i]!)) i++;
+    }
+    if (i >= line.length) return null; // pure assignment, no command after
+    // Whitespace follows: there may be more assignments or a command. Loop.
+  }
+}
 
 /** A pipe / logical chain / command separator followed by a command token —
  *  strong evidence that the span is shell and not prose. */
@@ -78,7 +139,8 @@ const SHELL_CHAIN = new RegExp(
  *   - pipe / chain / redirection into a recognized command token
  *  Keeps prose-style backticks (file paths, identifiers, quoted values) out. */
 export function looksLikeShell(body: string): boolean {
-  const stripped = body.replace(/^\s+/, "").replace(ENV_ASSIGNMENT_PREFIX, "");
+  const stripped = stripLeadingEnvAssignments(body.replace(/^\s+/, ""));
+  if (stripped === null) return false;
   if (SHELL_COMMAND_PREFIX.test(stripped)) return true;
   if (/\$\(|\$\{/.test(body)) return true;
   if (SHELL_CHAIN.test(body)) return true;
@@ -225,17 +287,14 @@ export function findFencedLines(lines: string[]): Set<number> {
  *  (no double-reporting), and non-shell blocks (e.g., ```ts) must not be
  *  inline-scanned at all.
  *
- *  Default skip is `classifyLines(lines)[i].kind !== "prose"` — the same
- *  partition the other scanners derive from. The optional `fencedLines`
- *  parameter is preserved for back-compat callers but is no longer the
- *  load-bearing skip mechanism. */
-export function findInlineShellSpans(lines: string[], fencedLines?: Set<number>): ShellSpan[] {
-  const skip: (i: number) => boolean = fencedLines
-    ? (i: number) => fencedLines.has(i)
-    : (() => {
-        const classes = classifyLines(lines);
-        return (i: number) => classes[i]!.kind !== "prose";
-      })();
+ *  Skip set is derived from `classifyLines(lines)`: any non-`prose` row is
+ *  skipped. This is the single source of truth for the partition; the
+ *  function takes no opt-in skip override — a previous `fencedLines?:
+ *  Set<number>` parameter was removed because it allowed callers to hand
+ *  in a stale set that disagreed with the partition. */
+export function findInlineShellSpans(lines: string[]): ShellSpan[] {
+  const classes = classifyLines(lines);
+  const skip = (i: number) => classes[i]!.kind !== "prose";
   const spans: ShellSpan[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (skip(i)) continue;

--- a/scripts/lint-template-safety.ts
+++ b/scripts/lint-template-safety.ts
@@ -108,8 +108,19 @@ export function stripLeadingEnvAssignments(line: string): string | null {
     } else if (ch === "$" && line[i + 1] === "(") {
       i += 2;
       let depth = 1;
+      // Track quoted regions so quoted `(` / `)` inside the substitution body
+      // don't skew the depth counter (e.g. `$(printf '(')` is a single
+      // balanced substitution despite the quoted `(`).
+      let quote: '"' | "'" | null = null;
       while (i < line.length && depth > 0) {
         const c = line[i]!;
+        if (quote) {
+          if (c === "\\" && i + 1 < line.length) { i += 2; continue; }
+          if (c === quote) quote = null;
+          i++;
+          continue;
+        }
+        if (c === '"' || c === "'") { quote = c; i++; continue; }
         if (c === "(") depth++;
         else if (c === ")") depth--;
         if (depth === 0) break;

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -259,14 +259,27 @@ export function resolveTemplatePath(
  * non-empty at template-substitution time. Templates may use these
  * variables freely inside shell contexts without `{{#IF VAR}}` guards.
  *
+ * **Empty-default-marker convention (project-wide for template-context
+ * builders).** Inside `buildSkillContext`'s `result` literal — and inside
+ * any analogous template-context builder that the lint pipeline classifies
+ * by RHS shape — every assignment whose RHS *may legitimately produce an
+ * empty string* must carry a visible `?? ""`, `: ""`, or `|| ""` marker on
+ * the assignment line itself. The marker hoists the "may be empty" signal
+ * from the upstream `const`/helper definition into the assignment site,
+ * where future readers (and the drift test) can see it without chasing
+ * through callees. Conversely, assignments backed by inherently non-empty
+ * sources (e.g. `agent.provider`, `state.round.toString()`, a literal) must
+ * NOT carry the marker — adding `|| ""` to a value that cannot produce an
+ * empty string would falsely advertise the field as optional and is the
+ * one explicit anti-pattern this convention guards against.
+ *
  * CI-drift-pair — see `scripts/lint-template-safety.test.ts`
  * "ALWAYS_POPULATED_KEYS drift" describe block: a bidirectional invariant
  * test parses the `result` object literal below and asserts every
  * non-empty-default assignment is in this set, and every key in this set
  * has such an assignment. Maintainers adding a new always-populated key
- * touch only this file (this set + the `result` literal). Empty-default
- * assignments must surface a `?? ""`, `: ""`, or `|| ""` marker on the
- * assignment line so the drift test can classify them correctly.
+ * touch only this file (this set + the `result` literal); the convention
+ * above is what lets the drift test classify each line correctly.
  */
 export const ALWAYS_POPULATED_KEYS: ReadonlySet<string> = new Set([
   "PHASE",


### PR DESCRIPTION
## Summary

Three small, tightly-coupled cleanups carried over from PR #398's retrospective (task-b435e58d), bundled per the neighbor-suggestions rule. ~50 lines net change across the same module pair (`scripts/lint-template-safety.{ts,test.ts}`) plus the neighboring `src/orchestration/skills.ts`.

1. **Empty-default-marker rule documented as a project-wide convention.** The JSDoc above `ALWAYS_POPULATED_KEYS` in `src/orchestration/skills.ts` now leads with the convention itself ("every assignment whose RHS may legitimately produce an empty string must carry a visible `?? \"\"`, `: \"\"`, or `|| \"\"` marker on the assignment line") and explicitly forbids the marker on inherently-non-empty sources, instead of framing the rule as "the drift test needs this".

2. **`$(...)`-aware env-prefix stripper lifted into the production lint module.** `stripLeadingEnvAssignments(line) -> string | null` now lives in `scripts/lint-template-safety.ts` near `ENV_ASSIGNMENT_PREFIX`. `looksLikeShell` consumes it directly. The test file imports the same helper; the duplicate body inside the `collectFailures` closure is gone. This closes the latent gap where pure-assignment lines whose RHS is `$(...)` (e.g. `PR_URL=$(cat \"x\" 2>/dev/null)`) were mis-classified as shell because the simpler regex's `\S*` halted mid-`$(...)` and left a residual `$(` for the independent recognizer to false-positive on. Follow-up commit (Codex P2): the `$(...)` walker tracks quoted regions so quoted `(` / `)` inside the substitution body don't skew the depth counter.

3. **Dead `fencedLines` parameter dropped from `findInlineShellSpans`.** Signature is now `(lines: string[]) => ShellSpan[]`; the function derives its skip predicate solely from `classifyLines`. No production caller passes the parameter; removing it retires the footgun where a caller could hand in a stale `Set<number>` disagreeing with the partition.

### AC revision in this PR

The original AC's literal probe — claiming `looksLikeShell(\"PR_URL=$(...) gh pr view\")` returns `false` today — is empirically false (today's behavior: `true`, via the `$(/${` recognizer firing on the residual `$(`). The actually-load-bearing case is the pure-assignment form `PR_URL=$(...)` (no trailing command), where today returns `true` incorrectly and the new helper produces the correct `false`. Updated AC text + drafting note added in the same PR per the "self-contradicting AC → revise the AC, not fabricate evidence" rule.

## Test plan

- [x] `bun test scripts/lint-template-safety.test.ts` — 68 pass / 0 fail / 167 `expect()` calls (60 pre-existing + 8 new: 2 `looksLikeShell` gap-closure cases + 6 `stripLeadingEnvAssignments` unit tests covering pure-assignment null-return, chained assignments, command-remainder, no-leading-assignment passthrough, single-quoted escape handling, and the Codex P2 regression for quoted parens inside `$(...)`).
- [x] `bun run lint:template-safety` — exits 0 with `✅  All orchestration templates use variables safely in shell contexts.`
- [x] `bun run typecheck` — green (validates the `findInlineShellSpans` signature drop didn't leave a stale 2-arg caller anywhere in the repo).
- [x] `bun run lint` — green.
- [x] `bun run build` — produces `bin/ludics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)