### PR TITLE
lint:cli-readme: fail on undocumented USAGE entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,104 @@ ludics mag queue promote <id> # Move a pending request to the head of the queue
 ludics mag queue cancel <id>  # Remove a pending request (prints the JSON line)
 ```
 
+### Dashboard
+
+```bash
+ludics dashboard generate         # Generate JSON data for the dashboard
+ludics dashboard serve [port]     # Serve dashboard (default port: 7678)
+ludics dashboard stop             # Stop the dashboard server
+ludics dashboard restart [port]   # Restart the dashboard server
+ludics dashboard install          # Install dashboard assets to state repo
+```
+
+### t3code adapter
+
+```bash
+ludics t3code [status]                    # Show shared t3code server status
+ludics t3code start                       # Start the shared t3code server
+ludics t3code stop                        # Stop the shared t3code server
+ludics t3code doctor                      # Verify binary, process, HTTP, and WebSocket
+ludics t3code thread <id> log [--last N]  # Show message history for a thread
+ludics t3code thread <id> send [--wait] "<msg>"
+                                          # Send a user message to a thread
+ludics t3code thread <id> response        # Show last assistant response for a thread
+ludics t3code slot <N> log [--agent coder|reviewer] [--last N]
+                                          # Show message history for a slot's agent thread
+ludics t3code slot <N> send [--agent coder|reviewer] [--wait] "<msg>"
+                                          # Send a user message to a slot's agent thread
+ludics t3code slot <N> response [--agent coder|reviewer]
+                                          # Show last assistant response for a slot's agent
+ludics t3code cleanup [--dry-run]         # Soft-delete stale threads/projects
+```
+
+### tmux adapter
+
+```bash
+ludics tmux status                  # Show tmux session state, windows, and ttyd processes
+ludics tmux list-panes              # Show all panes with process state
+ludics tmux attach <slot> [agent]   # Attach to a slot's agent tmux window
+ludics tmux capture <slot> [agent]  # Capture pane content for debugging
+```
+
+### Sessions
+
+```bash
+ludics sessions [--json]            # Discover and classify all agent sessions
+ludics sessions report [--json]     # Generate sessions report for Mag (Markdown + JSON)
+ludics sessions refresh [--json]    # Re-run discovery and update report
+ludics sessions show [filter]       # Show detailed session info (optional cwd/id filter)
+ludics sessions sweep [--dry-run]   # Cleanup detached known sessions after 3 sweeps
+```
+
+### State sync
+
+```bash
+ludics sync           # Pull + push state repo (full sync)
+ludics state pull     # Pull latest from state repo
+ludics state push     # Push local changes to state repo
+```
+
+### Journal & events
+
+```bash
+ludics journal                # Show today's journal entries
+ludics journal recent [n]     # Show last n journal entries
+ludics journal list [days]    # List journal files from last n days
+ludics events [--type X] [--task Y] [--scope S] [--source R] [--since T] [--limit N]
+                              # Query the structured event log
+```
+
+### Cluster & network
+
+```bash
+ludics network status         # Show network configuration
+ludics cluster status         # Show cluster status (multi-machine)
+ludics cluster tick           # Publish heartbeat + run election
+ludics cluster heartbeat      # Publish heartbeat only
+ludics cluster ping <machine> # Ping another cluster machine
+```
+
+### Queue control
+
+```bash
+ludics queue hold     # Suppress automatic slot assignments
+ludics queue resume   # Re-enable automatic slot assignments
+ludics queue status   # Show whether queue is held or active
+```
+
+### Configuration
+
+```bash
+ludics config proposals-path <project>
+                      # Print resolved proposals directory path for a project
+```
+
+### Misc
+
+```bash
+ludics quote          # Print a random quote
+```
+
 ### Using skills directly
 
 You don't need Mag to use ludics skills. Clone your harness repository and run Claude Code in the harness directory — skills like `ludics-briefing`, `ludics-elaborate`, and others work directly. This is useful for read-only tasks (checking status, getting briefings) or when you need something done immediately without waiting for Mag queue.

--- a/scripts/lint-cli-readme.test.ts
+++ b/scripts/lint-cli-readme.test.ts
@@ -289,6 +289,34 @@ describe("CLI integration", () => {
     }
   });
 
+  test("exits non-zero when USAGE has a command missing from README ## CLI Reference (additive direction)", () => {
+    // FIXTURE_INDEX_SYNCED lists `alpha` + `beta`; README CLI Reference here
+    // lists only `alpha`. The lint must fail (exit non-zero) — this is the
+    // additive direction this task elevates from warn-only to fatal.
+    // Per Clause 4: assert exitCode is *not* zero, not that it equals 1.
+    const FIXTURE_README_MISSING = [
+      "## CLI Reference",
+      "",
+      "ludics alpha",
+      "",
+    ].join("\n");
+    const { root, cleanup } = makeFixture({
+      "src/index.ts": FIXTURE_INDEX_SYNCED,
+      "README.md": FIXTURE_README_MISSING,
+    });
+    try {
+      const result = spawnSync({
+        cmd: ["bun", "run", join(import.meta.dir, "lint-cli-readme.ts"), root],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(result.exitCode).not.toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("exits non-zero when README cites a command not in USAGE (drives import.meta.main)", () => {
     // README "ghost" is stale (not in USAGE) — the lint exists to catch this.
     const FIXTURE_README_DRIFT = [

--- a/scripts/lint-cli-readme.ts
+++ b/scripts/lint-cli-readme.ts
@@ -5,9 +5,13 @@
  * Checks that every command listed in the README CLI Reference section is
  * still present in the USAGE constant in src/index.ts.
  *
- * Exit code:
- *   0 — no stale-doc errors (warnings about undocumented commands are non-fatal)
- *   1 — one or more README commands not found in USAGE (documentation drift)
+ * Exit code (symmetric contract — both directions are fatal):
+ *   0 — USAGE in src/index.ts and the README `## CLI Reference` section
+ *       list the same set of top-level subcommands.
+ *   1 — drift in either direction: a README command missing from USAGE
+ *       (stale docs) OR a USAGE command missing from the README CLI
+ *       Reference (undocumented). Both produce non-zero exit so CI catches
+ *       additions and removals on the same first round.
  */
 
 import { readFileSync } from "fs";
