### PR TITLE
gh-ludics-439: lint skill body CLI references against dispatchers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint CLI sub-command drift
         run: bun run lint:cli-subcommands
 
+      - name: Lint skill body CLI references
+        run: bun run lint:skill-cli-refs
+
       - name: Lint config reference drift
         run: bun run lint:config-reference
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ ludics mag suggest           # Get task suggestions
 ludics mag analyze <issue>   # Analyze GitHub issue
 ludics mag elaborate <id>    # Elaborate task into detailed spec
 ludics mag health-check      # Check for deadlines, issues
+ludics mag sync-learnings    # Queue a learnings-consolidation run
 ludics mag queue             # Show pending requests
 ludics mag queue pop one     # Atomic dequeue of one request
 ludics mag queue pop all     # Atomic dequeue of all requests

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "bun run --bun eslint \"src/**/*.ts\" --fix",
     "lint:cli-readme": "bun run scripts/lint-cli-readme.ts",
     "lint:cli-subcommands": "bun run scripts/lint-cli-subcommands.ts",
+    "lint:skill-cli-refs": "bun run scripts/lint-skill-cli-refs.ts",
     "lint:config-reference": "bun run scripts/lint-config-reference.ts",
     "lint:contracts": "bun run scripts/lint-contracts.ts",
     "lint:hooks": "bun run scripts/lint-hooks.ts",

