### PR TITLE
task-defe2e27: generic-typed console capture/silence helpers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -368,8 +368,10 @@ function readonlySet<T>(set: Set<T>): ReadonlySet<T> {
       if (prop === "add" || prop === "delete" || prop === "clear") {
         throw new TypeError(`readonly Set: '${String(prop)}' is not allowed`);
       }
-      const value = Reflect.get(target, prop, target);
-      return typeof value === "function" ? value.bind(target) : value;
+      const value: unknown = Reflect.get(target, prop, target);
+      return typeof value === "function"
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value;
     },
   }) as ReadonlySet<T>;
 }

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -60,6 +60,9 @@ afterEach(() => {
 });
 
 describe("eventsQuery validation", () => {
+  // TODO(once-import-is-static): replace with captureConsoleLog from ./test-utils.ts
+  // — the wrapper is only async because of the local `await import("./events.ts")`;
+  // once that becomes a static top-level import this collapses to a one-liner.
   async function captureOutput(args: string[]): Promise<string[]> {
     const lines: string[] = [];
     const origLog = console.log;

--- a/src/flow.test.ts
+++ b/src/flow.test.ts
@@ -56,7 +56,7 @@ describe("flowBlocked", () => {
     writeTask("task-b1", "B", ["task-blocker"]);
     writeTask("task-a1", "A", ["task-blocker"]);
 
-    const lines = captureConsoleLog(() => flowBlocked());
+    const { lines } = captureConsoleLog(() => flowBlocked());
 
     const ids = lines.map((l) => l.split(" ")[0]);
     expect(ids).toEqual(["task-s1", "task-a1", "task-b1", "task-c1", "task-d1"]);
@@ -67,7 +67,7 @@ describe("flowBlocked", () => {
     writeTask("task-x1", "X", ["task-blocker"]);
     writeTask("task-s1", "S", ["task-blocker"]);
 
-    const lines = captureConsoleLog(() => flowBlocked());
+    const { lines } = captureConsoleLog(() => flowBlocked());
 
     const ids = lines.map((l) => l.split(" ")[0]);
     expect(ids).toEqual(["task-s1", "task-d1", "task-x1"]);

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -438,7 +438,7 @@ describe("skills", () => {
     const origDev = process.env.LUDICS_DEV;
     process.env.LUDICS_DEV = "1";
     let text = "";
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
     });
     try {
@@ -456,7 +456,7 @@ describe("skills", () => {
     delete process.env.LUDICS_DEV;
     delete process.env.DEBUG;
     let text = "";
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       text = substituteTemplate("hello {{TYPO_VAR}} world", baseCtx());
     });
     try {

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -558,7 +558,7 @@ describe("ensureGitExcludes", () => {
     const countBefore = gitLogCount(repo);
 
     // Silence the expected warning so test output stays clean
-    const warnings = captureConsoleError(() => ensureGitExcludes(repo));
+    const { lines: warnings } = captureConsoleError(() => ensureGitExcludes(repo));
 
     // Warning emitted about the skip
     expect(warnings.some((w) => w.includes("skipping untrack") && w.includes("pre-existing staged"))).toBe(true);
@@ -737,7 +737,7 @@ describe("removeWorktreeByPath prefix guard", () => {
     const repo = join(TMP, "remove-guard");
     initRepo(repo);
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       removeWorktreeByPath(repo, "/some/random/path");
     });
 
@@ -749,7 +749,7 @@ describe("removeWorktreeByPath prefix guard", () => {
     const repo = join(TMP, "remove-guard-generic");
     initRepo(repo);
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       // These share the repo prefix but are not orchestration worktrees
       removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-backup"));
       removeWorktreeByPath(repo, join(dirname(repo), "remove-guard-generic-scratch"));
@@ -770,7 +770,7 @@ describe("removeWorktreeByPath prefix guard", () => {
     const setup = createWorktrees(repo, "task-abc123", [{ name: "a1" }], "main", 1);
 
     // Should not warn — path matches orchestration naming
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       removeWorktreeByPath(repo, setup.rootWorktree);
     });
 
@@ -789,7 +789,7 @@ describe("removeWorktreeByPath prefix guard", () => {
     // Create a worktree with single-token taskId + slot
     const setup = createWorktrees(repo, "feat", [{ name: "a1" }], "main", 1);
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       removeWorktreeByPath(repo, setup.rootWorktree);
     });
 
@@ -815,7 +815,7 @@ describe("deleteBranches prefix guard", () => {
     run(["git", "branch", "feature-safe"], repo);
 
     // Capture stderr to verify warning
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       deleteBranches(repo, [
         "ludics/test-task-s1/root",
         "main",
@@ -1020,7 +1020,7 @@ describe("purgeOrphanDirIfRecoverable", () => {
     const path = join(TMP, "myrepo-task-unrec-s1");
     seedOrphanLayout(path, { withStray: { name: "user-notes.md", contents: "keep me\n" } });
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
     });
     // No console.error from the purge itself — classify-only path is silent.
@@ -1050,7 +1050,7 @@ describe("purgeOrphanDirIfRecoverable", () => {
     const path = join(TMP, "user-data");
     seedOrphanLayout(path); // pure allow-list content
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
     });
     expect(warnings.some((w) => w.includes("refusing to purge") && w.includes("user-data"))).toBe(true);
@@ -1069,7 +1069,7 @@ describe("purgeOrphanDirIfRecoverable", () => {
     const path = join(TMP, "myrepo-backup");
     seedOrphanLayout(path);
 
-    const warnings = captureConsoleError(() => {
+    const { lines: warnings } = captureConsoleError(() => {
       expect(purgeOrphanDirIfRecoverable(projectDir, path)).toBe(false);
     });
     expect(warnings.some((w) => w.includes("refusing to purge"))).toBe(true);

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -314,7 +314,7 @@ describe("withSyntheticHarness", () => {
 describe("captureConsoleLog", () => {
   test("returns lines and restores console.log", () => {
     const orig = console.log;
-    const lines = captureConsoleLog(() => {
+    const { lines } = captureConsoleLog(() => {
       console.log("hello");
       console.log("world", 42);
     });
@@ -334,17 +334,34 @@ describe("captureConsoleLog", () => {
   });
 
   test("stringifies null arg as empty string (not 'null')", () => {
-    const lines = captureConsoleLog(() => {
+    const { lines } = captureConsoleLog(() => {
       console.log(null);
     });
     expect(lines).toEqual([""]);
+  });
+
+  test("returns fn's value alongside captured lines (T = number)", () => {
+    const result = captureConsoleLog(() => {
+      console.log("side-effect");
+      return 42;
+    });
+    expect(result.value).toBe(42);
+    expect(result.lines).toEqual(["side-effect"]);
+  });
+
+  test("infers T = void when fn returns nothing (caller-compat)", () => {
+    const result = captureConsoleLog(() => {
+      console.log("just side effects");
+    });
+    expect(result.lines).toEqual(["just side effects"]);
+    expect(result.value).toBeUndefined();
   });
 });
 
 describe("captureConsoleError", () => {
   test("returns lines and restores console.error", () => {
     const orig = console.error;
-    const lines = captureConsoleError(() => {
+    const { lines } = captureConsoleError(() => {
       console.error("a", "b");
       console.error("c");
     });
@@ -361,6 +378,15 @@ describe("captureConsoleError", () => {
       });
     }).toThrow("kaboom");
     expect(console.error).toBe(orig);
+  });
+
+  test("returns fn's value alongside captured lines (T = string)", () => {
+    const result = captureConsoleError(() => {
+      console.error("warn-1");
+      return "the-return";
+    });
+    expect(result.value).toBe("the-return");
+    expect(result.lines).toEqual(["warn-1"]);
   });
 });
 
@@ -390,6 +416,20 @@ describe("silenceConsoleError", () => {
     }).toThrow("silence-err");
     expect(console.error).toBe(orig);
   });
+
+  test("returns fn's value (T = number)", () => {
+    const value = silenceConsoleError(() => {
+      console.error("muted");
+      return 7;
+    });
+    expect(value).toBe(7);
+  });
+
+  test("returns fn's value (T = object identity)", () => {
+    const sentinel = { id: "sentinel" };
+    const value = silenceConsoleError(() => sentinel);
+    expect(value).toBe(sentinel);
+  });
 });
 
 describe("silenceConsoleWarn", () => {
@@ -417,5 +457,13 @@ describe("silenceConsoleWarn", () => {
       });
     }).toThrow("silence-warn");
     expect(console.warn).toBe(orig);
+  });
+
+  test("returns fn's value (T = string)", () => {
+    const value = silenceConsoleWarn(() => {
+      console.warn("muted");
+      return "warn-return";
+    });
+    expect(value).toBe("warn-return");
   });
 });

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -25,46 +25,49 @@ try {
 
 type ConsoleChannel = "log" | "error" | "warn";
 
-function withConsoleOverride(
+function withConsoleOverride<T>(
   channel: ConsoleChannel,
   override: (...args: unknown[]) => void,
-  fn: () => void,
-): void {
+  fn: () => T,
+): T {
   const orig = console[channel];
   console[channel] = override;
   try {
-    fn();
+    return fn();
   } finally {
     console[channel] = orig;
   }
 }
 
-function captureLines(channel: ConsoleChannel, fn: () => void): string[] {
+function captureLines<T>(
+  channel: ConsoleChannel,
+  fn: () => T,
+): { lines: string[]; value: T } {
   const lines: string[] = [];
-  withConsoleOverride(channel, (...args: unknown[]) => {
+  const value = withConsoleOverride(channel, (...args: unknown[]) => {
     lines.push(args.map((a) => String(a ?? "")).join(" "));
   }, fn);
-  return lines;
+  return { lines, value };
 }
 
 /** Capture lines written to `console.log` while running `fn`; restores on return or throw. */
-export function captureConsoleLog(fn: () => void): string[] {
+export function captureConsoleLog<T>(fn: () => T): { lines: string[]; value: T } {
   return captureLines("log", fn);
 }
 
 /** Capture lines written to `console.error` while running `fn`; restores on return or throw. */
-export function captureConsoleError(fn: () => void): string[] {
+export function captureConsoleError<T>(fn: () => T): { lines: string[]; value: T } {
   return captureLines("error", fn);
 }
 
 /** Run `fn` with `console.error` no-op'd; restores on return or throw. */
-export function silenceConsoleError(fn: () => void): void {
-  withConsoleOverride("error", () => {}, fn);
+export function silenceConsoleError<T>(fn: () => T): T {
+  return withConsoleOverride("error", () => {}, fn);
 }
 
 /** Run `fn` with `console.warn` no-op'd; restores on return or throw. */
-export function silenceConsoleWarn(fn: () => void): void {
-  withConsoleOverride("warn", () => {}, fn);
+export function silenceConsoleWarn<T>(fn: () => T): T {
+  return withConsoleOverride("warn", () => {}, fn);
 }
 
 /** Isolate LUDICS_HARNESS_DIR to a fresh tmpdir per test; returns a getter for the current path. */


### PR DESCRIPTION
## Summary

Refactor the four exported console helpers in `src/test-utils.ts` to be generic over `T` and forward `fn`'s value:

- `silenceConsoleError<T>(fn) -> T` and `silenceConsoleWarn<T>(fn) -> T` (was `void`)
- `captureConsoleLog<T>(fn) -> { lines: string[]; value: T }` and `captureConsoleError<T>(fn) -> { lines: string[]; value: T }` (was `string[]`)
- Private `withConsoleOverride` and `captureLines` updated in lockstep.

Migrates the 13 capture-variant consumer sites in `src/flow.test.ts`, `src/orchestration/skills.test.ts`, and `src/orchestration/worktrees.test.ts` to destructure `lines` from the new return shape. The 19 silence-variant call sites are untouched (TS infers `T = void`, return discarded).

Adds return-value tests for each variant in `src/test-utils.test.ts` (covering `T = void`, `T = number`, `T = string`, and `T = object identity`).

Adds a forward-pointing TODO at `src/events.test.ts::captureOutput` marking the dependency on the upstream dynamic-import being made static — at which point the async wrapper collapses to a one-liner over `captureConsoleLog`.

Round 2: tightened `readonlySet` Proxy types in `src/config.ts:371-373` to clear 4 pre-existing `@typescript-eslint/no-unsafe-*` errors that were blocking AC7's `bun run lint` gate. Declared as `scope-expansion:` in the commit body — 4-line type tightening in unrelated Proxy trap code.

See `docs/proposals/console-helpers-generic-return.md` for the proposal and AC.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (after round-2 readonlySet fix)
- [x] `bun run build` produces `bin/ludics`
- [x] `bun test` — 2008 pass / 0 fail / 4627 expect() calls across 96 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)