### PR TITLE
Prefix auto-fed queue requests with 'Ludics: ' (task-f6f80ed5)

### DIFF
--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix } from "./mag.ts";
 import type { RunGit } from "./git-runner.ts";
 
 describe("normalizeLaunchAdapter", () => {
@@ -220,6 +220,91 @@ describe("resolveQueueRequestCommand — backward compat parsing", () => {
       false,
     );
     expect(result).toBeNull();
+  });
+});
+
+describe("applyQueueFeedPrefix — structural prefix decision", () => {
+  // Positive case: task-bearing automated action gets prefix.
+  // Harness condition: rawLine has `task` field and NO `content` field.
+  // Invariant: any QueueAction whose JSON omits `content` is automated and
+  // must be visibly distinguishable to Mag (no leading `/`, so Claude Code
+  // does not auto-dispatch the embedded slash command).
+  test("automated task-bearing action gets 'Ludics: ' prefix", () => {
+    const raw = JSON.stringify({ action: "draft-proposal", task: "task-X" });
+    const result = applyQueueFeedPrefix(raw, "/ludics-draft-proposal task-X");
+    expect(result.startsWith("Ludics: ")).toBe(true);
+    expect(result).toBe("Ludics: /ludics-draft-proposal task-X");
+  });
+
+  // Negative case: content-bearing message action goes through verbatim.
+  // Harness condition: rawLine has `content: string` field.
+  // Invariant: content-bearing entries (user-typed messages OR auto-fed
+  // slash commands like `/compact` queued via the message channel) reach
+  // Mag without prefix so Claude Code's parser still dispatches them.
+  test("content-bearing message action does NOT get prefix", () => {
+    const raw = JSON.stringify({ action: "message", content: "hello" });
+    const result = applyQueueFeedPrefix(raw, "hello");
+    expect(result.startsWith("Ludics: ")).toBe(false);
+    expect(result).toBe("hello");
+  });
+
+  // AC 2a: load-bearing /compact case. The keepalive auto-schedules
+  // `/compact` as a `message` action whose content is fed verbatim;
+  // prefixing would break Claude Code's slash-command auto-dispatch.
+  // Harness condition: rawLine has `content: "/compact"`.
+  // Invariant: command remains exactly "/compact" — no prefix, even
+  // though it starts with `/`.
+  test("'/compact' message action is fed verbatim (load-bearing)", () => {
+    const raw = JSON.stringify({ action: "message", content: "/compact" });
+    const result = applyQueueFeedPrefix(raw, "/compact");
+    expect(result).toBe("/compact");
+  });
+
+  // Falsifier: empty-string content still counts as content-bearing.
+  // (typeof content === "string" — present but empty is still "user
+  // shape" and should not be prefixed.)
+  test("empty-string content is still content-bearing (no prefix)", () => {
+    const raw = JSON.stringify({ action: "message", content: "" });
+    const result = applyQueueFeedPrefix(raw, "");
+    expect(result).toBe("");
+  });
+
+  // Falsifier: non-string content (e.g. null) is NOT content-bearing,
+  // so the structural rule prefixes. Guards against a future variant
+  // accidentally sneaking through with a falsy non-string content.
+  test("non-string content field is treated as automated (gets prefix)", () => {
+    const raw = JSON.stringify({ action: "weird", content: null, task: "task-X" });
+    const result = applyQueueFeedPrefix(raw, "/ludics-weird task-X");
+    expect(result).toBe("Ludics: /ludics-weird task-X");
+  });
+
+  // Defensive default: malformed JSON → treat as automated.
+  test("parse failure defaults to prefixing (treat as automated)", () => {
+    const result = applyQueueFeedPrefix("not-json{{{", "/ludics-foo");
+    expect(result).toBe("Ludics: /ludics-foo");
+  });
+
+  // Falsifier: an action-name allowlist that omits `message` would
+  // pass the positive test but fail this — `process-suggestions` has
+  // a `task` field but no `content`, must be prefixed.
+  test("process-suggestions task-bearing action gets prefix", () => {
+    const raw = JSON.stringify({ action: "process-suggestions", task: "task-Y" });
+    const result = applyQueueFeedPrefix(raw, "/ludics-process-suggestions task-Y");
+    expect(result).toBe("Ludics: /ludics-process-suggestions task-Y");
+  });
+
+  // Inversion falsifier guard: if the structural condition is
+  // accidentally inverted (prefixing content-bearing, not prefixing
+  // task-bearing), the positive and negative tests above would both
+  // fail. This explicit cross-pair confirms both branches in one shot.
+  test("inversion-resistant: task-bearing prefixed, content-bearing not", () => {
+    const taskRaw = JSON.stringify({ action: "elaborate", task: "task-Z" });
+    const messageRaw = JSON.stringify({ action: "message", content: "free-form" });
+    const taskResult = applyQueueFeedPrefix(taskRaw, "/ludics-elaborate task-Z");
+    const messageResult = applyQueueFeedPrefix(messageRaw, "free-form");
+    // Task-bearing must start with "Ludics: ", content-bearing must not.
+    expect(taskResult.startsWith("Ludics: ")).toBe(true);
+    expect(messageResult.startsWith("Ludics: ")).toBe(false);
   });
 });
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -283,6 +283,32 @@ function clearStallState(): void {
 // --- Queue feed and stall nudge helpers ---
 
 /**
+ * Decide whether a queue-fed command should carry the `Ludics: ` prefix.
+ * Structural rule: if the raw queue record has a string `content` field
+ * (the `{ action: "message", content: string }` shape — user-typed messages
+ * and content-bearing automated entries like `/compact`), feed verbatim so
+ * Claude Code's slash-command parser still dispatches it. Otherwise (every
+ * automated skill invocation, which carries `task` or no payload) prefix
+ * with `Ludics: ` so Mag sees a normal user prompt and decides whether to
+ * act. Parse failure defaults to prefixing (treat as automated).
+ *
+ * Exported for testing.
+ */
+export function applyQueueFeedPrefix(rawLine: string, command: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawLine);
+  } catch {
+    return `Ludics: ${command}`;
+  }
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const content = (parsed as Record<string, unknown>).content;
+    if (typeof content === "string") return command;
+  }
+  return `Ludics: ${command}`;
+}
+
+/**
  * When Mag is ready for input and queue has Mag-turn work, pop one item
  * and deliver. "Ready" means either the settled sentinel is set (stop
  * hook fired at end of last turn) or isMagReady() reports the pane has
@@ -316,9 +342,10 @@ export async function maybeFeedMagQueue(): Promise<boolean> {
   const popped = await queuePopSkill();
   if (!popped) return false;
 
-  const sent = triggerSkill(MAG_SESSION_NAME, popped.command);
+  const delivered = applyQueueFeedPrefix(popped.line, popped.command);
+  const sent = triggerSkill(MAG_SESSION_NAME, delivered);
   if (sent) {
-    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${popped.command}` });
+    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${delivered}` });
   } else {
     // Requeue the failed item for retry on next keepalive cycle.
     let retryCount = 0;


### PR DESCRIPTION
## Summary

When the keepalive auto-feeds a queue entry into the Mag conversation, prefix the fed turn with `Ludics: ` so Claude Code's slash-command parser does not auto-dispatch the embedded `/ludics-X` command — Mag now sees a normal user prompt and gets the natural pushback step (decide whether to act).

The decision is **structural**: queue records that carry a string `content` field (the `{action:"message", content}` shape — including the auto-scheduled `/compact`) reach Mag verbatim so the parser still dispatches them; everything else (every automated skill invocation, which carries `task` or no payload) gets prefixed. No special-case for `/compact` — the structural rule gives the right answer.

## Changes

- `src/mag.ts` — new `applyQueueFeedPrefix(rawLine, command)` helper exported for testing; `maybeFeedMagQueue()` computes a single `delivered` string and uses it for both the `triggerSkill` call and the `mag_queue_feed` event message, so journal observability matches what Mag actually saw.
- `src/mag.test.ts` — eight tests in a new `describe("applyQueueFeedPrefix — structural prefix decision")` block: positive (task-bearing → prefix), negative (content-bearing → no prefix), `/compact` load-bearing case, parse-failure default (prefix), non-string `content` (prefix), `process-suggestions` (prefix), empty-string content (no prefix), and an inversion-resistance pair.

The requeue-on-failure path is unchanged: it reinserts `JSON.parse(popped.line)` (raw) so the prefix is transient at feed time, never persisted.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `bun test src/mag.test.ts` — 74 pass / 0 fail (includes the existing `resolveQueueRequestCommand — backward compat parsing` block)
- [x] Mutation probe: physically inverted the helper's structural condition and confirmed the AC1 positive assertion (`startsWith("Ludics: ")`) and AC2a load-bearing assertion (`=== "/compact"`) both flip from PASS to FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)