--- a/scripts/lint-skill-cli-refs.test.ts
+++ b/scripts/lint-skill-cli-refs.test.ts
@@ -1,0 +1,322 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  IN_SCOPE_GLOBS,
+  buildSubCommandIndex,
+  buildTopLevelIndex,
+  collectInScopeFiles,
+  extractCliRefs,
+  extractCodeSpans,
+  lintSkillCliRefs,
+  resolveCliRefs,
+} from "./lint-skill-cli-refs.ts";
+import { extractUsageBlock } from "./lint-cli-readme.ts";
+
+// ---------------------------------------------------------------------------
+// extractCodeSpans — code-context extractor (AC #3, AC #10)
+// ---------------------------------------------------------------------------
+
+describe("extractCodeSpans", () => {
+  test("captures inline backtick spans", () => {
+    const md = "Run `ludics mag start` to begin.\n";
+    const spans = extractCodeSpans("a.md", md);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.text).toBe("ludics mag start");
+    expect(spans[0]!.line).toBe(1);
+  });
+
+  test("captures fenced code-block content", () => {
+    const md = ["before", "```bash", "ludics tasks list", "```", "after"].join(
+      "\n",
+    );
+    const spans = extractCodeSpans("a.md", md);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.text).toBe("ludics tasks list");
+  });
+
+  test("ignores prose mentions outside backticks/fences", () => {
+    // AC #10 — prose-mention rejection. The line "the ludics harness ..."
+    // contains `ludics` followed by a space then a word, but it is not in
+    // any code formatting. extractCodeSpans must yield no span for it.
+    const md = "Use the ludics harness directory wisely.\n";
+    expect(extractCodeSpans("a.md", md)).toHaveLength(0);
+  });
+
+  test("recognizes fences indented inside list items", () => {
+    // Skill files like ludics-adopt-sessions.md nest fences at 3-space
+    // indent inside numbered lists. The walker must accept a leading
+    // \s* before the ``` delimiter.
+    const md = ["1. step one", "   ```bash", "   ludics flow ready", "   ```"].join(
+      "\n",
+    );
+    const spans = extractCodeSpans("a.md", md);
+    // The fenced block contributes one span (the body line).
+    expect(spans.some((s) => s.text.includes("ludics flow ready"))).toBe(true);
+  });
+
+  test("does not emit fence-delimiter lines as spans", () => {
+    const md = ["```", "ludics mag start", "```"].join("\n");
+    const spans = extractCodeSpans("a.md", md);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.text).toBe("ludics mag start");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCliRefs — verb / sub / slot-id extraction (AC #4-#7)
+// ---------------------------------------------------------------------------
+
+describe("extractCliRefs", () => {
+  test("extracts verb-only and verb+sub", () => {
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics mag start" },
+      { file: "a.md", line: 2, text: "ludics briefing" },
+    ]);
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toMatchObject({ verb: "mag", sub: "start", slotPlaceholder: null });
+    expect(refs[1]).toMatchObject({ verb: "briefing", sub: null, slotPlaceholder: null });
+  });
+
+  test("accepts hyphenated verbs and subs (AC #7)", () => {
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics mag verify-container-completion" },
+      { file: "a.md", line: 2, text: "ludics mag auto-start-evaluate" },
+    ]);
+    expect(refs[0]!.sub).toBe("verify-container-completion");
+    expect(refs[1]!.sub).toBe("auto-start-evaluate");
+  });
+
+  test("rejects hyphen-suffixed skill names (AC #6)", () => {
+    // `ludics-elaborate` and `/ludics-draft-proposal` are skill identifiers,
+    // not CLI invocations. The anchor `(?<![/\w-])ludics\s+` requires a
+    // space after `ludics`; the hyphen forms have no space and so do not
+    // match. The negative lookbehind also rejects the leading-slash form.
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics-elaborate" },
+      { file: "a.md", line: 2, text: "/ludics-draft-proposal-worker" },
+    ]);
+    expect(refs).toHaveLength(0);
+  });
+
+  test("rejects path segments where a slash precedes ludics (AC #6 regex anchor)", () => {
+    // `~/ludics worktree`, `~/repos/ludics scripts/...` reference the
+    // project root in a path, not a CLI invocation. The negative
+    // lookbehind `(?<![/\w-])` ensures these are filtered.
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "git -C ~/ludics worktree add foo" },
+      { file: "a.md", line: 2, text: "cwd: ~/repos/ludics scripts/foo.ts" },
+    ]);
+    expect(refs).toHaveLength(0);
+  });
+
+  test("dynamic-prefix `ludics slot N <sub>` (AC #5)", () => {
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics slot N assign task-101 -a tmux" },
+      { file: "a.md", line: 2, text: "ludics slot 2 clear ready" },
+      { file: "a.md", line: 3, text: "ludics slot $TASK_ID preempt urgent" },
+      { file: "a.md", line: 4, text: "ludics slot <N> start" },
+      { file: "a.md", line: 5, text: "ludics slot ${N} stop" },
+    ]);
+    expect(refs).toHaveLength(5);
+    for (const r of refs) {
+      expect(r.verb).toBe("slot");
+      expect(r.slotPlaceholder).not.toBeNull();
+    }
+    expect(refs[0]!.sub).toBe("assign");
+    expect(refs[1]!.sub).toBe("clear");
+    expect(refs[2]!.sub).toBe("preempt");
+    expect(refs[3]!.sub).toBe("start");
+    expect(refs[4]!.sub).toBe("stop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCliRefs — happy-path + negative-fixture (AC #10)
+// ---------------------------------------------------------------------------
+
+describe("resolveCliRefs", () => {
+  test("happy path: known verb + known sub resolves with no error", () => {
+    const top = new Set(["mag", "tasks", "briefing"]);
+    const subs = new Map<string, Set<string>>([
+      ["mag", new Set(["start", "stop", "elaborate"])],
+    ]);
+    const errors = resolveCliRefs(
+      [
+        { verb: "mag", sub: "start", slotPlaceholder: null, file: "a.md", line: 1 },
+        { verb: "briefing", sub: null, slotPlaceholder: null, file: "a.md", line: 2 },
+      ],
+      top,
+      subs,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test("negative-fixture: unknown sub is reported as unknown-sub error", () => {
+    // AC #10 — a markdown string with a known-bogus reference yields one
+    // resolution error. This is the exact shape that the triggering case
+    // would have caught (`ludics mag verify-container-completion <id>`
+    // pre-fix).
+    const top = new Set(["mag"]);
+    const subs = new Map<string, Set<string>>([["mag", new Set(["start"])]]);
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics mag does-not-exist" },
+    ]);
+    const errors = resolveCliRefs(refs, top, subs);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.kind).toBe("unknown-sub");
+    expect(errors[0]!.message).toContain("ludics mag does-not-exist");
+    expect(errors[0]!.message).toContain("a.md:1");
+  });
+
+  test("negative-fixture: unknown top-level verb is reported", () => {
+    const top = new Set(["mag"]);
+    const subs = new Map<string, Set<string>>();
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics ghost-verb arg" },
+    ]);
+    const errors = resolveCliRefs(refs, top, subs);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.kind).toBe("unknown-verb");
+    expect(errors[0]!.message).toContain("ludics ghost-verb");
+  });
+
+  test("verb without a sub-dispatcher passes after top-level check", () => {
+    // `ludics briefing` has no sub-dispatcher — no sub validation
+    // attempted, even when a token follows.
+    const top = new Set(["briefing"]);
+    const subs = new Map<string, Set<string>>(); // empty — no dispatchers
+    const refs = extractCliRefs([
+      { file: "a.md", line: 1, text: "ludics briefing today-please" },
+    ]);
+    const errors = resolveCliRefs(refs, top, subs);
+    expect(errors).toEqual([]);
+  });
+
+  test("ludics alias resolves via canonical (e.g. orchestration → orch)", () => {
+    // AC #8 — alias allow-list. `orchestration` is an alias of `orch` in
+    // 438's ALIASES["ludics"]. A skill citing `ludics orchestration status`
+    // must resolve cleanly even though the orch dispatcher index is keyed
+    // under `orch`. Conversely, `ludics orchestration bogus-sub` must
+    // still be flagged — the alias must be validated against the canonical
+    // dispatcher's case set, not silently skipped.
+    const top = new Set(["orch", "orchestration"]);
+    const subs = new Map<string, Set<string>>([
+      ["orch", new Set(["status", "diff"])],
+    ]);
+    const okErrors = resolveCliRefs(
+      [{ verb: "orchestration", sub: "status", slotPlaceholder: null, file: "a.md", line: 1 }],
+      top,
+      subs,
+    );
+    expect(okErrors).toEqual([]);
+    const bogusErrors = resolveCliRefs(
+      [{ verb: "orchestration", sub: "bogus-sub", slotPlaceholder: null, file: "a.md", line: 2 }],
+      top,
+      subs,
+    );
+    expect(bogusErrors).toHaveLength(1);
+    expect(bogusErrors[0]!.kind).toBe("unknown-sub");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-scope file collection
+// ---------------------------------------------------------------------------
+
+describe("collectInScopeFiles", () => {
+  test("matches the documented scope set (AC #2)", () => {
+    expect(IN_SCOPE_GLOBS).toEqual([
+      "skills/*.md",
+      "skills/orchestration/*.md",
+      "templates/harness/CLAUDE.md",
+      "templates/mag/memory/*.md",
+    ]);
+  });
+
+  test("collects real files in repo across all four globs", () => {
+    const root = join(import.meta.dir, "..");
+    const files = collectInScopeFiles(root);
+    // Pre-assertion harness probe: the world (real repo on main) must
+    // actually have at least one file from each glob. If any glob is
+    // empty, the integration test below would pass vacuously.
+    expect(files.some((f) => f.startsWith("skills/") && !f.startsWith("skills/orchestration/"))).toBe(true);
+    expect(files.some((f) => f.startsWith("skills/orchestration/"))).toBe(true);
+    expect(files.some((f) => f === "templates/harness/CLAUDE.md")).toBe(true);
+    expect(files.some((f) => f.startsWith("templates/mag/memory/"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration against the real repo (AC #10, #13)
+// ---------------------------------------------------------------------------
+
+describe("real repository", () => {
+  const root = join(import.meta.dir, "..");
+
+  test("lintSkillCliRefs returns zero errors against real corpus (AC #13)", () => {
+    const files = collectInScopeFiles(root);
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const usageBlock = extractUsageBlock(indexSrc);
+    const result = lintSkillCliRefs(
+      files,
+      (rel) => readFileSync(join(root, rel), "utf-8"),
+      usageBlock,
+      (rel) => readFileSync(join(root, rel), "utf-8"),
+    );
+    expect(result.errors).toEqual([]);
+  });
+
+  // Floor-count meta-test (AC #9, gh-ludics-406 convention). The lint's
+  // safety claim — "every backtick-/fence-scoped `ludics …` reference
+  // resolves to a live dispatcher" — depends on the regex actually
+  // matching meaningful refs in the corpus. A DRY refactor that hides
+  // skill prose behind a partials/include mechanism would let this lint
+  // pass vacuously. The current corpus has ~89 distinct refs across the
+  // four globs; the floor of 30 is conservative with slack so individual
+  // skill rewrites do not trip the lint.
+  test("extractCliRefs: floor count of 30 against real corpus", () => {
+    const files = collectInScopeFiles(root);
+    const spans = files.flatMap((f) =>
+      extractCodeSpans(f, readFileSync(join(root, f), "utf-8")),
+    );
+    const refs = extractCliRefs(spans);
+    expect(refs.length).toBeGreaterThanOrEqual(30);
+  });
+
+  test("buildTopLevelIndex includes USAGE commands plus ludics aliases", () => {
+    const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+    const top = buildTopLevelIndex(extractUsageBlock(indexSrc));
+    // Pre-assertion harness probe: known commands must be present.
+    expect(top.has("mag")).toBe(true);
+    expect(top.has("tasks")).toBe(true);
+    expect(top.has("slot")).toBe(true);
+    expect(top.has("briefing")).toBe(true);
+    // Alias coverage: `orchestration` is an alias of `orch` in 438's
+    // ALIASES["ludics"], so it must be in the recognized top-level set.
+    expect(top.has("orchestration")).toBe(true);
+  });
+
+  test("buildSubCommandIndex covers all 9 sub-dispatchers (8 from 438 + slot)", () => {
+    const subs = buildSubCommandIndex((rel) =>
+      readFileSync(join(root, rel), "utf-8"),
+    );
+    // Pre-assertion harness probe: each prefix has a non-empty case set.
+    for (const prefix of [
+      "mag", "flow", "tasks", "triggers", "notify", "cluster",
+      "dashboard", "orch", "network", "slot",
+    ]) {
+      const set = subs.get(prefix);
+      expect(set, `prefix "${prefix}" missing from sub index`).toBeDefined();
+      expect(set!.size, `prefix "${prefix}" has empty case set`).toBeGreaterThan(0);
+    }
+    // The newly-added `mag sync-learnings` (drift-fix in this PR) must
+    // be a recognized sub. If a future change drops the dispatcher case,
+    // this assertion fails — guarding the AC #13 day-one fix.
+    expect(subs.get("mag")!.has("sync-learnings")).toBe(true);
+    // Slot dispatcher must include the canonical sub-set.
+    for (const sub of ["assign", "clear", "start", "stop", "preempt", "resume", "restore", "mode", "note"]) {
+      expect(subs.get("slot")!.has(sub), `slot sub "${sub}" missing`).toBe(true);
+    }
+  });
+});

--- a/scripts/lint-skill-cli-refs.test.ts
+++ b/scripts/lint-skill-cli-refs.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import {
   IN_SCOPE_GLOBS,
@@ -11,7 +11,6 @@ import {
   lintSkillCliRefs,
   resolveCliRefs,
 } from "./lint-skill-cli-refs.ts";
-import { extractUsageBlock } from "./lint-cli-readme.ts";
 
 // ---------------------------------------------------------------------------
 // extractCodeSpans — code-context extractor (AC #3, AC #10)
@@ -257,11 +256,10 @@ describe("real repository", () => {
   test("lintSkillCliRefs returns zero errors against real corpus (AC #13)", () => {
     const files = collectInScopeFiles(root);
     const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
-    const usageBlock = extractUsageBlock(indexSrc);
     const result = lintSkillCliRefs(
       files,
       (rel) => readFileSync(join(root, rel), "utf-8"),
-      usageBlock,
+      indexSrc,
       (rel) => readFileSync(join(root, rel), "utf-8"),
     );
     expect(result.errors).toEqual([]);
@@ -270,23 +268,28 @@ describe("real repository", () => {
   // Floor-count meta-test (AC #9, gh-ludics-406 convention). The lint's
   // safety claim — "every backtick-/fence-scoped `ludics …` reference
   // resolves to a live dispatcher" — depends on the regex actually
-  // matching meaningful refs in the corpus. A DRY refactor that hides
-  // skill prose behind a partials/include mechanism would let this lint
-  // pass vacuously. The current corpus has ~89 distinct refs across the
-  // four globs; the floor of 30 is conservative with slack so individual
-  // skill rewrites do not trip the lint.
-  test("extractCliRefs: floor count of 30 against real corpus", () => {
+  // matching *distinct* (verb, sub) pairs in the corpus. A DRY refactor
+  // that hides skill prose behind a partials/include mechanism would
+  // collapse the pair set and let this lint pass vacuously. The current
+  // corpus has ~30 distinct (verb, sub|null) pairs across the four globs;
+  // the floor of 18 is conservative with slack so individual skill
+  // rewrites do not trip the lint.
+  test("extractCliRefs: floor count of 18 distinct (verb, sub) pairs against real corpus", () => {
     const files = collectInScopeFiles(root);
     const spans = files.flatMap((f) =>
       extractCodeSpans(f, readFileSync(join(root, f), "utf-8")),
     );
     const refs = extractCliRefs(spans);
-    expect(refs.length).toBeGreaterThanOrEqual(30);
+    const pairs = new Set<string>();
+    for (const r of refs) {
+      pairs.add(`${r.verb}\t${r.sub ?? ""}`);
+    }
+    expect(pairs.size).toBeGreaterThanOrEqual(18);
   });
 
   test("buildTopLevelIndex includes USAGE commands plus ludics aliases", () => {
     const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
-    const top = buildTopLevelIndex(extractUsageBlock(indexSrc));
+    const top = buildTopLevelIndex(indexSrc);
     // Pre-assertion harness probe: known commands must be present.
     expect(top.has("mag")).toBe(true);
     expect(top.has("tasks")).toBe(true);
@@ -317,6 +320,59 @@ describe("real repository", () => {
     // Slot dispatcher must include the canonical sub-set.
     for (const sub of ["assign", "clear", "start", "stop", "preempt", "resume", "restore", "mode", "note"]) {
       expect(subs.get("slot")!.has(sub), `slot sub "${sub}" missing`).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint exit-code behaviour (AC #1 — must fail CI with non-zero exit)
+// ---------------------------------------------------------------------------
+
+describe("CLI entrypoint", () => {
+  const root = join(import.meta.dir, "..");
+  const scriptPath = join(root, "scripts", "lint-skill-cli-refs.ts");
+
+  test("happy path: spawning the script against the real corpus exits 0", () => {
+    // Pre-assertion harness probe: the live tree is the same one the
+    // integration test asserts is clean. Spawning the actual CLI proves
+    // the entrypoint wires lintSkillCliRefs → process.exit(0) on the
+    // success branch.
+    const proc = Bun.spawnSync({
+      cmd: ["bun", "run", scriptPath],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("✅");
+  });
+
+  test("failure path: a tampered in-scope file causes the CLI to exit 1", () => {
+    // Harness condition: temporarily inject a known-bogus reference into
+    // an in-scope template file, run the CLI, then restore the file.
+    // The invariant being enforced is the AC #1 wording — *the CLI
+    // entrypoint* must fail with a non-zero exit when an unresolved
+    // ref is present, not just an in-process resolver call. Mutation-
+    // testing this path catches a future refactor that drops the
+    // process.exit(1) branch (e.g. by returning the error count without
+    // exiting).
+    const target = join(root, "templates", "harness", "CLAUDE.md");
+    const original = readFileSync(target, "utf-8");
+    const tampered = original + "\n\nProbe: `ludics mag does-not-exist-xyz`\n";
+    try {
+      writeFileSync(target, tampered);
+      const proc = Bun.spawnSync({
+        cmd: ["bun", "run", scriptPath],
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(proc.exitCode).toBe(1);
+      const stderr = proc.stderr.toString();
+      expect(stderr).toContain("does-not-exist-xyz");
+      expect(stderr).toContain("❌");
+    } finally {
+      writeFileSync(target, original);
     }
   });
 });

--- a/scripts/lint-skill-cli-refs.ts
+++ b/scripts/lint-skill-cli-refs.ts
@@ -52,7 +52,7 @@
 import { readFileSync } from "fs";
 import { Glob } from "bun";
 import { join } from "path";
-import { extractUsageBlock } from "./lint-cli-readme.ts";
+import { extractUsageCommands } from "./lint-cli-readme.ts";
 import {
   ALIASES,
   DISPATCHERS,
@@ -257,14 +257,14 @@ export function buildSubCommandIndex(
   return out;
 }
 
-// Recognized top-level verb set — USAGE commands ∪ ludics aliases.
-export function buildTopLevelIndex(usageBlock: string): Set<string> {
-  // extractUsageCommands operates on the whole index source — but here we
-  // already have just the block. Replay the same regex inline.
-  const out = new Set<string>();
-  const re = /^\s{1,4}([a-z][\w-]*)\b/gm;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(usageBlock)) !== null) out.add(m[1]!);
+// Recognized top-level verb set — USAGE commands ∪ ludics aliases. Reuses
+// `extractUsageCommands` from `lint-cli-readme.ts` (the existing
+// gh-ludics-431-aware extractor) so there is exactly one parser for the
+// USAGE template literal — adding a second copy here would reintroduce
+// the silent-truncation drift class that 431 fixed (per AC #4 / reviewer
+// item #3).
+export function buildTopLevelIndex(indexSrc: string): Set<string> {
+  const out = new Set<string>(extractUsageCommands(indexSrc));
   for (const [canonical, alias] of ALIASES["ludics"] ?? []) {
     if (canonical) out.add(canonical);
     if (alias) out.add(alias);
@@ -349,7 +349,7 @@ export interface LintResult {
 export function lintSkillCliRefs(
   files: ReadonlyArray<string>,
   readSource: (path: string) => string,
-  indexUsageBlock: string,
+  indexSrc: string,
   readDispatcherSource: (relPath: string) => string,
 ): LintResult {
   const spans: CodeSpan[] = [];
@@ -358,7 +358,7 @@ export function lintSkillCliRefs(
     spans.push(...extractCodeSpans(file, src));
   }
   const refs = extractCliRefs(spans);
-  const topLevel = buildTopLevelIndex(indexUsageBlock);
+  const topLevel = buildTopLevelIndex(indexSrc);
   const subsByPrefix = buildSubCommandIndex(readDispatcherSource);
   const errors = resolveCliRefs(refs, topLevel, subsByPrefix);
   return { refs, errors };
@@ -378,11 +378,10 @@ export function collectInScopeFiles(rootDir: string): string[] {
 if (import.meta.main) {
   const files = collectInScopeFiles(root);
   const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
-  const usageBlock = extractUsageBlock(indexSrc);
   const result = lintSkillCliRefs(
     files,
     (rel) => readFileSync(join(root, rel), "utf-8"),
-    usageBlock,
+    indexSrc,
     (rel) => readFileSync(join(root, rel), "utf-8"),
   );
 
@@ -408,7 +407,5 @@ if (import.meta.main) {
       `         + default-listing, which lint:cli-subcommands enforces).\n` +
       `   See scripts/lint-skill-cli-refs.ts for the regex shape.\n`,
   );
-  // Used by extractUsageCommands floor-count guard (gh-ludics-406 convention).
-  void extractUsageCommands;
   process.exit(1);
 }

--- a/scripts/lint-skill-cli-refs.ts
+++ b/scripts/lint-skill-cli-refs.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env bun
+/**
+ * lint-skill-cli-refs.ts (gh-ludics-439)
+ *
+ * Skill markdown bodies under `skills/` (and template files under
+ * `templates/harness/`, `templates/mag/memory/`) are executable specs — Mag
+ * (and humans following the skill) literally run the `ludics ...` commands
+ * cited in code formatting. The frontmatter `queue-action: …` is auto-
+ * registered by the harness, but the prose body is plain text and was
+ * historically validated only by reviewer eyeballs at PR time. Round-2 of
+ * task-7ae99643 caught two dangling references in a single new skill —
+ * `ludics mag verify-container-completion <id>` (no dispatcher case existed)
+ * and `ludics tasks list --json` (no `--json` flag).
+ *
+ * This lint scans the in-scope markdown set for backtick- or
+ * code-fence-scoped `ludics <verb> <sub>` references and verifies each one
+ * resolves against:
+ *   - the live USAGE top-level surface (`extractUsageCommands` from
+ *     `lint-cli-readme.ts`)
+ *   - the relevant sub-dispatcher's recognized cases (`extractCasesForSite`
+ *     from `lint-cli-subcommands.ts` — the gh-ludics-438 helper)
+ *
+ * Detection rule (Q2): only references that appear inside an inline
+ * backtick span (`` `ludics x y` ``) or a fenced code block
+ * (```` ``` ````) are flagged. Prose mentions like "the ludics harness
+ * directory" outside any code formatting are intentionally not flagged.
+ *
+ * Skill-name false-positive guard (AC #6): the anchor `(?<![/\w-])ludics\s+`
+ * requires a literal space after `ludics`, so hyphen-suffixed skill names
+ * like `` `ludics-elaborate` `` or `` `/ludics-draft-proposal` `` are
+ * naturally excluded. The negative lookbehind also rejects path segments
+ * like `~/repos/ludics worktree` or `cwd:~/ludics scripts/...` (where the
+ * char before `ludics` is `/`, a word-char, or `-`) — those mention the
+ * project root, not a CLI invocation.
+ *
+ * Dynamic-prefix special-case (AC #5): `ludics slot N <sub>` is recognized
+ * as `slot` + slot-id + sub. The slot-id matches `\d+`, the literal
+ * placeholder `N`, the angle-bracket placeholder `<N>`, or shell-variable
+ * forms `$N` / `${N}` / `$TASK_ID`. The dispatcher cases for `slot` are
+ * extracted from `runSlot` in `src/slots/index.ts` directly — gh-ludics-438's
+ * DISPATCHERS array does not yet cover slot. TODO: upstream a
+ * `runSlot` site descriptor into 438's helper once the slot dispatcher is
+ * stable enough.
+ *
+ * SILENT-DRIFT WARNING (gh-ludics-406): the markdown extractors below are
+ * regex over source. A DRY refactor that consolidates skill prose behind a
+ * partials/include mechanism would let this lint pass vacuously. The
+ * floor-count meta-test in `scripts/lint-skill-cli-refs.test.ts` guards
+ * against that.
+ */
+
+import { readFileSync } from "fs";
+import { Glob } from "bun";
+import { join } from "path";
+import { extractUsageBlock } from "./lint-cli-readme.ts";
+import {
+  ALIASES,
+  DISPATCHERS,
+  extractCasesForSite,
+  extractCasesFromFn,
+  extractNamedBody,
+} from "./lint-cli-subcommands.ts";
+
+const root = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// In-scope file globs (AC #2)
+// ---------------------------------------------------------------------------
+
+export const IN_SCOPE_GLOBS: ReadonlyArray<string> = [
+  "skills/*.md",
+  "skills/orchestration/*.md",
+  "templates/harness/CLAUDE.md",
+  "templates/mag/memory/*.md",
+];
+
+// ---------------------------------------------------------------------------
+// Code-context extraction (AC #3)
+// ---------------------------------------------------------------------------
+
+export interface CodeSpan {
+  file: string;
+  line: number;
+  text: string;
+}
+
+// Walk markdown line-by-line, tracking fence state. Inline-backtick spans
+// (within prose lines) and lines inside fenced code blocks both contribute
+// CodeSpans. Fenced delimiters are recognized as `^\s*` + three-or-more
+// backticks (any optional language tag). Inline backticks are matched as
+// the shortest span between paired single backticks on the same line.
+//
+// A fenced delimiter line itself is not emitted as a span, but a line whose
+// content begins with three backticks inside an *already open* fence is
+// treated as the closing delimiter and not emitted either.
+export function extractCodeSpans(file: string, source: string): CodeSpan[] {
+  const out: CodeSpan[] = [];
+  const lines = source.split("\n");
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? "";
+    const trimmed = raw.trimStart();
+    if (/^`{3,}/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      out.push({ file, line: i + 1, text: raw });
+      continue;
+    }
+    // Inline-backtick scan. Skip triple-backtick clusters mid-line (those are
+    // unbalanced fence-start fragments — markdown spec says they're literals;
+    // any matched ludics ref inside is treated like prose).
+    let j = 0;
+    while (j < raw.length) {
+      const ch = raw[j];
+      if (ch !== "`") {
+        j++;
+        continue;
+      }
+      // count run length
+      let runStart = j;
+      while (j < raw.length && raw[j] === "`") j++;
+      const runLen = j - runStart;
+      if (runLen >= 3) continue; // ignore — would have been a fence
+      // find matching closing run of the same length on this line
+      const search = "`".repeat(runLen);
+      const closeAt = raw.indexOf(search, j);
+      if (closeAt === -1) {
+        // unmatched — bail to next char after the opener
+        continue;
+      }
+      out.push({ file, line: i + 1, text: raw.slice(j, closeAt) });
+      j = closeAt + runLen;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Reference extraction (AC #4, #5, #6, #7)
+// ---------------------------------------------------------------------------
+
+export interface CliRef {
+  verb: string;
+  sub: string | null;
+  // For `ludics slot <id> <sub>`, holds the literal id token (e.g. "2",
+  // "N", "<N>", "$N", "${N}", "$TASK_ID"). null otherwise.
+  slotPlaceholder: string | null;
+  file: string;
+  line: number;
+}
+
+// Slot id token: digits, bareword `N`, angle-bracket placeholder `<N>` /
+// `<n>`, or any shell-variable form `$NAME` / `${NAME}`.
+const SLOT_ID_TOKEN = /^(?:\d+|[Nn]|<[A-Za-z_][\w-]*>|\$\{?[A-Za-z_]\w*\}?)$/;
+
+// `(?<![/\w-])ludics\s+` is the required anchor — the explicit space
+// excludes hyphen-suffixed skill names like `ludics-elaborate` (AC #6),
+// and the negative lookbehind excludes path segments like
+// `~/repos/ludics worktree` or `~/ludics scripts/foo.ts` (where `/`,
+// a word-char, or `-` precedes `ludics`). Verb / sub tokens follow
+// `[a-z][a-z0-9-]*` (hyphenated multi-word names like
+// `auto-start-evaluate` accepted, AC #7).
+const LUDICS_VERB_RE =
+  /(?<![/\w-])ludics\s+([a-z][a-z0-9-]*)\b(?:\s+(\S+))?(?:\s+(\S+))?/g;
+
+const VERB_OR_SUB_RE = /^[a-z][a-z0-9-]*$/;
+
+export function extractCliRefs(spans: ReadonlyArray<CodeSpan>): CliRef[] {
+  const out: CliRef[] = [];
+  for (const span of spans) {
+    LUDICS_VERB_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = LUDICS_VERB_RE.exec(span.text)) !== null) {
+      const verb = m[1]!;
+      const second = m[2] ?? null;
+      const third = m[3] ?? null;
+      if (verb === "slot" && second !== null && SLOT_ID_TOKEN.test(second)) {
+        // `ludics slot <id> <sub>?` — sub is the third token if present and
+        // matches the verb-or-sub shape.
+        const sub = third !== null && VERB_OR_SUB_RE.test(third) ? third : null;
+        out.push({
+          verb,
+          sub,
+          slotPlaceholder: second,
+          file: span.file,
+          line: span.line,
+        });
+        continue;
+      }
+      const sub = second !== null && VERB_OR_SUB_RE.test(second) ? second : null;
+      out.push({
+        verb,
+        sub,
+        slotPlaceholder: null,
+        file: span.file,
+        line: span.line,
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-dispatcher recognized-set computation (AC #4, #8)
+// ---------------------------------------------------------------------------
+
+// For a given prefix in 438's DISPATCHERS, compute the recognized sub-command
+// set: raw cases ∪ alias names from ALIASES[prefix]. Aliases are added so a
+// citation of either canonical or alias resolves cleanly. Internal-hidden
+// commands (`on-stop`, `queue-pop`, ...) remain in the set — they are real
+// dispatcher cases that work, just hidden from public help, and a skill that
+// fires them is still operating against a live entry point.
+function recognizedSubsFor(
+  cases: Set<string>,
+  prefix: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const c of cases) {
+    if (!c) continue;
+    out.add(c);
+  }
+  for (const [canonical, alias] of ALIASES[prefix] ?? []) {
+    if (canonical) out.add(canonical);
+    if (alias) out.add(alias);
+  }
+  return out;
+}
+
+// Compute the recognized sub-command sets keyed by prefix. The `slot` prefix
+// is computed inline because gh-ludics-438's DISPATCHERS does not yet cover
+// the slot dispatcher (TODO: upstream).
+export function buildSubCommandIndex(
+  readSource: (relPath: string) => string,
+): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  for (const site of DISPATCHERS) {
+    if (site.prefix === "ludics") continue; // top-level handled separately
+    const src = readSource(site.file);
+    const open = site.shape === "registry-map" ? "[" : "{";
+    const body = extractNamedBody(src, site.fnName, open);
+    const cases = extractCasesForSite(body, site.shape);
+    out.set(site.prefix, recognizedSubsFor(cases, site.prefix));
+  }
+  // slot dispatcher — inline extraction. TODO(gh-ludics-438): consolidate
+  // once 438's DISPATCHERS array grows a slot site descriptor.
+  const slotSrc = readSource("src/slots/index.ts");
+  const slotBody = extractNamedBody(slotSrc, "runSlot", "{");
+  const rawSlotCases = extractCasesFromFn(slotBody);
+  const slotCases = new Set<string>();
+  for (const c of rawSlotCases) {
+    if (!c || !VERB_OR_SUB_RE.test(c)) continue; // drop arg-parsing flags
+    slotCases.add(c);
+  }
+  out.set("slot", recognizedSubsFor(slotCases, "slot"));
+  return out;
+}
+
+// Recognized top-level verb set — USAGE commands ∪ ludics aliases.
+export function buildTopLevelIndex(usageBlock: string): Set<string> {
+  // extractUsageCommands operates on the whole index source — but here we
+  // already have just the block. Replay the same regex inline.
+  const out = new Set<string>();
+  const re = /^\s{1,4}([a-z][\w-]*)\b/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(usageBlock)) !== null) out.add(m[1]!);
+  for (const [canonical, alias] of ALIASES["ludics"] ?? []) {
+    if (canonical) out.add(canonical);
+    if (alias) out.add(alias);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolutionError {
+  ref: CliRef;
+  kind: "unknown-verb" | "unknown-sub";
+  message: string;
+}
+
+// 438's DISPATCHERS prefixes (those with a known sub-dispatcher) plus slot.
+// Used to decide whether a missing sub is a hard error or merely "the verb
+// has no sub-dispatcher; nothing to validate" (e.g. `ludics briefing`).
+function buildDispatcherPrefixSet(): Set<string> {
+  const out = new Set<string>();
+  for (const site of DISPATCHERS) {
+    if (site.prefix === "ludics") continue;
+    out.add(site.prefix);
+  }
+  out.add("slot");
+  return out;
+}
+
+const DISPATCHER_PREFIX_SET = buildDispatcherPrefixSet();
+
+export function resolveCliRefs(
+  refs: ReadonlyArray<CliRef>,
+  topLevel: Set<string>,
+  subsByPrefix: Map<string, Set<string>>,
+): ResolutionError[] {
+  const errors: ResolutionError[] = [];
+  for (const ref of refs) {
+    if (!topLevel.has(ref.verb)) {
+      errors.push({
+        ref,
+        kind: "unknown-verb",
+        message: `unknown top-level command: ludics ${ref.verb} (${ref.file}:${ref.line})`,
+      });
+      continue;
+    }
+    // Resolve through the ludics-level alias map first: e.g. `orchestration`
+    // → `orch`. The sub-dispatcher index is keyed by canonical prefix.
+    const canonicalPrefix = canonicalLudicsAlias(ref.verb);
+    if (!DISPATCHER_PREFIX_SET.has(canonicalPrefix)) continue;
+    if (ref.sub === null) continue; // bare `ludics mag` etc. — top-level OK
+    const subs = subsByPrefix.get(canonicalPrefix);
+    if (!subs) continue; // no sub index — nothing to validate
+    if (!subs.has(ref.sub)) {
+      errors.push({
+        ref,
+        kind: "unknown-sub",
+        message: `unknown sub-command: ludics ${ref.verb} ${ref.sub} (${ref.file}:${ref.line})`,
+      });
+    }
+  }
+  return errors;
+}
+
+function canonicalLudicsAlias(verb: string): string {
+  for (const [canonical, alias] of ALIASES["ludics"] ?? []) {
+    if (alias === verb) return canonical;
+  }
+  return verb;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry
+// ---------------------------------------------------------------------------
+
+export interface LintResult {
+  refs: CliRef[];
+  errors: ResolutionError[];
+}
+
+export function lintSkillCliRefs(
+  files: ReadonlyArray<string>,
+  readSource: (path: string) => string,
+  indexUsageBlock: string,
+  readDispatcherSource: (relPath: string) => string,
+): LintResult {
+  const spans: CodeSpan[] = [];
+  for (const file of files) {
+    const src = readSource(file);
+    spans.push(...extractCodeSpans(file, src));
+  }
+  const refs = extractCliRefs(spans);
+  const topLevel = buildTopLevelIndex(indexUsageBlock);
+  const subsByPrefix = buildSubCommandIndex(readDispatcherSource);
+  const errors = resolveCliRefs(refs, topLevel, subsByPrefix);
+  return { refs, errors };
+}
+
+export function collectInScopeFiles(rootDir: string): string[] {
+  const out: string[] = [];
+  for (const pattern of IN_SCOPE_GLOBS) {
+    const glob = new Glob(pattern);
+    for (const match of glob.scanSync({ cwd: rootDir, onlyFiles: true })) {
+      out.push(match);
+    }
+  }
+  return out.sort();
+}
+
+if (import.meta.main) {
+  const files = collectInScopeFiles(root);
+  const indexSrc = readFileSync(join(root, "src", "index.ts"), "utf-8");
+  const usageBlock = extractUsageBlock(indexSrc);
+  const result = lintSkillCliRefs(
+    files,
+    (rel) => readFileSync(join(root, rel), "utf-8"),
+    usageBlock,
+    (rel) => readFileSync(join(root, rel), "utf-8"),
+  );
+
+  if (result.errors.length === 0) {
+    console.log(
+      `✅  All ${result.refs.length} skill/template CLI refs across ${files.length} files resolve.`,
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `\n❌  Skill body CLI refs do not resolve to live dispatchers:\n`,
+  );
+  for (const e of result.errors) {
+    console.error(`     - ${e.message}`);
+  }
+  console.error(
+    `\n   Each error names a backtick- or code-fence-scoped 'ludics …'\n` +
+      `   reference that does not resolve to a real USAGE entry / dispatcher\n` +
+      `   case. Fix by either:\n` +
+      `     (a) updating the skill prose to a live command, or\n` +
+      `     (b) implementing the missing dispatcher case (and USAGE entry\n` +
+      `         + default-listing, which lint:cli-subcommands enforces).\n` +
+      `   See scripts/lint-skill-cli-refs.ts for the regex shape.\n`,
+  );
+  // Used by extractUsageCommands floor-count guard (gh-ludics-406 convention).
+  void extractUsageCommands;
+  process.exit(1);
+}

--- a/skills/ludics-adopt-sessions.md
+++ b/skills/ludics-adopt-sessions.md
@@ -167,7 +167,7 @@ Brief report:
 ```
 Adopted 2 sessions:
 - Slot 2: claude-code on ocannl → task-101 "Implement tensor concatenation" (agent-claude)
-- Slot 5: codex on ludics → ludics development (agent-codex)
+- Slot 5: codex on ludics → ludics-development (agent-codex)
 Skipped: 1 stale, 1 unmatched (scratch), 1 project already in slot 3
 ```
 

--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -184,7 +184,7 @@ This skill is invoked when:
 - Blocked tasks: 3
 - Queue pending: 0
 - Tasks needing elaboration: 5
-- Test suites: ludics passing, other-project passing
+- Test suites: ludics: passing, other-project: passing
 
 ## Elaboration Status
 - 2 tasks awaiting elaboration (queued automatically by mag keepalive)

--- a/skills/ludics-new-quote.md
+++ b/skills/ludics-new-quote.md
@@ -13,7 +13,7 @@ This skill searches for quotable passages from Jean-Yves Girard's writings and c
 
 2. **Search for Girard quotes.** Use web search to find quotable passages. Good sources and search strategies:
    - Search: `Girard "linear logic" quotes site:girard.perso.math.cnrs.fr`
-   - Search: `Girard "Locus Solum" ludics quotes remarks`
+   - Search: `Girard "Locus Solum" Ludics quotes remarks`
    - Search: `Girard "Blind Spot" lectures logic quotes`
    - Search: `Girard "meaning of logical rules" quotes`
    - Search: `Girard "geometry of interaction" quotes epigrams`

--- a/skills/worker-conventions.md
+++ b/skills/worker-conventions.md
@@ -26,6 +26,21 @@ Reach for declare/salvage/follow-up only when a fix exceeds the absorb
 boundary — a few lines, same file or sibling test, no new abstractions or
 imports, no new public surface.
 
+## Skill body CLI references
+
+Skill markdown bodies are executable specs — Mag and human readers literally
+run the `ludics ...` commands cited in code formatting. Every literal
+`ludics <verb> <sub>` written inside backticks or a fenced code block must
+resolve to a real dispatcher case and a USAGE entry in `src/index.ts`. The
+`lint:skill-cli-refs` script catches drift in CI; sanity-check locally
+before opening a PR with `bun run lint:skill-cli-refs`.
+
+**Prefer direct tools where an equivalent exists** — `Read`, `Glob`, and
+`Bash` are validated by the agent harness and compose better than shelling
+to `ludics tasks list --json` or similar. This is guidance only; firing
+`ludics notify`, `ludics slot N assign`, etc. remains entirely fine where
+there is no equivalent direct path.
+
 ## Manual-Smoke Evidence
 
 When an AC requires "manual smoke verification," reviewers will not accept

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,7 @@ Commands:
                                Evaluate auto-start decision and update task status
   mag completed <proposal>     Mark a proposal completed (without .md extension)
   mag feedback-digest          Queue a feedback digest run
+  mag sync-learnings           Queue a learnings-consolidation run
   mag message "text"           Send async message to Mag
   mag queue                    Show pending queue requests
   mag queue pop one            Pop and print first queue item (JSONL)

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3469,6 +3469,10 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
     queueRequest({ action: "elaborate", task: taskId });
     console.log(`Queued elaborate request for ${taskId}`);
   }],
+  ["sync-learnings", () => {
+    queueRequest({ action: "sync-learnings" });
+    console.log("Queued sync-learnings request");
+  }],
   ["health-check", () => {
     if (!clusterIsController()) {
       console.error("ludics: mag health-check skipped — not the cluster controller");

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -130,7 +130,7 @@ function nextRequestId(): string {
 }
 
 export type QueueAction =
-  | { action: "briefing" | "suggest" | "health-check" | "adopt-sessions" }
+  | { action: "briefing" | "suggest" | "health-check" | "adopt-sessions" | "sync-learnings" }
   | { action: "elaborate" | "draft-proposal" | "split-task" | "verify-completion" | "verify-container-completion" | "complete-task" | "process-suggestions"; task: string }
   | { action: "revise-proposal"; task: string; feedback?: string }
   | { action: "preempt"; task: string; autonomy: string }


### PR DESCRIPTION
## Summary

- New `scripts/lint-skill-cli-refs.ts` (registered as `lint:skill-cli-refs` in `package.json` and wired into `.github/workflows/ci.yml`) scans `skills/*.md`, `skills/orchestration/*.md`, `templates/harness/CLAUDE.md`, and `templates/mag/memory/*.md` for backtick- or fenced-block-scoped `ludics <verb> <sub>` references and verifies each resolves against USAGE plus the relevant sub-dispatcher's recognized cases. Closes the cross-artifact drift gap that round-2 of task-7ae99643 caught.
- Top-level resolution reuses `extractUsageCommands` from `scripts/lint-cli-readme.ts` (single parser for the USAGE template literal) plus the `ALIASES` allow-list from `scripts/lint-cli-subcommands.ts` (gh-ludics-438).
- Detection rule (Q2 resolved): only references inside inline backticks or fenced code blocks are flagged. Anchor `(?<![/\w-])ludics\s+` rejects hyphen-suffixed skill names (`ludics-elaborate`) and path segments (`~/ludics worktree`).
- Slot dispatcher (`runSlot` cases) extracted inline with a TODO to upstream into 438's `DISPATCHERS`. Slot-id placeholders accepted: `\d+`, `N`, `<N>`, `$N`, `${N}`.
- Day-one drift fixed in this PR (AC #13):
  - **`mag sync-learnings`**: `skills/ludics-sync-learnings.md` cited a CLI that had no dispatcher case. Implemented the manual-trigger CLI — `magSubcommands` entry in `src/mag.ts`, USAGE line in `src/index.ts`, README CLI Reference entry in `README.md`, `QueueAction` union extension in `src/queue.ts`. Mirrors the verify-container-completion fix from task-7ae99643.
  - **Three prose mentions** reformatted to escape the lint regex (project-name narrative output, test-suite status label, search-query proper-noun).
- Worker-conventions paragraph (Q4 resolved — guidance only): added to `skills/worker-conventions.md`.

Floor-count meta-test (gh-ludics-406 convention): asserts `≥ 18` distinct `(verb, sub)` pairs against the corpus; current count is 40.

## Round 2 — review feedback addressed

- **CI wiring** (`.github/workflows/ci.yml`): the lint runs as a CI step, not just locally.
- **README drift** (`README.md`): `ludics mag sync-learnings` added to the CLI Reference fenced block.
- **AC #4 helper reuse** (`scripts/lint-skill-cli-refs.ts`): `buildTopLevelIndex` delegates to `extractUsageCommands` instead of duplicating the regex.
- **AC #9 distinct pairs** (`scripts/lint-skill-cli-refs.test.ts`): floor-count test now compares `Set` size, not raw occurrences.
- **AC #1 CLI exit-code** (`scripts/lint-skill-cli-refs.test.ts`): two new `Bun.spawnSync` tests cover happy-path (exit 0) and failure-path (exit 1, stderr contains the bogus token).

## Test plan

- [x] `bun run lint:skill-cli-refs` — `✅  All 92 skill/template CLI refs across 51 files resolve.`
- [x] `bun test scripts/lint-skill-cli-refs.test.ts` — 23 pass / 0 fail / 91 expects (added 2 CLI exit-code tests in round 2).
- [x] `bun test src/ scripts/` — 1917 pass / 0 fail.
- [x] `bun run lint:cli-readme`, `bun run lint:cli-subcommands`, `bun run typecheck` — all green.
- [x] Mutation-tested the regex anchor (`(?<![/\w-])` → `\b`) — integration assertion fails as expected.

## AC verification

See `.peer-sync/workflow-feedback-coder.md` (committed in this branch) for the per-AC verification with cited assertions, harness conditions, and mutation-test results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
