### PR TITLE
task-bf451303: extract buildHandlers(deps) factory from startDashboardServer

### DIFF
--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -31,11 +31,13 @@ const MIME_TYPES: Record<string, string> = {
 
 const QUEUE_ID_RE = /^req-\d+-\d+$/;
 
-export function startDashboardServer(
-  port: number,
-  dashboardDir: string,
-  ttlSeconds: number,
-): ReturnType<typeof Bun.serve> {
+export interface DashboardHandlerDeps {
+  dashboardDir: string;
+  ttlSeconds: number;
+}
+
+export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Promise<Response> {
+  const { dashboardDir, ttlSeconds } = deps;
   // Normalize to absolute path with trailing separator for safe startsWith checks
   const resolvedRoot = resolve(dashboardDir) + "/";
   const tasksRoot = resolve(dashboardDir, "..", "tasks") + "/";
@@ -150,518 +152,525 @@ export function startDashboardServer(
     }
   }
 
-  const server = Bun.serve({
-    port,
-    async fetch(req) {
-      const url = new URL(req.url);
-      let pathname = url.pathname;
+  return async function fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    let pathname = url.pathname;
 
-      // Default to index.html
-      if (pathname === "/") pathname = "/index.html";
+    // Default to index.html
+    if (pathname === "/") pathname = "/index.html";
 
-      // Cluster HTTP endpoints — cross-node coordination via HTTP
-      if (pathname.startsWith("/cluster/") || pathname.startsWith("/api/cluster/")) {
-        return handleClusterRequest(req, pathname);
+    // Cluster HTTP endpoints — cross-node coordination via HTTP
+    if (pathname.startsWith("/cluster/") || pathname.startsWith("/api/cluster/")) {
+      return handleClusterRequest(req, pathname);
+    }
+
+    // Regenerate data if stale on any request to /data/
+    if (pathname.startsWith("/data/")) {
+      maybeRegenerate();
+    }
+
+    // API: clear a slot as done
+    if (pathname === "/api/slot-clear") {
+      const slotParam = url.searchParams.get("slot");
+      const status = url.searchParams.get("status") ?? CLEAR_STATUS_DONE;
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
       }
-
-      // Regenerate data if stale on any request to /data/
-      if (pathname.startsWith("/data/")) {
-        maybeRegenerate();
+      if (!(VALID_CLEAR_STATUSES as readonly string[]).includes(status)) {
+        return new Response(`Bad Request: status must be ${VALID_CLEAR_STATUSES.join(", ")}`, { status: 400 });
       }
-
-      // API: clear a slot as done
-      if (pathname === "/api/slot-clear") {
-        const slotParam = url.searchParams.get("slot");
-        const status = url.searchParams.get("status") ?? CLEAR_STATUS_DONE;
-        if (!slotParam || !/^[1-6]$/.test(slotParam)) {
-          return new Response("Bad Request: slot must be 1-6", { status: 400 });
-        }
-        if (!(VALID_CLEAR_STATUSES as readonly string[]).includes(status)) {
-          return new Response(`Bad Request: status must be ${VALID_CLEAR_STATUSES.join(", ")}`, { status: 400 });
-        }
-        try {
-          await slotClear(parseInt(slotParam, 10), status);
-          lastGenerated = 0; // force regeneration on next data request
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
-        }
+      try {
+        await slotClear(parseInt(slotParam, 10), status);
+        lastGenerated = 0; // force regeneration on next data request
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
       }
+    }
 
-      // API: set slot mode
-      if (pathname === "/api/slot-mode") {
-        const slotParam = url.searchParams.get("slot");
-        const mode = url.searchParams.get("mode");
-        if (!slotParam || !/^[1-6]$/.test(slotParam)) {
-          return new Response("Bad Request: slot must be 1-6", { status: 400 });
-        }
-        if (!mode || !ADAPTER_NAMES.includes(mode)) {
-          return new Response(`Bad Request: mode must be one of ${ADAPTER_NAMES.join(", ")}`, { status: 400 });
-        }
-        try {
-          await slotSetMode(parseInt(slotParam, 10), mode);
-          lastGenerated = 0;
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
-        }
+    // API: set slot mode
+    if (pathname === "/api/slot-mode") {
+      const slotParam = url.searchParams.get("slot");
+      const mode = url.searchParams.get("mode");
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
       }
-
-      // API: start a slot session
-      if (pathname === "/api/slot-start") {
-        const slotParam = url.searchParams.get("slot");
-        if (!slotParam || !/^[1-6]$/.test(slotParam)) {
-          return new Response("Bad Request: slot must be 1-6", { status: 400 });
-        }
-        try {
-          await slotStart(parseInt(slotParam, 10));
-          lastGenerated = 0;
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
-        }
+      if (!mode || !ADAPTER_NAMES.includes(mode)) {
+        return new Response(`Bad Request: mode must be one of ${ADAPTER_NAMES.join(", ")}`, { status: 400 });
       }
-
-      // API: resume an interrupted slot session
-      if (pathname === "/api/slot-resume") {
-        const slotParam = url.searchParams.get("slot");
-        if (!slotParam || !/^[1-6]$/.test(slotParam)) {
-          return new Response("Bad Request: slot must be 1-6", { status: 400 });
-        }
-        try {
-          await slotResume(parseInt(slotParam, 10));
-          lastGenerated = 0;
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
-        }
+      try {
+        await slotSetMode(parseInt(slotParam, 10), mode);
+        lastGenerated = 0;
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
       }
+    }
 
-      // API: postpone a slot (decrease task priority one level + clear as ready)
-      if (pathname === "/api/slot-postpone") {
-        const slotParam = url.searchParams.get("slot");
-        if (!slotParam || !/^[1-6]$/.test(slotParam)) {
-          return new Response("Bad Request: slot must be 1-6", { status: 400 });
-        }
-        try {
-          const slotNum = parseInt(slotParam, 10);
+    // API: start a slot session
+    if (pathname === "/api/slot-start") {
+      const slotParam = url.searchParams.get("slot");
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
+      }
+      try {
+        await slotStart(parseInt(slotParam, 10));
+        lastGenerated = 0;
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
+      }
+    }
 
-          // Resolve task ID and new priority *before* clearing, but do NOT write yet.
-          // Only write priority after the clear succeeds (atomicity).
-          let pendingPriorityWrite: (() => void) | null = null;
-          {
-            const slotData = readSlotJson(slotNum);
-            const taskId = normalizeTaskId(slotData.task);
-            if (taskId && TASK_ID_RE.test(taskId)) {
-              const taskResolved = resolveTaskFile(taskId);
-              if (!("error" in taskResolved)) {
-                const taskFile = taskResolved.path;
-                const content = readFileSync(taskFile, "utf-8");
-                const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
-                const newPriority = PRIORITY_DECREASE[currentPriority] ?? currentPriority;
-                if (newPriority !== currentPriority) {
-                  // Capture the write as a closure; execute only after clear succeeds.
-                  pendingPriorityWrite = () => updateFrontmatterField(taskFile, "priority", newPriority);
-                }
+    // API: resume an interrupted slot session
+    if (pathname === "/api/slot-resume") {
+      const slotParam = url.searchParams.get("slot");
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
+      }
+      try {
+        await slotResume(parseInt(slotParam, 10));
+        lastGenerated = 0;
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
+      }
+    }
+
+    // API: postpone a slot (decrease task priority one level + clear as ready)
+    if (pathname === "/api/slot-postpone") {
+      const slotParam = url.searchParams.get("slot");
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
+      }
+      try {
+        const slotNum = parseInt(slotParam, 10);
+
+        // Resolve task ID and new priority *before* clearing, but do NOT write yet.
+        // Only write priority after the clear succeeds (atomicity).
+        let pendingPriorityWrite: (() => void) | null = null;
+        {
+          const slotData = readSlotJson(slotNum);
+          const taskId = normalizeTaskId(slotData.task);
+          if (taskId && TASK_ID_RE.test(taskId)) {
+            const taskResolved = resolveTaskFile(taskId);
+            if (!("error" in taskResolved)) {
+              const taskFile = taskResolved.path;
+              const content = readFileSync(taskFile, "utf-8");
+              const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
+              const newPriority = PRIORITY_DECREASE[currentPriority] ?? currentPriority;
+              if (newPriority !== currentPriority) {
+                // Capture the write as a closure; execute only after clear succeeds.
+                pendingPriorityWrite = () => updateFrontmatterField(taskFile, "priority", newPriority);
               }
             }
           }
-
-          // Demote priority BEFORE clearing the slot, so the task never appears
-          // in the ready queue at its old priority (race with auto-assign).
-          pendingPriorityWrite?.();
-
-          await slotClear(slotNum, CLEAR_STATUS_READY);
-
-          lastGenerated = 0;
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
         }
+
+        // Demote priority BEFORE clearing the slot, so the task never appears
+        // in the ready queue at its old priority (race with auto-assign).
+        pendingPriorityWrite?.();
+
+        await slotClear(slotNum, CLEAR_STATUS_READY);
+
+        lastGenerated = 0;
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
       }
+    }
 
-      // API: promote task priority one level (D→C→B→A→S)
-      if (pathname === "/api/task-promote") {
-        const taskParam = url.searchParams.get("task");
-        if (!taskParam || !TASK_ID_RE.test(taskParam)) {
-          return new Response("Bad Request: invalid task id", { status: 400 });
-        }
-        try {
-          const resolved = resolveTaskFile(taskParam);
-          if ("error" in resolved) return resolved.error;
-          const taskFile = resolved.path;
-          const content = readFileSync(taskFile, "utf-8");
-          const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
-          const newPriority = PRIORITY_INCREASE[currentPriority] ?? currentPriority;
-          if (newPriority !== currentPriority) {
-            addFrontmatterField(taskFile, "priority", newPriority);
-          }
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ priority: newPriority }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
+    // API: promote task priority one level (D→C→B→A→S)
+    if (pathname === "/api/task-promote") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
       }
-
-      // API: confirm a needs-confirmation task (set status to ready)
-      if (pathname === "/api/task-confirm") {
-        const taskParam = url.searchParams.get("task");
-        if (!taskParam || !TASK_ID_RE.test(taskParam)) {
-          return new Response("Bad Request: invalid task id", { status: 400 });
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const content = readFileSync(taskFile, "utf-8");
+        const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
+        const newPriority = PRIORITY_INCREASE[currentPriority] ?? currentPriority;
+        if (newPriority !== currentPriority) {
+          addFrontmatterField(taskFile, "priority", newPriority);
         }
-        try {
-          const resolved = resolveTaskFile(taskParam);
-          if ("error" in resolved) return resolved.error;
-          const taskFile = resolved.path;
-          const content = readFileSync(taskFile, "utf-8");
-          const currentStatus = parseTaskFrontmatter(content).status ?? "";
-          if (currentStatus !== "needs-confirmation") {
-            return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
-              status: 409, headers: { "Content-Type": "application/json" },
-            });
-          }
-          updateFrontmatterField(taskFile, "status", "ready");
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ status: "ready" }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: dismiss a needs-confirmation task (set status to abandoned)
-      if (pathname === "/api/task-dismiss") {
-        const taskParam = url.searchParams.get("task");
-        if (!taskParam || !TASK_ID_RE.test(taskParam)) {
-          return new Response("Bad Request: invalid task id", { status: 400 });
-        }
-        try {
-          const resolved = resolveTaskFile(taskParam);
-          if ("error" in resolved) return resolved.error;
-          const taskFile = resolved.path;
-          const content = readFileSync(taskFile, "utf-8");
-          const currentStatus = parseTaskFrontmatter(content).status ?? "";
-          if (currentStatus !== "needs-confirmation") {
-            return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
-              status: 409, headers: { "Content-Type": "application/json" },
-            });
-          }
-          await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ status: "abandoned" }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: approve a deferred task (set status: ready)
-      if (pathname === "/api/deferred-approve") {
-        const taskParam = url.searchParams.get("task");
-        if (!taskParam || !TASK_ID_RE.test(taskParam)) {
-          return new Response("Bad Request: invalid task id", { status: 400 });
-        }
-        try {
-          const resolved = resolveTaskFile(taskParam);
-          if ("error" in resolved) return resolved.error;
-          const taskFile = resolved.path;
-          const approveContent = readFileSync(taskFile, "utf-8");
-          const approveStatus = parseTaskFrontmatter(approveContent).status;
-          if (approveStatus !== "deferred") {
-            return new Response(
-              JSON.stringify({ error: `task is ${approveStatus}, not deferred` }),
-              { status: 409, headers: { "Content-Type": "application/json" } },
-            );
-          }
-          updateFrontmatterField(taskFile, "status", "ready");
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ status: "approved" }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: abandon a deferred task (clear slot if assigned, set abandoned)
-      if (pathname === "/api/deferred-abandon") {
-        const taskParam = url.searchParams.get("task");
-        if (!taskParam || !TASK_ID_RE.test(taskParam)) {
-          return new Response("Bad Request: invalid task id", { status: 400 });
-        }
-        try {
-          const resolved = resolveTaskFile(taskParam);
-          if ("error" in resolved) return resolved.error;
-          await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ status: "abandoned" }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: set queue hold state (state=true → hold, state=false → resume)
-      if (pathname === "/api/queue-hold") {
-        const stateParam = url.searchParams.get("state");
-        if (stateParam !== "true" && stateParam !== "false") {
-          return new Response("Bad Request: state must be true or false", { status: 400 });
-        }
-        try {
-          const held = stateParam === "true";
-          setQueueHold(held, "dashboard");
-          lastGenerated = 0;
-          return new Response("OK", { status: 200 });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: trigger queue delivery without queuing a message
-      if (pathname === "/api/queue-deliver" && req.method === "POST") {
-        try {
-          const delivered = await maybeFeedMagQueue();
-          return new Response(JSON.stringify({ delivered }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
-        }
-      }
-
-      // API: enqueue a message
-      if (pathname === "/api/queue" && req.method === "POST") {
-        let body: Record<string, unknown>;
-        try {
-          body = await req.json() as Record<string, unknown>;
-        } catch {
-          return new Response("Bad Request: invalid JSON", { status: 400 });
-        }
-        const content = body.content;
-        if (!content || typeof content !== "string" || !content.trim()) {
-          return new Response("Bad Request: non-empty content required", { status: 400 });
-        }
-        try {
-          const requestId = queueRequest({ action: "message", content: content.trim() });
-          lastGenerated = 0;
-          // Attempt immediate delivery if Mag is settled
-          maybeFeedMagQueue().catch((e) => { console.error("ludics: dashboard queue-deliver:", e); });
-          return new Response(JSON.stringify({ id: requestId }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: promote a pending queue item to the head
-      if (pathname === "/api/queue-promote" && req.method === "POST") {
-        const idParam = url.searchParams.get("id");
-        if (!idParam || !QUEUE_ID_RE.test(idParam)) {
-          return new Response("Bad Request: invalid queue id", { status: 400 });
-        }
-        try {
-          const status = queuePromoteToTop(idParam);
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ status }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: cancel (remove) a pending queue item; return its payload for composer hydration
-      if (pathname === "/api/queue-cancel" && req.method === "POST") {
-        const idParam = url.searchParams.get("id");
-        if (!idParam || !QUEUE_ID_RE.test(idParam)) {
-          return new Response("Bad Request: invalid queue id", { status: 400 });
-        }
-        try {
-          const result = queueCancel(idParam);
-          lastGenerated = 0;
-          if (result.status === "not-found") {
-            return new Response(JSON.stringify({ status: "not-found" }), {
-              headers: { "Content-Type": "application/json" },
-            });
-          }
-          const request = result.request;
-          const content = typeof request.content === "string" ? request.content : null;
-          const action = typeof request.action === "string" ? request.action : "unknown";
-          const task = typeof request.task === "string" ? request.task : undefined;
-          const slashCommand = action !== "message" && action !== "unknown"
-            ? resolveSkillCommand(action, request as Record<string, unknown>)
-            : null;
-          const body: Record<string, unknown> = { status: "cancelled", content, action, slashCommand };
-          if (task !== undefined) body.task = task;
-          return new Response(JSON.stringify(body), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: list queue items and recent results
-      if (pathname === "/api/queue") {
-        try {
-          const pending = queueList();
-          const results = recentResults(20).map(r => {
-            const d = { ...r.data };
-            delete d.output; // strip large blobs — UI only needs id/status/timestamp
-            return d;
-          });
-          return new Response(JSON.stringify({ pending, results }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: list available projects from config
-      if (pathname === "/api/projects") {
-        try {
-          const config = loadConfigSync();
-          const projects = (config.projects ?? []).map((p: { name?: string }) => String(p.name ?? "")).filter(Boolean);
-          return new Response(JSON.stringify({ projects }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      // API: create a new task
-      if (pathname === "/api/task-create" && req.method === "POST") {
-        let body: Record<string, unknown>;
-        try {
-          body = await req.json() as Record<string, unknown>;
-        } catch {
-          return new Response("Bad Request: invalid JSON", { status: 400 });
-        }
-        const title = typeof body.title === "string" ? body.title.trim() : "";
-        if (!title) {
-          return new Response("Bad Request: title is required", { status: 400 });
-        }
-        const project = typeof body.project === "string" ? body.project.trim() || "personal" : "personal";
-        const priority = typeof body.priority === "string" && /^[A-DS]$/.test(body.priority) ? body.priority : "C";
-        const effort = typeof body.effort === "string" && ["tiny", "small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
-        const usesBrowser = body.usesBrowser === true;
-        const taskBody = typeof body.body === "string" ? body.body.trim() : "";
-
-        try {
-          const result = tasksCreate(title, project, priority, usesBrowser);
-
-          // Set effort if non-default
-          if (result.created && effort !== "medium") {
-            updateFrontmatterField(result.path, "effort", effort);
-          }
-
-          // Replace default body content if custom body provided
-          if (result.created && taskBody) {
-            const fileContent = readFileSync(result.path, "utf-8");
-            const fmEnd = fileContent.indexOf("\n---\n");
-            if (fmEnd !== -1) {
-              const frontmatter = fileContent.slice(0, fmEnd + 5); // include trailing \n---\n
-              const newContent = frontmatter + "\n# " + title + "\n\n" + taskBody + "\n";
-              writeFileSync(result.path, newContent);
-            }
-          }
-
-          lastGenerated = 0;
-          return new Response(JSON.stringify({ created: result.created, id: result.id }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        } catch (e) {
-          return new Response(String(e), { status: 500 });
-        }
-      }
-
-      if (pathname.startsWith("/task-files/")) {
-        const taskPath = pathname.slice("/task-files/".length);
-        const taskId = taskPath.endsWith(".md") ? taskPath.slice(0, -3) : null;
-        if (!taskId || !TASK_ID_RE.test(taskId)) {
-          return new Response("Bad Request", { status: 400 });
-        }
-
-        const taskFilePath = resolve(tasksRoot, taskId + ".md");
-        if (!taskFilePath.startsWith(tasksRoot)) {
-          return new Response("Forbidden", { status: 403 });
-        }
-        if (!existsSync(taskFilePath) || statSync(taskFilePath).isDirectory()) {
-          return new Response("Not Found", { status: 404 });
-        }
-
-        const body = readFileSync(taskFilePath);
-        return new Response(body, {
-          headers: { "Content-Type": MIME_TYPES[".md"]! },
-        });
-      }
-
-      if (pathname.startsWith("/proposal-files/")) {
-        const proposalPath = pathname.slice("/proposal-files/".length);
-        const proposalMatch = proposalPath.match(/^([A-Za-z0-9._-]+)\.md$/);
-        if (!proposalMatch) {
-          return new Response("Bad Request", { status: 400 });
-        }
-
-        const proposalFilePath = resolveProposalFile(proposalMatch[1]!);
-        if (!proposalFilePath) {
-          return new Response("Not Found", { status: 404 });
-        }
-
-        const body = readFileSync(proposalFilePath);
-        const ext = extname(proposalFilePath);
-        return new Response(body, {
-          headers: { "Content-Type": MIME_TYPES[ext] ?? MIME_TYPES[".md"]! },
-        });
-      }
-
-      if (pathname.startsWith("/retrospective-files/")) {
-        const retroPath = pathname.slice("/retrospective-files/".length);
-        const retroMatch = retroPath.match(/^([A-Za-z0-9._-]+)\.json$/);
-        if (!retroMatch) {
-          return new Response("Bad Request", { status: 400 });
-        }
-        const retroRoot = resolve(join(harnessDir(), "retrospectives"));
-        const retroFilePath = resolve(retroRoot, retroMatch[1]! + ".json");
-        if (!retroFilePath.startsWith(retroRoot)) {
-          return new Response("Forbidden", { status: 403 });
-        }
-        if (!existsSync(retroFilePath) || statSync(retroFilePath).isDirectory()) {
-          return new Response("Not Found", { status: 404 });
-        }
-        const retroBody = readFileSync(retroFilePath);
-        return new Response(retroBody, {
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ priority: newPriority }), {
           headers: { "Content-Type": "application/json" },
         });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: confirm a needs-confirmation task (set status to ready)
+    if (pathname === "/api/task-confirm") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const content = readFileSync(taskFile, "utf-8");
+        const currentStatus = parseTaskFrontmatter(content).status ?? "";
+        if (currentStatus !== "needs-confirmation") {
+          return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
+            status: 409, headers: { "Content-Type": "application/json" },
+          });
+        }
+        updateFrontmatterField(taskFile, "status", "ready");
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "ready" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: dismiss a needs-confirmation task (set status to abandoned)
+    if (pathname === "/api/task-dismiss") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const content = readFileSync(taskFile, "utf-8");
+        const currentStatus = parseTaskFrontmatter(content).status ?? "";
+        if (currentStatus !== "needs-confirmation") {
+          return new Response(JSON.stringify({ error: "task is not needs-confirmation" }), {
+            status: 409, headers: { "Content-Type": "application/json" },
+          });
+        }
+        await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "abandoned" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: approve a deferred task (set status: ready)
+    if (pathname === "/api/deferred-approve") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const approveContent = readFileSync(taskFile, "utf-8");
+        const approveStatus = parseTaskFrontmatter(approveContent).status;
+        if (approveStatus !== "deferred") {
+          return new Response(
+            JSON.stringify({ error: `task is ${approveStatus}, not deferred` }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        updateFrontmatterField(taskFile, "status", "ready");
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "approved" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: abandon a deferred task (clear slot if assigned, set abandoned)
+    if (pathname === "/api/deferred-abandon") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "abandoned" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: set queue hold state (state=true → hold, state=false → resume)
+    if (pathname === "/api/queue-hold") {
+      const stateParam = url.searchParams.get("state");
+      if (stateParam !== "true" && stateParam !== "false") {
+        return new Response("Bad Request: state must be true or false", { status: 400 });
+      }
+      try {
+        const held = stateParam === "true";
+        setQueueHold(held, "dashboard");
+        lastGenerated = 0;
+        return new Response("OK", { status: 200 });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: trigger queue delivery without queuing a message
+    if (pathname === "/api/queue-deliver" && req.method === "POST") {
+      try {
+        const delivered = await maybeFeedMagQueue();
+        return new Response(JSON.stringify({ delivered }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(e instanceof Error ? e.message : String(e), { status: 500 });
+      }
+    }
+
+    // API: enqueue a message
+    if (pathname === "/api/queue" && req.method === "POST") {
+      let body: Record<string, unknown>;
+      try {
+        body = await req.json() as Record<string, unknown>;
+      } catch {
+        return new Response("Bad Request: invalid JSON", { status: 400 });
+      }
+      const content = body.content;
+      if (!content || typeof content !== "string" || !content.trim()) {
+        return new Response("Bad Request: non-empty content required", { status: 400 });
+      }
+      try {
+        const requestId = queueRequest({ action: "message", content: content.trim() });
+        lastGenerated = 0;
+        // Attempt immediate delivery if Mag is settled
+        maybeFeedMagQueue().catch((e) => { console.error("ludics: dashboard queue-deliver:", e); });
+        return new Response(JSON.stringify({ id: requestId }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: promote a pending queue item to the head
+    if (pathname === "/api/queue-promote" && req.method === "POST") {
+      const idParam = url.searchParams.get("id");
+      if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+        return new Response("Bad Request: invalid queue id", { status: 400 });
+      }
+      try {
+        const status = queuePromoteToTop(idParam);
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: cancel (remove) a pending queue item; return its payload for composer hydration
+    if (pathname === "/api/queue-cancel" && req.method === "POST") {
+      const idParam = url.searchParams.get("id");
+      if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+        return new Response("Bad Request: invalid queue id", { status: 400 });
+      }
+      try {
+        const result = queueCancel(idParam);
+        lastGenerated = 0;
+        if (result.status === "not-found") {
+          return new Response(JSON.stringify({ status: "not-found" }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        const request = result.request;
+        const content = typeof request.content === "string" ? request.content : null;
+        const action = typeof request.action === "string" ? request.action : "unknown";
+        const task = typeof request.task === "string" ? request.task : undefined;
+        const slashCommand = action !== "message" && action !== "unknown"
+          ? resolveSkillCommand(action, request as Record<string, unknown>)
+          : null;
+        const body: Record<string, unknown> = { status: "cancelled", content, action, slashCommand };
+        if (task !== undefined) body.task = task;
+        return new Response(JSON.stringify(body), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: list queue items and recent results
+    if (pathname === "/api/queue") {
+      try {
+        const pending = queueList();
+        const results = recentResults(20).map(r => {
+          const d = { ...r.data };
+          delete d.output; // strip large blobs — UI only needs id/status/timestamp
+          return d;
+        });
+        return new Response(JSON.stringify({ pending, results }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: list available projects from config
+    if (pathname === "/api/projects") {
+      try {
+        const config = loadConfigSync();
+        const projects = (config.projects ?? []).map((p: { name?: string }) => String(p.name ?? "")).filter(Boolean);
+        return new Response(JSON.stringify({ projects }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: create a new task
+    if (pathname === "/api/task-create" && req.method === "POST") {
+      let body: Record<string, unknown>;
+      try {
+        body = await req.json() as Record<string, unknown>;
+      } catch {
+        return new Response("Bad Request: invalid JSON", { status: 400 });
+      }
+      const title = typeof body.title === "string" ? body.title.trim() : "";
+      if (!title) {
+        return new Response("Bad Request: title is required", { status: 400 });
+      }
+      const project = typeof body.project === "string" ? body.project.trim() || "personal" : "personal";
+      const priority = typeof body.priority === "string" && /^[A-DS]$/.test(body.priority) ? body.priority : "C";
+      const effort = typeof body.effort === "string" && ["tiny", "small", "medium", "large"].includes(body.effort) ? body.effort : "medium";
+      const usesBrowser = body.usesBrowser === true;
+      const taskBody = typeof body.body === "string" ? body.body.trim() : "";
+
+      try {
+        const result = tasksCreate(title, project, priority, usesBrowser);
+
+        // Set effort if non-default
+        if (result.created && effort !== "medium") {
+          updateFrontmatterField(result.path, "effort", effort);
+        }
+
+        // Replace default body content if custom body provided
+        if (result.created && taskBody) {
+          const fileContent = readFileSync(result.path, "utf-8");
+          const fmEnd = fileContent.indexOf("\n---\n");
+          if (fmEnd !== -1) {
+            const frontmatter = fileContent.slice(0, fmEnd + 5); // include trailing \n---\n
+            const newContent = frontmatter + "\n# " + title + "\n\n" + taskBody + "\n";
+            writeFileSync(result.path, newContent);
+          }
+        }
+
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ created: result.created, id: result.id }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    if (pathname.startsWith("/task-files/")) {
+      const taskPath = pathname.slice("/task-files/".length);
+      const taskId = taskPath.endsWith(".md") ? taskPath.slice(0, -3) : null;
+      if (!taskId || !TASK_ID_RE.test(taskId)) {
+        return new Response("Bad Request", { status: 400 });
       }
 
-      // Resolve file path with proper traversal prevention
-      const filePath = resolve(resolvedRoot, "." + pathname);
-      if (!filePath.startsWith(resolvedRoot)) {
+      const taskFilePath = resolve(tasksRoot, taskId + ".md");
+      if (!taskFilePath.startsWith(tasksRoot)) {
         return new Response("Forbidden", { status: 403 });
       }
-      if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+      if (!existsSync(taskFilePath) || statSync(taskFilePath).isDirectory()) {
         return new Response("Not Found", { status: 404 });
       }
 
-      const ext = extname(filePath);
-      const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
-
-      const body = readFileSync(filePath);
+      const body = readFileSync(taskFilePath);
       return new Response(body, {
-        headers: { "Content-Type": contentType },
+        headers: { "Content-Type": MIME_TYPES[".md"]! },
       });
-    },
-  });
+    }
 
+    if (pathname.startsWith("/proposal-files/")) {
+      const proposalPath = pathname.slice("/proposal-files/".length);
+      const proposalMatch = proposalPath.match(/^([A-Za-z0-9._-]+)\.md$/);
+      if (!proposalMatch) {
+        return new Response("Bad Request", { status: 400 });
+      }
+
+      const proposalFilePath = resolveProposalFile(proposalMatch[1]!);
+      if (!proposalFilePath) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      const body = readFileSync(proposalFilePath);
+      const ext = extname(proposalFilePath);
+      return new Response(body, {
+        headers: { "Content-Type": MIME_TYPES[ext] ?? MIME_TYPES[".md"]! },
+      });
+    }
+
+    if (pathname.startsWith("/retrospective-files/")) {
+      const retroPath = pathname.slice("/retrospective-files/".length);
+      const retroMatch = retroPath.match(/^([A-Za-z0-9._-]+)\.json$/);
+      if (!retroMatch) {
+        return new Response("Bad Request", { status: 400 });
+      }
+      const retroRoot = resolve(join(harnessDir(), "retrospectives"));
+      const retroFilePath = resolve(retroRoot, retroMatch[1]! + ".json");
+      if (!retroFilePath.startsWith(retroRoot)) {
+        return new Response("Forbidden", { status: 403 });
+      }
+      if (!existsSync(retroFilePath) || statSync(retroFilePath).isDirectory()) {
+        return new Response("Not Found", { status: 404 });
+      }
+      const retroBody = readFileSync(retroFilePath);
+      return new Response(retroBody, {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Resolve file path with proper traversal prevention
+    const filePath = resolve(resolvedRoot, "." + pathname);
+    if (!filePath.startsWith(resolvedRoot)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+    if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const ext = extname(filePath);
+    const contentType = MIME_TYPES[ext] ?? "application/octet-stream";
+
+    const body = readFileSync(filePath);
+    return new Response(body, {
+      headers: { "Content-Type": contentType },
+    });
+  };
+}
+
+export function startDashboardServer(
+  port: number,
+  dashboardDir: string,
+  ttlSeconds: number,
+): ReturnType<typeof Bun.serve> {
+  const server = Bun.serve({
+    port,
+    fetch: buildHandlers({ dashboardDir, ttlSeconds }),
+  });
   console.error(`ludics: dashboard server listening on http://localhost:${server.port}`);
   console.error(`ludics: data regenerates lazily (TTL: ${ttlSeconds}s)`);
   console.error("ludics: press Ctrl+C to stop");

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -541,20 +541,12 @@ describe("slots.json field shape", () => {
 // slotResume() itself is already tested in src/slots/index.test.ts.
 
 describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
-  async function startServer(): Promise<{ baseUrl: string; stop: () => void }> {
-    const { startDashboardServer } = await import("./dashboard-server.ts");
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
     const dashboardDir = join(harnessDir(), "dashboard");
     mkdirSync(dashboardDir, { recursive: true });
     mkdirSync(join(dashboardDir, "data"), { recursive: true });
-    // Silence boot logging + lazy-regeneration complaints
-    let server!: ReturnType<typeof startDashboardServer>;
-    silenceConsoleError(() => {
-      server = startDashboardServer(0, dashboardDir, 3600);
-    });
-    return {
-      baseUrl: `http://localhost:${server.port}`,
-      stop: () => { void server.stop(true); },
-    };
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
   }
 
   test("POST /api/queue-promote moves target to head and returns 'promoted'", async () => {
@@ -564,16 +556,12 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     const idC = queueRequest({ action: "briefing" });
     expect(queueList().map(i => i.id)).toEqual([idA, idB, idC]);
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-promote?id=${encodeURIComponent(idC)}`, { method: "POST" });
-      expect(resp.status).toBe(200);
-      expect(resp.headers.get("content-type")).toContain("application/json");
-      const body = await resp.json() as { status: string };
-      expect(body.status).toBe("promoted");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-promote?id=${encodeURIComponent(idC)}`, { method: "POST" }));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("application/json");
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("promoted");
     expect(queueList().map(i => i.id)).toEqual([idC, idA, idB]);
   });
 
@@ -582,14 +570,10 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     const idA = queueRequest({ action: "briefing" });
     const idB = queueRequest({ action: "briefing" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-promote?id=${encodeURIComponent(idA)}`, { method: "POST" });
-      const body = await resp.json() as { status: string };
-      expect(body.status).toBe("already-head");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-promote?id=${encodeURIComponent(idA)}`, { method: "POST" }));
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("already-head");
     expect(queueList().map(i => i.id)).toEqual([idA, idB]);
   });
 
@@ -597,25 +581,17 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     const { queueRequest } = await import("./queue.ts");
     queueRequest({ action: "briefing" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-promote?id=req-0-0`, { method: "POST" });
-      expect(resp.status).toBe(200);
-      const body = await resp.json() as { status: string };
-      expect(body.status).toBe("not-found");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue-promote?id=req-0-0", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("not-found");
   });
 
   test("POST /api/queue-promote rejects malformed id with 400", async () => {
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-promote?id=not-a-queue-id`, { method: "POST" });
-      expect(resp.status).toBe(400);
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue-promote?id=not-a-queue-id", { method: "POST" }));
+    expect(resp.status).toBe(400);
   });
 
   test("POST /api/queue-cancel removes item and returns content for message actions", async () => {
@@ -623,19 +599,15 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     const idA = queueRequest({ action: "message", content: "please recycle me" });
     const idB = queueRequest({ action: "briefing" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
-      expect(resp.status).toBe(200);
-      const body = await resp.json() as { status: string; content: string | null; action: string; task?: string; slashCommand: string | null };
-      expect(body.status).toBe("cancelled");
-      expect(body.content).toBe("please recycle me");
-      expect(body.action).toBe("message");
-      expect(body.task).toBeUndefined();
-      expect(body.slashCommand).toBeNull();
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string; content: string | null; action: string; task?: string; slashCommand: string | null };
+    expect(body.status).toBe("cancelled");
+    expect(body.content).toBe("please recycle me");
+    expect(body.action).toBe("message");
+    expect(body.task).toBeUndefined();
+    expect(body.slashCommand).toBeNull();
     expect(queueList().map(i => i.id)).toEqual([idB]);
   });
 
@@ -643,18 +615,14 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     const { queueRequest } = await import("./queue.ts");
     const idA = queueRequest({ action: "elaborate", task: "task-abc" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
-      const body = await resp.json() as { status: string; content: string | null; action: string; task?: string; slashCommand: string | null };
-      expect(body.status).toBe("cancelled");
-      expect(body.content).toBeNull();
-      expect(body.action).toBe("elaborate");
-      expect(body.task).toBe("task-abc");
-      expect(body.slashCommand).toBe("/ludics-elaborate task-abc");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" }));
+    const body = await resp.json() as { status: string; content: string | null; action: string; task?: string; slashCommand: string | null };
+    expect(body.status).toBe("cancelled");
+    expect(body.content).toBeNull();
+    expect(body.action).toBe("elaborate");
+    expect(body.task).toBe("task-abc");
+    expect(body.slashCommand).toBe("/ludics-elaborate task-abc");
   });
 
   test("POST /api/queue-cancel renders multi-line feedback below slash command", async () => {
@@ -665,55 +633,66 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
       feedback: "First concern.\nSecond concern.",
     });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
-      const body = await resp.json() as { status: string; slashCommand: string | null };
-      expect(body.status).toBe("cancelled");
-      expect(body.slashCommand).toBe("/ludics-revise-proposal task-abc\nFirst concern.\nSecond concern.");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" }));
+    const body = await resp.json() as { status: string; slashCommand: string | null };
+    expect(body.status).toBe("cancelled");
+    expect(body.slashCommand).toBe("/ludics-revise-proposal task-abc\nFirst concern.\nSecond concern.");
   });
 
   test("POST /api/queue-cancel returns null slashCommand for actions with no skill mapping", async () => {
     const { queueRequest } = await import("./queue.ts");
     const idA = queueRequest({ action: "complete-task", task: "task-abc" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" });
-      const body = await resp.json() as { status: string; slashCommand: string | null };
-      expect(body.status).toBe("cancelled");
-      expect(body.slashCommand).toBeNull();
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-cancel?id=${encodeURIComponent(idA)}`, { method: "POST" }));
+    const body = await resp.json() as { status: string; slashCommand: string | null };
+    expect(body.status).toBe("cancelled");
+    expect(body.slashCommand).toBeNull();
   });
 
   test("POST /api/queue-cancel returns 'not-found' for unknown id without mutating queue", async () => {
     const { queueRequest, queueList } = await import("./queue.ts");
     const idA = queueRequest({ action: "briefing" });
 
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=req-0-0`, { method: "POST" });
-      expect(resp.status).toBe(200);
-      const body = await resp.json() as { status: string };
-      expect(body.status).toBe("not-found");
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue-cancel?id=req-0-0", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("not-found");
     expect(queueList().map(i => i.id)).toEqual([idA]);
   });
 
   test("POST /api/queue-cancel rejects malformed id with 400", async () => {
-    const { baseUrl, stop } = await startServer();
-    try {
-      const resp = await fetch(`${baseUrl}/api/queue-cancel?id=`, { method: "POST" });
-      expect(resp.status).toBe(400);
-    } finally {
-      stop();
-    }
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue-cancel?id=", { method: "POST" }));
+    expect(resp.status).toBe(400);
+  });
+
+  test("buildHandlers gives each call its own lastGenerated counter (isolation)", async () => {
+    // Regression test for AC: dispatcher owns its own lastGenerated counter
+    // (one per factory call, isolated between callers). If lastGenerated were
+    // shared (e.g. module-level), regen-resetting endpoints called against
+    // handler A would influence handler B's regen state.
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const { queueRequest } = await import("./queue.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+
+    const handlerA = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+    const handlerB = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+    expect(handlerA).not.toBe(handlerB);
+
+    // Each handler must independently dispatch identical requests.
+    const idA = queueRequest({ action: "briefing" });
+    const respA = await handlerA(new Request("http://x/api/queue", { method: "GET" }));
+    const respB = await handlerB(new Request("http://x/api/queue", { method: "GET" }));
+    expect(respA.status).toBe(200);
+    expect(respB.status).toBe(200);
+    const bodyA = await respA.json() as { pending: { id: string }[] };
+    const bodyB = await respB.json() as { pending: { id: string }[] };
+    expect(bodyA.pending.map(p => p.id)).toEqual([idA]);
+    expect(bodyB.pending.map(p => p.id)).toEqual([idA]);
   });
 });

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -669,30 +669,39 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     expect(resp.status).toBe(400);
   });
 
-  test("buildHandlers gives each call its own lastGenerated counter (isolation)", async () => {
-    // Regression test for AC: dispatcher owns its own lastGenerated counter
-    // (one per factory call, isolated between callers). If lastGenerated were
-    // shared (e.g. module-level), regen-resetting endpoints called against
-    // handler A would influence handler B's regen state.
+  test("buildHandlers isolates lastGenerated debounce state across factory calls", async () => {
+    // AC1 falsifier: each buildHandlers(...) call must own its own
+    // lastGenerated counter. The handler debounces dashboardGenerate() via
+    // `now - lastGenerated >= ttlSeconds`. If lastGenerated were shared
+    // (e.g. module-level), handlerA's first /data hit would advance it for
+    // handlerB too, and handlerB's first /data hit would skip regeneration
+    // — failing the third assertion below. With per-factory state,
+    // handlerB starts at lastGenerated=0 and triggers its own regen.
+    const dashboardMod = await import("./dashboard.ts");
     const { buildHandlers } = await import("./dashboard-server.ts");
-    const { queueRequest } = await import("./queue.ts");
     const dashboardDir = join(harnessDir(), "dashboard");
     mkdirSync(dashboardDir, { recursive: true });
     mkdirSync(join(dashboardDir, "data"), { recursive: true });
 
-    const handlerA = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
-    const handlerB = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
-    expect(handlerA).not.toBe(handlerB);
+    const spy = spyOn(dashboardMod, "dashboardGenerate").mockImplementation(() => {});
+    try {
+      const handlerA = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+      const handlerB = buildHandlers({ dashboardDir, ttlSeconds: 3600 });
 
-    // Each handler must independently dispatch identical requests.
-    const idA = queueRequest({ action: "briefing" });
-    const respA = await handlerA(new Request("http://x/api/queue", { method: "GET" }));
-    const respB = await handlerB(new Request("http://x/api/queue", { method: "GET" }));
-    expect(respA.status).toBe(200);
-    expect(respB.status).toBe(200);
-    const bodyA = await respA.json() as { pending: { id: string }[] };
-    const bodyB = await respB.json() as { pending: { id: string }[] };
-    expect(bodyA.pending.map(p => p.id)).toEqual([idA]);
-    expect(bodyB.pending.map(p => p.id)).toEqual([idA]);
+      // handlerA, first /data/* hit: lastGenerated=0, ttlSeconds=3600 → regen.
+      await handlerA(new Request("http://x/data/slots.json"));
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // handlerA, second /data/* hit within TTL: no regen (debounce works).
+      await handlerA(new Request("http://x/data/slots.json"));
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // handlerB, first /data/* hit: independent counter starts at 0, so
+      // it must regen. With shared state this would still be 1.
+      await handlerB(new Request("http://x/data/slots.json"));
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Split dashboard HTTP handler dispatch into a pure `buildHandlers(deps): (req: Request) => Promise<Response>` factory in `src/dashboard-server.ts` so tests can call the dispatcher with `await handler(new Request(...))` — no port, no boot banner, no `console.error` swap.
- `startDashboardServer(port, dashboardDir, ttlSeconds)` is preserved as a thin wrapper around `Bun.serve({ port, fetch: buildHandlers({...}) })`; signature, return type, and three-line boot banner unchanged. Production caller in `src/dashboard.ts` is untouched.
- Migrated the `describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", ...)` tests in `src/dashboard.test.ts` to call `buildHandlers` directly. The local `startServer()` helper, `port: 0` binding, `silenceConsoleError` wrap, `server.stop(true)` teardown, and `try/finally` boilerplate are gone. Added an isolation regression test asserting two `buildHandlers(...)` calls return distinct dispatchers (each owning its own `lastGenerated`).

Source: retrospective of `task-cf3ef9f1` (PR #389), `suggestRefactorSummary` item 2.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — bin/ludics compiled
- [x] `bun test src/dashboard.test.ts` — 54 pass / 0 fail
- [x] Full `bun test` — 1770 pass / 1 fail (`skills > PROPOSAL_FRESHNESS_WARNING: boundary` reproduces on base, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)