### PR TITLE
ci: add lint:test-isolation step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Lint — no util.ts function shadows
         run: bun run lint:no-shadow-util
 
+      - name: Lint — test isolation
+        run: bun run lint:test-isolation
+
       - name: Lint — vendor sync
         run: bun run lint:vendor-sync
 


### PR DESCRIPTION
## Summary
- Adds a `Lint — test isolation` step to `.github/workflows/ci.yml`, invoking the existing `bun run lint:test-isolation` script.
- Placed immediately after `lint:no-shadow-util` and before `lint:vendor-sync`, matching the proposal's thematic-grouping default and the em-dash naming convention used by recent sibling steps.
- No changes to `package.json` or the linter script — closes the orphan-`lint:*` gap noted in `task-41b91ca3` follow-ups.

Proposal: `docs/proposals/ci-add-lint-test-isolation-step.md`. Closes task-72eb59ae.

## Test plan
- [x] `grep -c 'bun run lint:test-isolation' .github/workflows/ci.yml` → `1` (AC1).
- [x] Parsed `ci.yml`: new step at index 13, between `no-shadow-util` (12) and `vendor-sync` (14); no other `lint:*` step between them (AC2).
- [x] Step has both `name:` and `run:` keys; name is `Lint — test isolation`, em-dash matches sibling cohort (AC3).
- [x] `bun run lint:test-isolation` exits 0 on this branch (20 rule-3 warnings, 0 errors) (AC4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)