### PR TITLE
test: floor-count guards for regex-over-source extractor lints (gh-ludics-406)

### DIFF
--- a/scripts/lint-cli-readme.test.ts
+++ b/scripts/lint-cli-readme.test.ts
@@ -202,4 +202,28 @@ describe("real repository", () => {
     const { stale } = lintCliReadme(indexSrc, readmeSrc);
     expect(stale).toEqual([]);
   });
+
+  // Floor-count guards for the two regex-over-source extractors
+  // (gh-ludics-406). Mirrors the meta-test pattern in
+  // scripts/lint-template-safety.test.ts. The extractors have no second
+  // source of truth to assert equality against, so we use a floor instead of
+  // equality. Failure here means **either**:
+  //   (a) a DRY refactor collapsed call sites — e.g. USAGE was changed to be
+  //       built programmatically, or the README CLI Reference moved into a
+  //       shared partial — update the regex / extraction surface and re-run;
+  //   (b) commands were intentionally removed — lower the floor and note
+  //       what moved in this comment.
+  // Today USAGE has 27 commands and README has 14. Floors are set with
+  // slack so single-command removals do not trip the lint.
+  test("extractUsageCommands: floor count of 20 against real src/index.ts", () => {
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const cmds = extractUsageCommands(indexSrc);
+    expect(cmds.size).toBeGreaterThanOrEqual(20);
+  });
+
+  test("extractReadmeCommands: floor count of 10 against real README.md", () => {
+    const readmeSrc = readFileSync(join(root, "README.md"), "utf-8");
+    const cmds = extractReadmeCommands(readmeSrc);
+    expect(cmds.size).toBeGreaterThanOrEqual(10);
+  });
 });

--- a/scripts/lint-cli-readme.ts
+++ b/scripts/lint-cli-readme.ts
@@ -19,6 +19,27 @@ const root = join(import.meta.dir, "..");
 // Pure helpers (exported for unit testing)
 // ---------------------------------------------------------------------------
 
+// SILENT-DRIFT WARNING (gh-ludics-406):
+// `extractUsageCommands` and `extractReadmeCommands` are regex-over-source
+// extractors. Their safety claim — "every README CLI Reference command is
+// still in USAGE" — depends on the literal patterns below appearing in their
+// respective sources. A refactor that builds USAGE programmatically (e.g.
+// `commands.map(c => "  " + c.name).join("\n")`) or moves the README CLI
+// Reference into a shared markdown partial *deletes* the literals from view.
+// The regex still runs, just with fewer hits, and the lint passes silently.
+//
+// Recognised patterns:
+//   USAGE source — `^\s{1,4}([a-z][\w-]*)\b` against the USAGE template
+//                  literal body extracted via `extractUsageBlock`.
+//   README — `^ludics\s+([a-z][\w-]*)\b` against the `## CLI Reference`
+//            section sliced by `extractCliReferenceSection`.
+//
+// If you change how USAGE or the README CLI Reference is constructed, update
+// the patterns AND keep the floor-count tests in
+// scripts/lint-cli-readme.test.ts ("extractUsageCommands: floor count …",
+// "extractReadmeCommands: floor count …") in sync. The floor-count tests
+// are the mechanical guard that catches DRY-only collapses of either side.
+
 // Extract the contents of `const USAGE = \`...\`` as opaque text. Returns the
 // string between the opening and closing backticks (or "" if not found).
 //

--- a/scripts/lint-config-helpers.test.ts
+++ b/scripts/lint-config-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   extractInterfaceBody,
   parseFieldDeclarations,
   extractInterfacePaths,
+  extractMagPathsFromSource,
   flattenYamlPaths,
   collectArrayPaths,
   comparePaths,
