### PR TITLE
Thread formatYamlScalar through renderFrontmatterValue

### DIFF
--- a/docs/proposals/task-c2af46fa.md
+++ b/docs/proposals/task-c2af46fa.md
@@ -73,8 +73,16 @@ normalize, so they stay out of scope.
   `src/tasks/markdown.test.ts` suites pass without modification (other
   than the new helper-level tests added for the falsifiers above).
 - `grep -n '"null"' src/tasks/sync.ts` no longer matches the
-  `formatYamlScalar` body. (After the change, the only `"null"` literal
-  in `src/` outside of test files is in `renderFrontmatterValue`'s body.)
+  `formatYamlScalar` body. (After the change, the only **write-side**
+  `"null"` literal in `src/` outside of test files is in
+  `renderFrontmatterValue`'s body in `src/tasks/markdown.ts`. Read-side
+  normalizers — `normalizeOptionalString` and
+  `parseTaskFrontmatterLineFallback` in `src/tasks/markdown.ts`, plus the
+  similar `=== "null"` comparisons in `dashboard.ts`, `slots/index.ts`,
+  `mag.ts`, and the various adapter / sweep modules — necessarily compare
+  against the YAML `"null"` token coming back from disk and stay out of
+  scope, per the Approach section's grep expectation: "any read-side
+  normalizers … remain.")
 
 ## Context
 

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { contentFingerprint, formatYamlScalar, tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
+import { contentFingerprint, formatYamlScalar, setFrontmatterScalar, tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
+import { renderFrontmatterValue } from "./markdown.ts";
 import { emptySlotData, writeSlotJson } from "../slots/json.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-sync");
@@ -685,5 +686,87 @@ describe("formatYamlScalar", () => {
     expect(formatYamlScalar("hello world")).toBe('"hello world"');
     // Embedded quotes get backslash-escaped (yamlEscape behaviour preserved).
     expect(formatYamlScalar('he said "hi"')).toBe('"he said \\"hi\\""');
+  });
+
+  test("rendered output round-trips through renderFrontmatterValue unchanged (double-application no-op)", () => {
+    // Invariant for AC7: setFrontmatterScalar passes formatYamlScalar's
+    // output to updateFrontmatterField / addFrontmatterField, which re-apply
+    // renderFrontmatterValue. The double application must be a no-op for
+    // every rendered shape, otherwise desiredLine would not equal the
+    // existing line on the second identical write.
+    // Mutation: if renderFrontmatterValue is altered to not pass through
+    // non-empty rendered strings (e.g. wraps them in quotes), one of these
+    // would fail.
+    const cases: Array<string | number | boolean | null> = [
+      null, "", true, false, 0, 42, "hello-world", "hello world", 'has "quotes"',
+    ];
+    for (const v of cases) {
+      const rendered = formatYamlScalar(v);
+      expect(renderFrontmatterValue(rendered)).toBe(rendered);
+    }
+  });
+});
+
+describe("setFrontmatterScalar", () => {
+  // AC7 falsifier: identical second write returns false (desiredLine ===
+  // existingLine short-circuit). The double application of
+  // renderFrontmatterValue inside formatYamlScalar -> updateFrontmatterField
+  // must remain idempotent for this short-circuit to fire.
+
+  let tmpDir: string;
+  let taskFile: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync("/tmp/ludics-sfs-");
+    taskFile = join(tmpDir, "task.md");
+    writeFileSync(taskFile, `---
+id: task-x
+title: "x"
+---
+body
+`);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("first write of a null field adds the line and returns true", () => {
+    // Harness: the field does not exist on disk, so setFrontmatterScalar
+    // takes the addFrontmatterField branch and writes `<field>: null`.
+    expect(setFrontmatterScalar(taskFile, "github_state_reason", null)).toBe(true);
+    expect(readFileSync(taskFile, "utf-8")).toContain("github_state_reason: null\n");
+  });
+
+  test("identical second write returns false (desiredLine short-circuit)", () => {
+    // Harness condition: same value written twice in a row. The second call
+    // must hit the `existingLine === desiredLine` short-circuit and bail
+    // without rewriting. This *only* works because renderFrontmatterValue
+    // is idempotent on its own non-empty output — the double-application
+    // through updateFrontmatterField has to land back on the same string.
+    // Mutation: stub renderFrontmatterValue to return `<input>+":fixed"`,
+    // and the second call would render a different desiredLine, miss the
+    // short-circuit, and return true — failing this assertion.
+    expect(setFrontmatterScalar(taskFile, "github_state_reason", null)).toBe(true);
+    expect(setFrontmatterScalar(taskFile, "github_state_reason", null)).toBe(false);
+  });
+
+  test("identical second write of a quoted free-form string also short-circuits", () => {
+    // Same invariant for the quoted-string branch: the rendered shape
+    // `"hello world"` must round-trip through renderFrontmatterValue
+    // unchanged so the second write returns false.
+    expect(setFrontmatterScalar(taskFile, "title", "hello world")).toBe(true);
+    expect(setFrontmatterScalar(taskFile, "title", "hello world")).toBe(false);
+  });
+
+  test("empty-string write produces the YAML-null shape on disk (alignment shift)", () => {
+    // AC2's on-disk consequence: setFrontmatterScalar(file, field, "")
+    // writes `<field>: null` (was `<field>: ""` before this task). Mutation:
+    // revert the empty-string branch and the file would contain
+    // `github_labels: ""` instead.
+    expect(setFrontmatterScalar(taskFile, "github_labels", "")).toBe(true);
+    expect(readFileSync(taskFile, "utf-8")).toContain("github_labels: null\n");
+    // And the second identical write also short-circuits.
+    expect(setFrontmatterScalar(taskFile, "github_labels", "")).toBe(false);
   });
 });

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { contentFingerprint, tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
+import { contentFingerprint, formatYamlScalar, tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
 import { emptySlotData, writeSlotJson } from "../slots/json.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-sync");
@@ -635,5 +635,55 @@ describe("contentFingerprint", () => {
     // different fingerprint. A constant-output bug (e.g. hashing "" instead
     // of `normalized`) would flip this.
     expect(contentFingerprint("Completely different task")).not.toBe(baseline);
+  });
+});
+
+describe("formatYamlScalar", () => {
+  // Each branch is pinned by a per-mutation falsifier per the task's AC. The
+  // null/empty-string path is intentionally routed through the shared
+  // `renderFrontmatterValue` seam in `markdown.ts`; the boolean/number/
+  // identifier/quoted-string branches stay layered above it.
+
+  test("null renders to YAML null token via the shared seam", () => {
+    // Mutation: replace the helper's return with `"NULL"` and this assertion
+    // flips — proving the seam is wired in (not coincidental output from a
+    // legacy `if (value === null) return "null"` branch in this file).
+    expect(formatYamlScalar(null)).toBe("null");
+  });
+
+  test("empty string also collapses to null (alignment with renderFrontmatterValue)", () => {
+    // Mutation: drop the `value === ""` clause and `""` falls through to the
+    // identifier-regex / quoted-string branch, returning `'""'` — flipping
+    // this assertion.
+    expect(formatYamlScalar("")).toBe("null");
+  });
+
+  test("boolean true/false render to bare tokens", () => {
+    // Mutation: remove the boolean branch and `true` falls through to
+    // `renderFrontmatterValue` (or, if the type were widened, into the
+    // string branches) — neither yields the bare `"true"` token.
+    expect(formatYamlScalar(true)).toBe("true");
+    expect(formatYamlScalar(false)).toBe("false");
+  });
+
+  test("numbers stringify (including 0, which is falsy)", () => {
+    // Mutation: replace `typeof value === "number"` with `if (!value) return …`
+    // and `0` routes through the null/empty branch — flipping the 0 case.
+    expect(formatYamlScalar(42)).toBe("42");
+    expect(formatYamlScalar(0)).toBe("0");
+  });
+
+  test("identifier-shaped strings pass through unquoted", () => {
+    // Mutation: remove the identifier regex and `"hello-world"` falls through
+    // to the quoted-string branch, producing `'"hello-world"'` instead.
+    expect(formatYamlScalar("hello-world")).toBe("hello-world");
+  });
+
+  test("free-form strings are quoted with yamlEscape applied", () => {
+    // Mutation: remove the quoted-string branch and `"hello world"` returns
+    // unquoted — flipping this assertion.
+    expect(formatYamlScalar("hello world")).toBe('"hello world"');
+    // Embedded quotes get backslash-escaped (yamlEscape behaviour preserved).
+    expect(formatYamlScalar('he said "hi"')).toBe('"he said \\"hi\\""');
   });
 });

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -222,7 +222,7 @@ export function formatYamlScalar(value: string | number | boolean | null): strin
   return `"${yamlEscape(value)}"`;
 }
 
