### PR TITLE
task-2db5eca6: clear auto-proposal debounce on priority increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ ludics tasks convert           # Convert tasks.yaml to task files (also run by s
 ludics tasks update            # Refresh GitHub metadata for existing tasks (preserves local title edits)
 ludics tasks create <title>    # Create a new task manually
 ludics tasks files             # List individual task files
+ludics tasks priority <id> <level>
+                                # Set task priority (S, A, B, C, D); increases clear the auto-proposal debounce
 ```
 
 ### Flow engine

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -13,7 +13,7 @@ import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CL
 import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
-import { setQueueHold, maybeFeedMagQueue } from "./mag.ts";
+import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./mag.ts";
 import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
 import { resolveSkillCommand } from "./skill-queue-registry.ts";
 import { handleClusterRequest } from "./cluster-http.ts";
@@ -295,6 +295,10 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         const newPriority = PRIORITY_INCREASE[currentPriority] ?? currentPriority;
         if (newPriority !== currentPriority) {
           addFrontmatterField(taskFile, "priority", newPriority);
+          // Priority increase is a user-driven "act on this now" signal —
+          // invalidate the auto-proposal debounce so the next keepalive cycle
+          // re-evaluates this task instead of waiting out the TTL.
+          clearAutoProposalDebounce(taskParam);
         }
         lastGenerated = 0;
         return new Response(JSON.stringify({ priority: newPriority }), {
@@ -466,9 +470,19 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         return new Response("Bad Request: invalid queue id", { status: 400 });
       }
       try {
-        const status = queuePromoteToTop(idParam);
+        const result = queuePromoteToTop(idParam);
+        if (result.status === "promoted") {
+          // Promoting a task-bound queue item is the user's "act on this now"
+          // gesture for that task — clear its auto-proposal debounce so the
+          // next keepalive cycle re-evaluates eligibility. Items without a
+          // bound task (e.g. action: "briefing") are no-ops here.
+          const taskField = result.record["task"];
+          if (typeof taskField === "string" && taskField.length > 0) {
+            clearAutoProposalDebounce(taskField);
+          }
+        }
         lastGenerated = 0;
-        return new Response(JSON.stringify({ status }), {
+        return new Response(JSON.stringify({ status: result.status }), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (e) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { SlotData } from "./slots/types.ts";
@@ -746,5 +746,124 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// task-2db5eca6: priority-bump and queue-promote should clear the
+// auto-proposal debounce so the next keepalive cycle re-evaluates the task.
+// Decreases (slot-postpone) keep the sentinel intact (asymmetric by design).
+describe("dashboard HTTP debounce semantics — task-promote / queue-promote / slot-postpone", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+
+  function writeTaskFile(id: string, priority: string, status: string = "ready"): string {
+    const tasksRoot = join(harnessDir(), "tasks");
+    mkdirSync(tasksRoot, { recursive: true });
+    const file = join(tasksRoot, `${id}.md`);
+    writeFileSync(file, `---\nid: ${id}\ntitle: "${id}"\nstatus: ${status}\npriority: ${priority}\n---\n\n# ${id}\n`);
+    return file;
+  }
+
+  function writeSentinel(id: string): string {
+    const dir = join(harnessDir(), "mag", "auto-proposal-debounce");
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${encodeURIComponent(id)}.epoch`);
+    writeFileSync(path, String(Date.now()));
+    return path;
+  }
+
+  // AC3: increase clears sentinel
+  test("POST /api/task-promote on B → A clears the debounce sentinel", async () => {
+    writeTaskFile("task-X", "B");
+    const sentinel = writeSentinel("task-X");
+    expect(existsSync(sentinel)).toBe(true);
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/task-promote?task=task-X", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { priority: string };
+    expect(body.priority).toBe("A");
+    expect(existsSync(sentinel)).toBe(false);
+    const { parseTaskFrontmatter } = await import("./tasks/markdown.ts");
+    const fm = parseTaskFrontmatter(readFileSync(join(harnessDir(), "tasks", "task-X.md"), "utf-8"));
+    expect(fm.priority).toBe("A");
+  });
+
+  // AC4: no-op clamp at S preserves sentinel — gate on newPriority !== currentPriority
+  test("POST /api/task-promote at S clamp preserves the sentinel (no-op)", async () => {
+    writeTaskFile("task-Y", "S");
+    const sentinel = writeSentinel("task-Y");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/task-promote?task=task-Y", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { priority: string };
+    expect(body.priority).toBe("S");
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  // AC5: decrease via slot-postpone leaves the sentinel intact
+  test("POST /api/slot-postpone (A → B) leaves the sentinel intact", async () => {
+    const { writeSlotJson, emptySlotData } = await import("./slots/json.ts");
+    writeTaskFile("task-Z", "A", "in-progress");
+    const slotData = { ...emptySlotData(1), task: "task-Z" };
+    writeSlotJson(1, slotData);
+    const sentinel = writeSentinel("task-Z");
+
+    const handler = await makeHandler();
+    const origError = console.error;
+    console.error = () => {};
+    let resp: Response;
+    try {
+      resp = await handler(new Request("http://x/api/slot-postpone?slot=1", { method: "POST" }));
+    } finally {
+      console.error = origError;
+    }
+    expect(resp.status).toBe(200);
+    expect(existsSync(sentinel)).toBe(true);
+    const { parseTaskFrontmatter } = await import("./tasks/markdown.ts");
+    const fm = parseTaskFrontmatter(readFileSync(join(harnessDir(), "tasks", "task-Z.md"), "utf-8"));
+    expect(fm.priority).toBe("B");
+  });
+
+  // AC6: queue-promote of a task-bound item clears the matching sentinel
+  test("POST /api/queue-promote on a task-bound item clears that task's sentinel", async () => {
+    const { queueRequest, queueList } = await import("./queue.ts");
+    const idA = queueRequest({ action: "briefing" });
+    const idB = queueRequest({ action: "briefing" });
+    const idC = queueRequest({ action: "draft-proposal", task: "task-X" });
+    expect(queueList().map(i => i.id)).toEqual([idA, idB, idC]);
+    const sentinel = writeSentinel("task-X");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-promote?id=${encodeURIComponent(idC)}`, { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("promoted");
+    expect(queueList().map(i => i.id)).toEqual([idC, idA, idB]);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  // AC7: queue-promote of a task-less item is harmless (no spurious clear, no error)
+  test("POST /api/queue-promote on a task-less item is harmless", async () => {
+    const { queueRequest } = await import("./queue.ts");
+    const idA = queueRequest({ action: "briefing" });
+    const idB = queueRequest({ action: "briefing" });
+    // An unrelated sentinel must remain untouched — guards against clearing
+    // sentinels for tasks not named on the promoted record.
+    const otherSentinel = writeSentinel("task-other");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request(`http://x/api/queue-promote?id=${encodeURIComponent(idB)}`, { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("promoted");
+    expect(existsSync(otherSentinel)).toBe(true);
+    void idA;
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ Commands:
   tasks migrate-refs [--dry-run]
                                Migrate legacy task-<number> IDs to deterministic IDs and rewrite references
   tasks abandon <id>           Abandon a task (clears slot if assigned, sets status/completed)
+  tasks priority <id> <level>  Set task priority (S, A, B, C, D); increases clear the auto-proposal debounce
   tasks migrate-deferred       Migrate legacy deferred_launch/approved fields to status: deferred
 
   flow ready                   Priority-sorted ready tasks

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile } from "./mag.ts";
 import type { RunGit } from "./git-runner.ts";
 
 describe("normalizeLaunchAdapter", () => {
@@ -460,6 +460,51 @@ describe("settled sentinel atomic claim", () => {
     expect(atomicClaim()).toBe(true);
     expect(atomicClaim()).toBe(false);
     expect(atomicClaim()).toBe(false);
+  });
+});
+
+describe("clearAutoProposalDebounce", () => {
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  let TMP = "";
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-debounce-"));
+    process.env.LUDICS_HARNESS_DIR = TMP;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  // AC1: clear-when-present
+  test("removes a fresh debounce sentinel for the named task", () => {
+    const path = autoProposalDebounceFile("task-X");
+    mkdirSync(join(TMP, "mag", "auto-proposal-debounce"), { recursive: true });
+    writeFileSync(path, String(Date.now()));
+    expect(existsSync(path)).toBe(true);
+    clearAutoProposalDebounce("task-X");
+    expect(existsSync(path)).toBe(false);
+  });
+
+  // AC2: idempotent-when-absent
+  test("is a no-op when the sentinel does not exist", () => {
+    const path = autoProposalDebounceFile("task-Y");
+    expect(existsSync(path)).toBe(false);
+    expect(() => clearAutoProposalDebounce("task-Y")).not.toThrow();
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("does not affect debounce sentinels for other tasks", () => {
+    const keep = autoProposalDebounceFile("task-keep");
+    const drop = autoProposalDebounceFile("task-drop");
+    mkdirSync(join(TMP, "mag", "auto-proposal-debounce"), { recursive: true });
+    writeFileSync(keep, String(Date.now()));
+    writeFileSync(drop, String(Date.now()));
+    clearAutoProposalDebounce("task-drop");
+    expect(existsSync(keep)).toBe(true);
+    expect(existsSync(drop)).toBe(false);
   });
 });
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2028,7 +2028,7 @@ ${matches}
 
 const AUTO_PROPOSAL_DEBOUNCE_SECONDS = 1800;
 
-function autoProposalDebounceFile(taskId: string): string {
+export function autoProposalDebounceFile(taskId: string): string {
   return join(magStateDir(), "auto-proposal-debounce", `${encodeURIComponent(taskId)}.epoch`);
 }
 
@@ -2038,6 +2038,15 @@ function autoProposalDebounced(taskId: string): boolean {
 
 function markAutoProposalQueued(taskId: string): void {
   touchSentinel(autoProposalDebounceFile(taskId));
+}
+
+/**
+ * Remove the auto-proposal debounce sentinel for a task. Best-effort;
+ * absent files are silently ignored. Called from priority-bump and
+ * queue-promote seams as the user-driven "act on this now" lever.
+ */
+export function clearAutoProposalDebounce(taskId: string): void {
+  clearSentinel(autoProposalDebounceFile(taskId));
 }
 
 // --- Container completion sweep debounce + child-set fingerprint ---
@@ -3510,8 +3519,8 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
       }
       const { queuePromoteToTop } = await import("./queue.ts");
       const result = queuePromoteToTop(id);
-      if (result === "not-found") process.exitCode = 1;
-      console.log(result);
+      if (result.status === "not-found") process.exitCode = 1;
+      console.log(result.status);
     } else if (sub2 === "cancel") {
       const id = args[1];
       if (!id) throw new Error("id required (usage: mag queue cancel <id>)");

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -609,20 +609,20 @@ describe("queueRequest holds the queue lock", () => {
 describe("queuePromoteToTop", () => {
   test("returns not-found for empty queue", async () => {
     const { queuePromoteToTop } = await loadQueue();
-    expect(queuePromoteToTop("req-1-1")).toBe("not-found");
+    expect(queuePromoteToTop("req-1-1")).toEqual({ status: "not-found" });
   });
 
   test("returns not-found for unknown id", async () => {
     const { queueRequest, queuePromoteToTop } = await loadQueue();
     queueRequest({ action: "briefing" });
-    expect(queuePromoteToTop("req-never-1")).toBe("not-found");
+    expect(queuePromoteToTop("req-never-1")).toEqual({ status: "not-found" });
   });
 
   test("returns already-head when target is already at index 0", async () => {
     const qf = join(tmpDir, "mag", "queue.jsonl");
     writeFileSync(qf, '{"id":"req-1-1","action":"briefing"}\n{"id":"req-2-2","action":"briefing"}\n');
     const { queuePromoteToTop } = await loadQueue();
-    expect(queuePromoteToTop("req-1-1")).toBe("already-head");
+    expect(queuePromoteToTop("req-1-1")).toEqual({ status: "already-head" });
     expect(readFileSync(qf, "utf-8")).toBe('{"id":"req-1-1","action":"briefing"}\n{"id":"req-2-2","action":"briefing"}\n');
   });
 
@@ -634,7 +634,12 @@ describe("queuePromoteToTop", () => {
       '{"id":"req-c","action":"briefing"}\n',
     );
     const { queuePromoteToTop, queueList } = await loadQueue();
-    expect(queuePromoteToTop("req-b")).toBe("promoted");
+    const result = queuePromoteToTop("req-b");
+    expect(result.status).toBe("promoted");
+    if (result.status === "promoted") {
+      expect(result.record.id).toBe("req-b");
+      expect(result.record.action).toBe("briefing");
+    }
     const items = queueList();
     expect(items.map(i => i.id)).toEqual(["req-b", "req-a", "req-c"]);
   });
@@ -647,7 +652,7 @@ describe("queuePromoteToTop", () => {
       '{"id":"req-c","action":"briefing"}\n',
     );
     const { queuePromoteToTop, queueList } = await loadQueue();
-    expect(queuePromoteToTop("req-c")).toBe("promoted");
+    expect(queuePromoteToTop("req-c").status).toBe("promoted");
     const items = queueList();
     expect(items.map(i => i.id)).toEqual(["req-c", "req-a", "req-b"]);
   });

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -203,7 +203,10 @@ export function queuePopAll(): string[] {
   return lines;
 }
 
-export type QueuePromoteResult = "promoted" | "already-head" | "not-found";
+export type QueuePromoteResult =
+  | { status: "promoted"; record: Record<string, unknown> }
+  | { status: "already-head" }
+  | { status: "not-found" };
 
 function findLineIndexById(lines: string[], id: string): number {
   return lines.findIndex(line => {
@@ -216,13 +219,14 @@ export function queuePromoteToTop(id: string): QueuePromoteResult {
   const result = withQueueLock<QueuePromoteResult>(() => {
     const lines = readQueueLines();
     const idx = findLineIndexById(lines, id);
-    if (idx < 0) return "not-found";
-    if (idx === 0) return "already-head";
+    if (idx < 0) return { status: "not-found" };
+    if (idx === 0) return { status: "already-head" };
     const [promoted] = lines.splice(idx, 1);
     writeQueueLines([promoted!, ...lines]);
-    return "promoted";
+    const record = parseJsonRecord(promoted!) ?? {};
+    return { status: "promoted", record };
   });
-  if (result === "promoted") {
+  if (result.status === "promoted") {
     emitEvent({ event_type: "queue_mutate", source: "cli", scope: "queue", action: "promote", message: id });
   }
   return result;

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, renameSync } from "fs";
 import { extname, join } from "path";
 import { harnessDir } from "../config.ts";
-import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, priorityValue } from "./markdown.ts";
+import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, priorityValue, TASK_ID_RE } from "./markdown.ts";
 import { tasksSync, tasksConvert, tasksUpdate, tasksNeedsElaborationList, tasksQueueElaborations, contentFingerprint } from "./sync.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
@@ -654,6 +654,9 @@ const VALID_PRIORITY_RE = /^[SABCD]$/;
  * debounce intact (asymmetric by design; see task-2db5eca6).
  */
 export async function tasksSetPriority(taskId: string, newPriority: string): Promise<void> {
+  if (!TASK_ID_RE.test(taskId)) {
+    throw new Error(`invalid task ID: ${taskId} (must match ${TASK_ID_RE})`);
+  }
   if (!VALID_PRIORITY_RE.test(newPriority)) {
     throw new Error(`invalid priority: ${newPriority} (use: S, A, B, C, D)`);
   }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, renameSync } from "fs";
 import { extname, join } from "path";
 import { harnessDir } from "../config.ts";
-import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus } from "./markdown.ts";
+import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, priorityValue } from "./markdown.ts";
 import { tasksSync, tasksConvert, tasksUpdate, tasksNeedsElaborationList, tasksQueueElaborations, contentFingerprint } from "./sync.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
@@ -644,6 +644,40 @@ export async function tasksAbandon(
   });
 }
 
+const VALID_PRIORITY_RE = /^[SABCD]$/;
+
+/**
+ * Set a task's `priority` frontmatter field. When the new level is a strict
+ * increase over the current value (lower numeric `priorityValue`), also clear
+ * the auto-proposal debounce so the next keepalive cycle re-evaluates the
+ * task — the user's "act on this now" lever. Decreases and no-ops keep the
+ * debounce intact (asymmetric by design; see task-2db5eca6).
+ */
+export async function tasksSetPriority(taskId: string, newPriority: string): Promise<void> {
+  if (!VALID_PRIORITY_RE.test(newPriority)) {
+    throw new Error(`invalid priority: ${newPriority} (use: S, A, B, C, D)`);
+  }
+  const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+  if (!existsSync(taskFile)) {
+    throw new Error(`task not found: ${taskId}`);
+  }
+  const content = readFileSync(taskFile, "utf-8");
+  const currentPriority = parseTaskFrontmatter(content).priority ?? "B";
+  if (newPriority === currentPriority) {
+    console.log(`ludics: task ${taskId} already at priority ${currentPriority} (no change)`);
+    return;
+  }
+  addFrontmatterField(taskFile, "priority", newPriority);
+  const isIncrease = priorityValue(newPriority) < priorityValue(currentPriority);
+  if (isIncrease) {
+    const { clearAutoProposalDebounce } = await import("../mag.ts");
+    clearAutoProposalDebounce(taskId);
+    console.log(`ludics: task ${taskId} priority ${currentPriority} → ${newPriority} (debounce cleared)`);
+  } else {
+    console.log(`ludics: task ${taskId} priority ${currentPriority} → ${newPriority} (debounce kept)`);
+  }
+}
+
 export async function runTasks(args: string[]): Promise<void> {
   const sub = args[0] ?? "";
 
@@ -755,6 +789,17 @@ export async function runTasks(args: string[]): Promise<void> {
       console.log(`ludics: abandoned task ${id}`);
       break;
     }
+    case "priority": {
+      const id = args[1];
+      const level = args[2];
+      if (!id) throw new Error("task ID required (usage: tasks priority <task-id> <level>)");
+      if (!level) throw new Error("priority level required (usage: tasks priority <task-id> <level>; level is one of S, A, B, C, D)");
+      if (args.length > 3) {
+        throw new Error(`unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: tasks priority <task-id> <level>)`);
+      }
+      await tasksSetPriority(id, level);
+      break;
+    }
     case "migrate-deferred": {
       const dir = tasksDir();
       if (!existsSync(dir)) {
@@ -786,7 +831,7 @@ export async function runTasks(args: string[]): Promise<void> {
     }
     default:
       throw new Error(
-        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, migrate-refs, migrate-deferred)`,
+        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, priority, migrate-refs, migrate-deferred)`,
       );
   }
 }

--- a/src/tasks/priority-cli.test.ts
+++ b/src/tasks/priority-cli.test.ts
@@ -131,6 +131,23 @@ describe("tasksSetPriority", () => {
   test("missing task file throws", async () => {
     await expect(tasksSetPriority("task-missing", "A")).rejects.toThrow(/task not found/);
   });
+
+  // Path-traversal guard (codex review on PR #467): IDs containing path
+  // separators must be rejected before path construction so they cannot
+  // resolve outside the tasks directory and mutate unrelated *.md files.
+  test("rejects path-traversal task IDs before touching the filesystem", async () => {
+    // Sibling `decoy.md` in harness/ — would be hit by `../decoy` if the
+    // guard were missing. The assertion is twofold: (a) the helper rejects
+    // pre-construction, and (b) the decoy is byte-identical afterward.
+    const decoyPath = join(harness(), "decoy.md");
+    const decoyBefore = "---\nid: decoy\npriority: B\n---\n";
+    writeFileSync(decoyPath, decoyBefore);
+    await expect(tasksSetPriority("../decoy", "A")).rejects.toThrow(/invalid task ID/);
+    expect(readFileSync(decoyPath, "utf-8")).toBe(decoyBefore);
+    // Also reject embedded slash and other shell-meaningful chars.
+    await expect(tasksSetPriority("task/sub", "A")).rejects.toThrow(/invalid task ID/);
+    await expect(tasksSetPriority("", "A")).rejects.toThrow(/invalid task ID/);
+  });
 });
 
 describe("runTasks priority subcommand", () => {

--- a/src/tasks/priority-cli.test.ts
+++ b/src/tasks/priority-cli.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { runTasks, tasksSetPriority } from "./index.ts";
+
+// task-2db5eca6: `tasks priority` CLI subcommand. Increases clear the
+// auto-proposal debounce sentinel; decreases and no-ops keep it intact.
+
+const TMP = join(import.meta.dir, ".test-tmp-priority-cli");
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+`);
+  return configPath;
+}
+
+function harness(): string {
+  return join(TMP, "ludics-state", "harness");
+}
+
+function writeTaskFile(id: string, priority: string): string {
+  const tasksDir = join(harness(), "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  const file = join(tasksDir, `${id}.md`);
+  writeFileSync(file, `---\nid: ${id}\ntitle: "${id}"\nstatus: ready\npriority: ${priority}\n---\n`);
+  return file;
+}
+
+function sentinelPath(id: string): string {
+  return join(harness(), "mag", "auto-proposal-debounce", `${encodeURIComponent(id)}.epoch`);
+}
+
+function writeSentinel(id: string): string {
+  const path = sentinelPath(id);
+  mkdirSync(join(harness(), "mag", "auto-proposal-debounce"), { recursive: true });
+  writeFileSync(path, String(Date.now()));
+  return path;
+}
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  mkdirSync(TMP, { recursive: true });
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = harness();
+  mkdirSync(harness(), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("tasksSetPriority", () => {
+  // AC8: increase via CLI clears sentinel
+  test("B → A clears the auto-proposal debounce", async () => {
+    writeTaskFile("task-X", "B");
+    const sentinel = writeSentinel("task-X");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await tasksSetPriority("task-X", "A");
+    } finally {
+      console.log = origLog;
+    }
+    expect(existsSync(sentinel)).toBe(false);
+    const content = readFileSync(join(harness(), "tasks", "task-X.md"), "utf-8");
+    expect(content).toContain("priority: A");
+  });
+
+  // AC9: no-change preserves sentinel
+  test("B → B is a no-op and preserves the sentinel", async () => {
+    writeTaskFile("task-Y", "B");
+    const sentinel = writeSentinel("task-Y");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await tasksSetPriority("task-Y", "B");
+    } finally {
+      console.log = origLog;
+    }
+    expect(existsSync(sentinel)).toBe(true);
+    const content = readFileSync(join(harness(), "tasks", "task-Y.md"), "utf-8");
+    expect(content).toContain("priority: B");
+  });
+
+  // AC10: decrease via CLI preserves the sentinel — same asymmetry as slot-postpone
+  test("B → C (decrease) preserves the sentinel", async () => {
+    writeTaskFile("task-Z", "B");
+    const sentinel = writeSentinel("task-Z");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await tasksSetPriority("task-Z", "C");
+    } finally {
+      console.log = origLog;
+    }
+    expect(existsSync(sentinel)).toBe(true);
+    const content = readFileSync(join(harness(), "tasks", "task-Z.md"), "utf-8");
+    expect(content).toContain("priority: C");
+  });
+
+  // AC10 bridging: A → S is a 2-step jump increase across the priority scale —
+  // confirms the increase gate compares numeric ranks rather than relying on the
+  // single-step PRIORITY_INCREASE map.
+  test("A → S clears the sentinel (multi-step increase)", async () => {
+    writeTaskFile("task-W", "A");
+    const sentinel = writeSentinel("task-W");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await tasksSetPriority("task-W", "S");
+    } finally {
+      console.log = origLog;
+    }
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("missing task file throws", async () => {
+    await expect(tasksSetPriority("task-missing", "A")).rejects.toThrow(/task not found/);
+  });
+});
+
+describe("runTasks priority subcommand", () => {
+  // AC11: validation
+  test("rejects invalid level", async () => {
+    writeTaskFile("task-X", "B");
+    await expect(runTasks(["priority", "task-X", "Z"])).rejects.toThrow(/invalid priority/);
+  });
+
+  test("rejects missing args", async () => {
+    await expect(runTasks(["priority"])).rejects.toThrow(/task ID required/);
+    await expect(runTasks(["priority", "task-X"])).rejects.toThrow(/level required/);
+  });
+
+  test("rejects trailing arguments", async () => {
+    writeTaskFile("task-X", "B");
+    await expect(runTasks(["priority", "task-X", "A", "extra"])).rejects.toThrow(/trailing/);
+  });
+
+  // AC8 end-to-end via dispatcher
+  test("dispatcher routes B → A and clears the sentinel", async () => {
+    writeTaskFile("task-X", "B");
+    const sentinel = writeSentinel("task-X");
+    const origLog = console.log;
+    console.log = () => {};
+    try {
+      await runTasks(["priority", "task-X", "A"]);
+    } finally {
+      console.log = origLog;
+    }
+    expect(existsSync(sentinel)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `clearAutoProposalDebounce(taskId)` exported from `src/mag.ts`; called on every priority *increase* surface so the next keepalive cycle re-evaluates the task instead of waiting out the 1800s TTL.
- Dashboard `/api/task-promote` clears the sentinel on increase (gated on `newPriority !== currentPriority` so the S clamp stays a no-op). `/api/queue-promote` also clears when the promoted queue record carries a `task` field; the queue helper's return type widens to `{ status, record? }`.
- New CLI `ludics tasks priority <task-id> <level>` with the same clear-on-increase semantics, decided by numeric `priorityValue` rank (so multi-step jumps like A → S clear the sentinel too). `/api/slot-postpone` and CLI decreases keep the sentinel intact — asymmetric by design.

See `docs/proposals/task-2db5eca6.md` for ACs and rationale.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run lint:cli-readme` / `bun run lint:cli-subcommands`
- [x] `bun test src/mag.test.ts src/dashboard.test.ts src/queue.test.ts src/tasks/priority-cli.test.ts` — 218 pass
- [x] Full `bun test` — pre-existing pinned `lint-test-isolation` warning count (20 vs pinned 19) unchanged from base; not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)