### PR TITLE
Elaborate/stale workflow hardening: atomic has_questions + stale status (task-a804cb4d)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ ludics tasks create <title>    # Create a new task manually
 ludics tasks files             # List individual task files
 ludics tasks priority <id> <level>
                                 # Set task priority (S, A, B, C, D); increases clear the auto-proposal debounce
+ludics tasks status <id> <status>
+                                # Set task status (one of: ready, in-progress, deferred, preempted, preempt-queued, done, abandoned, merged, needs-confirmation, blocked, stale)
 ```
 
 ### Flow engine

--- a/docs/task-frontmatter-reference.md
+++ b/docs/task-frontmatter-reference.md
@@ -2,7 +2,7 @@
 
 Reference documentation for the YAML frontmatter on `task-*.md` files. Each section describes a single field: how to choose a value, what the orchestrator does with it, and worked examples drawn from real triage decisions.
 
-This doc grows over time. Today it covers `effort`; future additions are expected for the priority ladder (`S` / `A` / `B` / `C` / `D`), the status lifecycle (`ready` → `in-progress` → `done` / `merged` / etc.), and interaction flags like `skip_plan`, `uses_browser`, and `requirements`.
+This doc grows over time. Today it covers `effort`, `leaf` (container marker), and the full `## Status` lifecycle (see § Status below). Future additions are expected for the priority ladder (`S` / `A` / `B` / `C` / `D`) and interaction flags like `skip_plan`, `uses_browser`, and `requirements`.
 
 For the authoritative list of fields and their TypeScript types, see [`TaskFrontmatter` in `src/tasks/types.ts`](../src/tasks/types.ts). For the orchestration mapping, see `selectOrchestrationFlags` in [`src/adapters/t3code.ts`](../src/adapters/t3code.ts).
 
@@ -74,6 +74,146 @@ The `skip_plan: true` frontmatter flag is only consulted at `medium` effort:
 ### Notes on extension
 
 The four levels above describe today's scale. Nothing in the model precludes a future `huge` or `epic` level if a class of work emerges that genuinely needs a different orchestration shape; the framing here is descriptive rather than normative. New levels would need corresponding entries in the dashboard validation allowlist, the `selectOrchestrationFlags` mapping, and this section.
+
+## Status
+
+The `status` field is a single string drawn from the central allowlist
+`VALID_STATUSES` exported from `src/tasks/markdown.ts`. The runtime type
+on `TaskFrontmatter.status` is free-form `string` for backwards
+compatibility, but every code path that consumes status now flows
+through the centralised constants (`VALID_STATUSES`, `TERMINAL_STATUSES`,
+`READY_QUEUE_ELIGIBLE_STATUSES`, `BLOCKED_RECONCILE_SKIP_STATUSES`).
+
+The CLI `ludics tasks status <task-id> <status>` setter validates input
+against `VALID_STATUSES` and rejects unknown spellings.
+
+The eleven recognised statuses below cover the lifecycle from intake to
+terminal disposition. Each subsection documents the semantic of the
+status, the actor that flips a task into it, and the path that exits.
+
+### `ready`
+
+Fresh / unblocked / awaiting slot assignment. Auto-queued by the
+keepalive's `getSortedReadyCandidates()` ordering once the task is
+elaborated and has a proposal.
+
+Transitions: set by `tasks sync` for fresh GitHub-derived tasks, by the
+elaborate worker on completion, by `/api/task-confirm` (revive from
+`needs-confirmation`), by `/api/deferred-approve` (revive from
+`deferred`), and by `/api/stale-revive` (revive from `stale`). Exits to
+`in-progress` when assigned to a slot, or directly to `blocked` if
+`dependencies.blocked_by` becomes non-empty.
+
+### `in-progress`
+
+Task is assigned to a slot and the orchestration runner is actively
+working on it. The slot's `slot.json` records the assignment; the task's
+`slot:` and `started:` frontmatter fields point at the active slot.
+
+Transitions: set by `slotAssign()`. Exits to `done` (PR merged), `abandoned`
+(user gives up), `merged` (work folded into another task), or
+`needs-confirmation` (verify-completion produced ambiguity).
+
+### `deferred`
+
+A proposal has been generated but the user has not yet approved
+auto-start. The dashboard's "Deferred Launch" panel surfaces these for
+one-click approve / abandon.
+
+Transitions: set by `/ludics-draft-proposal` when the worker confidence
+is low or `start_sessions` autonomy is `manual` / `suggest`. Exits to
+`ready` via `/api/deferred-approve` or terminal `abandoned` via
+`/api/deferred-abandon`.
+
+### `preempted`
+
+The task was previously in-progress when a higher-priority task arrived
+and preempted its slot. The original task's stash is recorded so it can
+be resumed.
+
+Transitions: set by the slot preempt path. Exits to `in-progress` when
+resumed.
+
+### `preempt-queued`
+
+An earlier preempt attempt failed to clear the slot cleanly; the task is
+queued for a second-chance preempt.
+
+Transitions: set by the preempt retry logic. Exits to `preempted` once
+the preempt completes, or back to `in-progress` if the preempt is
+cancelled.
+
+### `done`
+
+Task is complete. The PR has merged (or the work was otherwise finished)
+and the retrospective has been written.
+
+Transitions: set by the orchestration runner when the PR-merged
+verification passes. Terminal.
+
+### `abandoned`
+
+Explicitly closed without completion. Auto-closes the corresponding
+GitHub issue (if any).
+
+Transitions: set by `ludics tasks abandon`, by `/api/task-dismiss`
+(needs-confirmation dismissal), by `/api/deferred-abandon`, or by
+`/api/stale-abandon` (which composes a `stale → ready` flip then
+`tasksAbandon`). Terminal.
+
+### `merged`
+
+Task content has been folded into another task via `merged_into`.
+Duplicate-detection (`tasks duplicates` + `tasks merge`) is the typical
+entry path.
+
+Transitions: set by `ludics tasks merge`. Terminal. Reversible only via
+`ludics tasks unmerge`.
+
+### `needs-confirmation`
+
+The verify-completion sweep produced ambiguity that the harness cannot
+auto-resolve. The dashboard's "Needs Confirmation" panel surfaces these
+for user disposition.
+
+Transitions: set by `/ludics-verify-container-completion` and the
+verify-failure path in the orchestration runner. Exits to `ready` via
+`/api/task-confirm` or `abandoned` via `/api/task-dismiss`.
+
+### `blocked`
+
+`dependencies.blocked_by` is non-empty. The blocked-status reconciler
+(`tasksReconcileBlockedStatus()`) maintains this in lockstep with the
+`blocked_by` field.
+
+Transitions: set automatically by the reconciler when a task gains a
+blocker; flipped back to `ready` when the last blocker resolves. The
+reconciler skips this transition for tasks already in
+`BLOCKED_RECONCILE_SKIP_STATUSES` (terminal + active states).
+
+### `stale`
+
+Task work has been superseded; the originally-proposed design has
+already shipped or the premise has been invalidated. Resolve by
+abandoning (auto-closes GH issue) or reviving via the dashboard
+(transitions back to `ready`).
+
+`stale` is in `TERMINAL_STATUSES` — the keepalive's auto-proposal
+queue, the unstick path, the duplicate filter, the abandon-path guard,
+the milestone warnings, the needs-elaboration sweep, the deadline
+warnings, and the t3code thread cleanup all treat stale tasks as
+terminal-for-active-work. The `containerCompletionSweep` also treats
+`stale` parents as terminal so children completing after the parent
+goes stale don't trigger a verify-container-completion request.
+
+Transitions: auto-set by `/ludics-draft-proposal` when the worker
+returns `status: stale` (the routing flips frontmatter via
+`transitionStatus(taskFile, "ready", "stale")` and appends rationale to
+`## Notes`). Auto-blocked-by-precondition: a subsequent
+`/ludics-draft-proposal` invocation for an already-stale task returns
+`status: blocked-stale` without delegating to the worker. Exits via the
+dashboard's "Stale" panel — Revive (`/api/stale-revive`, flip to
+`ready`) or Abandon (`/api/stale-abandon`, terminal disposition).
 
 ## `leaf` (container marker)
 