-function setFrontmatterScalar(filePath: string, field: string, value: string | number | boolean | null): boolean {
+export function setFrontmatterScalar(filePath: string, field: string, value: string | number | boolean | null): boolean {
   const content = readFileSync(filePath, "utf-8");
   const rendered = formatYamlScalar(value);
   const desiredLine = `${field}: ${rendered}`;

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { loadConfigSync, harnessDir, priorityProjects, preemptAutonomy, slotsCount, milestonesEnabledProjects } from "../config.ts";
 import { readAllSlotJson } from "../slots/json.ts";
 import { listStashes } from "../slots/preempt.ts";
-import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray } from "./markdown.ts";
+import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray, renderFrontmatterValue } from "./markdown.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
 import { queueRequest, queueHasPendingActionForTask, parseQueueLines } from "../queue.ts";
@@ -210,10 +210,13 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function formatYamlScalar(value: string | number | boolean | null): string {
-  if (value === null) return "null";
+export function formatYamlScalar(value: string | number | boolean | null): string {
   if (typeof value === "boolean") return value ? "true" : "false";
   if (typeof value === "number") return String(value);
+  // value is string | null here — delegate the null/empty-string normalization
+  // to the shared `renderFrontmatterValue` seam so the YAML-null token lives in
+  // exactly one place in src/.
+  if (value === null || value === "") return renderFrontmatterValue(value);
   // Only quote strings that contain special YAML characters or could be misinterpreted
   if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(value)) return value;
   return `"${yamlEscape(value)}"`;


### PR DESCRIPTION
## Summary

Closes the cleanup surfaced by `task-138eb60b`'s retrospective: thread the remaining frontmatter writer (`formatYamlScalar` in `src/tasks/sync.ts`) through the shared `renderFrontmatterValue` seam, so the canonical YAML-null write-side literal `"null"` lives in exactly one place in `src/` (the helper's body in `markdown.ts`).

