### PR TITLE
Add withSyntheticHarness test helper for resolveQueueRequestCommand integration tests

### DIFF
--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -92,6 +92,20 @@ describe("checkRule1", () => {
     expect(checkRule1(src, "t.test.ts")).toEqual([]);
   });
 
+  test("whole-file exemption when `withSyntheticHarness(` appears anywhere", () => {
+    // Mirror of the withTestHarness exemption: withSyntheticHarness is the
+    // task-bad0f605 sibling helper that also owns LUDICS_HARNESS_DIR teardown.
+    const src = [
+      "import { withSyntheticHarness } from './test-utils.ts';",
+      "const getDir = withSyntheticHarness(beforeEach, afterEach);",
+      "",
+      "afterEach(() => {",
+      "  delete process.env.LUDICS_HARNESS_DIR;  // would flag without the exemption",
+      "});",
+    ].join("\n");
+    expect(checkRule1(src, "t.test.ts")).toEqual([]);
+  });
+
   test("flags when a nearby `if (X === undefined)` does not control the delete (codex P1)", () => {
     // The prior line's `if (orig === undefined) log();` is self-terminated by
     // `;` — the delete on the next line is unconditional and must flag.
@@ -256,6 +270,9 @@ describe("hasIsolationSetup", () => {
   });
   test("true if source calls withTestHarness(", () => {
     expect(hasIsolationSetup("const g = withTestHarness(beforeEach, afterEach);")).toBe(true);
+  });
+  test("true if source calls withSyntheticHarness(", () => {
+    expect(hasIsolationSetup("const g = withSyntheticHarness(beforeEach, afterEach);")).toBe(true);
   });
   test("false when neither token is present", () => {
     expect(hasIsolationSetup("const x = 1;")).toBe(false);
@@ -423,6 +440,19 @@ describe("checkRule3", () => {
       source: [
         "import { harnessDir } from './config.ts';",
         "const getHarness = withTestHarness(beforeEach, afterEach);",
+      ].join("\n"),
+      directImports: ["./config.ts"],
+      resolver: () => "src/config.ts",
+    });
+    expect(issues).toEqual([]);
+  });
+
+  test("negative: file uses withSyntheticHarness", () => {
+    const issues = rule3({
+      file: "src/x.test.ts",
+      source: [
+        "import { harnessDir } from './config.ts';",
+        "const getDir = withSyntheticHarness(beforeEach, afterEach);",
       ].join("\n"),
       directImports: ["./config.ts"],
       resolver: () => "src/config.ts",

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -16,7 +16,7 @@
  *                    imports `src/config.ts`, `src/events.ts`,
  *                    `src/slots/json.ts`, or `src/adapters/base.ts` without
  *                    either setting `LUDICS_HARNESS_DIR` or invoking
- *                    `withTestHarness(`.
+ *                    `withTestHarness(` / `withSyntheticHarness(`.
  *
  * Exit code: 1 iff errorCount > 0. Warnings never fail.
  */
@@ -40,8 +40,9 @@ export const RULE_3_TARGETS = new Set<string>([
 
 /**
  * Test files known-safe despite no explicit harness setup. Repo-relative with
- * forward slashes. Keep this list short — prefer adding `withTestHarness(` or
- * an explicit `process.env.LUDICS_HARNESS_DIR = ` in the test itself.
+ * forward slashes. Keep this list short — prefer adding `withTestHarness(`,
+ * `withSyntheticHarness(`, or an explicit `process.env.LUDICS_HARNESS_DIR = `
+ * in the test itself.
  */
 export const RULE_3_ALLOWLIST = new Set<string>([
   "src/adapters/task-launch.test.ts",
@@ -100,7 +101,7 @@ const GUARD_EQ = /[!=]==\s*undefined\b/;
  *       `{`, and the line before ends with `)` and contains `if (` +
  *       `=== undefined`.
  *   (F) File-wide exemption: the source contains the literal
- *       `withTestHarness(` anywhere.
+ *       `withTestHarness(` or `withSyntheticHarness(` anywhere.
  *
  * Crucially the bare 3-line lookback of "`if (` + `undefined` present somewhere
  * nearby" is *not* sufficient — codex (PR #402) flagged that pattern as a
@@ -109,7 +110,7 @@ const GUARD_EQ = /[!=]==\s*undefined\b/;
  */
 export function checkRule1(source: string, file: string): LintIssue[] {
   const out: LintIssue[] = [];
-  if (source.includes("withTestHarness(")) return out; // (F)
+  if (source.includes("withTestHarness(") || source.includes("withSyntheticHarness(")) return out; // (F)
 
   const lines = source.split("\n");
 
@@ -252,6 +253,7 @@ export function parseImports(source: string): string[] {
 export function hasIsolationSetup(source: string): boolean {
   return (
     source.includes("withTestHarness(") ||
+    source.includes("withSyntheticHarness(") ||
     /process\.env\.LUDICS_HARNESS_DIR\s*=(?!=)/.test(source)
   );
 }
@@ -317,7 +319,7 @@ export function checkRule3(input: Rule3Input): LintIssue[] {
           rule: "rule-3",
           severity: "warning",
           file: input.file,
-          message: `imports ${resolved} without LUDICS_HARNESS_DIR setup or withTestHarness() (direct import "${raw}")`,
+          message: `imports ${resolved} without LUDICS_HARNESS_DIR setup or withTestHarness()/withSyntheticHarness() (direct import "${raw}")`,
         },
       ];
     }
@@ -335,7 +337,7 @@ export function checkRule3(input: Rule3Input): LintIssue[] {
             rule: "rule-3",
             severity: "warning",
             file: input.file,
-            message: `imports ${nres} via ${resolved} ("${raw}") without LUDICS_HARNESS_DIR setup or withTestHarness()`,
+            message: `imports ${nres} via ${resolved} ("${raw}") without LUDICS_HARNESS_DIR setup or withTestHarness()/withSyntheticHarness()`,
           },
         ];
       }

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -1,41 +1,24 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
-import { tmpdir } from "os";
+import { mkdirSync, readFileSync } from "fs";
 import { join } from "path";
+import { withSyntheticHarness } from "./test-utils.ts";
 
 // Regression test for task-a00fc0d9 / docs/proposals/auto-compact-after-checkpoints.md:
 // every queued health-check / briefing request must be followed by a
 // { action: "message", content: "/compact" } request.
 
-let tmpDir: string;
-const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
-const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
-const ORIGINAL_CLUSTER_NAME = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+const getTmpDir = withSyntheticHarness(beforeEach, afterEach);
 
 beforeEach(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "ludics-auto-compact-"));
-  mkdirSync(join(tmpDir, "mag"), { recursive: true });
-  process.env.LUDICS_HARNESS_DIR = tmpDir;
-  // No config file → loadConfigSync throws → clusterEnabled() is false →
+  // Synthetic config has no `cluster:` block → clusterEnabled() is false →
   // clusterIsController() returns true (standalone). That harness condition
   // is what lets these branches reach the queueRequest calls; if it stops
   // holding, both tests fail because the queue stays empty.
-  delete process.env.LUDICS_CONFIG;
-  delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-});
-
-afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
-  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
-  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
-  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
-  if (ORIGINAL_CLUSTER_NAME === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-  else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_CLUSTER_NAME;
+  mkdirSync(join(getTmpDir(), "mag"), { recursive: true });
 });
 
 function readQueue(): Record<string, unknown>[] {
-  const qf = join(tmpDir, "mag", "queue.jsonl");
+  const qf = join(getTmpDir(), "mag", "queue.jsonl");
   const content = readFileSync(qf, "utf-8");
   return content
     .split("\n")

--- a/src/mag-health-gate.test.ts
+++ b/src/mag-health-gate.test.ts
@@ -1,40 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { resolveQueueRequestCommand } from "./mag.ts";
+import { withSyntheticHarness } from "./test-utils.ts";
 
 describe("resolveQueueRequestCommand — health-check activity gate", () => {
-  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
-  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
-  const ORIGINAL_CLUSTER_NAME = process.env.LUDICS_CLUSTER_MACHINE_NAME;
-  let stateDir: string;
-  let configPath: string;
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
 
   beforeEach(() => {
-    stateDir = mkdtempSync(join(tmpdir(), "mag-health-gate-"));
-    mkdirSync(join(stateDir, "journal"), { recursive: true });
-    mkdirSync(join(stateDir, "mag"), { recursive: true });
-    // Minimal config with no projects so runAllTestHealth() is a no-op
-    // when the gate does not skip.
-    configPath = join(stateDir, "config.yaml");
-    writeFileSync(configPath, "state_repo: test/state\nstate_path: harness\nprojects: []\n");
-    process.env.LUDICS_HARNESS_DIR = stateDir;
-    process.env.LUDICS_CONFIG = configPath;
-    delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-  });
-
-  afterEach(() => {
-    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
-    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
-    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
-    else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
-    if (ORIGINAL_CLUSTER_NAME === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_CLUSTER_NAME;
-    rmSync(stateDir, { recursive: true, force: true });
+    mkdirSync(join(getStateDir(), "journal"), { recursive: true });
+    mkdirSync(join(getStateDir(), "mag"), { recursive: true });
   });
 
   test("returns null and emits health_check_skipped when delta < 50", async () => {
+    const stateDir = getStateDir();
     const lines = Array.from({ length: 1030 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
     writeFileSync(
@@ -58,6 +37,7 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
   });
 
   test("peek path (executeProgrammatic=false) returns skill command regardless of gate", async () => {
+    const stateDir = getStateDir();
     const lines = Array.from({ length: 10 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
     writeFileSync(
@@ -70,6 +50,7 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
   });
 
   test("first run (no health-last.json) returns skill command", async () => {
+    const stateDir = getStateDir();
     const lines = Array.from({ length: 5 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
 
@@ -78,6 +59,7 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
   });
 
   test("delta over threshold returns skill command", async () => {
+    const stateDir = getStateDir();
     const lines = Array.from({ length: 1200 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
     writeFileSync(

--- a/src/mag-ready-candidates.test.ts
+++ b/src/mag-ready-candidates.test.ts
@@ -1,32 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 
 import { getSortedReadyCandidates } from "./mag.ts";
+import { withSyntheticHarness } from "./test-utils.ts";
 
-let tmpDir: string;
-const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
-const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
-const ORIGINAL_CLUSTER_NAME = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+const getTmpDir = withSyntheticHarness(beforeEach, afterEach);
 
 beforeEach(() => {
-  tmpDir = mkdtempSync(join(tmpdir(), "ludics-ready-candidates-"));
-  mkdirSync(join(tmpDir, "tasks"), { recursive: true });
-  mkdirSync(join(tmpDir, "slots"), { recursive: true });
-  process.env.LUDICS_HARNESS_DIR = tmpDir;
-  delete process.env.LUDICS_CONFIG;
-  delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-});
-
-afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
-  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
-  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
-  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
-  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
-  if (ORIGINAL_CLUSTER_NAME === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
-  else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_CLUSTER_NAME;
+  mkdirSync(join(getTmpDir(), "tasks"), { recursive: true });
+  mkdirSync(join(getTmpDir(), "slots"), { recursive: true });
 });
 
 function writeTask(id: string, fm: Record<string, string | boolean>): void {
@@ -48,7 +31,7 @@ function writeTask(id: string, fm: Record<string, string | boolean>): void {
   lines.push("created: 2026-04-29");
   lines.push("source: manual");
   lines.push("---", "", `# ${id}`, "");
-  writeFileSync(join(tmpDir, "tasks", `${id}.md`), lines.join("\n"));
+  writeFileSync(join(getTmpDir(), "tasks", `${id}.md`), lines.join("\n"));
 }
 
 describe("getSortedReadyCandidates leaf filter (AC2)", () => {

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
+import YAML from "yaml";
 import {
   captureConsoleError,
   captureConsoleLog,
   silenceConsoleError,
   silenceConsoleWarn,
+  withSyntheticHarness,
   withTestHarness,
 } from "./test-utils.ts";
 
@@ -118,6 +120,193 @@ describe("withTestHarness", () => {
     } finally {
       if (pre === undefined) delete process.env.LUDICS_HARNESS_DIR;
       else process.env.LUDICS_HARNESS_DIR = pre;
+    }
+  });
+});
+
+describe("withSyntheticHarness", () => {
+  function snapshotEnv(): { harness: string | undefined; config: string | undefined; cluster: string | undefined } {
+    return {
+      harness: process.env.LUDICS_HARNESS_DIR,
+      config: process.env.LUDICS_CONFIG,
+      cluster: process.env.LUDICS_CLUSTER_MACHINE_NAME,
+    };
+  }
+  function restoreEnv(s: { harness: string | undefined; config: string | undefined; cluster: string | undefined }): void {
+    if (s.harness === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = s.harness;
+    if (s.config === undefined) delete process.env.LUDICS_CONFIG;
+    else process.env.LUDICS_CONFIG = s.config;
+    if (s.cluster === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = s.cluster;
+  }
+
+  test("sets all three env vars correctly during a before/after cycle", () => {
+    const pre = snapshotEnv();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "before-helper";
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      expect(dir).not.toBe("");
+      expect(existsSync(dir)).toBe(true);
+      expect(process.env.LUDICS_HARNESS_DIR).toBe(dir);
+      expect(process.env.LUDICS_CONFIG).toBe(`${dir}/config.yaml`);
+      // LUDICS_CLUSTER_MACHINE_NAME must be cleared, not set to "undefined".
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).toBeUndefined();
+    } finally {
+      hooks.runAfter();
+      restoreEnv(pre);
+    }
+  });
+
+  test("restores captured sentinel values after teardown", () => {
+    const pre = snapshotEnv();
+    process.env.LUDICS_HARNESS_DIR = "/sentinel-harness";
+    process.env.LUDICS_CONFIG = "/sentinel-config";
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "sentinel-cluster";
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      expect(existsSync(dir)).toBe(true);
+      hooks.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/sentinel-harness");
+      expect(process.env.LUDICS_CONFIG).toBe("/sentinel-config");
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).toBe("sentinel-cluster");
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      restoreEnv(pre);
+    }
+  });
+
+  test("restores undefined when originals were unset (not the literal 'undefined')", () => {
+    const pre = snapshotEnv();
+    delete process.env.LUDICS_HARNESS_DIR;
+    delete process.env.LUDICS_CONFIG;
+    delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      expect(existsSync(dir)).toBe(true);
+      hooks.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBeUndefined();
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("undefined");
+      expect(process.env.LUDICS_CONFIG).toBeUndefined();
+      expect(process.env.LUDICS_CONFIG).not.toBe("undefined");
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).toBeUndefined();
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).not.toBe("undefined");
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      restoreEnv(pre);
+    }
+  });
+
+  test("config.yaml is written with projects: [] by default", () => {
+    const pre = snapshotEnv();
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      const cfgPath = `${dir}/config.yaml`;
+      expect(existsSync(cfgPath)).toBe(true);
+      const parsed = YAML.parse(readFileSync(cfgPath, "utf-8")) as Record<string, unknown>;
+      expect(parsed.state_repo).toBe("test/state");
+      expect(parsed.state_path).toBe("harness");
+      expect(parsed.projects).toEqual([]);
+    } finally {
+      hooks.runAfter();
+      restoreEnv(pre);
+    }
+  });
+
+  test("config.yaml reflects an explicit projects override when provided", () => {
+    const pre = snapshotEnv();
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after, {
+      projects: [
+        { name: "alpha", repo: "user/alpha" },
+        { name: "beta", repo: "user/beta", issues: true },
+      ],
+    });
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      const cfgPath = `${dir}/config.yaml`;
+      const parsed = YAML.parse(readFileSync(cfgPath, "utf-8")) as Record<string, unknown>;
+      expect(parsed.projects).toEqual([
+        { name: "alpha", repo: "user/alpha" },
+        { name: "beta", repo: "user/beta", issues: true },
+      ]);
+    } finally {
+      hooks.runAfter();
+      restoreEnv(pre);
+    }
+  });
+
+  test("tmpdir is removed after teardown", () => {
+    const pre = snapshotEnv();
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const dir = getDir();
+      expect(existsSync(dir)).toBe(true);
+      hooks.runAfter();
+      expect(existsSync(dir)).toBe(false);
+    } finally {
+      restoreEnv(pre);
+    }
+  });
+
+  test("returns a fresh tmpdir on each before/after cycle", () => {
+    const pre = snapshotEnv();
+    const hooks = captureHooks();
+    const getDir = withSyntheticHarness(hooks.before, hooks.after);
+    try {
+      hooks.runBefore();
+      const first = getDir();
+      hooks.runAfter();
+      hooks.runBefore();
+      const second = getDir();
+      hooks.runAfter();
+      expect(first).not.toBe(second);
+    } finally {
+      restoreEnv(pre);
+    }
+  });
+
+  test("double registration: each helper restores the real original, not a sibling's tmpdir or config path", () => {
+    const pre = snapshotEnv();
+    process.env.LUDICS_HARNESS_DIR = "/real-harness";
+    process.env.LUDICS_CONFIG = "/real-config";
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "real-cluster";
+    const hooksA = captureHooks();
+    const hooksB = captureHooks();
+    try {
+      // Both helpers register at the same "real original" — i.e. before any before() runs.
+      withSyntheticHarness(hooksA.before, hooksA.after);
+      withSyntheticHarness(hooksB.before, hooksB.after);
+
+      // Simulate per-test lifecycle with both helpers active.
+      hooksA.runBefore();
+      hooksB.runBefore();
+      expect(process.env.LUDICS_HARNESS_DIR).not.toBe("/real-harness");
+      expect(process.env.LUDICS_CONFIG).not.toBe("/real-config");
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).toBeUndefined();
+      // Teardown in either order must land back on the real originals.
+      hooksA.runAfter();
+      hooksB.runAfter();
+      expect(process.env.LUDICS_HARNESS_DIR).toBe("/real-harness");
+      expect(process.env.LUDICS_CONFIG).toBe("/real-config");
+      expect(process.env.LUDICS_CLUSTER_MACHINE_NAME).toBe("real-cluster");
+    } finally {
+      restoreEnv(pre);
     }
   });
 });

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,8 +1,10 @@
 // Shared test utilities for the ludics test suite.
 
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import YAML from "yaml";
+import type { ProjectConfig } from "./config.ts";
 
 /**
  * Whether this environment can bind a loopback socket.
@@ -83,6 +85,57 @@ export function withTestHarness(
   after(() => {
     if (saved === undefined) delete process.env.LUDICS_HARNESS_DIR;
     else process.env.LUDICS_HARNESS_DIR = saved;
+    rmSync(dir, { recursive: true, force: true });
+  });
+  return () => dir;
+}
+
+export interface WithSyntheticHarnessOptions {
+  projects?: ProjectConfig[];
+}
+
+/**
+ * Isolate LUDICS_HARNESS_DIR + LUDICS_CONFIG + LUDICS_CLUSTER_MACHINE_NAME for tests
+ * that drive `resolveQueueRequestCommand` (or any code that hits `loadConfigSync()` /
+ * `runAllTestHealth()`). Without this trio, those code paths load the real user
+ * config and run actual project test suites — see task-4889872a / PR #390.
+ *
+ * Returns a getter for the current synthetic state directory so tests can write
+ * fixture files (`journal/events.jsonl`, `mag/health-last.json`, etc.) inside it.
+ */
+export function withSyntheticHarness(
+  before: (fn: () => void) => void,
+  after: (fn: () => void) => void,
+  opts?: WithSyntheticHarnessOptions,
+): () => string {
+  // Capture originals at registration time, not inside `before`, so a file that
+  // registers the helper twice doesn't save a sibling helper's tmp values as
+  // "original" and leak deleted paths back into process.env after teardown.
+  const savedHarness = process.env.LUDICS_HARNESS_DIR;
+  const savedConfig = process.env.LUDICS_CONFIG;
+  const savedCluster = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  const projects = opts?.projects ?? [];
+  let dir = "";
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "ludics-test-synthetic-"));
+    const cfgPath = join(dir, "config.yaml");
+    const cfgBody = YAML.stringify({
+      state_repo: "test/state",
+      state_path: "harness",
+      projects,
+    });
+    writeFileSync(cfgPath, cfgBody);
+    process.env.LUDICS_HARNESS_DIR = dir;
+    process.env.LUDICS_CONFIG = cfgPath;
+    delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  });
+  after(() => {
+    if (savedHarness === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = savedHarness;
+    if (savedConfig === undefined) delete process.env.LUDICS_CONFIG;
+    else process.env.LUDICS_CONFIG = savedConfig;
+    if (savedCluster === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = savedCluster;
     rmSync(dir, { recursive: true, force: true });
   });
   return () => dir;


### PR DESCRIPTION
## Summary

- Add `withSyntheticHarness(before, after, opts?)` to `src/test-utils.ts` — a sibling of `withTestHarness` that manages the `LUDICS_HARNESS_DIR` + `LUDICS_CONFIG` + `LUDICS_CLUSTER_MACHINE_NAME` trio. Without these three, `runAllTestHealth()` loads the real user config and runs actual project test suites (the trap from task-4889872a / PR #390).
- Optional `opts.projects` is serialised into the synthetic `config.yaml` for tests that want to drive iteration paths.
- Migrate `src/mag-health-gate.test.ts`, `src/mag-auto-compact.test.ts`, and `src/mag-ready-candidates.test.ts` to the helper. None of the three files now contains explicit env-var save/restore boilerplate.
- Extend `scripts/lint-test-isolation.ts` to recognise `withSyntheticHarness(` as an isolation-setup token (matches `withTestHarness(` for both rule-1 file-wide exemption and rule-3 setup detection), keeping the CI drift pair in sync.

See `docs/proposals/with-synthetic-harness-test-helper.md` for the authoritative ACs and the AC self-check in `.peer-sync/workflow-feedback-coder.md`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test src/test-utils.test.ts src/mag-health-gate.test.ts src/mag-auto-compact.test.ts src/mag-ready-candidates.test.ts scripts/lint-test-isolation.test.ts`
- [x] full `bun test` — 1878 pass; the two failures (`lint-test-isolation` pinned warning-count + `PROPOSAL_FRESHNESS_WARNING` boundary) reproduce on the base branch and are unrelated.
- [x] `bun run lint` — 4 pre-existing errors in `src/config.ts` (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)