--- a/docs/task-frontmatter-reference.shape.test.ts
+++ b/docs/task-frontmatter-reference.shape.test.ts
@@ -1,0 +1,43 @@
+// AC 11 — doc-shape probe for the `## Status` section in
+// docs/task-frontmatter-reference.md.
+//
+// The test pins two structural properties:
+// - cardinality: `^## Status` appears exactly once (the doc gains the
+//   section, not multiple competing sections).
+// - presence loop: each of the 11 recognised statuses has its own
+//   `### \`<status>\`` subsection — so future readers can link to
+//   `#status` and find every status documented under it.
+//
+// Mutation: drop any of the 11 subsection headings and the corresponding
+// assertion fails.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { ludicsRoot } from "./../src/config.ts";
+
+describe("docs/task-frontmatter-reference.md § Status (AC 11)", () => {
+  test("`## Status` cardinality is exactly 1", () => {
+    const md = readFileSync(join(ludicsRoot(), "docs/task-frontmatter-reference.md"), "utf-8");
+    const matches = md.match(/^## Status$/gm);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(1);
+  });
+
+  test("each of the 11 recognised statuses has a `### \\`<status>\\`` subsection", () => {
+    // Harness condition: the source-of-truth list is VALID_STATUSES from
+    // src/tasks/markdown.ts. If a status is added there but the doc isn't
+    // updated, this loop catches the drift.
+    const md = readFileSync(join(ludicsRoot(), "docs/task-frontmatter-reference.md"), "utf-8");
+    const expected = [
+      "ready", "in-progress", "deferred", "preempted", "preempt-queued",
+      "done", "abandoned", "merged", "needs-confirmation", "blocked", "stale",
+    ];
+    for (const status of expected) {
+      // Mutation: drop a `### \`<status>\`` heading and the per-status
+      // assertion below fails — the failure names which status went missing.
+      const re = new RegExp(`^### \`${status.replace(/-/g, "\\-")}\``, "m");
+      expect(md).toMatch(re);
+    }
+  });
+});

--- a/skills/ludics-draft-proposal.md
+++ b/skills/ludics-draft-proposal.md
@@ -73,6 +73,13 @@ questions from elaboration — skip the proposal:
 - Write result JSON with `"status": "blocked"` and `"unanswered questions"`.
 - Don't delegate to the worker; Mag's nag loop reminds the user to answer.
 
+If the task frontmatter has `status: stale`, this task has been previously
+marked stale and re-running draft-proposal would repeat the same conclusion
+at the same compute cost — skip:
+- Write result JSON `{"status": "blocked-stale", "reason": "task previously marked stale"}`.
+- Don't delegate to the worker; the dashboard's Stale panel exposes
+  Revive (flip to `ready`) and Abandon actions for user disposition.
+
 ### Container short-circuit
 
 If the task's frontmatter has `leaf: false`, the work has already been split
@@ -111,7 +118,13 @@ Routing by status:
   `skip_plan: true` as well; otherwise remove any stale `skip_plan` from a
   prior run. `skip_plan: true` causes medium-effort tasks to skip the plan
   phase in orchestration. Then go to auto-start evaluation.
-- **stale** — write result JSON with `"status": "stale"` and stop.
+- **stale** — call `transitionStatus(taskFile, "ready", "stale")` to flip
+  the task's frontmatter status; append a one-line rationale to the task's
+  `## Notes` section via `appendToSection(taskFile, "Notes", "<rationale>")`
+  (worker pointers + summary); then write result JSON with `"status": "stale"`
+  and stop. The flip is idempotent — `transitionStatus` returns `false` if
+  the current status is no longer `ready` (e.g. concurrent abandon won), and
+  the routing must not clobber that later state.
 - **split-needed** — queue the split skill and stop:
   ```bash
   ludics mag split-task <task_id>

--- a/skills/ludics-elaborate-worker.md
+++ b/skills/ludics-elaborate-worker.md
@@ -173,6 +173,22 @@ elaborated: <today's date>
 [numbered questions about genuine ambiguities, or "None."]
 ```
 
+**If your `questions` list is non-empty (i.e. you wrote at least one
+genuine question into the `## Questions` section above), also write
+`has_questions: true` to the frontmatter atomically with `elaborated:`:**
+
+```text
+addFrontmatterField(taskFile, "has_questions", "true")
+```
+
+This must land in the same write window as `elaborated:` so the keepalive's
+auto-proposal queue cannot fire between the two updates. The helper is the
+project's atomic upsert in `src/tasks/markdown.ts`.
+
+If your `questions` list is empty (you wrote `## Questions\n\nNone.`), do NOT
+write `has_questions` — its absence is the signal that proposal generation
+may proceed.
+
 <!-- section:final-response -->
 ## Final Response
 

--- a/skills/ludics-elaborate.md
+++ b/skills/ludics-elaborate.md
@@ -82,8 +82,21 @@ Routing by status:
 
 If `questions` is non-empty (and not `"none"`):
 
-1. Add `has_questions: true` to the task frontmatter — this blocks proposal
-   generation until the user answers and removes the field.
+1. Verify the worker wrote `has_questions: true`. The worker is now the sole
+   atomic writer of this field (see ludics-elaborate-worker.md
+   § Update task file) — collapsing to one writer per file eliminates the
+   race where the keepalive's auto-proposal queue fired between the worker's
+   `elaborated:` write and the orchestrator's post-worker `has_questions:`
+   write. Read the task frontmatter; if `questions` was non-empty but
+   `has_questions` is missing, emit a loud
+   `console.error("worker omitted has_questions for <task_id> — falling back")`
+   warning and call `addFrontmatterField(taskFile, "has_questions", "true")`
+   to paper over the omission. The fallback write is conditional on
+   absence: never re-write if the field is already present (the upsert
+   helper would create a duplicate frontmatter line in malformed files).
+   Per Q4's resolution, the failure mode is *agentic* (a worker LLM
+   forgetting an instruction), not algorithmic, so the orchestrator papers
+   over but logs visibly so regressions surface in the events log.
 2. Send the questions as a numbered list:
 
    ```bash

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -9,8 +9,9 @@ import YAML from "yaml";
 import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson, normalizeTaskId } from "./slots/json.ts";
-import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
-import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, transitionStatus, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
+import { slotClear, slotSetMode, slotStart, slotResume, findSlotForTask, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
+import { updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, transitionStatus, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
+import { emitEvent } from "./events.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
 import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./mag.ts";
@@ -438,10 +439,26 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       }
     }
 
-    // API: abandon a stale task (de-stale -> ready, then tasksAbandon).
-    // tasksAbandon's terminal-status guard rejects status: stale, so we
-    // sequence transitionStatus(stale -> ready) first, then call abandon.
-    // The order also yields a clean 409 when the task is no longer stale.
+    // API: abandon a stale task. We bypass tasksAbandon and do the abandon
+    // flow inline because (a) tasksAbandon's terminal-status guard rejects
+    // status: stale, and (b) the de-stale-then-abandon sequence does not
+    // compose with tasksAbandon's slot-aware path — for a slotted task,
+    // tasksAbandon delegates to slotClear -> taskUpdateForSlotClear, whose
+    // `expectedFrom` for `abandoned` is [in-progress, deferred, preempted];
+    // a freshly-de-staled task is `ready`, so the status flip silently
+    // no-ops while the endpoint reports success (Codex PR #476 review).
+    //
+    // Inline order:
+    //  1. transitionStatus(stale → abandoned) — atomic, returns false if
+    //     the task is no longer stale (raced with another writer).
+    //  2. Mirror tasksAbandon's frontmatter cleanup (completed timestamp,
+    //     remove deferred_launch/approved).
+    //  3. If slotted, clear the slot's runtime state with finalStatus
+    //     "ready" so taskUpdateForSlotClear's `expectedFrom` (which now
+    //     would see status=abandoned, not in [in-progress, deferred])
+    //     silently leaves the already-correct frontmatter alone. The
+    //     console.error inside taskUpdateForSlotClear is informational.
+    //  4. Emit task_abandon event to mirror tasksAbandon's observability.
     if (pathname === "/api/stale-abandon") {
       const taskParam = url.searchParams.get("task");
       if (!taskParam || !TASK_ID_RE.test(taskParam)) {
@@ -451,13 +468,35 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         const resolved = resolveTaskFile(taskParam);
         if ("error" in resolved) return resolved.error;
         const taskFile = resolved.path;
-        const ok = transitionStatus(taskFile, "stale", "ready");
+
+        const ok = transitionStatus(taskFile, "stale", "abandoned");
         if (!ok) {
           return new Response(JSON.stringify({ error: "task is not stale" }), {
             status: 409, headers: { "Content-Type": "application/json" },
           });
         }
-        await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
+
+        const completed = new Date().toISOString().slice(0, 19) + "Z";
+        updateFrontmatterField(taskFile, "completed", completed);
+        removeFrontmatterField(taskFile, "deferred_launch");
+        removeFrontmatterField(taskFile, "approved");
+
+        const slotNum = findSlotForTask(taskParam);
+        if (slotNum !== null) {
+          await slotClear(slotNum, "ready");
+        }
+
+        emitEvent({
+          event_type: "task_abandon",
+          source: "dashboard",
+          scope: "task",
+          task: taskParam,
+          status: "abandoned",
+          message: slotNum !== null
+            ? `abandoned from slot ${slotNum} (stale → abandoned)`
+            : "abandoned (stale → abandoned, no slot)",
+        });
+
         lastGenerated = 0;
         return new Response(JSON.stringify({ status: "abandoned" }), {
           headers: { "Content-Type": "application/json" },

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -10,7 +10,7 @@ import { dashboardGenerate } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson, normalizeTaskId } from "./slots/json.ts";
 import { slotClear, slotSetMode, slotStart, slotResume, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
-import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
+import { updateFrontmatterField, addFrontmatterField, parseTaskFrontmatter, transitionStatus, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
 import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./mag.ts";
@@ -400,6 +400,63 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       try {
         const resolved = resolveTaskFile(taskParam);
         if ("error" in resolved) return resolved.error;
+        await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "abandoned" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: revive a stale task (flip status: stale -> ready)
+    if (pathname === "/api/stale-revive") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        // transitionStatus enforces stale -> ready exactly. Any other current
+        // status returns false (the endpoint must NOT silently revive
+        // unrelated statuses — see proposal § Edge Cases #5).
+        const ok = transitionStatus(taskFile, "stale", "ready");
+        if (!ok) {
+          return new Response(JSON.stringify({ error: "task is not stale" }), {
+            status: 409, headers: { "Content-Type": "application/json" },
+          });
+        }
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "ready" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: abandon a stale task (de-stale -> ready, then tasksAbandon).
+    // tasksAbandon's terminal-status guard rejects status: stale, so we
+    // sequence transitionStatus(stale -> ready) first, then call abandon.
+    // The order also yields a clean 409 when the task is no longer stale.
+    if (pathname === "/api/stale-abandon") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const ok = transitionStatus(taskFile, "stale", "ready");
+        if (!ok) {
+          return new Response(JSON.stringify({ error: "task is not stale" }), {
+            status: 409, headers: { "Content-Type": "application/json" },
+          });
+        }
         await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
         lastGenerated = 0;
         return new Response(JSON.stringify({ status: "abandoned" }), {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -998,4 +998,36 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     const resp = await handler(new Request("http://x/api/stale-revive?task=not%20a%20task"));
     expect(resp.status).toBe(400);
   });
+
+  test("POST /api/stale-abandon on a slotted stale task ends with status: abandoned (not silently left at ready)", async () => {
+    // Harness condition: a `stale` task is also assigned to a slot. Codex
+    // round-2 review noted that the de-stale-then-abandon composition is
+    // unsafe: tasksAbandon for a slotted task delegates to slotClear ->
+    // taskUpdateForSlotClear, whose abandoned `expectedFrom` is
+    // [in-progress, deferred, preempted] — `ready` is NOT in that list, so
+    // the freshly-de-staled task silently stays at `ready` while the
+    // endpoint still returns `{"status":"abandoned"}`. The fix lifts that
+    // gate; this test pins the invariant.
+    const file = writeTask("task-slotted-stale", "stale");
+    // Mark the task as assigned to slot 1 so findSlotForTask picks it up.
+    const { writeSlotJson, emptySlotData } = await import("./slots/json.ts");
+    const slotData = { ...emptySlotData(1), task: "task-slotted-stale", process: "tmux:s1" };
+    writeSlotJson(1, slotData);
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-abandon?task=task-slotted-stale"));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("abandoned");
+    // Invariant: file MUST end at status: abandoned, not silently stay at
+    // some intermediate state while the endpoint reports success.
+    // Mutation: revert /api/stale-abandon to delegate to tasksAbandon
+    // after a `stale → ready` flip and this assertion fails because
+    // taskUpdateForSlotClear's `expectedFrom` does not include `ready`,
+    // so the slotted task silently keeps the intermediate `ready` while
+    // the endpoint returns 200 (the exact Codex PR #476 review finding).
+    const after = readFileSync(file, "utf-8");
+    expect(after).toContain("status: abandoned");
+    expect(after).not.toMatch(/^status: ready$/m);
+  });
 });

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -867,3 +867,135 @@ describe("dashboard HTTP debounce semantics — task-promote / queue-promote / s
     void idA;
   });
 });
+
+describe("stale.json tile (AC 10)", () => {
+  function writeStaleTask(id: string, title: string, created: string | null): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const createdLine = created ? `created: "${created}"` : "created: null";
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nstatus: stale\npriority: B\n${createdLine}\ncontext: ludics\n---\n\n# ${title}\n`,
+    );
+  }
+  function writeReadySibling(id: string): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${id}"\nstatus: ready\npriority: B\ncreated: "2026-04-30"\ncontext: ludics\n---\n\n# ${id}\n`,
+    );
+  }
+
+  test("stale.json contains only status: stale tasks, sorted created desc null-last", async () => {
+    // Harness condition: three stale tasks differing only in `created`, plus
+    // a ready sibling. Without the staleConfig.filter, the ready sibling
+    // would surface; without the byCreatedDescNullLast sort, ordering would
+    // be filesystem order. Both invariants are exercised.
+    writeStaleTask("task-stale-old", "Old", "2026-01-15");
+    writeStaleTask("task-stale-new", "New", "2026-04-15");
+    writeStaleTask("task-stale-no-date", "Undated", null);
+    writeReadySibling("task-ready-sibling");
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    silenceConsoleError(() => dashboardGenerate());
+
+    const outFile = join(harnessDir(), "dashboard", "data", "stale.json");
+    const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
+    const ids = items.map((it) => it.id);
+
+    // Invariant: ready sibling NOT present (filter holds).
+    // Mutation: change filter to `task.status !== "done"` and ready sibling
+    // surfaces, flipping this assertion.
+    expect(ids).not.toContain("task-ready-sibling");
+    // Invariant: all three stale tasks present, ordered by created desc
+    // with null last.
+    expect(ids).toEqual(["task-stale-new", "task-stale-old", "task-stale-no-date"]);
+  });
+});
+
+describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+
+  function writeTask(id: string, status: string): string {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const file = join(tasksDir, `${id}.md`);
+    writeFileSync(
+      file,
+      `---\nid: ${id}\ntitle: "${id}"\nstatus: ${status}\npriority: B\ncontext: ludics\ndependencies:\n  blocks: []\n  blocked_by: []\n  relates_to: []\n  subtask_of: null\n---\n\n# ${id}\n\n## Notes\n\n`,
+    );
+    return file;
+  }
+
+  test("POST /api/stale-revive flips stale -> ready and returns 'ready'", async () => {
+    // Harness condition: the task starts at status: stale. If transitionStatus
+    // were called with the wrong expected source (e.g. "deferred"), the
+    // assertion that the file ends up at "status: ready" would fail.
+    const file = writeTask("task-stale-revive", "stale");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-revive?task=task-stale-revive"));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("ready");
+    // Invariant: frontmatter now reads status: ready. Mutation: drop the
+    // updateFrontmatterField inside transitionStatus and this fails.
+    expect(readFileSync(file, "utf-8")).toContain("status: ready");
+  });
+
+  test("POST /api/stale-revive on non-stale task returns 409 and does not mutate", async () => {
+    // Harness condition: task is `ready`, not stale. The endpoint must NOT
+    // silently re-flip — see proposal § Edge Cases #5.
+    const file = writeTask("task-not-stale", "ready");
+    const before = readFileSync(file, "utf-8");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-revive?task=task-not-stale"));
+    expect(resp.status).toBe(409);
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
+
+  test("POST /api/stale-abandon de-stales then abandons, ending in status: abandoned", async () => {
+    // Harness condition: task starts at status: stale. The endpoint composes
+    // transitionStatus(stale -> ready) + tasksAbandon. If either step is
+    // skipped or the order is reversed, tasksAbandon's terminal-status guard
+    // (which now includes stale) throws and the response status flips to 500.
+    const file = writeTask("task-stale-abandon", "stale");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-abandon?task=task-stale-abandon"));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("abandoned");
+    // Invariant: file ends up status: abandoned. Mutation: drop the
+    // tasksAbandon call and the file would still read status: ready.
+    expect(readFileSync(file, "utf-8")).toContain("status: abandoned");
+  });
+
+  test("POST /api/stale-abandon on non-stale task returns 409 and does not abandon", async () => {
+    // Harness condition: task is `ready`. tasksAbandon must NOT fire —
+    // dashboard's stale-abandon must only operate on stale tasks.
+    const file = writeTask("task-ready-abandon-attempt", "ready");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-abandon?task=task-ready-abandon-attempt"));
+    expect(resp.status).toBe(409);
+    // Invariant: status: ready preserved (not flipped to abandoned).
+    const after = readFileSync(file, "utf-8");
+    expect(after).toContain("status: ready");
+    expect(after).not.toContain("status: abandoned");
+  });
+
+  test("POST /api/stale-revive rejects malformed task id with 400", async () => {
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/stale-revive?task=not%20a%20task"));
+    expect(resp.status).toBe(400);
+  });
+});

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -551,6 +551,15 @@ const deferredLaunchConfig: FilteredTaskTileConfig = {
   sort: byCreatedDescNullLast,
 };
 