@@ -308,6 +309,29 @@ describe("harness config subset of reference", () => {
     };
     const extras = [...hp].filter((p) => !rp.has(p) && !isUnderRefArray(p));
     expect(extras).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Floor-count guard for extractMagPathsFromSource (gh-ludics-406)
+//
+// Mirrors the meta-test pattern in scripts/lint-template-safety.test.ts (the
+// "expected size for the current result literal" sanity check). The extractor
+// has no second source of truth to assert equality against, so we use a floor
+// instead of equality. Failure here means **either**:
+//   (a) a DRY refactor collapsed call sites — add a regex / register the new
+//       helper in extractMagPathsFromSource, then re-run this test;
+//   (b) keys were intentionally removed — lower the floor and note what
+//       moved in this comment.
+// Today the extractor finds 15 keys; the floor is set to 10 with slack so
+// single-key removal does not trip the lint.
+// ---------------------------------------------------------------------------
+
+describe("extractMagPathsFromSource floor count", () => {
+  test("real src/ yields at least 10 mag.* paths (silent-drift guard)", () => {
+    const repoRoot = join(import.meta.dir, "..");
+    const set = extractMagPathsFromSource(join(repoRoot, "src"));
+    expect(set.size).toBeGreaterThanOrEqual(10);
   });
 });
 

--- a/scripts/lint-config-helpers.ts
+++ b/scripts/lint-config-helpers.ts
@@ -180,6 +180,27 @@ function extractPathsFromBody(
 // Mag Source Grep
 // ---------------------------------------------------------------------------
 
+// SILENT-DRIFT WARNING (gh-ludics-406):
+// `extractMagPathsFromSource` is a regex-over-source extractor. Its safety
+// claim — "every mag config key reachable from src/ is documented" — depends
+// on the literal access patterns below appearing at the call sites. A
+// "DRY-only" refactor that wraps any of these patterns behind a new helper,
+// table, or loop *deletes* the literals from source. The regex still runs,
+// just with fewer hits, and the lint passes silently with reduced coverage.
+//
+// If you introduce a new helper that reads `mag?.<key>` (or sibling), add a
+// matching regex pattern below AND keep the floor-count test in
+// scripts/lint-config-helpers.test.ts ("extractMagPathsFromSource: floor
+// count of N keys") in sync. The floor-count test is the mechanical guard
+// that catches the next instance of this silent-drift class.
+//
+// Recognised patterns (mirror in the test's failure-mode comment):
+//   - mag?.property                              (local variable after cast)
+//   - magXxx?.property                           (e.g. magConfig?.x)
+//   - (config.mag as ...)?.property              (inline cast)
+//   - config.mag?.property                       (direct optional chaining)
+//   - magSecondsConfig("property", ...)          (shared *_seconds helper)
+
 /**
  * Extract first-level mag property names accessed in source code.
  * Scans .ts files for mag config access patterns:

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -518,5 +518,51 @@ describe("integration", () => {
     // found new real-world hits (coverage upgrade — justify and update the
     // count).
     expect(result.warningCount).toBe(0);
+  });
+
+  // Floor-count guards for the two regex-over-markdown extractors
+  // (gh-ludics-406). Per-pair field counts are small (5–10), so the
+  // assertion is on the **total field count summed across all paired skill
+  // files** in the real skills/ directory — that aggregate is the
+  // meaningful integrity signal. Mirrors the meta-test pattern in
+  // scripts/lint-template-safety.test.ts. Failure here means **either**:
+  //   (a) a docs refactor collapsed contract surfaces — e.g. the
+  //       `### Response Contract` numbered list moved into a shared partial
+  //       or routing tables were generated rather than authored — update the
+  //       extractor and re-run;
+  //   (b) skill pairs were intentionally consolidated/removed — lower the
+  //       floor and note what moved in this comment.
+  // Today both totals are 37 across 5 paired skills. Floors are set to 25
+  // each with slack to tolerate skill churn.
+  function sumPairedFields(skillsDir: string): { worker: number; orch: number } {
+    let worker = 0;
+    let orch = 0;
+    const entries = readdirSync(skillsDir);
+    for (const f of entries) {
+      if (!/^ludics-.*-worker\.md$/.test(f)) continue;
+      const orchFile = f.replace(/-worker\.md$/, ".md");
+      try {
+        const wMd = readFileSync(join(skillsDir, f), "utf-8");
+        const oMd = readFileSync(join(skillsDir, orchFile), "utf-8");
+        worker += extractWorkerFields(wMd).fields.size;
+        orch += extractOrchestratorFields(oMd).fields.size;
+      } catch {
+        // missing orchestrator counterpart — skip; covered by the
+        // worker-without-orchestrator warning in runCli.
+      }
+    }
+    return { worker, orch };
+  }
+
+  test("extractWorkerFields: floor count of 25 across paired skills", () => {
+    const repo = join(import.meta.dir, "..");
+    const { worker } = sumPairedFields(join(repo, "skills"));
+    expect(worker).toBeGreaterThanOrEqual(25);
+  });
+
+  test("extractOrchestratorFields: floor count of 25 across paired skills", () => {
+    const repo = join(import.meta.dir, "..");
+    const { orch } = sumPairedFields(join(repo, "skills"));
+    expect(orch).toBeGreaterThanOrEqual(25);
   });
 });

--- a/scripts/lint-contracts.ts
+++ b/scripts/lint-contracts.ts
@@ -26,6 +26,28 @@ const skillsDir = join(root, "skills");
 // Pure extractors (exported for tests)
 // ---------------------------------------------------------------------------
 
+// SILENT-DRIFT WARNING (gh-ludics-406):
+// `extractWorkerFields` and `extractOrchestratorFields` are regex-over-markdown
+// extractors. Their safety claim — "worker contract fields and orchestrator
+// routing fields stay in sync per pair" — depends on the literal patterns
+// below appearing in each skill markdown file. A docs refactor that extracts
+// the `### Response Contract` numbered list into a shared partial, or replaces
+// the routing table with a generated one, *deletes* the literals from view.
+// The extractor still runs, just with fewer hits, and the lint passes silently.
+//
+// Recognised patterns:
+//   worker — `^\s*\d+\.\s+\`([a-z_][\w]*)\`` under `### Response Contract`,
+//            outside fenced (```) blocks.
+//   orchestrator — `^\|\s*\`([a-z_][\w]*)\`\s*\|` under
+//            `## Status routing` or `## Verdict routing`.
+//
+// If you change how either contract surface is authored (templating, table
+// generation, alternate heading), update the patterns AND keep the floor-count
+// tests in scripts/lint-contracts.test.ts ("extractWorkerFields: floor count
+// across paired skills", "extractOrchestratorFields: floor count across
+// paired skills") in sync. The floor-count tests are the mechanical guard
+// that catches DRY-only collapses across the skill set.
+
 export interface ExtractResult {
   fields: Set<string>;
   hasSection: boolean;


### PR DESCRIPTION
## Summary

Prophylactic floor-count assertions for the three regex-based extractor lints in `scripts/` (gh-ludics-406):

- `extractMagPathsFromSource` (15 keys → floor 10)
- `extractUsageCommands` / `extractReadmeCommands` (27/14 → floors 20/10)
- `extractWorkerFields` / `extractOrchestratorFields` summed across paired skills (37/37 → floors 25/25)

Each extractor source file also gains a co-located **SILENT-DRIFT WARNING (gh-ludics-406)** comment block enumerating the recognised regex patterns and pointing at the sibling floor-count test. Mirrors the meta-test pattern at `scripts/lint-template-safety.test.ts:596–602`.

The triggering case (`magSecondsConfig` consolidation in `src/mag.ts`) is not on `main` today, so this is the prophylactic guard for the *next* recurrence — not a fix for live drift.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test scripts/lint-config-helpers.test.ts scripts/lint-cli-readme.test.ts scripts/lint-contracts.test.ts` → 66 pass, 0 fail
- [x] `bun run lint:config-reference` / `lint:cli-readme` / `lint:contracts` continue to pass
- [x] Manual trip verification: temporarily raised the mag-paths floor from 10 → 16, observed `Expected: >= 16 / Received: 15` at the assertion site; reverted to 10 and the suite went back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)