- Refactor `formatYamlScalar` to delegate the `string | null` subcase to `renderFrontmatterValue`. Boolean / number / identifier / quoted-string branches are unchanged and stay layered above the helper.
- Export `formatYamlScalar` and `setFrontmatterScalar`; add per-branch falsifier tests in `src/tasks/sync.test.ts` (one assertion per AC mutation: null, empty-string, boolean, number, identifier, quoted string), plus an AC7 falsifier harness for `setFrontmatterScalar`'s `desiredLine` short-circuit (first write `true`, identical second write `false`, mutation-verified by stubbing `renderFrontmatterValue` to a non-idempotent body — both the round-trip and the short-circuit tests fail).
- Known behavioural shift: `formatYamlScalar("")` now returns `"null"` instead of `'""'`. Only `github_labels` (zero-label issues) can hit this in production; the reader collapses both shapes to `undefined`, so in-memory state is unchanged. See proposal §"Known Behavioral Change" for the audit.
- Round 2 also amends `docs/proposals/task-c2af46fa.md` AC9 to fix a self-contradiction (the parenthetical broader claim conflicted with the Approach section's own grep expectation): the AC now reads **write-side** `"null"` literal, with read-side normalizers (`normalizeOptionalString`, `parseTaskFrontmatterLineFallback`, plus `=== "null"` comparisons in unrelated modules) explicitly out of scope.

Refs `docs/proposals/task-c2af46fa.md`.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run build` — clean.
- [x] `bun test src/tasks/sync.test.ts src/tasks/markdown.test.ts` — all pass (10 new tests this round across `formatYamlScalar` + `setFrontmatterScalar` blocks).
- [x] `bun test` — 1877 pass (pre-change baseline 1867), 2 pre-existing failures unrelated to this change (lint-test-isolation / PROPOSAL_FRESHNESS_WARNING boundary, both red on the pre-change base).
- [x] Mutation-tested AC7: replacing `renderFrontmatterValue`'s body with a non-idempotent stub flips the round-trip and short-circuit assertions; restored.
- [x] `grep -n '"null"' src/tasks/sync.ts` — no matches.
- [x] `bun run lint` — 4 pre-existing errors in `src/config.ts` (unrelated to this change), no new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)