+const staleConfig: FilteredTaskTileConfig = {
+  filter: (task) => task.status === "stale",
+  extraFields: (task) => ({
+    created: task.created,
+    relatesTo: task.dependencies.relates_to,
+  }),
+  sort: byCreatedDescNullLast,
+};
+
 function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
   if (tasks.length === 0) return [];
 
@@ -1077,6 +1086,9 @@ export function dashboardGenerate(): void {
 
   writeFileSync(join(dataDir, "deferred-launch.json"), JSON.stringify(generateFilteredTaskList(tasks, deferredLaunchConfig), null, 2));
   console.error("  deferred-launch.json");
+
+  writeFileSync(join(dataDir, "stale.json"), JSON.stringify(generateFilteredTaskList(tasks, staleConfig), null, 2));
+  console.error("  stale.json");
 
   writeFileSync(join(dataDir, "tasks-tree.json"), JSON.stringify(generateTasksTree(tasks), null, 2));
   console.error("  tasks-tree.json");

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -6,7 +6,7 @@ import YAML from "yaml";
 import { harnessDir, slotsCount, effectivePriority, effectivePriorityValue, milestonesEnabledProjects, postponedProjectSet } from "./config.ts";
 import { readAllSlotJson } from "./slots/json.ts";
 import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
-import { priorityValue } from "./tasks/markdown.ts";
+import { priorityValue, TERMINAL_STATUSES } from "./tasks/markdown.ts";
 
 interface TaskData {
   id: string;
@@ -240,9 +240,7 @@ export function flowCritical(): void {
     .filter(
       (t) =>
         t.deadline &&
-        t.status !== "done" &&
-        t.status !== "abandoned" &&
-        t.status !== "merged",
+        !TERMINAL_STATUSES.includes(t.status ?? ""),
     )
     .map((t) => {
       const deadlineEpoch = new Date(t.deadline!).getTime() / 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ Commands:
                                Migrate legacy task-<number> IDs to deterministic IDs and rewrite references
   tasks abandon <id>           Abandon a task (clears slot if assigned, sets status/completed)
   tasks priority <id> <level>  Set task priority (S, A, B, C, D); increases clear the auto-proposal debounce
+  tasks status <id> <status>   Set task status (one of: ready, in-progress, deferred, preempted, preempt-queued, done, abandoned, merged, needs-confirmation, blocked, stale)
   tasks migrate-deferred       Migrate legacy deferred_launch/approved fields to status: deferred
 
   flow ready                   Priority-sorted ready tasks

--- a/src/mag-ready-candidates.test.ts
+++ b/src/mag-ready-candidates.test.ts
@@ -63,3 +63,20 @@ describe("getSortedReadyCandidates leaf filter (AC2)", () => {
     expect(getSortedReadyCandidates()).toEqual([]);
   });
 });
+
+describe("getSortedReadyCandidates excludes status: stale (AC 9)", () => {
+  test("stale tasks do not surface in the ready candidate list", () => {
+    // Harness condition: a stale task and a sibling ready task in the same
+    // harness. If the `status !== "ready"` filter were removed (or stale
+    // were treated as ready-eligible), the stale task would surface alongside
+    // the ready one.
+    writeTask("task-ready-sibling", {});
+    writeTask("task-stale-victim", { status: "stale" });
+
+    const ids = getSortedReadyCandidates().map((c) => c.id).sort();
+
+    expect(ids).toContain("task-ready-sibling");
+    // Invariant: status: stale MUST be excluded from the ready queue.
+    expect(ids).not.toContain("task-stale-victim");
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -29,7 +29,7 @@ import {
   expirePendingRevises,
   expirePendingFollowupRevises,
 } from "./notify.ts";
-import { updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, priorityValue } from "./tasks/markdown.ts";
+import { updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, priorityValue, TERMINAL_STATUSES } from "./tasks/markdown.ts";
 import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
@@ -2202,9 +2202,9 @@ function maybeUnstickAssignedSlots(): void {
     if (!existsSync(taskFile)) continue;
     const content = readFileSync(taskFile, "utf-8");
 
-    // Task already completed or abandoned — nothing to unstick
-    const unstickStatus = parseTaskFrontmatter(content).status;
-    if (unstickStatus === "done" || unstickStatus === "abandoned" || unstickStatus === "merged") continue;
+    // Task is terminal (done / abandoned / merged / stale) — nothing to unstick.
+    const unstickStatus = parseTaskFrontmatter(content).status ?? "";
+    if (TERMINAL_STATUSES.includes(unstickStatus)) continue;
 
     // Already has proposal — maybeAutoStartSlots handles this
     if (content.includes("\nproposal:")) continue;

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -2334,7 +2334,10 @@ describe("skill templates — stale + has_questions atomic write", () => {
     // orchestrator to the pre-fix two-writer shape and this fails.
     expect(md).not.toMatch(/^\d+\.\s*Add `has_questions: true` to the task frontmatter/m);
     // Property: verify-and-fallback vocabulary is present in the section.
-    const section = md.match(/## Questions notification([\s\S]*?)(?:^## |\Z)/m);
+    // Capture body from `## Questions notification` to the next `## ` heading
+    // or end-of-file. Multi-line $-anchor on its own would match line-end and
+    // capture an empty body — use a `\n## ` lookahead boundary instead.
+    const section = md.match(/## Questions notification\n([\s\S]*?)(?=\n## |$)/);
     expect(section).not.toBeNull();
     const body = section![1]!;
     expect(body).toMatch(/verify|fallback|warning/i);

--- a/src/orchestration/skills.test.ts
+++ b/src/orchestration/skills.test.ts
@@ -2262,3 +2262,81 @@ describe("skills", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Skill template contracts: stale workflow + atomic has_questions write
+// ---------------------------------------------------------------------------
+//
+// These tests pin invariants on the *content* of skill markdown files
+// (skills/ludics-elaborate.md, skills/ludics-elaborate-worker.md,
+// skills/ludics-draft-proposal.md). The skills run in forked agent
+// contexts so we cannot exercise them as TS functions; the regression
+// boundary is the literal instruction text the orchestrator/worker reads.
+// Each assertion below cites the structural property whose absence would
+// re-introduce the regression the AC exists to prevent.
+
+describe("skill templates — stale + has_questions atomic write", () => {
+  const skillsDir = join(ludicsRoot(), "skills");
+
+  test("ludics-draft-proposal precondition rejects status: stale (AC 8)", () => {
+    // Harness condition: the precondition section in the live template
+    // must contain `blocked-stale`. If a refactor removed the stale
+    // precondition, the orchestrator would delegate to the worker for an
+    // already-stale task and re-do the same compute — the regression Part 2
+    // exists to prevent.
+    const md = readFileSync(join(skillsDir, "ludics-draft-proposal.md"), "utf-8");
+    expect(md).toContain("blocked-stale");
+    // Property: the blocked-stale text sits inside the precondition-check
+    // section. A presence check anywhere in the file would not pin
+    // section-locality; we extract the section and search within it.
+    const section = md.match(/<!-- section:precondition-check -->([\s\S]*?)<!-- section:/);
+    expect(section).not.toBeNull();
+    expect(section![1]!).toContain("blocked-stale");
+    expect(section![1]!).toContain("status: stale");
+  });
+
+  test("ludics-draft-proposal stale routing flips status and appends to Notes (AC 7)", () => {
+    // Harness condition: the routing block contains BOTH the
+    // `transitionStatus(taskFile, "ready", "stale")` invocation AND the
+    // `appendToSection(taskFile, "Notes", ...)` invocation. Mutation: drop
+    // either helper from the markdown and the corresponding assertion fails.
+    const md = readFileSync(join(skillsDir, "ludics-draft-proposal.md"), "utf-8");
+    expect(md).toMatch(/transitionStatus\([^)]*"stale"/);
+    expect(md).toMatch(/appendToSection\([^)]*Notes/);
+  });
+
+  test("ludics-elaborate-worker writes has_questions atomically when questions non-empty (AC 1)", () => {
+    // Harness condition: the worker template's `### 6. Update task file`
+    // section names `addFrontmatterField` with `has_questions` as the field.
+    // This is the contract that makes the elaborate worker the sole writer
+    // of `has_questions: true`, eliminating the race window with the
+    // orchestrator's post-worker write.
+    const md = readFileSync(join(skillsDir, "ludics-elaborate-worker.md"), "utf-8");
+    // Probe per AC 1: the canonical call form starts a line.
+    expect(md).toMatch(/^addFrontmatterField\(.*has_questions/m);
+    // Property: the instruction sits inside the section delimited by
+    // `<!-- section:update-task -->` and the next `<!-- section: -->`
+    // marker. The boundary is the next *section comment*, NOT a `##`
+    // heading — the section's body contains an example fenced block with
+    // `## Context`, `## Tentative Design`, `## Questions` placeholders that
+    // would otherwise cut the capture short.
+    const section = md.match(/<!-- section:update-task -->([\s\S]*?)<!-- section:/);
+    expect(section).not.toBeNull();
+    expect(section![1]!).toMatch(/addFrontmatterField[\s\S]*has_questions/);
+  });
+
+  test("ludics-elaborate orchestrator no longer unconditionally writes has_questions (AC 2)", () => {
+    // Harness condition: the orchestrator template's Questions notification
+    // section is the verify-and-fallback shape, not the original
+    // imperative "Add has_questions: true" line.
+    const md = readFileSync(join(skillsDir, "ludics-elaborate.md"), "utf-8");
+    // Property: original imperative line gone. Mutation: revert the
+    // orchestrator to the pre-fix two-writer shape and this fails.
+    expect(md).not.toMatch(/^\d+\.\s*Add `has_questions: true` to the task frontmatter/m);
+    // Property: verify-and-fallback vocabulary is present in the section.
+    const section = md.match(/## Questions notification([\s\S]*?)(?:^## |\Z)/m);
+    expect(section).not.toBeNull();
+    const body = section![1]!;
+    expect(body).toMatch(/verify|fallback|warning/i);
+  });
+});

--- a/src/skills/ludics-elaborate-worker.test.ts
+++ b/src/skills/ludics-elaborate-worker.test.ts
@@ -1,0 +1,94 @@
+// AC 3: atomicity invariant for the elaborate worker's frontmatter writes.
+//
+// The worker is a markdown skill that runs in a forked agent context, so we
+// can't exercise the agent itself in a unit test. The regression boundary is
+// the *contract*: when the worker emits non-empty `questions`, both
+// `elaborated:` AND `has_questions: true` must land on disk in the same write
+// window — eliminating the race where the keepalive's auto-proposal cycle
+// fired between the two writes (the original Part 1 symptom).
+//
+// This test simulates the worker's frontmatter writes against a fixture task
+// file using the same `addFrontmatterField` helper the skill markdown
+// instructs. Mutation: drop the `has_questions` write from the simulated
+// worker call sequence and the atomicity assertion fails — exactly the
+// regression Part 1 exists to prevent.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { addFrontmatterField, parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { withSyntheticHarness } from "../test-utils.ts";
+
+const getTmpDir = withSyntheticHarness(beforeEach, afterEach);
+
+function writeFixtureTask(): string {
+  const tasksDir = join(getTmpDir(), "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  const file = join(tasksDir, "task-fixture.md");
+  writeFileSync(file, [
+    "---",
+    "id: task-fixture",
+    "title: Fixture",
+    "status: ready",
+    "---",
+    "",
+    "# Fixture",
+    "",
+    "## Context",
+    "",
+    "## Notes",
+    "",
+  ].join("\n"));
+  return file;
+}
+
+describe("elaborate worker atomic has_questions write (AC 3)", () => {
+  test("when questions is non-empty, BOTH elaborated and has_questions land in the worker's write window", () => {
+    // Harness condition: a fresh fixture task with neither `elaborated:` nor
+    // `has_questions:` in its frontmatter. Without this initial absence, the
+    // assertions wouldn't be measuring the worker's writes — they'd be
+    // measuring some prior state.
+    const taskFile = writeFixtureTask();
+    const before = parseTaskFrontmatter(readFileSync(taskFile, "utf-8"));
+    expect(before.elaborated).toBeUndefined();
+    expect(readFileSync(taskFile, "utf-8")).not.toContain("has_questions");
+
+    // Simulate the worker's `### 6. Update task file` step with a non-empty
+    // questions list. Per the skill markdown, the worker calls
+    // addFrontmatterField for both fields atomically (one writer per file
+    // = race-free).
+    const questions = ["Is option A or B preferred?"];
+    addFrontmatterField(taskFile, "elaborated", "2026-04-30");
+    if (questions.length > 0) {
+      addFrontmatterField(taskFile, "has_questions", "true");
+    }
+
+    // Invariant: after the worker portion runs, the file has both fields.
+    // Mutation: comment out the `has_questions` write above and this
+    // assertion fails — exactly the regression Part 1 prevents.
+    const content = readFileSync(taskFile, "utf-8");
+    expect(content).toContain("elaborated: 2026-04-30");
+    expect(content).toContain("has_questions: true");
+  });
+
+  test("when questions is empty, has_questions is NOT written", () => {
+    // Harness condition: same fixture, but the worker emits an empty
+    // questions list (`## Questions\n\nNone.`). Per the skill contract,
+    // `has_questions` must remain absent — its absence is the signal that
+    // proposal generation may proceed.
+    const taskFile = writeFixtureTask();
+    const questions: string[] = [];
+
+    addFrontmatterField(taskFile, "elaborated", "2026-04-30");
+    if (questions.length > 0) {
+      addFrontmatterField(taskFile, "has_questions", "true");
+    }
+
+    const content = readFileSync(taskFile, "utf-8");
+    expect(content).toContain("elaborated: 2026-04-30");
+    // Invariant: has_questions absent under the empty-questions branch.
+    // Mutation: writing has_questions unconditionally would block proposal
+    // generation forever for tasks the user never asked questions about.
+    expect(content).not.toContain("has_questions");
+  });
+});

--- a/src/skills/ludics-elaborate-worker.test.ts
+++ b/src/skills/ludics-elaborate-worker.test.ts
@@ -14,7 +14,7 @@
 // regression Part 1 exists to prevent.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { addFrontmatterField, parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { withSyntheticHarness } from "../test-utils.ts";

--- a/src/t3code/index.ts
+++ b/src/t3code/index.ts
@@ -6,7 +6,7 @@ import type { AgentConfig } from "../orchestration/state.ts";
 import { T3CodeClient, waitForNewTurn } from "./client.ts";
 import { doctorServer, ensureServer, readServerRecord, readSlotState, serverStatus, stopServer, t3codeServerPath } from "./server.ts";
 import type { T3ThreadMessage } from "./types.ts";
-import { parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { parseTaskFrontmatter, TERMINAL_STATUSES as TASK_TERMINAL_STATUSES } from "../tasks/markdown.ts";
 import { isoNow, makeId } from "../orchestration/util.ts";
 
 // ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@ function stripFlags(
 // Cleanup stale threads and projects
 // ---------------------------------------------------------------------------
 
-const TERMINAL_STATUSES = new Set(["done", "abandoned", "merged"]);
+const TERMINAL_STATUSES = new Set<string>([...TASK_TERMINAL_STATUSES]);
 const STALE_AGE_MS = 25 * 60 * 60 * 1_000; // 25 hours
 
 /** Collect all thread IDs currently referenced by slot state files. */

--- a/src/tasks/abandon.test.ts
+++ b/src/tasks/abandon.test.ts
@@ -130,7 +130,12 @@ describe("tasksAbandon", () => {
     const tasksDir = join(harness, "tasks");
     mkdirSync(tasksDir, { recursive: true });
 
-    for (const status of ["done", "abandoned", "merged"]) {
+    // Harness condition: each terminal status (done, abandoned, merged, stale)
+    // must trip the abandon-path's TERMINAL_STATUSES guard. Adding `stale` to
+    // TERMINAL_STATUSES (AC 6) is what makes the stale iteration succeed —
+    // mutation: drop `stale` from TERMINAL_STATUSES and the stale loop
+    // iteration would no longer reject (tasksAbandon would re-flip status).
+    for (const status of ["done", "abandoned", "merged", "stale"]) {
       writeTaskFile(tasksDir, "task-term", { status });
       eventSpy.mockClear();
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -3,7 +3,7 @@
 import { existsSync, readFileSync, readdirSync, mkdirSync, writeFileSync, renameSync } from "fs";
 import { extname, join } from "path";
 import { harnessDir } from "../config.ts";
-import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, priorityValue, TASK_ID_RE } from "./markdown.ts";
+import { parseTaskFrontmatter, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, transitionStatus, priorityValue, TASK_ID_RE, TERMINAL_STATUSES, VALID_STATUSES } from "./markdown.ts";
 import { tasksSync, tasksConvert, tasksUpdate, tasksNeedsElaborationList, tasksQueueElaborations, contentFingerprint } from "./sync.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
@@ -364,7 +364,7 @@ function tasksDuplicates(): void {
   for (const f of files) {
     const content = readFileSync(join(dir, f), "utf-8");
     const fm = parseTaskFrontmatter(content);
-    if (["done", "abandoned", "merged"].includes(fm.status ?? "")) continue;
+    if (TERMINAL_STATUSES.includes(fm.status ?? "")) continue;
     if (!fm.title || !fm.id) continue;
 
     const fp = contentFingerprint(fm.title);
@@ -621,7 +621,7 @@ export async function tasksAbandon(
   const content = readFileSync(taskFile, "utf-8");
   const fm = parseTaskFrontmatter(content);
   const currentStatus = fm.status ?? "";
-  if (["done", "abandoned", "merged"].includes(currentStatus)) {
+  if (TERMINAL_STATUSES.includes(currentStatus)) {
     throw new Error(`task ${taskId} is already in terminal status: ${currentStatus}`);
   }
 

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -803,6 +803,31 @@ export async function runTasks(args: string[]): Promise<void> {
       await tasksSetPriority(id, level);
       break;
     }
+    case "status": {
+      const id = args[1];
+      const value = args[2];
+      if (!id) throw new Error("task ID required (usage: tasks status <task-id> <status>)");
+      if (!value) {
+        throw new Error(
+          `status required (usage: tasks status <task-id> <status>; status is one of: ${VALID_STATUSES.join(", ")})`,
+        );
+      }
+      if (args.length > 3) {
+        throw new Error(
+          `unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: tasks status <task-id> <status>)`,
+        );
+      }
+      if (!(VALID_STATUSES as readonly string[]).includes(value)) {
+        throw new Error(
+          `invalid status: ${value} (use one of: ${VALID_STATUSES.join(", ")})`,
+        );
+      }
+      const taskFile = join(tasksDir(), `${id}.md`);
+      if (!existsSync(taskFile)) throw new Error(`task not found: ${id}`);
+      updateFrontmatterField(taskFile, "status", value);
+      console.log(`ludics: set ${id} status → ${value}`);
+      break;
+    }
     case "migrate-deferred": {
       const dir = tasksDir();
       if (!existsSync(dir)) {
@@ -834,7 +859,7 @@ export async function runTasks(args: string[]): Promise<void> {
     }
     default:
       throw new Error(
-        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, priority, migrate-refs, migrate-deferred)`,
+        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, priority, status, migrate-refs, migrate-deferred)`,
       );
   }
 }

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -817,6 +817,13 @@ export async function runTasks(args: string[]): Promise<void> {
           `unexpected trailing arguments: ${args.slice(3).join(" ")} (usage: tasks status <task-id> <status>)`,
         );
       }
+      // Path-safety guard: reject IDs containing `/`, `..`, or other
+      // characters that would let `join(tasksDir(), `${id}.md`)` escape the
+      // tasks directory or touch a sibling file. Mirrors the guard in
+      // tasksSetPriority (line 657).
+      if (!TASK_ID_RE.test(id)) {
+        throw new Error(`invalid task ID: ${id} (must match ${TASK_ID_RE})`);
+      }
       if (!(VALID_STATUSES as readonly string[]).includes(value)) {
         throw new Error(
           `invalid status: ${value} (use one of: ${VALID_STATUSES.join(", ")})`,

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, frontmatterBounds, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize, VALID_STATUSES, TERMINAL_STATUSES, READY_QUEUE_ELIGIBLE_STATUSES, BLOCKED_RECONCILE_SKIP_STATUSES } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -914,5 +914,80 @@ None.
     const p = join(TMP_DIR, "task-newfile.md");
     expect(existsSync(p)).toBe(true);
     expect(existsSync(p + ".tmp")).toBe(false);
+  });
+});
+
+describe("VALID_STATUSES centralised constant", () => {
+  test("VALID_STATUSES enumerates the full status set including stale", () => {
+    // Harness condition: VALID_STATUSES is the contract for the CLI status
+    // setter and the central source of truth for status names. If `stale`
+    // is missing, the new `tasks status <id> stale` subcommand would reject
+    // a valid input.
+    const set = new Set(VALID_STATUSES);
+    expect(set.has("ready")).toBe(true);
+    expect(set.has("in-progress")).toBe(true);
+    expect(set.has("deferred")).toBe(true);
+    expect(set.has("preempted")).toBe(true);
+    expect(set.has("preempt-queued")).toBe(true);
+    expect(set.has("done")).toBe(true);
+    expect(set.has("abandoned")).toBe(true);
+    expect(set.has("merged")).toBe(true);
+    expect(set.has("needs-confirmation")).toBe(true);
+    expect(set.has("blocked")).toBe(true);
+    expect(set.has("stale")).toBe(true);
+  });
+
+  test("TERMINAL_STATUSES includes stale alongside done/abandoned/merged", () => {
+    // Harness condition: TERMINAL_STATUSES is consumed by the skip-list
+    // refactor sites in mag.ts / sync.ts / index.ts. Removing `stale` from
+    // this constant would silently re-allow stale tasks to be unstuck,
+    // duplicated, or surfaced in milestone warnings.
+    expect(TERMINAL_STATUSES).toContain("done");
+    expect(TERMINAL_STATUSES).toContain("abandoned");
+    expect(TERMINAL_STATUSES).toContain("merged");
+    expect(TERMINAL_STATUSES).toContain("stale");
+    // Negative control: ready and in-progress are NOT terminal.
+    expect(TERMINAL_STATUSES).not.toContain("ready");
+    expect(TERMINAL_STATUSES).not.toContain("in-progress");
+  });
+
+  test("READY_QUEUE_ELIGIBLE_STATUSES is exactly { ready }", () => {
+    expect(READY_QUEUE_ELIGIBLE_STATUSES).toEqual(["ready"]);
+  });
+
+  test("BLOCKED_RECONCILE_SKIP_STATUSES is the union of TERMINAL_STATUSES and the active states", () => {
+    // Harness condition: BLOCKED_RECONCILE_SKIP_STATUSES drives
+    // tasksReconcileBlockedStatus's skip predicate. Stale tasks must be in
+    // the skip list so the reconciler doesn't flip them between ready and
+    // blocked.
+    const set = new Set(BLOCKED_RECONCILE_SKIP_STATUSES);
+    for (const t of TERMINAL_STATUSES) expect(set.has(t)).toBe(true);
+    expect(set.has("in-progress")).toBe(true);
+    expect(set.has("deferred")).toBe(true);
+    expect(set.has("preempt-queued")).toBe(true);
+    expect(set.has("preempted")).toBe(true);
+    expect(set.has("stale")).toBe(true);
+    // Negative control: `ready` and `blocked` are not in the skip list
+    // (those are the two endpoints of the reconciler's flip).
+    expect(set.has("ready")).toBe(false);
+    expect(set.has("blocked")).toBe(false);
+  });
+
+  test("transitionStatus accepts stale as a target", () => {
+    // Harness condition: orchestrator's stale routing path calls
+    // transitionStatus(taskFile, "ready", "stale"). If the helper rejected
+    // unknown targets (it does not — free-form), this test falsifies that
+    // change.
+    const f = tmpFile("transition-stale.md", [
+      "---",
+      "id: task-1",
+      "status: ready",
+      "---",
+      "",
+      "# Title",
+    ].join("\n"));
+    const ok = transitionStatus(f, "ready", "stale");
+    expect(ok).toBe(true);
+    expect(readFileSync(f, "utf-8")).toContain("status: stale");
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -9,6 +9,40 @@ import type { TaskFrontmatter } from "./types.ts";
 /** Regex for valid task IDs — used across all task-related endpoints. */
 export const TASK_ID_RE = /^[A-Za-z0-9._-]+$/;
 
+/** Full enumeration of recognised task statuses. The runtime type on
+ *  `TaskFrontmatter.status` remains free-form `string` for backwards
+ *  compatibility — this constant is the central allowlist consumed by
+ *  the CLI status setter and the inline skip-lists in `mag.ts` /
+ *  `tasks/sync.ts` / `tasks/index.ts`. */
+export const VALID_STATUSES = [
+  "ready", "in-progress", "deferred", "preempted", "preempt-queued",
+  "done", "abandoned", "merged", "needs-confirmation", "blocked", "stale",
+] as const;
+
+/** Statuses that mark a task as terminal: no further automated work,
+ *  no auto-elaboration, no proposal queueing. `stale` joins the classic
+ *  `done`/`abandoned`/`merged` triple as a terminal disposition for
+ *  superseded work. Note this is narrower than
+ *  `containerCompletionSweep`'s `TERMINAL_FOR_PARENT` (which also
+ *  includes `needs-confirmation` and the active states); the asymmetry
+ *  is preserved deliberately. */
+export const TERMINAL_STATUSES: readonly string[] = [
+  "done", "abandoned", "merged", "stale",
+];
+
+/** Statuses eligible for the auto-proposal ready queue. Today only
+ *  `ready`; named for intent-locality so future readers see the
+ *  invariant rather than re-deriving it from the inline filter. */
+export const READY_QUEUE_ELIGIBLE_STATUSES: readonly string[] = ["ready"];
+
+/** Statuses skipped by `tasksReconcileBlockedStatus` — the reconciler
+ *  must not flip terminal or already-active tasks between `ready` and
+ *  `blocked`. */
+export const BLOCKED_RECONCILE_SKIP_STATUSES: readonly string[] = [
+  ...TERMINAL_STATUSES,
+  "in-progress", "deferred", "preempt-queued", "preempted",
+];
+
 export const PRIORITY_INCREASE: Record<string, string> = { D: "C", C: "B", B: "A", A: "S" };
 export const PRIORITY_DECREASE: Record<string, string> = { S: "A", A: "B", B: "C", C: "D" };
 

--- a/src/tasks/status-cli.test.ts
+++ b/src/tasks/status-cli.test.ts
@@ -1,0 +1,118 @@
+// AC 12 — `ludics tasks status <id> <status>` CLI subcommand smoke test.
+//
+// The proposal's literal probe (`ludics tasks update --status stale`) was
+// substituted with `ludics tasks status <id> <status>` per the merged
+// plan's documented assumption gap (tasks update is a GitHub-metadata
+// refresh with no positional args). This test pins the substitute
+// surface: the command flips frontmatter status, validates input
+// against VALID_STATUSES, and rejects unknown spellings.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { runTasks } from "./index.ts";
+import { silenceConsoleError } from "../test-utils.ts";
+
+const TMP = join(import.meta.dir, ".test-tmp-status-cli");
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+`);
+  return configPath;
+}
+
+function harness(): string {
+  return join(TMP, "ludics-state", "harness");
+}
+
+function writeTaskFile(id: string, status: string): string {
+  const tasksDir = join(harness(), "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  const file = join(tasksDir, `${id}.md`);
+  writeFileSync(file, `---\nid: ${id}\ntitle: "${id}"\nstatus: ${status}\npriority: B\n---\n\n# ${id}\n`);
+  return file;
+}
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  mkdirSync(TMP, { recursive: true });
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = harness();
+  mkdirSync(harness(), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("ludics tasks status <id> <status> (AC 12)", () => {
+  test("flips frontmatter status: ready → stale on a fixture task", async () => {
+    // Harness condition: a fixture task at status: ready. Without the
+    // command flip, the assertion that the file ends at status: stale
+    // fails directly.
+    const file = writeTaskFile("task-ready-victim", "ready");
+
+    await silenceConsoleError(async () => {
+      await runTasks(["status", "task-ready-victim", "stale"]);
+    });
+
+    expect(readFileSync(file, "utf-8")).toContain("status: stale");
+  });
+
+  test("rejects unknown status spellings with a VALID_STATUSES error", async () => {
+    // Harness condition: a fixture task exists; the rejection must come
+    // from the VALID_STATUSES guard, not from a missing-file error.
+    writeTaskFile("task-victim", "ready");
+
+    await expect(
+      silenceConsoleError(async () => runTasks(["status", "task-victim", "not-a-real-status"])),
+    ).rejects.toThrow(/invalid status/);
+  });
+
+  test("rejects missing status argument with a usage error", async () => {
+    writeTaskFile("task-victim", "ready");
+    await expect(
+      silenceConsoleError(async () => runTasks(["status", "task-victim"])),
+    ).rejects.toThrow(/status required/);
+  });
+
+  test("rejects missing task id with a usage error", async () => {
+    await expect(
+      silenceConsoleError(async () => runTasks(["status"])),
+    ).rejects.toThrow(/task ID required/);
+  });
+
+  test("rejects unknown task id with task-not-found error", async () => {
+    await expect(
+      silenceConsoleError(async () => runTasks(["status", "task-does-not-exist", "ready"])),
+    ).rejects.toThrow(/task not found/);
+  });
+
+  test("accepts every status in VALID_STATUSES (smoke loop)", async () => {
+    // Harness condition: a fresh fixture for each iteration. Mutation: drop
+    // a status from VALID_STATUSES and the corresponding loop iteration
+    // raises `invalid status: X`.
+    const valid = [
+      "ready", "in-progress", "deferred", "preempted", "preempt-queued",
+      "done", "abandoned", "merged", "needs-confirmation", "blocked", "stale",
+    ];
+    const file = writeTaskFile("task-loop", "ready");
+    for (const s of valid) {
+      await silenceConsoleError(async () => runTasks(["status", "task-loop", s]));
+      expect(readFileSync(file, "utf-8")).toContain(`status: ${s}`);
+    }
+  });
+});

--- a/src/tasks/status-cli.test.ts
+++ b/src/tasks/status-cli.test.ts
@@ -101,6 +101,54 @@ describe("ludics tasks status <id> <status> (AC 12)", () => {
     ).rejects.toThrow(/task not found/);
   });
 
+  test("rejects path-traversal task IDs before any sibling file is touched (TASK_ID_RE guard)", async () => {
+    // Harness condition: a *sibling* directory next to tasks/ contains a
+    // decoy file whose path would be reachable via `../decoy/sibling.md`
+    // if the CLI did `join(tasksDir(), `${id}.md`)` without validation.
+    // The decoy file is non-empty and has no frontmatter, so any
+    // updateFrontmatterField mutation would either leave a `.tmp` sibling
+    // or rewrite the file's contents. We assert the file is byte-identical
+    // before and after the rejected call.
+    const harnessDir = harness();
+    mkdirSync(join(harnessDir, "tasks"), { recursive: true });
+    const decoyDir = join(harnessDir, "decoy");
+    mkdirSync(decoyDir, { recursive: true });
+    const decoyFile = join(decoyDir, "sibling.md");
+    const decoyContent = "# Decoy — must not be touched by the CLI\n";
+    writeFileSync(decoyFile, decoyContent);
+
+    // Each rejected ID below contains a character TASK_ID_RE explicitly
+    // forbids (`/`, space, `$`, `..` with leading slash). Without the
+    // guard the first id would resolve to `<tasks>/../decoy/sibling.md`
+    // — escaping the tasks directory and overwriting the decoy file.
+    // (Note: a bare `..` happens to be safe because `${id}.md` renders as
+    // `...md` and lands inside the tasks dir; we don't include it because
+    // TASK_ID_RE *accepts* it, so a "rejected" assertion would be wrong.
+    // We test the IDs the regex truly rejects.)
+    const malicious = [
+      "../decoy/sibling",
+      "task/sub",
+      "task with space",
+      "task$injection",
+    ];
+
+    for (const id of malicious) {
+      const before = readFileSync(decoyFile, "utf-8");
+      await expect(
+        silenceConsoleError(async () => runTasks(["status", id, "ready"])),
+      ).rejects.toThrow(/invalid task ID/);
+      // Invariant: the rejection happens at the CLI boundary, BEFORE the
+      // join+updateFrontmatterField sequence. Mutation: drop the
+      // TASK_ID_RE.test guard and the first iteration's `..` path would
+      // resolve to `<harness>/tasks/../decoy/sibling.md` — the
+      // updateFrontmatterField call would either touch the decoy file or
+      // throw a different error path (not "invalid task ID").
+      const after = readFileSync(decoyFile, "utf-8");
+      expect(after).toBe(decoyContent);
+      expect(after).toBe(before);
+    }
+  });
+
   test("accepts every status in VALID_STATUSES (smoke loop)", async () => {
     // Harness condition: a fresh fixture for each iteration. Mutation: drop
     // a status from VALID_STATUSES and the corresponding loop iteration

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -302,6 +302,38 @@ describe("tasksReconcileBlockedStatus", () => {
     }
   });
 
+  test("stale task with blockers is NOT flipped to blocked (stale is in skip list)", () => {
+    // Harness condition: a `stale` task with non-empty blocked_by. Without
+    // BLOCKED_RECONCILE_SKIP_STATUSES including stale, the reconciler would
+    // try to flip ready→blocked here. Since stale is terminal, it must be
+    // left alone.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeTaskWithBlockedBy(tasksDir, "task-stale-with-blockers", "stale", ["task-dep"]);
+    tasksReconcileBlockedStatus(tasksDir);
+
+    // Invariant: stale status survives the sweep verbatim.
+    expect(readFileSync(join(tasksDir, "task-stale-with-blockers.md"), "utf-8")).toContain("status: stale");
+  });
+
+  test("stale task with no blockers is NOT flipped to ready (stale is in skip list)", () => {
+    // Harness condition: a `stale` task with empty blocked_by. The
+    // status==="blocked" reset path must not catch stale tasks.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeTaskWithBlockedBy(tasksDir, "task-stale-no-blockers", "stale", []);
+    tasksReconcileBlockedStatus(tasksDir);
+
+    // Invariant: stale survives even with empty blocked_by.
+    const after = readFileSync(join(tasksDir, "task-stale-no-blockers.md"), "utf-8");
+    expect(after).toContain("status: stale");
+    expect(after).not.toContain("status: ready");
+  });
+
   test("does not change already-consistent statuses", () => {
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");
@@ -423,6 +455,27 @@ describe("containerCompletionSweep", () => {
 
     tasksReconcileBlockedStatus(tasksDir);
     const entries = readQueueActions(join(harness, "mag", "queue.jsonl"));
+    expect(entries.filter(e => e.action === "verify-container-completion")).toHaveLength(0);
+  });
+
+  test("stale parent does not enqueue verify-container-completion (AC 6 — stale ∈ TERMINAL_FOR_PARENT)", () => {
+    // Harness condition: leaf:false parent is `stale`; both children are
+    // terminal. Without `stale` in TERMINAL_FOR_PARENT, the sweep would
+    // queue a verify-container-completion request for a task whose work
+    // has already been superseded.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(join(harness, "mag"), { recursive: true });
+    writeContainerTask(tasksDir, "task-stale-parent", "ludics", "stale");
+    writeChildTask(tasksDir, "task-stale-child-a", "task-stale-parent", "done");
+    writeChildTask(tasksDir, "task-stale-child-b", "task-stale-parent", "abandoned");
+
+    tasksReconcileBlockedStatus(tasksDir);
+    const entries = readQueueActions(join(harness, "mag", "queue.jsonl"));
+    // Invariant: stale parent is skipped — no verify-container-completion
+    // queued. Mutation: removing `stale` from TERMINAL_FOR_PARENT flips this
+    // assertion (the sweep would queue a request).
     expect(entries.filter(e => e.action === "verify-container-completion")).toHaveLength(0);
   });
 
@@ -593,6 +646,52 @@ dependencies:
     // it is unelaborated and ready. Removing the filter flips this assertion.
     expect(list).not.toContain("task-container");
     expect(list).toContain("task-leaf");
+  });
+
+  test("stale tasks are excluded from the needs-elaboration list (AC 6 scope expansion)", () => {
+    // Harness condition: a stale task that is both unelaborated AND has
+    // status: stale. Without `stale` in the skip list, the function would
+    // return its id, causing keepalive to auto-queue elaboration for a
+    // superseded task.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeFileSync(join(tasksDir, "task-stale-unelaborated.md"), `---
+id: task-stale-unelaborated
+title: "stale-victim"
+project: ludics
+status: stale
+priority: B
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+    // Sibling unelaborated leaf — proves the function would have included
+    // the stale task if the filter were absent.
+    writeFileSync(join(tasksDir, "task-leaf-eligible.md"), `---
+id: task-leaf-eligible
+title: "leaf"
+project: ludics
+status: ready
+priority: B
+dependencies:
+  blocks: []
+  blocked_by: []
+  relates_to: []
+  subtask_of: null
+---
+`);
+
+    const list = tasksNeedsElaborationList(tasksDir);
+
+    // Invariant: stale tasks must not appear in the needs-elaboration list.
+    // Mutation: removing `stale` from the skip list flips this assertion.
+    expect(list).not.toContain("task-stale-unelaborated");
+    expect(list).toContain("task-leaf-eligible");
   });
 });
 

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { loadConfigSync, harnessDir, priorityProjects, preemptAutonomy, slotsCount, milestonesEnabledProjects } from "../config.ts";
 import { readAllSlotJson } from "../slots/json.ts";
 import { listStashes } from "../slots/preempt.ts";
-import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray, renderFrontmatterValue } from "./markdown.ts";
+import { writeTaskFile, updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, updateDependencyArray, renderFrontmatterValue, TERMINAL_STATUSES, BLOCKED_RECONCILE_SKIP_STATUSES } from "./markdown.ts";
 import { isElaborated } from "./elaboration.ts";
 import { emitEvent } from "../events.ts";
 import { queueRequest, queueHasPendingActionForTask, parseQueueLines } from "../queue.ts";
@@ -745,7 +745,7 @@ function healBlockedByLinks(tasksDir: string): TaskMap {
  */
 function containerCompletionSweep(taskMap: TaskMap): void {
   const TERMINAL_FOR_PARENT = new Set([
-    "done", "abandoned", "merged", "needs-confirmation",
+    "done", "abandoned", "merged", "stale", "needs-confirmation",
     "in-progress", "deferred", "preempt-queued", "preempted",
   ]);
   const TERMINAL_FOR_CHILD = new Set(["done", "abandoned"]);
@@ -824,7 +824,7 @@ function tasksReconcileBlockedStatus(tasksDir: string): void {
     const blockedBy = fm.dependencies.blocked_by;
 
     // Skip terminal and active statuses
-    if (["done", "abandoned", "merged", "in-progress", "deferred", "preempt-queued", "preempted"].includes(status)) continue;
+    if (BLOCKED_RECONCILE_SKIP_STATUSES.includes(status)) continue;
 
     if (blockedBy.length > 0 && status === "ready") {
       if (setFrontmatterScalar(filePath, "status", "blocked")) {
@@ -858,7 +858,7 @@ function tasksMilestoneWarnings(tasksDir: string): void {
 
     // Only warn for active (non-terminal) tasks
     const status = fm.status ?? "ready";
-    if (["done", "abandoned", "merged"].includes(status)) continue;
+    if (TERMINAL_STATUSES.includes(status)) continue;
 
     if (!milestonesProjects.has(fm.project ?? "")) continue;
 
@@ -923,7 +923,7 @@ function tasksNeedsElaborationList(tasksDir: string): string[] {
     if (!id) continue;
 
     const status = fm.status ?? "";
-    if (["merged", "done", "abandoned", "needs-confirmation"].includes(status)) continue;
+    if ([...TERMINAL_STATUSES, "needs-confirmation"].includes(status)) continue;
     // Container tasks (work split into subtasks) are not actionable; never
     // queue them for elaboration even if they happen to be unelaborated.
     if (fm.leaf === false) continue;

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -4,7 +4,7 @@ export interface TaskFrontmatter {
   id: string;
   title: string;
   project: string;
-  status: string; // ready, in-progress, deferred, preempted, done, abandoned, merged, needs-confirmation
+  status: string; // ready, in-progress, deferred, preempted, preempt-queued, done, abandoned, merged, needs-confirmation, blocked, stale
   priority: string; // S, A, B, C, D (D reached only via demote/postpone)
   deadline: string | null;
   dependencies: {

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -67,6 +67,7 @@ async function fetchAllData() {
             fetchNeedsConfirmation(),
             fetchUnansweredQuestions(),
             fetchDeferredLaunch(),
+            fetchStale(),
             fetchNotifications(),
             fetchMagStatus(),
             fetchT3codeLink(),
@@ -646,6 +647,63 @@ function fetchDeferredLaunch() {
             </li>`;
         },
     });
+}
+
+function fetchStale() {
+    return fetchAndRenderTaskList({
+        jsonFile: 'stale.json',
+        listId: 'stale-list',
+        emptyText: 'No stale tasks',
+        renderItem(task) {
+            const priority = task.priority || '-';
+            const priorityClass = `priority-${priority}`;
+            return `
+            <li class="stale-item">
+                <span class="priority ${priorityClass}">${escapeHtml(priority)}</span>
+                <a class="task-title stale-link" href="${taskLink(task.id)}" target="_blank">${escapeHtml(task.title || task.id)}</a>
+                <span class="stale-actions">
+                    <button class="revive-btn" onclick="reviveStale('${escapeHtml(task.id)}')" title="Revive: flip stale → ready">Revive</button>
+                    <button class="abandon-btn" onclick="abandonStale('${escapeHtml(task.id)}')" title="Abandon task">Abandon</button>
+                </span>
+            </li>`;
+        },
+    });
+}
+
+async function reviveStale(taskId) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+        const response = await fetch(`/api/stale-revive?task=${encodeURIComponent(taskId)}`);
+        if (response.ok) {
+            fetchAllData();
+        } else {
+            btn.textContent = 'Revive';
+            setTimeout(() => { btn.disabled = false; }, 2000);
+        }
+    } catch {
+        btn.textContent = 'Revive';
+        setTimeout(() => { btn.disabled = false; }, 2000);
+    }
+}
+
+async function abandonStale(taskId) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = '…';
+    try {
+        const response = await fetch(`/api/stale-abandon?task=${encodeURIComponent(taskId)}`);
+        if (response.ok) {
+            fetchAllData();
+        } else {
+            btn.textContent = 'Abandon';
+            setTimeout(() => { btn.disabled = false; }, 2000);
+        }
+    } catch {
+        btn.textContent = 'Abandon';
+        setTimeout(() => { btn.disabled = false; }, 2000);
+    }
 }
 
 async function approveDeferred(taskId) {

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -133,6 +133,14 @@
                     </ul>
                 </section>
 
+                <!-- Stale -->
+                <section class="stale panel">
+                    <h2>Stale</h2>
+                    <ul id="stale-list">
+                        <li class="loading">Loading...</li>
+                    </ul>
+                </section>
+
                 <!-- Recent Notifications -->
                 <section class="notifications panel">
                     <h2>Recent Notifications</h2>


### PR DESCRIPTION
## Summary

Lands both halves of the elaborate/stale workflow hardening proposal in one PR (proposal: `docs/proposals/elaborate-stale-workflow-hardening.md`).

**Part 1 — atomic `has_questions` write.** The `/ludics-elaborate` flow had two writers per task (worker wrote `elaborated:` + design; orchestrator wrote `has_questions: true`), and the keepalive's auto-proposal queue raced the gap. Now the worker is the sole writer of `has_questions: true`, and the orchestrator only verifies + falls back with a loud warning if the field is missing.

**Part 2 — `stale` status.** When `/ludics-draft-proposal` returned `stale`, the disposition lived only in the result JSON; the task stayed `ready` and got re-queued (`gh-ocannl-203` was invoked 3 times in one session). Now the orchestrator flips `status: stale`, appends rationale to `## Notes`, and a precondition check rejects re-invocation with `status: blocked-stale`. The dashboard surfaces a Stale panel with Revive (`stale → ready`) and Abandon buttons.

**Centralisation.** Per the resolved Q3, introduces `VALID_STATUSES`, `TERMINAL_STATUSES`, `READY_QUEUE_ELIGIBLE_STATUSES`, and `BLOCKED_RECONCILE_SKIP_STATUSES` in `src/tasks/markdown.ts`, and refactors the ~7 inline skip-list sites in `mag.ts`/`tasks/sync.ts`/`tasks/index.ts`/`t3code/index.ts`/`flow.ts` to consume them. `cleanupDoneTaskThreads` is intentionally left at `done/abandoned` only — its predicate gates a folded loop that also queues retrospectives, which would be wrong for stale tasks.

**Documented assumption gap (AC 12).** The proposal's literal probe `ludics tasks update --status stale` cannot be satisfied because `tasks update` is a GitHub-metadata refresh with no positional args. Substituted with `ludics tasks status <id> <status>` mirroring `tasks priority`'s shape; validates against `VALID_STATUSES` AND against `TASK_ID_RE` (round-2 fix: rejects path-traversal IDs at the boundary so malicious IDs like `../decoy/sibling` cannot resolve to a sibling file before the join).

**Doc.** `docs/task-frontmatter-reference.md` gains a full `## Status` lifecycle section with one subsection per recognised status (resolved Q2 — extended scope).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (`--max-warnings=0`)
- [x] `bun run lint:cli-readme` — USAGE/README pair confirmed
- [x] `bun run lint:contracts` — worker/orchestrator field contracts in sync
- [x] `bun run lint:test-isolation` — no anti-patterns (only pre-existing 20 warnings)
- [x] `bun test` — 2039 pass / 2 fail; the two failures are pre-existing vendor-drift tests (`templates/dashboard/markdown.test.ts > vendored purify` + `CLI integration > vendored copies match upstream`) confirmed failing at base commit `5faa95e`. **Net new failures: 0.**
- [x] AC self-check checklist filed at `.peer-sync/workflow-feedback-coder.md`

### Regression tests

- `src/tasks/markdown.test.ts > "VALID_STATUSES centralised constant"` — five tests pinning constant membership.
- `src/mag-ready-candidates.test.ts > "stale tasks do not surface in the ready candidate list"`.
- `src/tasks/sync.test.ts` — three new tests for stale-skip in `tasksReconcileBlockedStatus`, `containerCompletionSweep`, and `tasksNeedsElaborationList`.
- `src/tasks/abandon.test.ts > "abandon task in terminal status"` — extended to iterate `done/abandoned/merged/stale`.
- `src/orchestration/skills.test.ts` — four template-shape tests pinning the literal contract on the three skill markdown files.
- `src/skills/ludics-elaborate-worker.test.ts` (new) — AC 3 atomicity invariant.
- `src/dashboard.test.ts` — six new tests for the Stale panel JSON, the two endpoints, their 409 rejection paths, AND the slotted-stale-abandon round-3 fix.
- `src/tasks/status-cli.test.ts` (new) — seven smoke tests for `tasks status` including a smoke loop over every status in `VALID_STATUSES` AND a mutation-tested path-traversal rejection test (round 2 fix).
- `docs/task-frontmatter-reference.shape.test.ts` (new) — cardinality + 11-status presence loop.

## Round 2 — TASK_ID_RE guard

Round-2 review flagged that `tasks status <id>` lacked the `TASK_ID_RE` guard adjacent CLI surfaces enforce. Commit `ef6814a` adds the guard mirroring `tasksSetPriority` (line 657) and a mutation-tested regression test that seeds a sibling decoy file outside the tasks directory and asserts byte-identity before/after each rejected malicious call. Mutation: stashing the guard out of the source caused the `../decoy/sibling` iteration to *resolve* (actually wrote the decoy file via traversal) — confirming the test catches the exact unsafe shape.

## Round 3 — Codex review (slotted stale-abandon)

Codex review on `612623a` flagged that `/api/stale-abandon`'s de-stale-then-abandon composition silently left a slotted stale task at `status: ready` while the endpoint reported success. Root cause: `tasksAbandon` for a slotted task delegates to `slotClear → taskUpdateForSlotClear`, whose `expectedFrom` for "abandoned" is `[in-progress, deferred, preempted]`. The freshly-de-staled task is `ready`, so the status flip silently no-ops; meanwhile the endpoint returns `{"status":"abandoned"}`.

Commit `481ade3` rewrites the endpoint to bypass `tasksAbandon` and do the abandon flow inline:
1. `transitionStatus(stale → abandoned)` — atomic, no terminal guard to trip.
2. Set `completed` timestamp; remove `deferred_launch`/`approved`.
3. If slotted, `slotClear(slotNum, "ready")` — clears the runtime state; `taskUpdateForSlotClear` correctly leaves the already-correct `abandoned` frontmatter alone (its `ready` `expectedFrom` is `[in-progress, deferred]`, which excludes `abandoned`).
4. Emit `task_abandon` event with `source: "dashboard"`.

Regression test `"POST /api/stale-abandon on a slotted stale task ends with status: abandoned"` mutation-tested: reverting to the `tasksAbandon`-delegating shape causes the file to end at `status: ready` while the endpoint returns 200 — the exact Codex-flagged shape.

## Out-of-scope flags (per proposal § Out of scope)

- Retroactive flip of historically-stale tasks (e.g. `gh-ocannl-203`) — not done in this PR; user can file a separate task to sweep.
- `cleanupDoneTaskThreads` asymmetry intentionally preserved (see commit body of `refactor(tasks): consume centralised TERMINAL_STATUSES`).
- `tasksAbandon`'s pre-existing latent issue with slotted-abandon (re-reads the file post-`slotClear` and re-trips the `TERMINAL_STATUSES` guard) — out of scope; the dashboard endpoint sidesteps it by not delegating.
- The two pre-existing vendor failures are unrelated and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)