### PR TITLE
task-41b91ca3: dedup util.ts shadows + add lint:no-shadow-util

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Lint worker/orchestrator contracts
         run: bun run lint:contracts
 
+      - name: Lint — no util.ts function shadows
+        run: bun run lint:no-shadow-util
+
       - name: Lint — vendor sync
         run: bun run lint:vendor-sync
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint:template-safety": "bun run scripts/lint-template-safety.ts",
     "lint:test-isolation": "bun run scripts/lint-test-isolation.ts",
     "lint:vendor-sync": "bun run scripts/lint-vendor-sync.ts",
-    "lint:no-mock-module": "! grep -r 'mock\\.module(' src/ templates/ --include='*.test.ts' -l"
+    "lint:no-mock-module": "! grep -r 'mock\\.module(' src/ templates/ --include='*.test.ts' -l",
+    "lint:no-shadow-util": "bun run scripts/lint-no-shadow-util.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/lint-no-shadow-util.test.ts
+++ b/scripts/lint-no-shadow-util.test.ts
@@ -1,0 +1,321 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import {
+  extractCanonicalNames,
+  findShadowsInFile,
+  runCli,
+} from "./lint-no-shadow-util.ts";
+
+// ---------------------------------------------------------------------------
+// extractCanonicalNames — dynamic name discovery from util.ts source
+// ---------------------------------------------------------------------------
+
+describe("extractCanonicalNames", () => {
+  test("returns the seven canonical names from a synthetic util.ts", () => {
+    const src = [
+      'import { existsSync } from "fs";',
+      'export { readJsonFile, writeJsonFile } from "../json.ts";',
+      "",
+      "export function isoNow(): string { return ''; }",
+      "export function nowEpoch(): number { return 0; }",
+      "export function makeId(prefix: string): string { return prefix; }",
+      "export function slugify(value: string): string { return value; }",
+      "export function ludicsSelfCommand(args: string[]): string[] { return args; }",
+      "export function sleepMs(ms: number): Promise<void> { return Promise.resolve(); }",
+      "export function setsidWrap(command: string[]): string[] { return command; }",
+    ].join("\n");
+    const names = extractCanonicalNames(src);
+    expect(names).toEqual(
+      new Set([
+        "isoNow",
+        "nowEpoch",
+        "makeId",
+        "slugify",
+        "ludicsSelfCommand",
+        "sleepMs",
+        "setsidWrap",
+      ]),
+    );
+  });
+
+  test("ignores `export { ... } from` re-exports", () => {
+    const src = [
+      'export { readJsonFile, writeJsonFile } from "../json.ts";',
+      "export function isoNow(): string { return ''; }",
+    ].join("\n");
+    const names = extractCanonicalNames(src);
+    expect(names).toEqual(new Set(["isoNow"]));
+    // Critically, `readJsonFile` and `writeJsonFile` are NOT picked up — they
+    // would over-flag every consumer if they were.
+    expect(names.has("readJsonFile")).toBe(false);
+  });
+
+  test("dynamic discovery picks up an eighth helper added later", () => {
+    const src = [
+      "export function isoNow(): string { return ''; }",
+      "export function newHelper(): void {}",
+    ].join("\n");
+    const names = extractCanonicalNames(src);
+    expect(names.has("newHelper")).toBe(true);
+  });
+
+  test("does not match indented or method-form definitions", () => {
+    const src = [
+      "  export function notAtStart(): void {}", // leading spaces — not a top-level export
+      "obj.isoNow = function (): string { return ''; };",
+      "const slugify = (value: string) => value;",
+    ].join("\n");
+    expect(extractCanonicalNames(src).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findShadowsInFile — per-file scan
+// ---------------------------------------------------------------------------
+
+describe("findShadowsInFile", () => {
+  const names = new Set(["isoNow", "makeId"]);
+
+  test("flags `function isoNow(`", () => {
+    const src = [
+      "// header",
+      "function isoNow(): string {",
+      "  return '';",
+      "}",
+    ].join("\n");
+    expect(findShadowsInFile(src, names)).toEqual([{ line: 2, name: "isoNow" }]);
+  });
+
+  test("flags `export function makeId(` (export prefix)", () => {
+    const src = "export function makeId(p: string): string { return p; }";
+    expect(findShadowsInFile(src, names)).toEqual([{ line: 1, name: "makeId" }]);
+  });
+
+  test("does NOT flag method-form `obj.isoNow = function`", () => {
+    const src = "obj.isoNow = function (): string { return ''; };";
+    expect(findShadowsInFile(src, names)).toEqual([]);
+  });
+
+  test("does NOT flag commented-out `// function isoNow(`", () => {
+    const src = "// function isoNow(): string { return ''; }";
+    expect(findShadowsInFile(src, names)).toEqual([]);
+  });
+
+  test("does NOT flag call sites `isoNow()`", () => {
+    const src = "const t = isoNow();";
+    expect(findShadowsInFile(src, names)).toEqual([]);
+  });
+
+  test("does NOT flag arrow-form `const isoNow = () =>`", () => {
+    const src = "const isoNow = (): string => '';";
+    expect(findShadowsInFile(src, names)).toEqual([]);
+  });
+
+  test("does NOT flag a function whose name is not in the canonical set", () => {
+    const src = "function helper(): void {}";
+    expect(findShadowsInFile(src, names)).toEqual([]);
+  });
+
+  test("flags multiple shadows in the same file", () => {
+    const src = [
+      "function isoNow(): string { return ''; }",
+      "function makeId(p: string): string { return p; }",
+    ].join("\n");
+    expect(findShadowsInFile(src, names)).toEqual([
+      { line: 1, name: "isoNow" },
+      { line: 2, name: "makeId" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCli — end-to-end on a temp tree
+// ---------------------------------------------------------------------------
+
+function makeTempTree(): string {
+  return mkdtempSync("/tmp/lint-no-shadow-util-");
+}
+
+function writeUtil(srcDir: string): string {
+  const utilDir = join(srcDir, "orchestration");
+  mkdirSync(utilDir, { recursive: true });
+  const utilPath = join(utilDir, "util.ts");
+  const utilSource = [
+    "export function isoNow(): string {",
+    "  return new Date().toISOString();",
+    "}",
+    "",
+    "export function makeId(prefix: string): string {",
+    "  return prefix;",
+    "}",
+    "",
+  ].join("\n");
+  writeFileSync(utilPath, utilSource);
+  return utilPath;
+}
+
+describe("runCli", () => {
+  test("exits 0 on a clean tree (only util.ts defines the helpers)", () => {
+    const root = makeTempTree();
+    try {
+      const srcDir = join(root, "src");
+      mkdirSync(srcDir, { recursive: true });
+      const utilPath = writeUtil(srcDir);
+      mkdirSync(join(srcDir, "consumer"), { recursive: true });
+      writeFileSync(
+        join(srcDir, "consumer", "uses-util.ts"),
+        [
+          'import { isoNow } from "../orchestration/util.ts";',
+          "export const x = isoNow();",
+        ].join("\n"),
+      );
+
+      const errs: string[] = [];
+      const outs: string[] = [];
+      const result = runCli({
+        srcDir,
+        utilPath,
+        repoRoot: root,
+        writeErr: (m) => errs.push(m),
+        writeOut: (m) => outs.push(m),
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.offenseCount).toBe(0);
+      expect(result.issues).toEqual([]);
+      expect(errs).toEqual([]);
+      expect(outs.length).toBe(1);
+      expect(outs[0]!).toMatch(/✅/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("exits 1 with path:line on a planted shadow", () => {
+    const root = makeTempTree();
+    try {
+      const srcDir = join(root, "src");
+      mkdirSync(srcDir, { recursive: true });
+      const utilPath = writeUtil(srcDir);
+      mkdirSync(join(srcDir, "rogue"), { recursive: true });
+      writeFileSync(
+        join(srcDir, "rogue", "shadow.ts"),
+        [
+          "// some comment",
+          "function isoNow(): string {",
+          "  return 'fake';",
+          "}",
+          "export const x = isoNow();",
+        ].join("\n"),
+      );
+
+      const errs: string[] = [];
+      const outs: string[] = [];
+      const result = runCli({
+        srcDir,
+        utilPath,
+        repoRoot: root,
+        writeErr: (m) => errs.push(m),
+        writeOut: (m) => outs.push(m),
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.offenseCount).toBe(1);
+      expect(result.issues).toEqual([
+        { file: "src/rogue/shadow.ts", line: 2, name: "isoNow" },
+      ]);
+      // Offense line must include `path:line` and the canonical name.
+      const offenseMessage = errs.find((m) => m.includes("src/rogue/shadow.ts:2"));
+      expect(offenseMessage).toBeDefined();
+      expect(offenseMessage!).toContain("isoNow");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes util.ts itself (otherwise it would self-flag)", () => {
+    const root = makeTempTree();
+    try {
+      const srcDir = join(root, "src");
+      mkdirSync(srcDir, { recursive: true });
+      const utilPath = writeUtil(srcDir);
+
+      const result = runCli({
+        srcDir,
+        utilPath,
+        repoRoot: root,
+        writeErr: () => {},
+        writeOut: () => {},
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.issues).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("excludes *.test.ts files (fixtures legitimately redefine helpers)", () => {
+    const root = makeTempTree();
+    try {
+      const srcDir = join(root, "src");
+      mkdirSync(srcDir, { recursive: true });
+      const utilPath = writeUtil(srcDir);
+      mkdirSync(join(srcDir, "consumer"), { recursive: true });
+      writeFileSync(
+        join(srcDir, "consumer", "fixture.test.ts"),
+        [
+          "function isoNow(): string {",
+          "  return 'fixture-stub';",
+          "}",
+          "export const stub = isoNow;",
+        ].join("\n"),
+      );
+
+      const result = runCli({
+        srcDir,
+        utilPath,
+        repoRoot: root,
+        writeErr: () => {},
+        writeOut: () => {},
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.issues).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("flags multiple offenses across multiple files", () => {
+    const root = makeTempTree();
+    try {
+      const srcDir = join(root, "src");
+      mkdirSync(srcDir, { recursive: true });
+      const utilPath = writeUtil(srcDir);
+      mkdirSync(join(srcDir, "a"), { recursive: true });
+      mkdirSync(join(srcDir, "b"), { recursive: true });
+      writeFileSync(
+        join(srcDir, "a", "f.ts"),
+        "function isoNow(): string { return ''; }\n",
+      );
+      writeFileSync(
+        join(srcDir, "b", "g.ts"),
+        "function makeId(p: string): string { return p; }\n",
+      );
+
+      const result = runCli({
+        srcDir,
+        utilPath,
+        repoRoot: root,
+        writeErr: () => {},
+        writeOut: () => {},
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.offenseCount).toBe(2);
+      expect(result.issues.map((i) => i.file).sort()).toEqual([
+        "src/a/f.ts",
+        "src/b/g.ts",
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/lint-no-shadow-util.test.ts
+++ b/scripts/lint-no-shadow-util.test.ts
@@ -60,6 +60,19 @@ describe("extractCanonicalNames", () => {
     expect(names.has("newHelper")).toBe(true);
   });
 
+  test("dynamic discovery picks up `export async function` helpers", () => {
+    // Without the `async` arm, an `export async function` added to util.ts
+    // would silently fall out of the canonical set — duplicates of it
+    // elsewhere would not be flagged. This test pins the async arm so a
+    // future regex narrowing would fail here.
+    const src = [
+      "export function isoNow(): string { return ''; }",
+      "export async function fetchSomething(): Promise<void> {}",
+    ].join("\n");
+    const names = extractCanonicalNames(src);
+    expect(names.has("fetchSomething")).toBe(true);
+  });
+
   test("does not match indented or method-form definitions", () => {
     const src = [
       "  export function notAtStart(): void {}", // leading spaces — not a top-level export
@@ -125,6 +138,32 @@ describe("findShadowsInFile", () => {
     expect(findShadowsInFile(src, names)).toEqual([
       { line: 1, name: "isoNow" },
       { line: 2, name: "makeId" },
+    ]);
+  });
+
+  test("flags an INDENTED shadow (inside another scope or just formatted with indent)", () => {
+    // Without leading-whitespace tolerance, a redefinition could bypass the
+    // rule by simply indenting the line — e.g., wrapping it inside another
+    // function. This test pins the `^\s*` tolerance.
+    const src = [
+      "function outer() {",
+      "  function isoNow(): string { return 'shadow'; }",
+      "  return isoNow();",
+      "}",
+    ].join("\n");
+    expect(findShadowsInFile(src, names)).toEqual([
+      { line: 2, name: "isoNow" },
+    ]);
+  });
+
+  test("flags an `async function` shadow (canonical name matched ignoring async modifier)", () => {
+    // Names like `fetchSomething` could legitimately be added as async
+    // helpers in util.ts; the shadow scan must accept the `async` modifier
+    // for parity with extractCanonicalNames.
+    const namesAsync = new Set(["fetchSomething"]);
+    const src = "async function fetchSomething(): Promise<void> {}";
+    expect(findShadowsInFile(src, namesAsync)).toEqual([
+      { line: 1, name: "fetchSomething" },
     ]);
   });
 });

--- a/scripts/lint-no-shadow-util.ts
+++ b/scripts/lint-no-shadow-util.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+/**
+ * lint-no-shadow-util.ts
+ *
+ * Catches file-private re-implementations of helpers that already live in
+ * `src/orchestration/util.ts`. Those shadows are a known drift pattern
+ * (predecessor: task-fc8f0e2b / task-41b91ca3) — copy-pasted bodies that
+ * silently fork from the canonical source.
+ *
+ * The canonical helper-name set is read **dynamically** from
+ * `src/orchestration/util.ts` (every `^export function NAME` line). Adding
+ * an eighth helper to util.ts automatically extends this lint's coverage.
+ *
+ * Rule: any file outside `src/orchestration/util.ts` whose source contains
+ *   ^(export\s+)?function\s+NAME\s*\(
+ * for one of those names is an offense. `*.test.ts` files are excluded —
+ * test fixtures legitimately redefine helpers.
+ *
+ * Exit code: 1 iff any offense found.
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, sep } from "path";
+
+const repoRoot = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Issue shape
+// ---------------------------------------------------------------------------
+
+export interface ShadowIssue {
+  /** Repo-relative path with forward slashes. */
+  file: string;
+  /** 1-based line number. */
+  line: number;
+  /** Canonical helper name being shadowed. */
+  name: string;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical name extraction (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the canonical helper-name set from a `util.ts` source string by
+ * collecting every `^export function NAME` declaration. Re-exports
+ * (`export { ... } from`) are ignored — they're not `function`
+ * declarations and cannot be shadowed by a `function` definition.
+ */
+export function extractCanonicalNames(utilSource: string): Set<string> {
+  const names = new Set<string>();
+  const re = /^export\s+function\s+([A-Za-z_][\w]*)\s*\(/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(utilSource)) !== null) {
+    names.add(m[1]!);
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Per-file scan (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find shadow definitions in `source` against the canonical `names` set.
+ * Matches `^(export\s+)?function NAME(` line-anchored — does not match
+ * method assignments (`obj.NAME = function`), arrow-form (`const NAME =`),
+ * commented-out lines (`// function NAME(`), or call sites (`NAME(...)`).
+ */
+export function findShadowsInFile(
+  source: string,
+  names: Set<string>,
+): { line: number; name: string }[] {
+  const out: { line: number; name: string }[] = [];
+  const lines = source.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = /^(?:export\s+)?function\s+([A-Za-z_][\w]*)\s*\(/.exec(lines[i]!);
+    if (m && names.has(m[1]!)) {
+      out.push({ line: i + 1, name: m[1]! });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/** Recursively list `*.ts` files under `dir`, returning absolute paths. */
+export function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  function walk(d: string): void {
+    for (const entry of readdirSync(d)) {
+      if (entry.startsWith(".")) continue;
+      const full = join(d, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && entry.endsWith(".ts")) out.push(full);
+    }
+  }
+  walk(dir);
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// runCli
+// ---------------------------------------------------------------------------
+
+export interface RunCliOptions {
+  /** Source dir to scan. Defaults to `<repo-root>/src`. */
+  srcDir?: string;
+  /** Path to the canonical util.ts. Defaults to `<srcDir>/orchestration/util.ts`. */
+  utilPath?: string;
+  /** Repo root (for repo-relative paths in output). Defaults to `<srcDir>/..`. */
+  repoRoot?: string;
+  /** Sink for offense lines (default: process.stderr.write). */
+  writeErr?: (msg: string) => void;
+  /** Sink for the success summary line (default: process.stdout.write). */
+  writeOut?: (msg: string) => void;
+}
+
+export interface RunCliResult {
+  exitCode: number;
+  offenseCount: number;
+  issues: ShadowIssue[];
+  canonicalNames: string[];
+}
+
+export function runCli(options: RunCliOptions = {}): RunCliResult {
+  const srcDir = options.srcDir ?? join(repoRoot, "src");
+  const utilPath = options.utilPath ?? join(srcDir, "orchestration", "util.ts");
+  const root = options.repoRoot ?? join(srcDir, "..");
+  const writeErr =
+    options.writeErr ??
+    ((msg) => {
+      process.stderr.write(msg + "\n");
+    });
+  const writeOut =
+    options.writeOut ??
+    ((msg) => {
+      process.stdout.write(msg + "\n");
+    });
+
+  const utilSource = readFileSync(utilPath, "utf-8");
+  const canonical = extractCanonicalNames(utilSource);
+  const utilRel = relative(root, utilPath).split(sep).join("/");
+
+  const issues: ShadowIssue[] = [];
+  for (const abs of listSourceFiles(srcDir)) {
+    const rel = relative(root, abs).split(sep).join("/");
+    if (rel === utilRel) continue;
+    if (rel.endsWith(".test.ts")) continue;
+    const source = readFileSync(abs, "utf-8");
+    for (const hit of findShadowsInFile(source, canonical)) {
+      issues.push({ file: rel, line: hit.line, name: hit.name });
+    }
+  }
+
+  for (const iss of issues) {
+    writeErr(
+      `❌  ${iss.file}:${iss.line}  function ${iss.name} shadows ${utilRel}`,
+    );
+  }
+
+  const sortedNames = [...canonical].sort();
+  if (issues.length === 0) {
+    writeOut(
+      `✅  No util.ts function shadows detected (${sortedNames.length} canonical names: ${sortedNames.join(", ")}).`,
+    );
+    return { exitCode: 0, offenseCount: 0, issues, canonicalNames: sortedNames };
+  }
+  writeErr(
+    `\n${issues.length} shadow${issues.length === 1 ? "" : "s"} of ${utilRel}.`,
+  );
+  return { exitCode: 1, offenseCount: issues.length, issues, canonicalNames: sortedNames };
+}
+
+if (import.meta.main) {
+  process.exit(runCli().exitCode);
+}

--- a/scripts/lint-no-shadow-util.ts
+++ b/scripts/lint-no-shadow-util.ts
@@ -43,13 +43,16 @@ export interface ShadowIssue {
 
 /**
  * Parse the canonical helper-name set from a `util.ts` source string by
- * collecting every `^export function NAME` declaration. Re-exports
+ * collecting every `^export [async] function NAME` declaration. Re-exports
  * (`export { ... } from`) are ignored — they're not `function`
- * declarations and cannot be shadowed by a `function` definition.
+ * declarations and cannot be shadowed by a `function` definition. The
+ * `async` modifier is accepted so a future `export async function ...`
+ * helper enters the canonical set automatically (otherwise async exports
+ * would be a false-negative bypass for the shadow rule).
  */
 export function extractCanonicalNames(utilSource: string): Set<string> {
   const names = new Set<string>();
-  const re = /^export\s+function\s+([A-Za-z_][\w]*)\s*\(/gm;
+  const re = /^export\s+(?:async\s+)?function\s+([A-Za-z_][\w]*)\s*\(/gm;
   let m: RegExpExecArray | null;
   while ((m = re.exec(utilSource)) !== null) {
     names.add(m[1]!);
@@ -63,9 +66,13 @@ export function extractCanonicalNames(utilSource: string): Set<string> {
 
 /**
  * Find shadow definitions in `source` against the canonical `names` set.
- * Matches `^(export\s+)?function NAME(` line-anchored — does not match
- * method assignments (`obj.NAME = function`), arrow-form (`const NAME =`),
- * commented-out lines (`// function NAME(`), or call sites (`NAME(...)`).
+ * Matches `^\s*(export\s+)?(async\s+)?function NAME(` — line-anchored but
+ * tolerant of leading whitespace so an indented redefinition (inside
+ * another scope, or just formatted with indentation) cannot bypass the
+ * rule. Also accepts the `async` modifier so async helpers are caught.
+ * Does not match method assignments (`obj.NAME = function`), arrow-form
+ * (`const NAME = () =>`), commented-out lines (`// function NAME(`), or
+ * call sites (`NAME(...)`).
  */
 export function findShadowsInFile(
   source: string,
@@ -74,7 +81,9 @@ export function findShadowsInFile(
   const out: { line: number; name: string }[] = [];
   const lines = source.split("\n");
   for (let i = 0; i < lines.length; i++) {
-    const m = /^(?:export\s+)?function\s+([A-Za-z_][\w]*)\s*\(/.exec(lines[i]!);
+    const m = /^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_][\w]*)\s*\(/.exec(
+      lines[i]!,
+    );
     if (m && names.has(m[1]!)) {
       out.push({ line: i + 1, name: m[1]! });
     }

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -52,24 +52,11 @@ import {
   tmuxRunShell,
 } from "./adapters/tmux.ts";
 import { safeSyncOutput } from "./spawn.ts";
+import { ludicsSelfCommand } from "./orchestration/util.ts";
 
 const MAG_SESSION_NAME = process.env.LUDICS_MAG_SESSION ?? "ludics-mag";
 const MAG_DEFAULT_PORT = process.env.LUDICS_MAG_PORT ?? "7679";
 const FEEDBACK_DIGEST_COOLDOWN_SECONDS = 120;
-const SCRIPT_EXT_RE = /\.(?:[cm]?[jt]sx?)$/i;
-
-function ludicsSelfCommand(args: string[]): string[] {
-  // Compiled binary: invoke directly via process.execPath.
-  // Script mode (bun/node): invoke the current entry script.
-  const entry = process.argv[1];
-  if (entry && SCRIPT_EXT_RE.test(entry) && existsSync(entry)) {
-    if (process.execPath.toLowerCase().endsWith("bun")) {
-      return [process.execPath, "run", entry, ...args];
-    }
-    return [process.execPath, entry, ...args];
-  }
-  return [process.execPath, ...args];
-}
 
 function magStateDir(): string {
   return join(harnessDir(), "mag");

--- a/src/sessions/sweep-state.ts
+++ b/src/sessions/sweep-state.ts
@@ -8,6 +8,7 @@ import { harnessDir } from "../config.ts";
 import { isPlainObject } from "../json.ts";
 import { isGitWorktree, getMainRepoFromWorktree } from "../adapters/base.ts";
 import { expandHome } from "../git-runner.ts";
+import { isoNow } from "../orchestration/util.ts";
 
 export type SweepMode = "agent-claude" | "agent-codex" | "t3code";
 
@@ -40,10 +41,6 @@ export interface KnownSessionInput {
   name: string;
   cleanupCommand?: string[];
   seenAt?: string;
-}
-
-function isoNow(): string {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
 export function normalizeProjectDirForSweep(raw: string): string {

--- a/src/sessions/sweep.ts
+++ b/src/sessions/sweep.ts
@@ -14,6 +14,7 @@ import { resolveProjectDir } from "../adapters/base.ts";
 import { findSessionByPrefixOrTask } from "../adapters/peer-sync.ts";
 import { readSlotState, serverStatus } from "../t3code/server.ts";
 import type { T3Snapshot } from "../t3code/types.ts";
+import { isoNow } from "../orchestration/util.ts";
 import {
   type KnownSessionRecord,
   type SweepMode,
@@ -26,10 +27,6 @@ import {
 
 interface SweepOptions {
   dryRun: boolean;
-}
-
-function isoNow(): string {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
 function resolveProjectDirForSlot(mode: SweepMode, slotPath: string, slotSession: string): string {

--- a/src/t3code/index.ts
+++ b/src/t3code/index.ts
@@ -7,18 +7,11 @@ import { T3CodeClient, waitForNewTurn } from "./client.ts";
 import { doctorServer, ensureServer, readServerRecord, readSlotState, serverStatus, stopServer, t3codeServerPath } from "./server.ts";
 import type { T3ThreadMessage } from "./types.ts";
 import { parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { isoNow, makeId } from "../orchestration/util.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function isoNow(): string {
-  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-}
-
-function makeId(prefix: string): string {
-  return `${prefix}-${crypto.randomUUID()}`;
-}
 
 async function withClient<T>(
   fn: (client: T3CodeClient) => Promise<T>,


### PR DESCRIPTION
## Summary

- Drop file-private `isoNow`/`makeId` shadows in `src/t3code/index.ts`, `src/sessions/sweep.ts`, `src/sessions/sweep-state.ts` and import from `src/orchestration/util.ts`. Bodies verified byte-identical before deletion (no behavior change).
- **Scope expansion**: `src/mag.ts` also shadowed `ludicsSelfCommand`. The proposal enumerated three files but AC8 ("lint exits 0 on the cleaned tree") combined with the dynamic name set forces this fourth dedup. Body was functionally identical but carried two explanatory comments util.ts lacks; the comments are dropped — flagged in commit trailer rather than silently normalized.
- New `scripts/lint-no-shadow-util.ts` dynamically reads `^export [async] function NAME` from util.ts and flags any file outside util.ts (including indented redefinitions and async forms) that redefines one of those names. `*.test.ts` files are excluded.
- Wired into `package.json` as `lint:no-shadow-util` and into `.github/workflows/ci.yml` as a separate CI step. Top-level `lint` remains eslint-only (orphan-tier pattern preserved).

## Round 2 — codex P2 fixes (commit bea8eb0)

Two bypass paths closed:
- `extractCanonicalNames` now accepts `export async function` (else async helpers added to util.ts later would silently fall out of the canonical set).
- `findShadowsInFile` regex now allows leading whitespace and `async` modifier (else an indented or `async function` redefinition bypassed the rule trivially).

Three new regression tests pin both arms; live lint still exits 0.

## Byte-identity verification (AC4)

| File | Helper | Match |
|------|--------|-------|
| `src/t3code/index.ts` | `isoNow` | byte-identical to `util.ts:7-9` |
| `src/t3code/index.ts` | `makeId` | byte-identical to `util.ts:15-17` |
| `src/sessions/sweep.ts` | `isoNow` | byte-identical to `util.ts:7-9` |
| `src/sessions/sweep-state.ts` | `isoNow` | byte-identical to `util.ts:7-9` |
| `src/mag.ts` (scope expansion) | `ludicsSelfCommand` | functionally identical; two internal comments dropped |

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run lint:no-shadow-util` — exits 0, prints all 7 canonical names
- [x] `bun run build` — compiles to `bin/ludics`
- [x] `bun test scripts/lint-no-shadow-util.test.ts` — 20 pass (was 17 in round 1; +3 for the codex P2 arms)
- [x] `bun test` — pre-existing single failure on base (`PROPOSAL_FRESHNESS_WARNING: boundary`), unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)