### PR TITLE
gh-ludics-405: retrofit deep-freeze + identity-eviction tests

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   effectivePriority,
   _resetPostponedProjectsCache,
   _resetPriorityProjectsCache,
+  _peekPriorityProjectsCache,
 } from "./config.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-config");
@@ -108,23 +109,36 @@ describe("postponedProjectSet cache", () => {
   });
 });
 
-describe("priorityProjectSet cache (observed via effectivePriority)", () => {
-  test("priority cache identity holds across effectivePriority calls", () => {
-    // First call materializes the cache; second call must hit it. Observable
-    // signal is the boost behaviour: alpha (priority: true) gets bumped from
-    // C → B; beta (no priority) stays at C.
+describe("priorityProjectSet cache", () => {
+  test("returns the same singleton reference across calls (cache identity)", () => {
+    // Pre-eviction reference: first effectivePriority call materializes the
+    // cache; capture via the test-only peek helper.
+    expect(_peekPriorityProjectsCache()).toBeNull();
     expect(effectivePriority("C", "alpha")).toBe("B");
+    const beforeReset = _peekPriorityProjectsCache();
+    expect(beforeReset).not.toBeNull();
+    // Mid-fill identity: a subsequent effectivePriority call must hit the
+    // same cached set, not allocate a fresh one. If priorityProjectSet()
+    // started returning a fresh ReadonlySet each call (while preserving
+    // .has() semantics) this assertion would fail.
     expect(effectivePriority("C", "alpha")).toBe("B");
+    expect(_peekPriorityProjectsCache()).toBe(beforeReset);
     expect(effectivePriority("C", "beta")).toBe("C");
+    expect(_peekPriorityProjectsCache()).toBe(beforeReset);
   });
 
-  test("eviction (cache reset) re-reads config so updated priorities take effect", () => {
-    // Pre-reset: alpha is the only priority project.
+  test("eviction (cache reset) replaces the singleton — post-reset reference is not the pre-reset one", () => {
     expect(effectivePriority("C", "alpha")).toBe("B");
-    expect(effectivePriority("C", "beta")).toBe("C");
+    const beforeReset = _peekPriorityProjectsCache();
+    expect(beforeReset).not.toBeNull();
 
-    // Rewrite config to make beta the priority project; without resetting the
-    // cache, the bump would still apply to alpha (stale singleton).
+    _resetPriorityProjectsCache();
+    // Reset clears the singleton — peek must return null until next call.
+    expect(_peekPriorityProjectsCache()).toBeNull();
+
+    // Rewrite config to make beta (not alpha) the priority project, so the
+    // post-reset re-read both materialises a *different* ReadonlySet
+    // reference AND reflects the new on-disk state.
     const configPath = process.env.LUDICS_CONFIG!;
     writeFileSync(configPath, `state_repo: owner/ludics-state
 state_path: harness
@@ -136,14 +150,31 @@ projects:
     priority: true
 `);
 
-    // Without reset: stale cache still bumps alpha (proves the cache was
-    // serving by identity rather than re-reading on each call).
-    expect(effectivePriority("C", "alpha")).toBe("B");
-
-    _resetPriorityProjectsCache();
-
-    // After reset: fresh load. alpha no longer priority; beta now is.
     expect(effectivePriority("C", "alpha")).toBe("C");
+    const afterReset = _peekPriorityProjectsCache();
+    expect(afterReset).not.toBeNull();
+    expect(afterReset).not.toBe(beforeReset);
+    // Behaviour cross-check: fresh load reflects new config.
     expect(effectivePriority("C", "beta")).toBe("B");
+  });
+
+  test("stale cache (no reset) ignores config rewrite — proves the cache served by identity, not re-read", () => {
+    expect(effectivePriority("C", "alpha")).toBe("B");
+    const beforeRewrite = _peekPriorityProjectsCache();
+
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: alpha
+    repo: owner/alpha
+  - name: beta
+    repo: owner/beta
+    priority: true
+`);
+
+    // Without reset: same singleton reference, same stale boost.
+    expect(effectivePriority("C", "alpha")).toBe("B");
+    expect(_peekPriorityProjectsCache()).toBe(beforeRewrite);
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import {
+  postponedProjectSet,
+  effectivePriority,
+  _resetPostponedProjectsCache,
+  _resetPriorityProjectsCache,
+} from "./config.ts";
+
+const TMP = join(import.meta.dir, ".test-tmp-config");
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: alpha
+    repo: owner/alpha
+    priority: true
+  - name: beta
+    repo: owner/beta
+    postponed: true
+  - name: gamma
+    repo: owner/gamma
+    postponed: true
+`);
+  return configPath;
+}
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  mkdirSync(TMP, { recursive: true });
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = join(TMP, "ludics-state", "harness");
+  _resetPostponedProjectsCache();
+  _resetPriorityProjectsCache();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  _resetPostponedProjectsCache();
+  _resetPriorityProjectsCache();
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("postponedProjectSet cache", () => {
+  test("returns the same singleton reference across calls (cache identity)", () => {
+    const first = postponedProjectSet();
+    const second = postponedProjectSet();
+    expect(first).toBe(second);
+    expect(first.has("beta")).toBe(true);
+    expect(first.has("gamma")).toBe(true);
+  });
+
+  test("mutator methods (add/delete/clear) throw via the Proxy trap", () => {
+    const set = postponedProjectSet();
+    // TypeScript's ReadonlySet blocks these at compile time; we cast through
+    // `unknown` to a mutable Set to drive the runtime trap.
+    const mutable = set as unknown as Set<string>;
+    expect(() => mutable.add("evil")).toThrow(TypeError);
+    expect(() => mutable.delete("beta")).toThrow(TypeError);
+    expect(() => mutable.clear()).toThrow(TypeError);
+    // Cache is not polluted: the original membership still holds, identity
+    // unchanged.
+    expect(postponedProjectSet()).toBe(set);
+    expect(postponedProjectSet().has("beta")).toBe(true);
+    expect(postponedProjectSet().has("gamma")).toBe(true);
+    expect(postponedProjectSet().has("evil")).toBe(false);
+  });
+
+  test("read methods (has, size, iteration) still work", () => {
+    const set = postponedProjectSet();
+    expect(set.size).toBe(2);
+    expect(set.has("beta")).toBe(true);
+    expect(set.has("alpha")).toBe(false);
+    const collected: string[] = [];
+    for (const p of set) collected.push(p);
+    expect(collected.sort()).toEqual(["beta", "gamma"]);
+  });
+
+  test("eviction (cache reset) replaces the singleton — post-reset reference is not the pre-reset one", () => {
+    const beforeReset = postponedProjectSet();
+    // Mid-call identity is preserved while the cache is live.
+    expect(postponedProjectSet()).toBe(beforeReset);
+
+    _resetPostponedProjectsCache();
+
+    const afterReset = postponedProjectSet();
+    expect(afterReset).not.toBe(beforeReset);
+    // Both reflect the same on-disk config state (no config rewrite).
+    expect(afterReset.has("beta")).toBe(true);
+    expect(afterReset.has("gamma")).toBe(true);
+  });
+});
+
+describe("priorityProjectSet cache (observed via effectivePriority)", () => {
+  test("priority cache identity holds across effectivePriority calls", () => {
+    // First call materializes the cache; second call must hit it. Observable
+    // signal is the boost behaviour: alpha (priority: true) gets bumped from
+    // C → B; beta (no priority) stays at C.
+    expect(effectivePriority("C", "alpha")).toBe("B");
+    expect(effectivePriority("C", "alpha")).toBe("B");
+    expect(effectivePriority("C", "beta")).toBe("C");
+  });
+
+  test("eviction (cache reset) re-reads config so updated priorities take effect", () => {
+    // Pre-reset: alpha is the only priority project.
+    expect(effectivePriority("C", "alpha")).toBe("B");
+    expect(effectivePriority("C", "beta")).toBe("C");
+
+    // Rewrite config to make beta the priority project; without resetting the
+    // cache, the bump would still apply to alpha (stale singleton).
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: alpha
+    repo: owner/alpha
+  - name: beta
+    repo: owner/beta
+    priority: true
+`);
+
+    // Without reset: stale cache still bumps alpha (proves the cache was
+    // serving by identity rather than re-reading on each call).
+    expect(effectivePriority("C", "alpha")).toBe("B");
+
+    _resetPriorityProjectsCache();
+
+    // After reset: fresh load. alpha no longer priority; beta now is.
+    expect(effectivePriority("C", "alpha")).toBe("C");
+    expect(effectivePriority("C", "beta")).toBe("B");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -355,10 +355,39 @@ export function postponedProjects(): Set<string> {
   return new Set((config.projects ?? []).filter((p) => p.postponed).map((p) => p.name.toLowerCase()));
 }
 
-let _postponedProjectsCache: Set<string> | null = null;
-export function postponedProjectSet(): Set<string> {
-  if (!_postponedProjectsCache) _postponedProjectsCache = postponedProjects();
+/**
+ * Wrap a Set in a Proxy that throws on any mutator method, so cached singletons
+ * cannot be polluted by callers (`postponedProjectSet().add(x)`). `Object.freeze`
+ * is inert on Set — `.add()` / `.delete()` / `.clear()` still mutate the backing
+ * store. The Proxy enforces the read-only contract at runtime; the public return
+ * type is `ReadonlySet<string>` so TypeScript blocks mutation calls at compile time.
+ */
+function readonlySet<T>(set: Set<T>): ReadonlySet<T> {
+  return new Proxy(set, {
+    get(target, prop) {
+      if (prop === "add" || prop === "delete" || prop === "clear") {
+        throw new TypeError(`readonly Set: '${String(prop)}' is not allowed`);
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as ReadonlySet<T>;
+}
+
+// Cached singleton of postponed-project names. Audit (gh-ludics-405): callers
+// in mag.ts and flow.ts use `.has()` only, but the structural hazard remains —
+// any future caller doing `postponedProjectSet().add(x)` would permanently
+// pollute the cache. The Proxy mutator-trap closes that hazard at runtime;
+// `ReadonlySet<string>` closes it at compile time.
+let _postponedProjectsCache: ReadonlySet<string> | null = null;
+export function postponedProjectSet(): ReadonlySet<string> {
+  if (!_postponedProjectsCache) _postponedProjectsCache = readonlySet(postponedProjects());
   return _postponedProjectsCache;
+}
+
+/** Test-only: reset cached postponed-project set. Not exported via index.ts. */
+export function _resetPostponedProjectsCache(): void {
+  _postponedProjectsCache = null;
 }
 
 export function preemptAutonomy(): "auto" | "suggest" {
@@ -455,13 +484,25 @@ export function resolveProposalsPath(projectDir: string, configuredPath?: string
   return join(projectDir, "docs", "proposals");
 }
 
-/** Set of projects with `priority: true` in config, cached per process. */
-let _priorityProjectsCache: Set<string> | null = null;
-function priorityProjectSet(): Set<string> {
+/**
+ * Set of projects with `priority: true` in config, cached per process.
+ * Audit (gh-ludics-405): `priorityProjectSet` is module-private and only
+ * `.has()` is read by callers, but it shares the same structural hazard as
+ * `postponedProjectSet` — a singleton mutable Set returned by getter. Same
+ * Proxy + ReadonlySet strategy applied for consistency with the postponed
+ * cache; both sites use `readonlySet()`.
+ */
+let _priorityProjectsCache: ReadonlySet<string> | null = null;
+function priorityProjectSet(): ReadonlySet<string> {
   if (!_priorityProjectsCache) {
-    _priorityProjectsCache = new Set(priorityProjects().map((p) => p.toLowerCase()));
+    _priorityProjectsCache = readonlySet(new Set(priorityProjects().map((p) => p.toLowerCase())));
   }
   return _priorityProjectsCache;
+}
+
+/** Test-only: reset cached priority-project set. Not exported via index.ts. */
+export function _resetPriorityProjectsCache(): void {
+  _priorityProjectsCache = null;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -506,6 +506,15 @@ export function _resetPriorityProjectsCache(): void {
 }
 
 /**
+ * Test-only: peek the cached priority-project set reference for identity-based
+ * eviction tests (mirrors the canonical pre/post-eviction `===`/`!==` rungs in
+ * `src/tasks/markdown.test.ts`). Not exported via index.ts.
+ */
+export function _peekPriorityProjectsCache(): ReadonlySet<string> | null {
+  return _priorityProjectsCache;
+}
+
+/**
  * Returns the effective (virtual) priority for a task, applying a one-level
  * boost when the task's project has `priority: true` in config:
  *   A → S, B → A, C → B, D → C (non-priority tasks keep their actual priority).

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -221,7 +221,7 @@ describe("generateHealthData", () => {
     expect(second.doctor.timestamp).toBe(first.doctor.timestamp);
   });
 
-  test("doctor cache TTL eviction replaces the cached record (identity assertion)", async () => {
+  test("doctor cache TTL eviction replaces the returned doctor.timestamp across the boundary", async () => {
     const {
       generateHealthData,
       _resetDoctorCache,
@@ -230,27 +230,38 @@ describe("generateHealthData", () => {
     } = await import("./dashboard.ts");
     _resetDoctorCache();
 
-    // First read materializes the cache record; capture pre-eviction reference.
-    generateHealthData();
-    const beforeEviction = _peekDoctorCache();
-    expect(beforeEviction).not.toBeNull();
+    // Read 1: populate the cache; capture the returned timestamp at the
+    // public boundary (the AC's identity proxy is `data.doctor.timestamp`,
+    // not `_peekDoctorCache()` — that would test an internal seam, not the
+    // observable invariant).
+    const data1 = generateHealthData() as { doctor: { timestamp: string } };
+    const ts1 = data1.doctor.timestamp;
+    expect(typeof ts1).toBe("string");
+    // Cross-check the cache is in fact materialised (positive control on
+    // the harness condition: a real cached record exists to be evicted).
+    expect(_peekDoctorCache()).not.toBeNull();
 
-    // Mid-fill identity assertion: a second read inside TTL must serve the
-    // same record by reference (not just field-equivalent). This is the
-    // "cache is serving by identity until eviction" rung from
-    // markdown.test.ts:583-680.
-    generateHealthData();
-    expect(_peekDoctorCache()).toBe(beforeEviction);
+    // Read 2 within TTL: returned timestamp must equal ts1. If the cache
+    // were a no-op (re-spawning every call), ts2 would generally differ
+    // from ts1 because the subprocess sets a fresh `new Date().toISOString()`
+    // on each miss.
+    const data2 = generateHealthData() as { doctor: { timestamp: string } };
+    const ts2 = data2.doctor.timestamp;
+    expect(ts2).toBe(ts1);
 
-    // Back-date `cachedAt` past the 5-minute TTL boundary so the next read
-    // forces a re-spawn deterministically (no clock waiting).
+    // Force the cache past the 5-minute TTL deterministically; pair with a
+    // small clock advance so the post-eviction `new Date().toISOString()`
+    // is guaranteed to differ from ts1 even on the fastest hardware.
     _setDoctorCacheCachedAt(Date.now() - 600_000);
+    await Bun.sleep(5);
 
-    generateHealthData();
-    const afterEviction = _peekDoctorCache();
-    expect(afterEviction).not.toBeNull();
-    // Post-eviction identity is broken: a fresh record was constructed.
-    expect(afterEviction).not.toBe(beforeEviction);
+    // Read 3 post-TTL: cache miss, re-spawn → fresh timestamp at the public
+    // boundary. This is the AC's "replaced across the boundary" assertion.
+    const data3 = generateHealthData() as { doctor: { timestamp: string } };
+    const ts3 = data3.doctor.timestamp;
+    expect(ts3).not.toBe(ts1);
+    // Sanity: ts3 is a real ISO string, not a stale empty/null value.
+    expect(new Date(ts3).toISOString()).toBe(ts3);
   });
 });
 

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -220,6 +220,38 @@ describe("generateHealthData", () => {
     expect(second.doctor.output).toBe(first.doctor.output);
     expect(second.doctor.timestamp).toBe(first.doctor.timestamp);
   });
+
+  test("doctor cache TTL eviction replaces the cached record (identity assertion)", async () => {
+    const {
+      generateHealthData,
+      _resetDoctorCache,
+      _setDoctorCacheCachedAt,
+      _peekDoctorCache,
+    } = await import("./dashboard.ts");
+    _resetDoctorCache();
+
+    // First read materializes the cache record; capture pre-eviction reference.
+    generateHealthData();
+    const beforeEviction = _peekDoctorCache();
+    expect(beforeEviction).not.toBeNull();
+
+    // Mid-fill identity assertion: a second read inside TTL must serve the
+    // same record by reference (not just field-equivalent). This is the
+    // "cache is serving by identity until eviction" rung from
+    // markdown.test.ts:583-680.
+    generateHealthData();
+    expect(_peekDoctorCache()).toBe(beforeEviction);
+
+    // Back-date `cachedAt` past the 5-minute TTL boundary so the next read
+    // forces a re-spawn deterministically (no clock waiting).
+    _setDoctorCacheCachedAt(Date.now() - 600_000);
+
+    generateHealthData();
+    const afterEviction = _peekDoctorCache();
+    expect(afterEviction).not.toBeNull();
+    // Post-eviction identity is broken: a fresh record was constructed.
+    expect(afterEviction).not.toBe(beforeEviction);
+  });
 });
 
 describe("generateNotifications shape guard", () => {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -980,12 +980,38 @@ function generateBriefing(): Record<string, unknown> {
 
 // --- Generate health.json ---
 
+/**
+ * Audit (gh-ludics-405): skip-with-rationale on the deep-freeze retrofit.
+ * `generateHealthData` returns a fresh shallow `{ output, timestamp }` literal
+ * built at the return site (see below) — callers never receive the cached
+ * record itself, so mutation through the returned object cannot pollute the
+ * cache. The identity-based TTL eviction test still applies: see
+ * `_setDoctorCacheCachedAt` below and `dashboard.test.ts`'s
+ * "doctor cache TTL eviction replaces the cached record" test.
+ */
 let doctorCache: { output: string; timestamp: string; cachedAt: number } | null = null;
 const DOCTOR_CACHE_TTL = 300_000; // 5 minutes
 
 /** Exported for testing; resets the doctor subprocess cache. */
 export function _resetDoctorCache(): void {
   doctorCache = null;
+}
+
+/**
+ * Test-only: back-date the doctor cache's `cachedAt` so the next read crosses
+ * the TTL boundary deterministically. Not exported via index.ts.
+ */
+export function _setDoctorCacheCachedAt(epochMs: number): void {
+  if (doctorCache) doctorCache.cachedAt = epochMs;
+}
+
+/**
+ * Test-only: peek the underlying cached record reference so identity-based
+ * eviction tests can compare pre/post-TTL references directly. Not exported
+ * via index.ts.
+ */
+export function _peekDoctorCache(): { output: string; timestamp: string; cachedAt: number } | null {
+  return doctorCache;
 }
 
 export function generateHealthData(): Record<string, unknown> {

--- a/src/skill-queue-registry.ts
+++ b/src/skill-queue-registry.ts
@@ -29,7 +29,18 @@ interface SkillQueueEntry {
   requiredArgs: string[];
 }
 
-/** Module-level cache; null means "not yet loaded". */
+/**
+ * Module-level cache; null means "not yet loaded".
+ *
+ * Audit (gh-ludics-405): skip-with-rationale on the deep-freeze retrofit.
+ * `SkillQueueEntry` records (with mutable `args[]`, `defaults`, `requiredArgs`)
+ * never escape this module's public surface — `resolveSkillCommand` returns a
+ * resolved `string | null`, `hasRegisteredAction` returns a `boolean`. Verified
+ * callers: `mag.ts:resolveSkillCommand/hasRegisteredAction`,
+ * `dashboard-server.ts:resolveSkillCommand`. None receive entries by reference.
+ * If a future caller surface returns `SkillQueueEntry` directly, that change
+ * must add the freeze.
+ */
 let cache: Map<string, SkillQueueEntry> | null = null;
 
 /** Clear the registry cache. Useful in tests and for process-lifetime resets. */


### PR DESCRIPTION
## Summary

- Per-site audit of the four parsed/computed-object caches outside the canonical `parseTaskFrontmatter` site.
- Per-site decisions recorded as comment blocks next to each cache declaration (and re-summarised below).
- Two retrofits + two skip-with-rationale, mirroring the canonical identity-eviction pattern from `src/tasks/markdown.test.ts:583-680`.

## Per-site decisions

| Site | Decision | Rationale |
|---|---|---|
| `src/skill-queue-registry.ts` `cache` | **Skip** | `SkillQueueEntry` records never escape the public surface — `resolveSkillCommand` returns `string \| null`, `hasRegisteredAction` returns `boolean`. Verified callers: `mag.ts`, `dashboard-server.ts`. Skip-with-rationale comment in source. |
| `src/config.ts` `_postponedProjectsCache` | **Retrofit** | Singleton `Set<string>` exposed via `postponedProjectSet()`. `Object.freeze` is inert on `Set`. Adopted `ReadonlySet<string>` + Proxy mutator-trap. |
| `src/config.ts` `_priorityProjectsCache` | **Retrofit** | Same shape as above; same strategy applied for consistency. Both share a single `readonlySet()` helper. |
| `src/dashboard.ts` `doctorCache` | **Skip freeze, add identity test** | `generateHealthData` returns a fresh shallow wrapper at line 1014 — callers cannot receive the cached record by reference. Identity-based TTL eviction test added at the public return boundary using `data.doctor.timestamp` as the AC's stated identity proxy. |

## Test-only helpers (not re-exported via `index.ts`)

- `_resetPostponedProjectsCache()`, `_resetPriorityProjectsCache()`, `_peekPriorityProjectsCache()` in `src/config.ts`
- `_setDoctorCacheCachedAt(epochMs)`, `_peekDoctorCache()` in `src/dashboard.ts`

## Round 2: reviewer action items

- **Action item 1** (priorityProjectSet identity test): added `_peekPriorityProjectsCache()` and replaced behaviour-only assertions on `effectivePriority` with the canonical pre-eviction / mid-fill / post-eviction identity rungs. Round-1 tests would have passed even if `priorityProjectSet()` returned a fresh `ReadonlySet` each call.
- **Action item 2** (doctor TTL test at the return boundary): rewrote the test to observe `data.doctor.timestamp` at the public return boundary instead of `_peekDoctorCache()`. Asserts `ts2 === ts1` within TTL, then `ts3 !== ts1` post-TTL. Pairs `_setDoctorCacheCachedAt(Date.now() - 600_000)` with a 5ms `Bun.sleep` to guarantee clock advance.

## Mutation tests run before claiming AC enforcement

- AC3 mutator-trap: removed the `readonlySet()` wrap → `expect(() => mutable.add("evil")).toThrow(TypeError)` failed.
- AC4 TTL identity (round 2): removed the `_setDoctorCacheCachedAt` back-date → `expect(ts3).not.toBe(ts1)` failed.
- AC5 priority-cache identity (round 2): made `priorityProjectSet` return a fresh ReadonlySet each call → 3 priority-cache tests failed including `expect(_peekPriorityProjectsCache()).toBe(beforeReset)`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/config.test.ts src/dashboard.test.ts src/skill-queue-registry.test.ts` → 90 pass / 0 fail / 200 expect() calls
- [x] Full suite previously: 1790 pass / 2 fail (the 2 failures are pre-existing on base — `lint-test-isolation` count drift and `PROPOSAL_FRESHNESS_WARNING` boundary; reviewer confirmed not a regression from this round)
- [x] Mutation-tested all three new AC assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)