@@ -135,17 +139,15 @@ if (import.meta.main) {
   }
 
   if (undocumented.length > 0) {
-    console.warn(`\n⚠️   USAGE commands not documented in README (undocumented — warnings only):`);
+    console.error(`\n❌  USAGE commands not documented in README ## CLI Reference:`);
     for (const cmd of undocumented) {
-      console.warn(`     - ${cmd}`);
+      console.error(`     - ${cmd}`);
     }
   }
 
   if (stale.length === 0 && undocumented.length === 0) {
     console.log("✅  CLI Reference is in sync with USAGE.");
-  } else if (stale.length === 0) {
-    console.log("✅  No stale docs found (some commands are undocumented — see warnings above).");
   }
 
-  process.exit(stale.length > 0 ? 1 : 0);
+  process.exit(stale.length > 0 || undocumented.length > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## Summary

- Make `lint:cli-readme` non-zero on the additive direction (USAGE has a top-level subcommand absent from `README.md` `## CLI Reference`), bringing it to the same bar as the stale direction.
- Document the 13 previously-undocumented top-level subcommand groups (`dashboard`, `t3code`, `tmux`, `sessions`, `sync`, `state`, `journal`, `events`, `network`, `cluster`, `queue`, `config`, `quote`) under `## CLI Reference` so the new fail-predicate stays green at HEAD.
- Add a CLI integration test mirroring the stale-direction test (USAGE lists `alpha` + `beta`, README lists only `alpha` ⇒ `exitCode !== 0`); mutation-tested against the lint fix.

Closes task-78cbb135. Derived from task-2db5eca6 / PR #467 retrospective.

## Test plan

- [x] `bun run lint:cli-readme` exits 0 with `✅  CLI Reference is in sync with USAGE.`
- [x] `bun test scripts/lint-cli-readme.test.ts` — 15/15 pass
- [x] `bun test` — full suite 2003/2003 pass
- [x] `bun run typecheck` — clean
- [x] Mutation test: stash the lint fix → new test fails with `Expected: not 0` (as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)