### PR TITLE
gh-ludics-438: lint sub-command CLI drift + registry refactor for runMag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Lint CLI/README drift
         run: bun run lint:cli-readme
 
+      - name: Lint CLI sub-command drift
+        run: bun run lint:cli-subcommands
+
       - name: Lint config reference drift
         run: bun run lint:config-reference
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "bun run --bun eslint \"src/**/*.ts\" --max-warnings=0",
     "lint:fix": "bun run --bun eslint \"src/**/*.ts\" --fix",
     "lint:cli-readme": "bun run scripts/lint-cli-readme.ts",
+    "lint:cli-subcommands": "bun run scripts/lint-cli-subcommands.ts",
     "lint:config-reference": "bun run scripts/lint-config-reference.ts",
     "lint:contracts": "bun run scripts/lint-contracts.ts",
     "lint:hooks": "bun run scripts/lint-hooks.ts",

--- a/scripts/lint-cli-subcommands.test.ts
+++ b/scripts/lint-cli-subcommands.test.ts
@@ -1,0 +1,382 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  DISPATCHERS,
+  ALIASES,
+  INTERNAL_HIDDEN,
+  USAGE_INLINE_HANDLED,
+  extractNamedBody,
+  extractCasesFromFn,
+  extractRegistryMapKeys,
+  extractRegistryRecordKeys,
+  extractIfElseSubs,
+  extractListing,
+  extractUsageSubs,
+  extractCasesForSite,
+  checkSite,
+  lintCliSubcommands,
+} from "./lint-cli-subcommands.ts";
+import { extractUsageBlock } from "./lint-cli-readme.ts";
+import { runTasks } from "../src/tasks/index.ts";
+
+const root = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Pure extractor unit tests (in-memory fixtures)
+// ---------------------------------------------------------------------------
+
+describe("extractNamedBody", () => {
+  test("returns the body of a function declaration via brace balancing", () => {
+    const src = `function foo() {\n  if (1) { x }\n  return 2;\n}\n`;
+    const body = extractNamedBody(src, "foo", "{");
+    expect(body).toContain("if (1)");
+    expect(body).toContain("return 2");
+  });
+
+  test("returns the array body of a const = new Map([...]) literal", () => {
+    const src = [
+      "const reg = new Map<string, Handler>([",
+      `  ["alpha", () => {}],`,
+      `  ["beta",  betaHandler],`,
+      "]);",
+    ].join("\n");
+    const body = extractNamedBody(src, "reg", "[");
+    expect(body).toContain(`"alpha"`);
+    expect(body).toContain(`"beta"`);
+  });
+
+  test("returns empty string when the name is absent", () => {
+    expect(extractNamedBody("// nothing here", "missing", "{")).toBe("");
+  });
+});
+
+describe("extractCasesFromFn (switch shape)", () => {
+  test("captures every case literal at any indent depth", () => {
+    const body = `
+      switch (sub) {
+        case "alpha": doA(); break;
+        case "beta": {
+          doB();
+          break;
+        }
+        default:
+          throw new Error("nope");
+      }
+    `;
+    const cases = extractCasesFromFn(body);
+    expect([...cases].sort()).toEqual(["alpha", "beta"]);
+  });
+
+  test("ignores nested switch case literals when scoped to outer body", () => {
+    // Nested switch sits inside an outer `case` body. We deliberately keep
+    // the regex flat — both the outer "alpha" and inner "x"/"y" are picked
+    // up. The lint relies on first-level scoping at the *site* level
+    // (we run extractCasesFromFn against the registered fnName's body
+    // only), not on this regex understanding nesting.
+    const body = `
+      case "alpha": {
+        switch (sub2) {
+          case "x": break;
+          case "y": break;
+        }
+        break;
+      }
+    `;
+    const cases = extractCasesFromFn(body);
+    expect(cases.has("alpha")).toBe(true);
+    expect(cases.has("x")).toBe(true);
+    expect(cases.has("y")).toBe(true);
+  });
+});
+
+describe("extractRegistryMapKeys (registry-map shape)", () => {
+  test("captures every entry with mixed handler shapes", () => {
+    const body = [
+      `["one", oneHandler],`,
+      `["two", async (args) => { doB(args); }],`,
+      `["three", (args) => doC(args)],`,
+      `["four-with-dash", async () => doD()],`,
+    ].join("\n  ");
+    const keys = extractRegistryMapKeys(body);
+    expect([...keys].sort()).toEqual(["four-with-dash", "one", "three", "two"]);
+  });
+});
+
+describe("extractRegistryRecordKeys (registry-record shape)", () => {
+  test("captures top-level record keys but not nested object literals", () => {
+    const body = [
+      "  alpha: handlerA,",
+      "  beta: async (args) => {",
+      "    if (args[0]) {",
+      "      something({ inner: true });", // nested key — must be ignored
+      "    }",
+      "  },",
+      "  gamma: handlerG,",
+    ].join("\n");
+    const keys = extractRegistryRecordKeys(body);
+    expect([...keys].sort()).toEqual(["alpha", "beta", "gamma"]);
+    expect(keys.has("inner")).toBe(false);
+  });
+});
+
+describe("extractIfElseSubs (if-else shape)", () => {
+  test("captures every `sub === \"X\"` branch and ignores empty-string", () => {
+    const body = `
+      if (sub === "status" || sub === "") {
+        statusFn();
+      } else if (sub === "alpha") {
+        alphaFn();
+      } else if (sub === "beta") {
+        betaFn();
+      } else {
+        throw new Error("unknown");
+      }
+    `;
+    const subs = extractIfElseSubs(body);
+    expect([...subs].sort()).toEqual(["alpha", "beta", "status"]);
+  });
+});
+
+describe("extractListing", () => {
+  test("captures the (use: ...) entries via the unknown-<prefix> pattern", () => {
+    const body = `throw new Error(\`unknown flow command: \${sub} (use: ready, blocked, critical)\`);`;
+    const set = extractListing(body, "flow");
+    expect(set).not.toBeNull();
+    expect([...set!].sort()).toEqual(["blocked", "critical", "ready"]);
+  });
+
+  test("tolerates 'subcommand' wording (runTasks shape)", () => {
+    const body = `throw new Error(\`unknown tasks subcommand: \${sub} (use: a, b, c)\`);`;
+    const set = extractListing(body, "tasks");
+    expect(set).not.toBeNull();
+    expect([...set!].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns null when the pattern is absent", () => {
+    expect(extractListing("nothing relevant", "mag")).toBeNull();
+  });
+});
+
+describe("extractUsageSubs", () => {
+  test("scopes matches to the requested prefix", () => {
+    const usage = [
+      "  mag start                 Start",
+      "  mag elaborate <id>        Elab",
+      "  flow ready                Show",
+      "  flow blocked              Show",
+    ].join("\n");
+    const mag = extractUsageSubs(usage, "mag");
+    const flow = extractUsageSubs(usage, "flow");
+    expect([...mag].sort()).toEqual(["elaborate", "start"]);
+    expect([...flow].sort()).toEqual(["blocked", "ready"]);
+  });
+
+  test("for the ludics top-level prefix returns top-level commands", () => {
+    const usage = [
+      "  tasks ls                  List",
+      "  flow ready                Show",
+      "  status                    Overview",
+    ].join("\n");
+    const top = extractUsageSubs(usage, "ludics");
+    expect(top.has("tasks")).toBe(true);
+    expect(top.has("flow")).toBe(true);
+    expect(top.has("status")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkSite — negative fixtures, one per invariant
+// ---------------------------------------------------------------------------
+
+describe("checkSite — negative fixtures", () => {
+  test("flags case implemented but undocumented in USAGE", () => {
+    const src = [
+      "function runFoo(args: string[]) {",
+      `  switch (args[0]) {`,
+      `    case "alpha": break;`,
+      `    case "beta": break;`,
+      `    default: throw new Error(\`unknown foo command: \${sub} (use: alpha, beta)\`);`,
+      "  }",
+      "}",
+    ].join("\n");
+    const usage = "  foo alpha   first\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: true },
+      src,
+      usage,
+    );
+    expect(result.errors.some((e) => e.includes("undocumented in USAGE"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("beta"))).toBe(true);
+  });
+
+  test("flags case implemented but missing from default listing", () => {
+    const src = [
+      "function runFoo(args: string[]) {",
+      `  switch (args[0]) {`,
+      `    case "alpha": break;`,
+      `    case "beta": break;`,
+      `    default: throw new Error(\`unknown foo command: \${sub} (use: alpha)\`);`,
+      "  }",
+      "}",
+    ].join("\n");
+    const usage = "  foo alpha   first\n  foo beta   second\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: true },
+      src,
+      usage,
+    );
+    expect(result.errors.some((e) => e.includes("missing from default (use:"))).toBe(true);
+  });
+
+  test("flags listing entry with no implementation", () => {
+    const src = [
+      "function runFoo(args: string[]) {",
+      `  switch (args[0]) {`,
+      `    case "alpha": break;`,
+      `    default: throw new Error(\`unknown foo command: \${sub} (use: alpha, ghost)\`);`,
+      "  }",
+      "}",
+    ].join("\n");
+    const usage = "  foo alpha   first\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: true },
+      src,
+      usage,
+    );
+    expect(result.errors.some((e) => e.includes("no implementation"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("ghost"))).toBe(true);
+  });
+
+  test("flags documented command with no implementation", () => {
+    const src = [
+      "function runFoo(args: string[]) {",
+      `  switch (args[0]) {`,
+      `    case "alpha": break;`,
+      `    default: throw new Error(\`unknown foo command: \${sub} (use: alpha)\`);`,
+      "  }",
+      "}",
+    ].join("\n");
+    const usage = "  foo alpha   first\n  foo phantom  fake\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: true },
+      src,
+      usage,
+    );
+    expect(result.errors.some((e) => e.includes("documented in USAGE but no implementation"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("phantom"))).toBe(true);
+  });
+
+  test("flags zero-case extractor breakage", () => {
+    const src = "function runFoo() {}\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: false },
+      src,
+      "",
+    );
+    expect(result.errors.some((e) => e.includes("zero cases"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allow-list and internal-hidden tables — sanity
+// ---------------------------------------------------------------------------
+
+describe("ALIASES + INTERNAL_HIDDEN tables", () => {
+  test("each ALIASES prefix is a real DISPATCHERS prefix", () => {
+    const validPrefixes = new Set(DISPATCHERS.map((d) => d.prefix));
+    for (const prefix of Object.keys(ALIASES)) {
+      expect(validPrefixes.has(prefix)).toBe(true);
+    }
+  });
+
+  test("INTERNAL_HIDDEN names are subsets of valid prefixes", () => {
+    const validPrefixes = new Set(DISPATCHERS.map((d) => d.prefix));
+    for (const prefix of Object.keys(INTERNAL_HIDDEN)) {
+      expect(validPrefixes.has(prefix)).toBe(true);
+    }
+  });
+
+  test("USAGE_INLINE_HANDLED is restricted to ludics today", () => {
+    expect(Object.keys(USAGE_INLINE_HANDLED)).toEqual(["ludics"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-repo smoke — must hold after Phases 1+2 land
+// ---------------------------------------------------------------------------
+
+describe("real repository", () => {
+  test("lintCliSubcommands returns no errors against the real source", () => {
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const usageBlock = extractUsageBlock(indexSrc);
+    const results = lintCliSubcommands(
+      (rel) => readFileSync(join(root, rel), "utf-8"),
+      usageBlock,
+    );
+    const allErrors = results.flatMap((r) => r.errors);
+    if (allErrors.length > 0) {
+      // Surface the actual mismatches in the test failure message.
+      throw new Error(`real-repo drift:\n${allErrors.map((e) => "  - " + e).join("\n")}`);
+    }
+    expect(allErrors).toEqual([]);
+    expect(results.length).toBe(10);
+  });
+
+  test("runTasks unknown-subcommand listing now contains queue-elaborations", async () => {
+    // Invariant: the runTasks default listing on `main` was missing
+    // queue-elaborations even though the case existed. The Phase 1 fix
+    // restored it; this test catches regressions.
+    // Harness condition: invoke runTasks with a sentinel sub that is not
+    // any real case label.
+    let err: Error | null = null;
+    try {
+      await runTasks(["__bogus__"]);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain("queue-elaborations");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Floor-count meta-tests (gh-ludics-406 convention)
+// ---------------------------------------------------------------------------
+
+describe("floor-count guards (gh-ludics-406)", () => {
+  // Failure modes these guards catch:
+  //   (a) a future DRY refactor collapses the case literals (e.g. introduces
+  //       a generated table) — extractor returns 0/few hits, lint passes
+  //       vacuously without the guard;
+  //   (b) the extractor regex itself drifts and silently stops matching.
+  //
+  // Today: runMag registry has 25 entries; MIGRATED_COMMANDS has 27. Floors
+  // are set with slack so single-command removals do not trip the guard.
+
+  test("magSubcommands registry size ≥ 20", () => {
+    const src = readFileSync(join(root, "src", "mag.ts"), "utf-8");
+    const body = extractNamedBody(src, "magSubcommands", "[");
+    const keys = extractCasesForSite(body, "registry-map");
+    expect(keys.size).toBeGreaterThanOrEqual(20);
+  });
+
+  test("MIGRATED_COMMANDS top-level keys ≥ 20", () => {
+    const src = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const body = extractNamedBody(src, "MIGRATED_COMMANDS", "{");
+    const keys = extractCasesForSite(body, "registry-record");
+    expect(keys.size).toBeGreaterThanOrEqual(20);
+  });
+
+  test("each switch dispatcher has at least one case extracted", () => {
+    // Positive control for the switch extractor across every site that uses
+    // the shape; protects against the regex breaking on a syntax variation.
+    for (const site of DISPATCHERS) {
+      if (site.shape !== "switch") continue;
+      const src = readFileSync(join(root, site.file), "utf-8");
+      const body = extractNamedBody(src, site.fnName, "{");
+      const cases = extractCasesForSite(body, "switch");
+      expect(cases.size).toBeGreaterThan(0);
+    }
+  });
+});

--- a/scripts/lint-cli-subcommands.test.ts
+++ b/scripts/lint-cli-subcommands.test.ts
@@ -276,6 +276,32 @@ describe("checkSite — negative fixtures", () => {
     );
     expect(result.errors.some((e) => e.includes("zero cases"))).toBe(true);
   });
+
+  test("flags hasListing: true site whose default error drops the (use: ...) clause", () => {
+    // Codex review (2026-04-30): without this guard, a dispatcher with
+    // `hasListing: true` whose default error reverts to the bare
+    // `unknown foo command: ${sub}` (no `(use: ...)` clause) silently
+    // passes — extractListing returns null and the cases ⊄ listing /
+    // listing ⊄ cases checks are skipped entirely.
+    const src = [
+      "function runFoo(args: string[]) {",
+      `  switch (args[0]) {`,
+      `    case "alpha": break;`,
+      `    case "beta": break;`,
+      `    default: throw new Error(\`unknown foo command: \${sub}\`);`,
+      "  }",
+      "}",
+    ].join("\n");
+    const usage = "  foo alpha   first\n  foo beta   second\n";
+    const result = checkSite(
+      { file: "f.ts", prefix: "foo", fnName: "runFoo", shape: "switch", hasListing: true },
+      src,
+      usage,
+    );
+    expect(
+      result.errors.some((e) => e.includes("expected canonical default") && e.includes("(use: ...)")),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lint-cli-subcommands.ts
+++ b/scripts/lint-cli-subcommands.ts
@@ -314,6 +314,18 @@ export function checkSite(
     );
   }
 
+  // hasListing: true means the dispatcher promises a default `(use: …)`
+  // listing. If extractListing returned null (the clause is missing or its
+  // shape no longer matches the canonical regex), surface that as a
+  // violation — silently skipping the comparison would let a regression
+  // that drops the listing pass the lint, which is the very drift this
+  // script exists to catch.
+  if (site.hasListing && listing === null) {
+    errors.push(
+      `[${site.prefix}] expected canonical default '(use: ...)' listing in ${site.fnName} body, found none — listing must match /unknown ${site.prefix} (sub)?command: \\$\\{var\\} \\(use: …\\)/`,
+    );
+  }
+
   if (normListing) {
     const casesNotInListing = setDiff(normCases, normListing);
     if (casesNotInListing.length > 0) {

--- a/scripts/lint-cli-subcommands.ts
+++ b/scripts/lint-cli-subcommands.ts
@@ -287,8 +287,12 @@ export function checkSite(
   const usageSubs = extractUsageSubs(usageBlock, site.prefix);
 
   // For comparison, normalise (alias-resolve, drop empty/hidden).
+  // The listing is NOT stripped of hidden entries: that way, if a hidden
+  // hook/internal entry leaks back into the user-facing listing, the
+  // listing-vs-cases comparison surfaces the leak (listing has it, normCases
+  // does not). All current dispatcher listings exclude hidden entries.
   const normCases = normalise(cases, site.prefix, { stripHidden: true });
-  const normListing = listing ? normalise(listing, site.prefix, { stripHidden: true }) : null;
+  const normListing = listing ? normalise(listing, site.prefix, { stripHidden: false }) : null;
   const inlineHandled = new Set(USAGE_INLINE_HANDLED[site.prefix] ?? []);
   const normUsage = new Set(
     [...normalise(usageSubs, site.prefix, { stripHidden: false })].filter((x) => !inlineHandled.has(x)),

--- a/scripts/lint-cli-subcommands.ts
+++ b/scripts/lint-cli-subcommands.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env bun
+/**
+ * lint-cli-subcommands.ts (gh-ludics-438)
+ *
+ * Catches the silent triple-edit drift that `lint:cli-readme` doesn't see:
+ *   - cases / registry keys in each sub-dispatcher
+ *   - sub-command lines in src/index.ts USAGE for the matching prefix
+ *   - the literal listing in the dispatcher's default `(use: …)` clause
+ *
+ * Invariants enforced for each registered site:
+ *   1. cases ⊆ usageSubs        — implemented but undocumented
+ *   2. cases ⊆ listing          — implemented but missing from default error
+ *   3. listing ⊆ cases          — listing entry with no implementation
+ *   4. usageSubs ⊆ cases        — documented but unimplemented
+ *
+ * Aliases (allow-list) and internal-hidden commands are normalised before
+ * comparison. The top-level ludics site has no hand-maintained listing — the
+ * unknown-command message is derived from MIGRATED_COMMANDS keys via
+ * formatUnknownTopLevel — so only invariants 1 and 4 apply there.
+ *
+ * SILENT-DRIFT WARNING (gh-ludics-406): the per-shape extractors below are
+ * regex over source. A DRY refactor that collapses the literals would let
+ * this lint pass vacuously. Floor-count meta-tests in
+ * scripts/lint-cli-subcommands.test.ts guard against that.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { extractUsageBlock } from "./lint-cli-readme.ts";
+
+const root = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Site registry
+// ---------------------------------------------------------------------------
+
+export type DispatcherShape = "switch" | "registry-map" | "registry-record" | "if-else";
+
+export interface DispatcherSite {
+  file: string;          // e.g. "src/mag.ts" — repo-relative
+  prefix: string;        // appears in USAGE block + unknown-command error
+  fnName: string;        // function or top-level identifier scoping the body
+  shape: DispatcherShape;
+  hasListing: boolean;   // false for ludics (listing is derived from keys)
+}
+
+export const DISPATCHERS: ReadonlyArray<DispatcherSite> = [
+  // mag: hasListing: false because the unknown-command listing in runMag is
+  // derived programmatically from magSubcommands.keys() — checking it would
+  // be tautological. The cases set IS the listing by construction.
+  { file: "src/mag.ts",                  prefix: "mag",       fnName: "magSubcommands",     shape: "registry-map",    hasListing: false },
+  { file: "src/flow.ts",                 prefix: "flow",      fnName: "runFlow",            shape: "switch",          hasListing: true },
+  { file: "src/tasks/index.ts",          prefix: "tasks",     fnName: "runTasks",           shape: "switch",          hasListing: true },
+  { file: "src/triggers.ts",             prefix: "triggers",  fnName: "runTriggers",        shape: "switch",          hasListing: true },
+  { file: "src/notify.ts",               prefix: "notify",    fnName: "runNotify",          shape: "switch",          hasListing: true },
+  { file: "src/cluster.ts",              prefix: "cluster",   fnName: "runCluster",         shape: "switch",          hasListing: true },
+  { file: "src/dashboard.ts",            prefix: "dashboard", fnName: "runDashboard",       shape: "switch",          hasListing: true },
+  { file: "src/orchestration/index.ts",  prefix: "orch",      fnName: "runOrchestrationCli",shape: "switch",          hasListing: true },
+  { file: "src/network.ts",              prefix: "network",   fnName: "runNetwork",         shape: "if-else",         hasListing: true },
+  { file: "src/index.ts",                prefix: "ludics",    fnName: "MIGRATED_COMMANDS",  shape: "registry-record", hasListing: false },
+];
+
+// canonical → alias. The alias may legitimately be missing from USAGE/listing
+// as long as the canonical name is present.
+export const ALIASES: Record<string, ReadonlyArray<readonly [string, string]>> = {
+  mag:      [["on-stop", "queue-pop"]],          // queue-pop deprecated
+  triggers: [["pause", "disable"], ["status", ""]],
+  cluster:  [["status", ""]],
+  orch:     [["status", ""]],
+  notify:   [["outgoing", "pai"]],
+  network:  [["status", ""]],
+  ludics:   [["orch", "orchestration"]],
+};
+
+// Real cases / keys excluded from the public USAGE + listing comparisons.
+// These are internal entry points (hook scripts, self-relaunch) that should
+// stay callable but never surface in user help.
+export const INTERNAL_HIDDEN: Record<string, ReadonlyArray<string>> = {
+  mag: ["on-stop", "queue-pop"],     // Stop-hook entry; queue-pop is deprecated alias of on-stop
+  orch: ["run-internal", "on-stop"], // run-internal is self-relaunch; on-stop is Stop-hook entry
+};
+
+// USAGE-side allow-list: documented commands that are intentionally not
+// dispatched through the registered cases (e.g. ludics `help` is handled
+// inline in main() before dispatch). These are dropped from the
+// "documented but no implementation" comparison only.
+export const USAGE_INLINE_HANDLED: Record<string, ReadonlyArray<string>> = {
+  ludics: ["help"],
+};
+
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+// Locate the body of a named function declaration / arrow / top-level const,
+// returning the substring inside its outermost balanced delimiters. `open`
+// selects whether to track `{}` (function/object bodies) or `[]` (Map([...])
+// registry-map shape). Walks balanced delimiters with a depth counter; no AST.
+// Returns "" if the name is not found.
+export function extractNamedBody(
+  source: string,
+  name: string,
+  open: "{" | "[" = "{",
+): string {
+  const close = open === "{" ? "}" : "]";
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$1");
+  const pattern = new RegExp(
+    `(?:async\\s+function|function|const|let|export\\s+(?:async\\s+function|function|const|let))\\s+${escaped}\\b`,
+    "g",
+  );
+  let m: RegExpExecArray | null;
+  while ((m = pattern.exec(source)) !== null) {
+    const startIdx = source.indexOf(open, m.index);
+    if (startIdx === -1) continue;
+    let depth = 0;
+    for (let i = startIdx; i < source.length; i++) {
+      const ch = source[i];
+      if (ch === open) depth++;
+      else if (ch === close) {
+        depth--;
+        if (depth === 0) {
+          return source.slice(startIdx + 1, i);
+        }
+      }
+    }
+  }
+  return "";
+}
+
+// Pick the body-delimiter pair for a given dispatcher shape.
+function openBracketFor(shape: DispatcherShape): "{" | "[" {
+  return shape === "registry-map" ? "[" : "{";
+}
+
+// switch-shape: extract `case "X":` literals.
+export function extractCasesFromFn(body: string): Set<string> {
+  const out = new Set<string>();
+  const re = /^\s*case\s+"([\w-]+)":/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.add(m[1]!);
+  return out;
+}
+
+// registry-map shape: extract first elements of `["X", handler]` tuples.
+export function extractRegistryMapKeys(body: string): Set<string> {
+  const out = new Set<string>();
+  // `\[\s*"X",\s*<identifier-or-async-arrow-or-paren>` — handler shape varies.
+  const re = /\[\s*"([\w-]+)"\s*,\s*(?:[a-zA-Z_$]|async\s|\()/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.add(m[1]!);
+  return out;
+}
+
+// registry-record shape: extract object-literal keys at top indent of body.
+// Two-space indent matches the existing convention in src/index.ts.
+export function extractRegistryRecordKeys(body: string): Set<string> {
+  const out = new Set<string>();
+  // Bareword keys followed by ":". Excludes nested object keys via indent
+  // restriction (only the outer record's two-space-indented keys).
+  const re = /^\s{2}([a-zA-Z_$][\w-]*):\s*/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.add(m[1]!);
+  return out;
+}
+
+// if-else shape (e.g. runNetwork): extract `sub === "X"` literals.
+export function extractIfElseSubs(body: string): Set<string> {
+  const out = new Set<string>();
+  const re = /sub\s*===\s*"([\w-]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) out.add(m[1]!);
+  return out;
+}
+
+// Parse the (use: a, b, c) listing from a default-case error string.
+// Tolerates both "command" and "subcommand" wording.
+export function extractListing(body: string, prefix: string): Set<string> | null {
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$1");
+  const re = new RegExp(
+    `unknown\\s+${escaped}\\s+(?:sub)?command:\\s+\\$\\{[^}]+\\}\\s+\\(use:\\s*([^)]*)\\)`,
+  );
+  const m = body.match(re);
+  if (!m) return null;
+  const out = new Set<string>();
+  for (const raw of m[1]!.split(/,\s*/)) {
+    const trimmed = raw.trim();
+    if (trimmed) out.add(trimmed);
+  }
+  return out;
+}
+
+// Extract sub-command names documented in USAGE for a given prefix.
+// For the top-level "ludics" prefix, return the top-level commands instead
+// (matching the existing lint:cli-readme regex).
+export function extractUsageSubs(usageBlock: string, prefix: string): Set<string> {
+  const out = new Set<string>();
+  if (prefix === "ludics") {
+    const re = /^\s{1,4}([a-z][\w-]*)\b/gm;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(usageBlock)) !== null) out.add(m[1]!);
+    return out;
+  }
+  const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$1");
+  const re = new RegExp(`^\\s{2,4}${escaped}\\s+([a-z][\\w-]*)\\b`, "gm");
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(usageBlock)) !== null) out.add(m[1]!);
+  return out;
+}
+
+function aliasMapsFor(prefix: string): { aliasOf: Map<string, string> } {
+  const aliasOf = new Map<string, string>();
+  for (const [canonical, alias] of ALIASES[prefix] ?? []) {
+    aliasOf.set(alias, canonical);
+  }
+  return { aliasOf };
+}
+
+// Normalise a set: drop empty strings, drop aliases (resolve to canonical),
+// drop internal-hidden commands (only when stripping for public comparison).
+function normalise(
+  set: Set<string>,
+  prefix: string,
+  options: { stripHidden: boolean },
+): Set<string> {
+  const { aliasOf } = aliasMapsFor(prefix);
+  const hidden = options.stripHidden
+    ? new Set(INTERNAL_HIDDEN[prefix] ?? [])
+    : new Set<string>();
+  const out = new Set<string>();
+  for (const x of set) {
+    if (!x) continue;
+    if (hidden.has(x)) continue;
+    const canonical = aliasOf.get(x) ?? x;
+    out.add(canonical);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Per-site invariant check
+// ---------------------------------------------------------------------------
+
+export interface SiteResult {
+  site: DispatcherSite;
+  caseCount: number;          // raw count, useful for floor-count meta-tests
+  errors: string[];
+  cases: Set<string>;          // raw extracted (pre-normalisation) — for tests
+  listing: Set<string> | null; // raw extracted
+  usageSubs: Set<string>;      // raw extracted
+}
+
+export function extractCasesForSite(
+  body: string,
+  shape: DispatcherShape,
+): Set<string> {
+  switch (shape) {
+    case "switch":           return extractCasesFromFn(body);
+    case "registry-map":     return extractRegistryMapKeys(body);
+    case "registry-record":  return extractRegistryRecordKeys(body);
+    case "if-else":          return extractIfElseSubs(body);
+  }
+}
+
+function setDiff<T>(a: Set<T>, b: Set<T>): T[] {
+  const out: T[] = [];
+  for (const x of a) if (!b.has(x)) out.push(x);
+  return out.sort();
+}
+
+export function checkSite(
+  site: DispatcherSite,
+  source: string,
+  usageBlock: string,
+): SiteResult {
+  // Cases come from the shape-appropriate body (array-literal for
+  // registry-map, brace body otherwise). The default-case listing always
+  // lives inside the function's brace body, so re-extract with `{` for the
+  // listing search even when the cases body was an array literal.
+  const caseBody = extractNamedBody(source, site.fnName, openBracketFor(site.shape));
+  const cases = extractCasesForSite(caseBody, site.shape);
+  // Listings always live inside a brace-bodied function. For switch /
+  // if-else / registry-record sites, that function is the same as fnName.
+  const listing = site.hasListing
+    ? extractListing(extractNamedBody(source, site.fnName, "{"), site.prefix)
+    : null;
+  const usageSubs = extractUsageSubs(usageBlock, site.prefix);
+
+  // For comparison, normalise (alias-resolve, drop empty/hidden).
+  const normCases = normalise(cases, site.prefix, { stripHidden: true });
+  const normListing = listing ? normalise(listing, site.prefix, { stripHidden: true }) : null;
+  const inlineHandled = new Set(USAGE_INLINE_HANDLED[site.prefix] ?? []);
+  const normUsage = new Set(
+    [...normalise(usageSubs, site.prefix, { stripHidden: false })].filter((x) => !inlineHandled.has(x)),
+  );
+
+  const errors: string[] = [];
+
+  const casesNotInUsage = setDiff(normCases, normUsage);
+  if (casesNotInUsage.length > 0) {
+    errors.push(
+      `[${site.prefix}] implemented but undocumented in USAGE: ${casesNotInUsage.join(", ")}`,
+    );
+  }
+
+  const usageNotInCases = setDiff(normUsage, normCases);
+  if (usageNotInCases.length > 0) {
+    errors.push(
+      `[${site.prefix}] documented in USAGE but no implementation: ${usageNotInCases.join(", ")}`,
+    );
+  }
+
+  if (normListing) {
+    const casesNotInListing = setDiff(normCases, normListing);
+    if (casesNotInListing.length > 0) {
+      errors.push(
+        `[${site.prefix}] implemented but missing from default (use: ...) listing: ${casesNotInListing.join(", ")}`,
+      );
+    }
+
+    const listingNotInCases = setDiff(normListing, normCases);
+    if (listingNotInCases.length > 0) {
+      errors.push(
+        `[${site.prefix}] listed in default (use: ...) but no implementation: ${listingNotInCases.join(", ")}`,
+      );
+    }
+  }
+
+  if (cases.size === 0) {
+    errors.push(
+      `[${site.prefix}] extractor returned zero cases — regex over ${site.file} (${site.shape}) likely broken; check the lint extractor`,
+    );
+  }
+
+  return { site, caseCount: cases.size, errors, cases, listing, usageSubs };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry
+// ---------------------------------------------------------------------------
+
+export function lintCliSubcommands(
+  readSource: (relPath: string) => string,
+  indexUsageBlock: string,
+): SiteResult[] {
+  return DISPATCHERS.map((site) => {
+    const src = readSource(site.file);
+    return checkSite(site, src, indexUsageBlock);
+  });
+}
+
+if (import.meta.main) {
+  const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+  const usageBlock = extractUsageBlock(indexSrc);
+  const results = lintCliSubcommands(
+    (rel) => readFileSync(join(root, rel), "utf-8"),
+    usageBlock,
+  );
+
+  const allErrors = results.flatMap((r) => r.errors);
+  if (allErrors.length === 0) {
+    console.log(`✅  CLI sub-command parity holds across ${results.length} dispatchers.`);
+    process.exit(0);
+  }
+
+  console.error(`\n❌  CLI sub-command drift detected:\n`);
+  for (const err of allErrors) {
+    console.error(`     - ${err}`);
+  }
+  console.error(
+    `\n   Each error names the prefix and the mismatch class. Fix by either:\n` +
+      `     (a) updating the dispatcher source (case / registry key / if-else branch),\n` +
+      `     (b) updating src/index.ts USAGE for the prefix, or\n` +
+      `     (c) updating the default-case (use: ...) listing in the dispatcher.\n` +
+      `   Aliases (e.g. queue-pop, disable, pai) are pinned in scripts/lint-cli-subcommands.ts ALIASES.\n`,
+  );
+  process.exit(1);
+}

--- a/src/cli-dispatch.test.ts
+++ b/src/cli-dispatch.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "bun:test";
+import { formatUnknownTopLevel, TOP_LEVEL_ALIAS_NAMES } from "./cli-dispatch.ts";
+
+describe("formatUnknownTopLevel", () => {
+  test("emits the canonical 'unknown ludics command: ${cmd} (use: ...)' shape", () => {
+    const out = formatUnknownTopLevel("bogus", ["foo", "bar", "baz"]);
+    expect(out).toBe("unknown ludics command: bogus (use: bar, baz, foo)");
+  });
+
+  test("listing is alphabetically sorted regardless of input order", () => {
+    const out = formatUnknownTopLevel("x", ["zeta", "alpha", "mu"]);
+    expect(out).toBe("unknown ludics command: x (use: alpha, mu, zeta)");
+  });
+
+  test("filters out the 'orchestration' alias of 'orch'", () => {
+    const out = formatUnknownTopLevel("bogus", ["orch", "orchestration", "tasks"]);
+    expect(out).toBe("unknown ludics command: bogus (use: orch, tasks)");
+    expect(out).not.toContain("orchestration");
+  });
+
+  test("does not emit the legacy 'not yet migrated' wording", () => {
+    const out = formatUnknownTopLevel("bogus", ["tasks", "flow"]);
+    expect(out).not.toContain("not yet migrated");
+  });
+
+  test("does not mutate the input array", () => {
+    const input: ReadonlyArray<string> = ["zeta", "alpha"];
+    const before = [...input];
+    formatUnknownTopLevel("x", input);
+    expect([...input]).toEqual(before);
+  });
+});
+
+describe("TOP_LEVEL_ALIAS_NAMES", () => {
+  test("contains the documented top-level aliases", () => {
+    expect(TOP_LEVEL_ALIAS_NAMES.has("orchestration")).toBe(true);
+  });
+});

--- a/src/cli-dispatch.ts
+++ b/src/cli-dispatch.ts
@@ -1,0 +1,24 @@
+// Import-safe helpers for the top-level command dispatcher in src/index.ts.
+//
+// Extracted so tests and the CLI-subcommand drift lint
+// (scripts/lint-cli-subcommands.ts) can import without side-effecting `main()`
+// execution. src/index.ts has an unguarded `main().catch(...)` at the bottom
+// of the file; importing it for the helper alone would run the CLI.
+//
+// This module must remain side-effect-free: no top-level statements, no
+// imports from src/index.ts, and no module-level work beyond declarations.
+
+const TOP_LEVEL_ALIASES = new Set<string>(["orchestration"]);
+
+export const TOP_LEVEL_ALIAS_NAMES: ReadonlySet<string> = TOP_LEVEL_ALIASES;
+
+export function formatUnknownTopLevel(
+  cmd: string,
+  knownCommands: ReadonlyArray<string>,
+): string {
+  const canonical = knownCommands
+    .filter((k) => !TOP_LEVEL_ALIASES.has(k))
+    .slice()
+    .sort();
+  return `unknown ludics command: ${cmd} (use: ${canonical.join(", ")})`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { runEvents } from "./events.ts";
 import { runT3Code } from "./t3code/index.ts";
 import { runOrchestrationCli } from "./orchestration/index.ts";
 import { safeSyncOutput } from "./spawn.ts";
+import { formatUnknownTopLevel } from "./cli-dispatch.ts";
 
 const MIGRATED_COMMANDS: Record<string, (args: string[]) => Promise<void>> = {
   sessions: runSessions,
@@ -386,7 +387,7 @@ async function main(): Promise<void> {
   if (handler) {
     await handler(args.slice(1));
   } else {
-    console.error(`ludics ${cmd}: not yet migrated`);
+    console.error(formatUnknownTopLevel(cmd, Object.keys(MIGRATED_COMMANDS)));
     process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,12 @@ Commands:
   mag health-check             Check for deadlines, issues
   mag adopt-sessions [--force] Discover sessions and queue adoption for Mag
   mag process-suggestions <id> Queue suggestion processing for completed task
+  mag revise-proposal <ids> ["feedback"]
+                               Reset task(s) to deferred and queue revision (comma-separated ids)
+  mag auto-start-evaluate <id> <high|low> [rationale]
+                               Evaluate auto-start decision and update task status
+  mag completed <proposal>     Mark a proposal completed (without .md extension)
+  mag feedback-digest          Queue a feedback digest run
   mag message "text"           Send async message to Mag
   mag queue                    Show pending queue requests
   mag queue pop one            Pop and print first queue item (JSONL)
@@ -176,6 +182,8 @@ Commands:
 
   notify outgoing <msg>        Send notification to user
   notify agents <msg>          Send operational notification
+  notify proposal <id> <title> <summary> <file>
+                               Notify a proposal-ready event
   notify subscribe             Subscribe to incoming messages (long-running)
   notify recent [n]            Show recent notifications
 
@@ -234,8 +242,8 @@ Commands:
   network status               Show network configuration
   cluster status              Show cluster status (multi-machine)
   cluster tick                Publish heartbeat
-  
   cluster heartbeat           Publish heartbeat only
+  cluster ping <machine>      Ping another cluster machine
 
   queue hold                   Suppress automatic slot assignments
   queue resume                 Re-enable automatic slot assignments

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -870,4 +870,33 @@ describe("runMag unknown-command listing (gh-ludics-438)", () => {
     expect(msg).not.toContain("queue pop one");
     expect(msg).not.toContain("queue pop all");
   });
+
+  test("listing excludes internal hook entry points (on-stop / queue-pop)", async () => {
+    // Invariant: hook entries (`on-stop`, deprecated alias `queue-pop`) stay
+    // callable for templates/hooks/ludics-on-stop.sh but never surface in
+    // user-facing help. Without the MAG_HIDDEN_SUBCOMMANDS filter, the
+    // derived listing would leak both names into `(use: ...)` output.
+    //
+    // Harness condition: invoke runMag with a sentinel sub so the
+    // unknown-handler branch fires; capture the listing string.
+    let err: Error | null = null;
+    try {
+      await runMag(["__bogus__"]);
+    } catch (e) {
+      err = e as Error;
+    }
+    const msg = err!.message;
+    // The (use: …) listing must not contain either internal entry. Anchor
+    // the assertion to that segment so we don't trip on the `${sub}`
+    // payload: the sentinel would never collide with these names anyway,
+    // but the listing-side check is the real contract.
+    const useMatch = msg.match(/\(use: ([^)]*)\)/);
+    expect(useMatch).not.toBeNull();
+    const useEntries = useMatch![1]!.split(/,\s*/);
+    expect(useEntries).not.toContain("on-stop");
+    expect(useEntries).not.toContain("queue-pop");
+    // Sanity: the public commands are still present.
+    expect(useEntries).toContain("start");
+    expect(useEntries).toContain("completed");
+  });
 });

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag } from "./mag.ts";
 import type { RunGit } from "./git-runner.ts";
 
 describe("normalizeLaunchAdapter", () => {
@@ -822,5 +822,52 @@ describe("magStateFile atomic write", () => {
     expect(readFileSync(file, "utf-8")).toBe(body);
     expect(existsSync(file + ".tmp")).toBe(false);
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("runMag unknown-command listing (gh-ludics-438)", () => {
+  // Invariant: the default-case error listing is derived from the
+  // `magSubcommands` registry keys, not a hand-maintained literal. If the
+  // registry refactor is reverted, the message would either drift from
+  // reality (current `analyze`/`feedback-digest` mismatch) or fail to
+  // include newly added cases. These assertions enforce that derivation.
+  //
+  // Harness condition: invoke runMag with a sentinel sub the registry has
+  // never had; the dispatcher takes the missing-handler branch and emits
+  // the derived listing.
+
+  test("listing includes every live first-level case (no drift)", async () => {
+    let err: Error | null = null;
+    try {
+      await runMag(["__bogus__"]);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    const msg = err!.message;
+    expect(msg).toMatch(/^unknown mag command: __bogus__ \(use: /);
+    // Real cases that drift on `main`'s hand-maintained listing — must
+    // appear in the derived listing.
+    expect(msg).toContain("auto-start-evaluate");
+    expect(msg).toContain("revise-proposal");
+    expect(msg).toContain("feedback-digest");
+    // Spot-check a handful of long-standing cases.
+    expect(msg).toContain("start");
+    expect(msg).toContain("verify-container-completion");
+  });
+
+  test("listing excludes stale entries previously hand-typed in default", async () => {
+    let err: Error | null = null;
+    try {
+      await runMag(["__bogus__"]);
+    } catch (e) {
+      err = e as Error;
+    }
+    const msg = err!.message;
+    // `analyze` had no handler — it was literal-only drift.
+    expect(msg).not.toContain("analyze");
+    // Nested second-level commands must not pollute the first-level listing.
+    expect(msg).not.toContain("queue pop one");
+    expect(msg).not.toContain("queue pop all");
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3427,6 +3427,12 @@ async function magCompleted(proposalName: string): Promise<void> {
 // subcommand name (i.e. args.slice(1) from runMag's input).
 type MagSubHandler = (args: string[]) => Promise<void> | void;
 
+// Hook entry points / deprecated compat aliases that stay callable but never
+// surface in user-facing help. Mirrors INTERNAL_HIDDEN.mag in
+// scripts/lint-cli-subcommands.ts — the lint also strips these when
+// comparing against src/index.ts USAGE.
+const MAG_HIDDEN_SUBCOMMANDS: ReadonlySet<string> = new Set(["on-stop", "queue-pop"]);
+
 // Registry of mag subcommands. Insertion order is the help-listing order.
 // Lint enforcement: scripts/lint-cli-subcommands.ts reads the keys via regex
 // to validate parity with src/index.ts USAGE and the runMag default error.
@@ -3720,7 +3726,9 @@ export async function runMag(args: string[]): Promise<void> {
   const sub = args[0] ?? "";
   const handler = magSubcommands.get(sub);
   if (!handler) {
-    const listing = [...magSubcommands.keys()].join(", ");
+    const listing = [...magSubcommands.keys()]
+      .filter((k) => !MAG_HIDDEN_SUBCOMMANDS.has(k))
+      .join(", ");
     throw new Error(`unknown mag command: ${sub} (use: ${listing})`);
   }
   await handler(args.slice(1));

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3423,321 +3423,305 @@ async function magCompleted(proposalName: string): Promise<void> {
   emitEvent({ event_type: "mag_completed", source: "mag", scope: "mag", task: matchedTaskId, slot: matchedSlot ?? undefined, message: `completed via proposal signal: ${proposalName}` });
 }
 
+// First-level subcommand handler. Each handler receives the args after the
+// subcommand name (i.e. args.slice(1) from runMag's input).
+type MagSubHandler = (args: string[]) => Promise<void> | void;
+
+// Registry of mag subcommands. Insertion order is the help-listing order.
+// Lint enforcement: scripts/lint-cli-subcommands.ts reads the keys via regex
+// to validate parity with src/index.ts USAGE and the runMag default error.
+//
+// `queue-pop` is a DEPRECATED alias of `on-stop`, kept for backward
+// compatibility with older hook scripts. The lint allow-list pins this pair.
+const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSubHandler>([
+  ["start", async (args) => { await magStart(args); }],
+  ["stop", () => { magStop(); }],
+  ["status", () => { magStatusCmd(); }],
+  ["attach", () => { magAttach(); }],
+  ["logs", (args) => {
+    const lines = args[0] ? parseInt(args[0], 10) : 100;
+    magLogs(lines);
+  }],
+  ["doctor", () => { magDoctor(); }],
+  ["briefing", () => { magBriefing(); }],
+  ["suggest", () => {
+    queueRequest({ action: "suggest" });
+    console.log("Queued suggest request");
+  }],
+  ["elaborate", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "elaborate", task: taskId });
+    console.log(`Queued elaborate request for ${taskId}`);
+  }],
+  ["health-check", () => {
+    if (!clusterIsController()) {
+      console.error("ludics: mag health-check skipped — not the cluster controller");
+      return;
+    }
+    queueRequest({ action: "health-check" });
+    // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
+    // docs/proposals/auto-compact-after-checkpoints.md). Enqueued unconditionally;
+    // a no-op /compact on a small context is acceptable.
+    queueRequest({ action: "message", content: "/compact" });
+    console.log("Queued health-check request");
+  }],
+  ["message", (args) => {
+    const text = args.join(" ");
+    if (!text) throw new Error("message text required");
+    magMessage(text);
+  }],
+  ["queue", async (args) => {
+    const sub2 = args[0];
+    if (sub2 === "pop") {
+      const mode = args[1];
+      if (args.length > 2) {
+        throw new Error(`unexpected trailing arguments: ${args.slice(2).join(" ")} (usage: mag queue pop one|all)`);
+      }
+      const { queuePopOne, queuePopAll } = await import("./queue.ts");
+      if (mode === "one") {
+        const line = queuePopOne();
+        if (line === null) {
+          process.exitCode = 1;
+        } else {
+          console.log(line);
+        }
+      } else if (mode === "all") {
+        const lines = queuePopAll();
+        if (lines.length === 0) {
+          process.exitCode = 1;
+        } else {
+          for (const l of lines) console.log(l);
+        }
+      } else {
+        throw new Error(`unknown queue pop mode: ${mode ?? "(missing)"} (use: one, all)`);
+      }
+    } else if (sub2 === "promote") {
+      const id = args[1];
+      if (!id) throw new Error("id required (usage: mag queue promote <id>)");
+      if (args.length > 2) {
+        throw new Error(`unexpected trailing arguments: ${args.slice(2).join(" ")} (usage: mag queue promote <id>)`);
+      }
+      const { queuePromoteToTop } = await import("./queue.ts");
+      const result = queuePromoteToTop(id);
+      if (result === "not-found") process.exitCode = 1;
+      console.log(result);
+    } else if (sub2 === "cancel") {
+      const id = args[1];
+      if (!id) throw new Error("id required (usage: mag queue cancel <id>)");
+      if (args.length > 2) {
+        throw new Error(`unexpected trailing arguments: ${args.slice(2).join(" ")} (usage: mag queue cancel <id>)`);
+      }
+      const { queueCancel } = await import("./queue.ts");
+      const result = queueCancel(id);
+      if (result.status === "not-found") {
+        process.exitCode = 1;
+        console.log("not-found");
+      } else {
+        console.log(result.line);
+      }
+    } else if (!sub2) {
+      const { queueShow } = await import("./queue.ts");
+      queueShow();
+    } else {
+      throw new Error(`unknown queue subcommand: ${sub2} (use: pop one, pop all, promote <id>, cancel <id>)`);
+    }
+  }],
+  ["context", async () => { await magContext(); }],
+  ["auto-start-evaluate", async (args) => {
+    const taskId = args[0];
+    const confidence = args[1];
+    const rationale = args[2] ?? "";
+    if (!taskId) throw new Error("task id required");
+    const result = evaluateAutoStartDecisionPure(
+      confidence === "high" || confidence === "low" ? confidence : undefined,
+      rationale,
+      startSessionsAutonomy(),
+      findSlotForTask(taskId) !== null,
+    );
+    // Side effect: set or clear deferred status in task frontmatter
+    const evalTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+    if (existsSync(evalTaskFile)) {
+      if (result.decision === "defer-to-user") {
+        // If the task is already in a slot, clear the slot to free it for other work
+        const evalSlot = findSlotForTask(taskId);
+        if (evalSlot !== null) {
+          await slotClear(evalSlot, "deferred");
+        } else {
+          updateFrontmatterField(evalTaskFile, "status", "deferred");
+        }
+      } else {
+        // Only clear deferred — do not downgrade other statuses
+        const evalContent = readFileSync(evalTaskFile, "utf-8");
+        const evalStatus = parseTaskFrontmatter(evalContent).status;
+        if (evalStatus === "deferred") {
+          updateFrontmatterField(evalTaskFile, "status", "ready");
+        }
+      }
+    }
+    console.log(JSON.stringify(result));
+  }],
+  ["draft-proposal", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "draft-proposal", task: taskId });
+    console.log(`Queued draft-proposal request for ${taskId}`);
+  }],
+  ["revise-proposal", async (args) => {
+    const taskArg = args[0];
+    if (!taskArg) throw new Error("task id required (comma-separated for multiple)");
+    const taskIds = taskArg.split(",");
+    const feedback = args.slice(1).join(" ");
+    for (const taskId of taskIds) {
+      // Set status back to deferred so re-evaluation after revision can re-assess
+      const reviseTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+      if (existsSync(reviseTaskFile)) {
+        const revContent = readFileSync(reviseTaskFile, "utf-8");
+        const revStatus = parseTaskFrontmatter(revContent).status;
+        if (revStatus === "ready" || revStatus === "in-progress") {
+          const revSlot = findSlotForTask(taskId);
+          if (revSlot !== null) {
+            await slotClear(revSlot, "deferred");
+          } else {
+            updateFrontmatterField(reviseTaskFile, "status", "deferred");
+          }
+        }
+      }
+      if (feedback) {
+        queueRequest({ action: "revise-proposal", task: taskId, feedback });
+      } else {
+        queueRequest({ action: "revise-proposal", task: taskId });
+      }
+    }
+    console.log(`Queued revise-proposal request for ${taskIds.join(", ")}`);
+  }],
+  ["split-task", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "split-task", task: taskId });
+    console.log(`Queued split-task request for ${taskId}`);
+  }],
+  ["verify-completion", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "verify-completion", task: taskId });
+    console.log(`Queued verify-completion request for ${taskId}`);
+  }],
+  ["verify-container-completion", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "verify-container-completion", task: taskId });
+    console.log(`Queued verify-container-completion request for ${taskId}`);
+  }],
+  ["feedback-digest", () => {
+    const fdResult = tryQueueFeedbackDigest("ludics");
+    if (fdResult.queued) {
+      console.log("Queued feedback-digest request");
+    } else {
+      console.log(`Skipped feedback-digest: ${fdResult.reason}`);
+    }
+  }],
+  ["adopt-sessions", (args) => {
+    if (!clusterIsController()) {
+      console.error("ludics: mag adopt-sessions skipped — not the cluster controller");
+      return;
+    }
+    const force = args.includes("--force");
+    const refresh = safeSyncOutput(ludicsSelfCommand(["sessions", "report"]));
+    if (!refresh.ok) {
+      throw new Error(refresh.stderr ? `adopt-sessions: failed to refresh sessions: ${refresh.stderr}` : "adopt-sessions: failed to refresh sessions");
+    }
+
+    const sessionsFile = join(harnessDir(), "sessions.json");
+    const fingerprint = adoptSessionsFingerprintData(sessionsFile);
+    if (!fingerprint) {
+      throw new Error("adopt-sessions: failed to read sessions.json after refresh");
+    }
+
+    mkdirSync(magStateDir(), { recursive: true });
+    const fingerprintFile = adoptSessionsFingerprintFile();
+    const previous = existsSync(fingerprintFile) ? readFileSync(fingerprintFile, "utf-8").trim() : "";
+    const changed = previous !== fingerprint.hash;
+    writeFileSync(fingerprintFile, fingerprint.hash + "\n");
+
+    if (!force && !changed) {
+      console.log("Skipped adopt-sessions: no unclassified session changes");
+      return;
+    }
+
+    if (!force && fingerprint.unclassifiedCount === 0) {
+      console.log("Skipped adopt-sessions: no unclassified sessions");
+      return;
+    }
+
+    if (queueHasPendingAction("adopt-sessions")) {
+      console.log("Skipped adopt-sessions request: already pending in queue");
+      return;
+    }
+
+    queueRequest({ action: "adopt-sessions" });
+    console.log(`Queued adopt-sessions request (${fingerprint.unclassifiedCount} unclassified session(s))`);
+  }],
+  ["process-suggestions", (args) => {
+    const taskId = args[0];
+    if (!taskId) throw new Error("task id required");
+    queueRequest({ action: "process-suggestions", task: taskId });
+    console.log(`Queued process-suggestions request for ${taskId}`);
+  }],
+  ["completed", async (args) => {
+    const proposalName = args[0];
+    if (!proposalName) throw new Error("proposal name required (without .md extension)");
+    await magCompleted(proposalName);
+  }],
+  ["on-stop", async (args) => {
+    // Called by the stop hook to mark Mag as settled and attempt immediate queue delivery
+    const cwd = args[0] ?? "";
+    const hookEventName = args[1] ?? "";
+    if (hookEventName && hookEventName !== "Stop") return;
+    if (cwd) {
+      const harness = harnessDir();
+      if (!cwd.startsWith(harness)) return;
+    }
+    writeStopHookTimestamp();
+    clearStartupWatchdogEpoch();
+    if (existsSync(join(harnessDir(), "mag", "paused"))) return;
+    if (!clusterIsController()) return;
+    markMagSettled();
+    clearStallState();
+    // Attempt immediate queue delivery (keepalive is fallback for items queued while idle)
+    await maybeFeedMagQueue();
+  }],
+  // DEPRECATED: kept for backward compatibility with older hook scripts.
+  // New hook scripts use "on-stop" instead. Pinned in lint allow-list.
+  ["queue-pop", async (args) => {
+    const cwd = args[0] ?? "";
+    const hookEventName = args[1] ?? "";
+    if (hookEventName && hookEventName !== "Stop") {
+      return;
+    }
+    if (cwd) {
+      const harness = harnessDir();
+      if (!cwd.startsWith(harness)) {
+        return;
+      }
+    }
+    writeStopHookTimestamp();
+    clearStartupWatchdogEpoch();
+    if (existsSync(join(harnessDir(), "mag", "paused"))) return;
+    if (!clusterIsController()) return;
+    const popped = await queuePopSkill();
+    if (popped) {
+      console.log(JSON.stringify({ decision: "block", reason: popped.command }));
+    }
+  }],
+]);
+
 export async function runMag(args: string[]): Promise<void> {
   const sub = args[0] ?? "";
-
-  switch (sub) {
-    case "start":
-      await magStart(args.slice(1));
-      break;
-    case "stop":
-      magStop();
-      break;
-    case "status":
-      magStatusCmd();
-      break;
-    case "attach":
-      magAttach();
-      break;
-    case "logs": {
-      const lines = args[1] ? parseInt(args[1], 10) : 100;
-      magLogs(lines);
-      break;
-    }
-    case "doctor":
-      magDoctor();
-      break;
-    case "briefing":
-      magBriefing();
-      break;
-    case "suggest":
-      queueRequest({ action: "suggest" });
-      console.log("Queued suggest request");
-      break;
-    case "elaborate": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "elaborate", task: taskId });
-      console.log(`Queued elaborate request for ${taskId}`);
-      break;
-    }
-    case "health-check":
-      if (!clusterIsController()) {
-        console.error("ludics: mag health-check skipped — not the cluster controller");
-        break;
-      }
-      queueRequest({ action: "health-check" });
-      // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
-      // docs/proposals/auto-compact-after-checkpoints.md). Enqueued unconditionally;
-      // a no-op /compact on a small context is acceptable.
-      queueRequest({ action: "message", content: "/compact" });
-      console.log("Queued health-check request");
-      break;
-    case "message": {
-      const text = args.slice(1).join(" ");
-      if (!text) throw new Error("message text required");
-      magMessage(text);
-      break;
-    }
-    case "queue": {
-      const sub2 = args[1];
-      if (sub2 === "pop") {
-        const mode = args[2];
-        if (args.length > 3) {
-          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue pop one|all)`);
-        }
-        const { queuePopOne, queuePopAll } = await import("./queue.ts");
-        if (mode === "one") {
-          const line = queuePopOne();
-          if (line === null) {
-            process.exitCode = 1;
-          } else {
-            console.log(line);
-          }
-        } else if (mode === "all") {
-          const lines = queuePopAll();
-          if (lines.length === 0) {
-            process.exitCode = 1;
-          } else {
-            for (const l of lines) console.log(l);
-          }
-        } else {
-          throw new Error(`unknown queue pop mode: ${mode ?? "(missing)"} (use: one, all)`);
-        }
-      } else if (sub2 === "promote") {
-        const id = args[2];
-        if (!id) throw new Error("id required (usage: mag queue promote <id>)");
-        if (args.length > 3) {
-          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue promote <id>)`);
-        }
-        const { queuePromoteToTop } = await import("./queue.ts");
-        const result = queuePromoteToTop(id);
-        if (result === "not-found") process.exitCode = 1;
-        console.log(result);
-      } else if (sub2 === "cancel") {
-        const id = args[2];
-        if (!id) throw new Error("id required (usage: mag queue cancel <id>)");
-        if (args.length > 3) {
-          throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: mag queue cancel <id>)`);
-        }
-        const { queueCancel } = await import("./queue.ts");
-        const result = queueCancel(id);
-        if (result.status === "not-found") {
-          process.exitCode = 1;
-          console.log("not-found");
-        } else {
-          console.log(result.line);
-        }
-      } else if (!sub2) {
-        const { queueShow } = await import("./queue.ts");
-        queueShow();
-      } else {
-        throw new Error(`unknown queue subcommand: ${sub2} (use: pop one, pop all, promote <id>, cancel <id>)`);
-      }
-      break;
-    }
-    case "context":
-      await magContext();
-      break;
-    case "auto-start-evaluate": {
-      const taskId = args[1];
-      const confidence = args[2];
-      const rationale = args[3] ?? "";
-      if (!taskId) throw new Error("task id required");
-      const result = evaluateAutoStartDecisionPure(
-        confidence === "high" || confidence === "low" ? confidence : undefined,
-        rationale,
-        startSessionsAutonomy(),
-        findSlotForTask(taskId) !== null,
-      );
-      // Side effect: set or clear deferred status in task frontmatter
-      const evalTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
-      if (existsSync(evalTaskFile)) {
-        if (result.decision === "defer-to-user") {
-          // If the task is already in a slot, clear the slot to free it for other work
-          const evalSlot = findSlotForTask(taskId);
-          if (evalSlot !== null) {
-            await slotClear(evalSlot, "deferred");
-          } else {
-            updateFrontmatterField(evalTaskFile, "status", "deferred");
-          }
-        } else {
-          // Only clear deferred — do not downgrade other statuses
-          const evalContent = readFileSync(evalTaskFile, "utf-8");
-          const evalStatus = parseTaskFrontmatter(evalContent).status;
-          if (evalStatus === "deferred") {
-            updateFrontmatterField(evalTaskFile, "status", "ready");
-          }
-        }
-      }
-      console.log(JSON.stringify(result));
-      break;
-    }
-    case "draft-proposal": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "draft-proposal", task: taskId });
-      console.log(`Queued draft-proposal request for ${taskId}`);
-      break;
-    }
-    case "revise-proposal": {
-      const taskArg = args[1];
-      if (!taskArg) throw new Error("task id required (comma-separated for multiple)");
-      const taskIds = taskArg.split(",");
-      const feedback = args.slice(2).join(" ");
-      for (const taskId of taskIds) {
-        // Set status back to deferred so re-evaluation after revision can re-assess
-        const reviseTaskFile = join(harnessDir(), "tasks", `${taskId}.md`);
-        if (existsSync(reviseTaskFile)) {
-          const revContent = readFileSync(reviseTaskFile, "utf-8");
-          const revStatus = parseTaskFrontmatter(revContent).status;
-          if (revStatus === "ready" || revStatus === "in-progress") {
-            const revSlot = findSlotForTask(taskId);
-            if (revSlot !== null) {
-              await slotClear(revSlot, "deferred");
-            } else {
-              updateFrontmatterField(reviseTaskFile, "status", "deferred");
-            }
-          }
-        }
-        if (feedback) {
-          queueRequest({ action: "revise-proposal", task: taskId, feedback });
-        } else {
-          queueRequest({ action: "revise-proposal", task: taskId });
-        }
-      }
-      console.log(`Queued revise-proposal request for ${taskIds.join(", ")}`);
-      break;
-    }
-    case "split-task": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "split-task", task: taskId });
-      console.log(`Queued split-task request for ${taskId}`);
-      break;
-    }
-    case "verify-completion": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "verify-completion", task: taskId });
-      console.log(`Queued verify-completion request for ${taskId}`);
-      break;
-    }
-    case "verify-container-completion": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "verify-container-completion", task: taskId });
-      console.log(`Queued verify-container-completion request for ${taskId}`);
-      break;
-    }
-    case "feedback-digest": {
-      const fdResult = tryQueueFeedbackDigest("ludics");
-      if (fdResult.queued) {
-        console.log("Queued feedback-digest request");
-      } else {
-        console.log(`Skipped feedback-digest: ${fdResult.reason}`);
-      }
-      break;
-    }
-    case "adopt-sessions": {
-      if (!clusterIsController()) {
-        console.error("ludics: mag adopt-sessions skipped — not the cluster controller");
-        break;
-      }
-      const force = args.includes("--force");
-      const refresh = safeSyncOutput(ludicsSelfCommand(["sessions", "report"]));
-      if (!refresh.ok) {
-        throw new Error(refresh.stderr ? `adopt-sessions: failed to refresh sessions: ${refresh.stderr}` : "adopt-sessions: failed to refresh sessions");
-      }
-
-      const sessionsFile = join(harnessDir(), "sessions.json");
-      const fingerprint = adoptSessionsFingerprintData(sessionsFile);
-      if (!fingerprint) {
-        throw new Error("adopt-sessions: failed to read sessions.json after refresh");
-      }
-
-      mkdirSync(magStateDir(), { recursive: true });
-      const fingerprintFile = adoptSessionsFingerprintFile();
-      const previous = existsSync(fingerprintFile) ? readFileSync(fingerprintFile, "utf-8").trim() : "";
-      const changed = previous !== fingerprint.hash;
-      writeFileSync(fingerprintFile, fingerprint.hash + "\n");
-
-      if (!force && !changed) {
-        console.log("Skipped adopt-sessions: no unclassified session changes");
-        break;
-      }
-
-      if (!force && fingerprint.unclassifiedCount === 0) {
-        console.log("Skipped adopt-sessions: no unclassified sessions");
-        break;
-      }
-
-      if (queueHasPendingAction("adopt-sessions")) {
-        console.log("Skipped adopt-sessions request: already pending in queue");
-        break;
-      }
-
-      queueRequest({ action: "adopt-sessions" });
-      console.log(`Queued adopt-sessions request (${fingerprint.unclassifiedCount} unclassified session(s))`);
-      break;
-    }
-    case "process-suggestions": {
-      const taskId = args[1];
-      if (!taskId) throw new Error("task id required");
-      queueRequest({ action: "process-suggestions", task: taskId });
-      console.log(`Queued process-suggestions request for ${taskId}`);
-      break;
-    }
-    case "completed": {
-      const proposalName = args[1];
-      if (!proposalName) throw new Error("proposal name required (without .md extension)");
-      await magCompleted(proposalName);
-      break;
-    }
-    case "on-stop": {
-      // Called by the stop hook to mark Mag as settled and attempt immediate queue delivery
-      const cwd = args[1] ?? "";
-      const hookEventName = args[2] ?? "";
-      if (hookEventName && hookEventName !== "Stop") break;
-      if (cwd) {
-        const harness = harnessDir();
-        if (!cwd.startsWith(harness)) break;
-      }
-      writeStopHookTimestamp();
-      clearStartupWatchdogEpoch();
-      if (existsSync(join(harnessDir(), "mag", "paused"))) break;
-      if (!clusterIsController()) break;
-      markMagSettled();
-      clearStallState();
-      // Attempt immediate queue delivery (keepalive is fallback for items queued while idle)
-      await maybeFeedMagQueue();
-      break;
-    }
-    // DEPRECATED: kept for backward compatibility with older hook scripts.
-    // New hook scripts use "on-stop" instead.
-    case "queue-pop": {
-      const cwd = args[1] ?? "";
-      const hookEventName = args[2] ?? "";
-      if (hookEventName && hookEventName !== "Stop") {
-        break;
-      }
-      if (cwd) {
-        const harness = harnessDir();
-        if (!cwd.startsWith(harness)) {
-          break;
-        }
-      }
-      writeStopHookTimestamp();
-      clearStartupWatchdogEpoch();
-      if (existsSync(join(harnessDir(), "mag", "paused"))) break;
-      if (!clusterIsController()) break;
-      const popped = await queuePopSkill();
-      if (popped) {
-        console.log(JSON.stringify({ decision: "block", reason: popped.command }));
-      }
-      break;
-    }
-    default:
-      throw new Error(`unknown mag command: ${sub} (use: start, stop, status, attach, logs, doctor, briefing, suggest, analyze, elaborate, draft-proposal, split-task, verify-completion, verify-container-completion, health-check, adopt-sessions, process-suggestions, completed, message, queue, queue pop one, queue pop all, queue-pop, on-stop, context, feedback-digest)`);
+  const handler = magSubcommands.get(sub);
+  if (!handler) {
+    const listing = [...magSubcommands.keys()].join(", ");
+    throw new Error(`unknown mag command: ${sub} (use: ${listing})`);
   }
+  await handler(args.slice(1));
 }

--- a/src/orchestration/index.test.ts
+++ b/src/orchestration/index.test.ts
@@ -192,17 +192,17 @@ describe("orchDiff / runOrchestrationCli diff", () => {
 });
 
 describe("runOrchestrationCli unknown-subcommand listing (gh-ludics-438)", () => {
-  // Invariant: the default-case error includes the canonical
-  // `(use: status, confirm, interrupt, skip, log, diff, on-stop)` listing.
-  // If the wording reverts to the bare `unknown orch subcommand: ${sub}`
-  // it had on `main`, the regex below fails. `run-internal` is an internal
-  // self-relaunch entrypoint and must NOT appear in the public listing.
+  // Invariant: the default-case error names every public subcommand and
+  // excludes internal entry points. `run-internal` (self-relaunch) and
+  // `on-stop` (Stop-hook entry) stay callable but are absent from public
+  // help — mirrors INTERNAL_HIDDEN.orch in scripts/lint-cli-subcommands.ts
+  // and the templates/hooks/ludics-on-stop.sh:106 caller.
   //
   // Harness condition: invoke runOrchestrationCli with a sentinel sub that
   // is not a real case label and not the empty default; the dispatcher
   // takes the unknown-subcommand branch.
 
-  test("emits canonical (use: ...) listing and excludes run-internal", async () => {
+  test("emits canonical (use: ...) listing and excludes internal entries", async () => {
     let err: Error | null = null;
     try {
       await runOrchestrationCli(["__bogus__"]);
@@ -212,8 +212,13 @@ describe("runOrchestrationCli unknown-subcommand listing (gh-ludics-438)", () =>
     expect(err).not.toBeNull();
     const msg = err!.message;
     expect(msg).toBe(
-      "unknown orch subcommand: __bogus__ (use: status, confirm, interrupt, skip, log, diff, on-stop)",
+      "unknown orch subcommand: __bogus__ (use: status, confirm, interrupt, skip, log, diff)",
     );
-    expect(msg).not.toContain("run-internal");
+    // Both internal entries must be absent from user-facing help.
+    const useMatch = msg.match(/\(use: ([^)]*)\)/);
+    expect(useMatch).not.toBeNull();
+    const useEntries = useMatch![1]!.split(/,\s*/);
+    expect(useEntries).not.toContain("run-internal");
+    expect(useEntries).not.toContain("on-stop");
   });
 });

--- a/src/orchestration/index.test.ts
+++ b/src/orchestration/index.test.ts
@@ -190,3 +190,30 @@ describe("orchDiff / runOrchestrationCli diff", () => {
     );
   });
 });
+
+describe("runOrchestrationCli unknown-subcommand listing (gh-ludics-438)", () => {
+  // Invariant: the default-case error includes the canonical
+  // `(use: status, confirm, interrupt, skip, log, diff, on-stop)` listing.
+  // If the wording reverts to the bare `unknown orch subcommand: ${sub}`
+  // it had on `main`, the regex below fails. `run-internal` is an internal
+  // self-relaunch entrypoint and must NOT appear in the public listing.
+  //
+  // Harness condition: invoke runOrchestrationCli with a sentinel sub that
+  // is not a real case label and not the empty default; the dispatcher
+  // takes the unknown-subcommand branch.
+
+  test("emits canonical (use: ...) listing and excludes run-internal", async () => {
+    let err: Error | null = null;
+    try {
+      await runOrchestrationCli(["__bogus__"]);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    const msg = err!.message;
+    expect(msg).toBe(
+      "unknown orch subcommand: __bogus__ (use: status, confirm, interrupt, skip, log, diff, on-stop)",
+    );
+    expect(msg).not.toContain("run-internal");
+  });
+});

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -173,7 +173,7 @@ export async function runOrchestrationCli(args: string[]): Promise<void> {
       orchOnStop(args.slice(1));
       return;
     default:
-      throw new Error(`unknown orch subcommand: ${sub}`);
+      throw new Error(`unknown orch subcommand: ${sub} (use: status, confirm, interrupt, skip, log, diff, on-stop)`);
   }
 }
 

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -173,7 +173,10 @@ export async function runOrchestrationCli(args: string[]): Promise<void> {
       orchOnStop(args.slice(1));
       return;
     default:
-      throw new Error(`unknown orch subcommand: ${sub} (use: status, confirm, interrupt, skip, log, diff, on-stop)`);
+      // `on-stop` and `run-internal` are hook / self-relaunch entry points;
+      // they stay callable but are intentionally absent from public help.
+      // Mirrors INTERNAL_HIDDEN.orch in scripts/lint-cli-subcommands.ts.
+      throw new Error(`unknown orch subcommand: ${sub} (use: status, confirm, interrupt, skip, log, diff)`);
   }
 }
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -786,7 +786,7 @@ export async function runTasks(args: string[]): Promise<void> {
     }
     default:
       throw new Error(
-        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, check, merge, unmerge, duplicates, abandon, migrate-refs, migrate-deferred)`,
+        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, migrate-refs, migrate-deferred)`,
       );
   }
 }


### PR DESCRIPTION
## Summary

Closes the silent triple-edit gap where adding a new `mag <new-sub>` previously required hand-coordinating a `case` in the dispatcher, a USAGE line, and the literal `(use: …)` listing in the dispatcher's `default` clause — none of which `lint:cli-readme` catches (that lint covers only top-level CLI vs README).

- New `scripts/lint-cli-subcommands.ts` enforces `cases ≡ USAGE-subs ≡ default-listing` (modulo a documented allow-list) across **10 sites**: `runMag`, `runFlow`, `runTasks`, `runTriggers`, `runNotify`, `runCluster`, `runDashboard`, `runOrchestrationCli`, `runNetwork`, and the top-level `MIGRATED_COMMANDS` registry.
- `runMag` (`src/mag.ts`) refactored from a 25-case `switch` to a `Map<string, MagSubHandler>`; the unknown-command listing is now derived from `magSubcommands.keys()` minus `MAG_HIDDEN_SUBCOMMANDS` (Stop-hook entries `on-stop` / `queue-pop`).
- `runOrchestrationCli` default-case error gains a canonical `(use: status, confirm, interrupt, skip, log, diff)` listing; `run-internal` and `on-stop` (hook entries) stay callable but are intentionally absent from public help.
- Top-level `src/index.ts` `not yet migrated` fallback replaced by a derived `unknown ludics command: <cmd> (use: …)` message via a new side-effect-free helper module `src/cli-dispatch.ts`.
- Drift fixed as a side effect: `runMag` listing on `main` claimed `analyze` (no handler) and missed `auto-start-evaluate` / `revise-proposal` / `feedback-digest`; `runTasks` listing missed `queue-elaborations`. USAGE was missing 6 documented commands — added.
- Round 2 (post-review): aligned runtime help with `INTERNAL_HIDDEN` policy. Hook entry points (`mag on-stop`, `mag queue-pop`, `orch on-stop`) no longer leak into user-facing `(use: …)` output. The lint also asserts hidden absence from listings (defense in depth).
- Codex inline-review fix: `hasListing: true` sites whose default error drops the `(use: …)` clause entirely now raise an explicit `expected canonical default '(use: ...)' listing` lint error instead of silently passing.

## Commits in this PR (5)

1. `gh-ludics-438: normalize default-case format and add cli-dispatch helper`
2. `gh-ludics-438: refactor runMag to a registry-derived dispatcher`
3. `gh-ludics-438: lint:cli-subcommands across 10 dispatcher sites + USAGE drift fixes`
4. `gh-ludics-438 round 2: align runtime help with INTERNAL_HIDDEN policy`
5. `gh-ludics-438: lint guards against missing (use: ...) clause`

## Test plan

- [x] `bun run typecheck` — passes.
- [x] `bun test` — 1914 pass / 1 baseline failure (`lint-test-isolation`, pre-existing on `main`).
- [x] `bun run lint:cli-subcommands` — exits 0 against the real repo.
- [x] `bun run lint:cli-readme` — no new staleness.
- [x] Smoke-tested canonical error strings via `bun run dev mag bogus`, `bun run dev orch bogus 1`, `bun run dev bogus`, `bun run dev network bogus`.
- [x] Mutation-tested the round-2 hidden-filter and the Codex listing-presence guard: removing each filter / clause trips the named assertion / lint error.
- [x] Floor-count meta-tests guard `magSubcommands` (≥ 20) and `MIGRATED_COMMANDS` (≥ 20) against silent extractor collapse (gh-ludics-406 convention).
- [x] CI workflow gains a `Lint CLI sub-command drift` step alongside `lint:cli-readme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)