### PR TITLE
Slot ttyd observability + flap-suppression

### DIFF
--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -355,6 +355,35 @@ describe("buildTtydSpawnArgs — bash wrapper appends to per-agent log file", ()
     // Single-quoted target name.
     expect(cmd).toContain("-t 's2_reviewer_task-abc'");
   });
+
+  test("HOME containing an apostrophe is escaped via '\\'' so the bash command stays parseable", async () => {
+    const savedHome = process.env.HOME;
+    const tmpRoot = mkdtempSync(join(tmpdir(), "ludics-quote-home-"));
+    // Simulate /Users/O'Connor: a directory whose name actually contains '.
+    const home = join(tmpRoot, "O'Connor");
+    mkdirSync(join(home, "Library/Logs"), { recursive: true });
+    process.env.HOME = home;
+    try {
+      // Re-import to re-resolve HOME (function reads process.env.HOME on each call).
+      const mod = await import("./tmux-adapter.ts");
+      const args = mod.buildTtydSpawnArgs(1, "coder", "coder", "task-xyz");
+      const cmd = args[args.length - 1]!;
+      // Invariant: the literal apostrophe in HOME must be encoded as the
+      // POSIX close-reopen sequence '\''. A naive single-quote interpolation
+      // would emit `'/.../O'Connor/.../...-ttyd.log'` — bash would parse
+      // that as: <single-quoted "/.../O">, <Connor/.../...>, <single-quoted
+      // ".log">, which has unbalanced state and command parsing fails or
+      // misroutes redirection. Mutation: dropping the .replace() call here
+      // makes this assertion fail.
+      expect(cmd).toContain(`O'\\''Connor`);
+      // Sanity: the escaped path is still the redirection target.
+      expect(cmd).toMatch(/>>'.*O'\\''Connor.*ludics-slot-1-coder-ttyd\.log'/);
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", () => {

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -385,20 +385,46 @@ describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", (
     expect(Object.prototype.hasOwnProperty.call(state, "ttydRestartCounts")).toBe(false);
   });
 
-  test("ttydRestartCounts round-trips byte-faithfully when present", async () => {
+  test("ttydRestartCounts round-trips byte-faithfully when present (includes lastRestartAt)", async () => {
     const { readTmuxSlotState, writeTmuxSlotState } = await import("./tmux-adapter.ts");
     const fixture = {
       slot: 4,
       ttydPids: { coder: 1234 },
       ttydRestartCounts: {
-        coder: { count: 3, firstRestartAt: 1700000000 },
-        reviewer: { count: 10, firstRestartAt: 1700000100, backoffUntil: Number.MAX_SAFE_INTEGER },
+        coder: { count: 3, firstRestartAt: 1700000000, lastRestartAt: 1700000060 },
+        reviewer: {
+          count: 10,
+          firstRestartAt: 1700000100,
+          lastRestartAt: 1700000400,
+          backoffUntil: Number.MAX_SAFE_INTEGER,
+        },
       },
     } as unknown as Parameters<typeof writeTmuxSlotState>[0];
     writeTmuxSlotState(fixture, tmpDir);
     const round = readTmuxSlotState(4, tmpDir);
     expect(round).toEqual(fixture);
-    // Sentinel value survives JSON round-trip.
+    // Sentinel value AND new lastRestartAt field both survive JSON round-trip.
     expect(round!.ttydRestartCounts!.reviewer!.backoffUntil).toBe(Number.MAX_SAFE_INTEGER);
+    expect(round!.ttydRestartCounts!.coder!.lastRestartAt).toBe(1700000060);
+    expect(round!.ttydRestartCounts!.reviewer!.lastRestartAt).toBe(1700000400);
+  });
+
+  test("legacy record without lastRestartAt round-trips with the field undefined", async () => {
+    const { readTmuxSlotState, writeTmuxSlotState } = await import("./tmux-adapter.ts");
+    const legacy = {
+      slot: 5,
+      ttydPids: {},
+      ttydRestartCounts: {
+        // Pre-fix shape — explicitly OMITs lastRestartAt.
+        coder: { count: 1, firstRestartAt: 1700000000 },
+      },
+    } as unknown as Parameters<typeof writeTmuxSlotState>[0];
+    writeTmuxSlotState(legacy, tmpDir);
+    const round = readTmuxSlotState(5, tmpDir);
+    expect(round!.ttydRestartCounts!.coder!.count).toBe(1);
+    expect(round!.ttydRestartCounts!.coder!.firstRestartAt).toBe(1700000000);
+    // Invariant: legacy field stays undefined on read; the runner falls
+    // back to firstRestartAt only when this field is absent.
+    expect(round!.ttydRestartCounts!.coder!.lastRestartAt).toBeUndefined();
   });
 });

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -286,3 +286,119 @@ describe("writeTmuxSlotState atomic write", () => {
     expect(existsSync(join(tmpDir, "orchestration", "tmux-slot-9.json"))).toBe(true);
   });
 });
+
+// task-7476a03a — slot ttyd observability + flap-suppression. The next three
+// describe blocks lock in (1) per-agent log path resolution, (2) bash-wrapper
+// spawn argv shape, and (3) read-boundary preservation of the new optional
+// ttydRestartCounts field.
+describe("ttydLogPath — log location follows Mag's HOME/Library/Logs precedent", () => {
+  let TMP = "";
+  let savedHome: string | undefined;
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-ttyd-log-"));
+    savedHome = process.env.HOME;
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("returns ~/Library/Logs/ludics-slot-{N}-{agent}-ttyd.log when HOME/Library/Logs exists", async () => {
+    process.env.HOME = TMP;
+    mkdirSync(join(TMP, "Library/Logs"), { recursive: true });
+    const { ttydLogPath } = await import("./tmux-adapter.ts");
+    expect(ttydLogPath(1, "coder")).toBe(join(TMP, "Library/Logs", "ludics-slot-1-coder-ttyd.log"));
+    expect(ttydLogPath(6, "reviewer")).toBe(join(TMP, "Library/Logs", "ludics-slot-6-reviewer-ttyd.log"));
+  });
+
+  test("falls back to /tmp when HOME/Library/Logs is absent", async () => {
+    process.env.HOME = TMP;
+    // Do not create Library/Logs.
+    const { ttydLogPath } = await import("./tmux-adapter.ts");
+    expect(ttydLogPath(2, "coder")).toBe("/tmp/ludics-slot-2-coder-ttyd.log");
+  });
+});
+
+describe("buildTtydSpawnArgs — bash wrapper appends to per-agent log file", () => {
+  test("argv ends with bash -c containing exec ttyd and append-redirection to ttydLogPath", async () => {
+    const mod = await import("./tmux-adapter.ts");
+    const args = mod.buildTtydSpawnArgs(3, "coder", "coder", "task-7476a03a");
+    // Last three argv entries are always: bash, -c, <command-string>
+    expect(args[args.length - 3]).toBe("bash");
+    expect(args[args.length - 2]).toBe("-c");
+    const cmd = args[args.length - 1]!;
+    // Must `exec` so proc.pid is ttyd's, not bash's. Append-redirection
+    // (>>) preserves cause-of-death history across restarts.
+    expect(cmd).toContain("exec ttyd");
+    expect(cmd).toContain("--writable");
+    const expectedLog = mod.ttydLogPath(3, "coder");
+    expect(cmd).toContain(`>>'${expectedLog}'`);
+    expect(cmd).toContain("2>&1");
+    // The argv must still go through setsidWrap — either setsid prefix
+    // (Linux) or perl POSIX::setsid fallback (macOS without setsid).
+    const head = args[0]!;
+    const usesSetsid = head.endsWith("/setsid") || head === "setsid";
+    const usesPerl = head === "perl";
+    expect(usesSetsid || usesPerl).toBe(true);
+  });
+
+  test("port and target derive from slot+role+taskId", async () => {
+    const { buildTtydSpawnArgs } = await import("./tmux-adapter.ts");
+    const cmd = buildTtydSpawnArgs(2, "reviewer", "reviewer", "task-abc")[
+      buildTtydSpawnArgs(2, "reviewer", "reviewer", "task-abc").length - 1
+    ]!;
+    // Slot 2 reviewer port: 7681 + (2-1)*2 + 1 = 7684.
+    expect(cmd).toContain("--port 7684");
+    // Single-quoted target name.
+    expect(cmd).toContain("-t 's2_reviewer_task-abc'");
+  });
+});
+
+describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", () => {
+  let tmpDir = "";
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ludics-ttyd-readboundary-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("legacy on-disk JSON without ttydRestartCounts reads back as undefined (no {} backfill)", async () => {
+    const { readTmuxSlotState } = await import("./tmux-adapter.ts");
+    const orchDir = join(tmpDir, "orchestration");
+    mkdirSync(orchDir, { recursive: true });
+    // Hand-write a legacy state — explicitly OMITs ttydRestartCounts.
+    writeFileSync(
+      join(orchDir, "tmux-slot-1.json"),
+      JSON.stringify({ slot: 1, ttydPids: {} }),
+    );
+    const state = readTmuxSlotState(1, tmpDir);
+    expect(state).not.toBeNull();
+    // Invariant: read boundary keeps the field sparse — undefined, not {}.
+    // Mutation: replacing the read with `parsed.ttydRestartCounts ??= {}` makes this fail.
+    expect(state!.ttydRestartCounts).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(state, "ttydRestartCounts")).toBe(false);
+  });
+
+  test("ttydRestartCounts round-trips byte-faithfully when present", async () => {
+    const { readTmuxSlotState, writeTmuxSlotState } = await import("./tmux-adapter.ts");
+    const fixture = {
+      slot: 4,
+      ttydPids: { coder: 1234 },
+      ttydRestartCounts: {
+        coder: { count: 3, firstRestartAt: 1700000000 },
+        reviewer: { count: 10, firstRestartAt: 1700000100, backoffUntil: Number.MAX_SAFE_INTEGER },
+      },
+    } as unknown as Parameters<typeof writeTmuxSlotState>[0];
+    writeTmuxSlotState(fixture, tmpDir);
+    const round = readTmuxSlotState(4, tmpDir);
+    expect(round).toEqual(fixture);
+    // Sentinel value survives JSON round-trip.
+    expect(round!.ttydRestartCounts!.reviewer!.backoffUntil).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -262,13 +262,24 @@ function createTmuxAgentSession(slot: number, agentName: string, cwd: string, ta
 }
 
 /**
+ * POSIX shell single-quote escape: wrap `s` in single quotes and replace
+ * any embedded `'` with `'\''` (close-quote, literal-quote, reopen-quote).
+ * Required because HOME may legitimately contain an apostrophe (e.g.
+ * `/Users/O'Connor`) and a naive single-quote interpolation would make
+ * the bash command unparseable, causing ttyd restarts to fail repeatedly.
+ */
+function shellSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
  * Build the spawn argv for slot ttyd, mirroring src/mag.ts's bash-with-`exec`
  * redirection so ttyd's stdout/stderr append to a per-agent log file. The
  * `exec` makes bash replace itself with ttyd, so `proc.pid` continues to
  * point at ttyd (preserves processAlive semantics). Substitutions are
- * single-quoted defensively even though all inputs are validated upstream
- * (numeric slot, alpha agent name, TASK_ID_RE-validated taskId, fixed log
- * directory).
+ * shell-quoted via shellSingleQuote so HOMEs / agent names containing `'`
+ * round-trip correctly even though most inputs are validated upstream
+ * (numeric slot, alpha agent name, TASK_ID_RE-validated taskId).
  */
 export function buildTtydSpawnArgs(
   slot: number,
@@ -279,7 +290,7 @@ export function buildTtydSpawnArgs(
   const port = ttydPort(slot, role);
   const target = tmuxTarget(slot, agentName, taskId);
   const logFile = ttydLogPath(slot, agentName);
-  const cmd = `exec ttyd --writable --port ${port} tmux attach -t '${target}' >>'${logFile}' 2>&1`;
+  const cmd = `exec ttyd --writable --port ${port} tmux attach -t ${shellSingleQuote(target)} >>${shellSingleQuote(logFile)} 2>&1`;
   return setsidWrap(["bash", "-c", cmd]);
 }
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -46,9 +46,18 @@ const PORT_BASE = 7681; // port 7680 reserved
 // Tmux slot state — persisted alongside orchestration state
 // ---------------------------------------------------------------------------
 
+export interface TtydRestartRecord {
+  count: number;
+  firstRestartAt: number;
+  backoffUntil?: number;
+}
+
 interface TmuxSlotState {
   slot: number;
   ttydPids: Record<string, number>; // agent name → ttyd PID
+  // Per-agent flap-suppression counters. Optional: legacy on-disk JSON omits
+  // it. Sparse-shape contract — see readTmuxSlotState below.
+  ttydRestartCounts?: Record<string, TtydRestartRecord>;
   orchestration?: {
     stateFile: string;
     mode: "duo" | "pair" | "solo";
@@ -60,10 +69,24 @@ function tmuxSlotPath(slot: number, harnessDir: string): string {
   return join(harnessDir, "orchestration", `tmux-slot-${slot}.json`);
 }
 
+// Per-slot per-agent ttyd log path. Mirrors src/mag.ts's HOME/Library/Logs
+// preference with a /tmp fallback for non-macOS hosts so newsyslog rotates
+// the macOS path for free.
+export function ttydLogPath(slot: number, agentName: string): string {
+  const home = process.env.HOME ?? "~";
+  const libraryLogs = join(home, "Library/Logs");
+  const dir = existsSync(libraryLogs) ? libraryLogs : "/tmp";
+  return join(dir, `ludics-slot-${slot}-${agentName}-ttyd.log`);
+}
+
 function readTmuxSlotState(slot: number, harnessDir: string): TmuxSlotState | null {
   const path = tmuxSlotPath(slot, harnessDir);
   if (!existsSync(path)) return null;
   try {
+    // Read-boundary for TmuxSlotState. Optional persisted fields stay sparse:
+    // ttydRestartCounts is preserved as-on-disk (undefined for legacy files,
+    // populated Record when present). New optional fields should land here so
+    // every reader sees the same normalized shape.
     return JSON.parse(readFileSync(path, "utf-8")) as TmuxSlotState;
   } catch {
     return null;
@@ -228,17 +251,39 @@ function createTmuxAgentSession(slot: number, agentName: string, cwd: string, ta
   safeSyncOutput(["tmux", "set-option", "-t", sessionName, "mouse", "off"]);
 }
 
-export function startTtyd(slot: number, agentName: string, role: "coder" | "reviewer", taskId?: string): number {
+/**
+ * Build the spawn argv for slot ttyd, mirroring src/mag.ts's bash-with-`exec`
+ * redirection so ttyd's stdout/stderr append to a per-agent log file. The
+ * `exec` makes bash replace itself with ttyd, so `proc.pid` continues to
+ * point at ttyd (preserves processAlive semantics). Substitutions are
+ * single-quoted defensively even though all inputs are validated upstream
+ * (numeric slot, alpha agent name, TASK_ID_RE-validated taskId, fixed log
+ * directory).
+ */
+export function buildTtydSpawnArgs(
+  slot: number,
+  agentName: string,
+  role: "coder" | "reviewer",
+  taskId?: string,
+): string[] {
   const port = ttydPort(slot, role);
   const target = tmuxTarget(slot, agentName, taskId);
+  const logFile = ttydLogPath(slot, agentName);
+  const cmd = `exec ttyd --writable --port ${port} tmux attach -t '${target}' >>'${logFile}' 2>&1`;
+  return setsidWrap(["bash", "-c", cmd]);
+}
+
+export function startTtyd(slot: number, agentName: string, role: "coder" | "reviewer", taskId?: string): number {
+  const port = ttydPort(slot, role);
 
   // Kill any stale ttyd on this port
   safeSyncOutput(["pkill", "-f", `ttyd.*--port ${port}`]);
 
   // Use setsidWrap to detach ttyd into its own process session so it survives
-  // when the parent (launchd oneshot keepalive) exits.
+  // when the parent (launchd oneshot keepalive) exits. The bash wrapper
+  // appends ttyd's output to the per-agent log file at ttydLogPath.
   const proc = Bun.spawn(
-    setsidWrap(["ttyd", "--writable", "--port", String(port), "tmux", "attach", "-t", target]),
+    buildTtydSpawnArgs(slot, agentName, role, taskId),
     { stdin: "ignore", stdout: "ignore", stderr: "ignore" },
   );
   if (typeof (proc as { unref?: () => void }).unref === "function") {
@@ -668,4 +713,5 @@ async function lastActivity(ctx: AdapterContext): Promise<string | null> {
 const adapter = { readState, start, stop, lastActivity } satisfies Adapter;
 
 export { readState, start, stop, lastActivity, readTmuxSlotState, writeTmuxSlotState, removeTmuxSlotState, agentPortRole };
+export type { TmuxSlotState };
 export default adapter;

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -49,6 +49,16 @@ const PORT_BASE = 7681; // port 7680 reserved
 export interface TtydRestartRecord {
   count: number;
   firstRestartAt: number;
+  /** Epoch seconds of the most-recent restart. Used by `ensureTtydAlive`'s
+   *  window-reset gate: a quiet period is measured against the *last*
+   *  restart, not the first, so an active flap whose first incident is
+   *  older than the quiet window does not get spuriously reset.
+   *
+   *  Optional only for back-compat with records persisted before this
+   *  field was introduced; readers fall back to `firstRestartAt` when
+   *  absent (correct for the count==1 case where they coincide).
+   */
+  lastRestartAt?: number;
   backoffUntil?: number;
 }
 

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -13,6 +13,7 @@ import { slotClear, slotSetMode, slotStart, slotResume, findSlotForTask, VALID_C
 import { updateFrontmatterField, addFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, transitionStatus, TASK_ID_RE, PRIORITY_INCREASE, PRIORITY_DECREASE } from "./tasks/markdown.ts";
 import { emitEvent } from "./events.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
+import { readTmuxSlotState, writeTmuxSlotState } from "./adapters/tmux-adapter.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
 import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./mag.ts";
 import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
@@ -168,6 +169,37 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
     // Regenerate data if stale on any request to /data/
     if (pathname.startsWith("/data/")) {
       maybeRegenerate();
+    }
+
+    // API: clear ttyd flap-suppression counters for a slot (or one agent in it).
+    // Triggered from the Terminals tab on full page reload — the user's
+    // natural "kick it" gesture becomes the recovery action.
+    // task-7476a03a — slot ttyd observability + flap-suppression.
+    if (pathname === "/api/ttyd-reset" && req.method === "POST") {
+      const slotParam = url.searchParams.get("slot");
+      const agentParam = url.searchParams.get("agent");
+      if (!slotParam || !/^[1-6]$/.test(slotParam)) {
+        return new Response("Bad Request: slot must be 1-6", { status: 400 });
+      }
+      const slot = parseInt(slotParam, 10);
+      const tmuxState = readTmuxSlotState(slot, harnessDir());
+      if (!tmuxState) return new Response("Not Found", { status: 404 });
+      if (!tmuxState.ttydRestartCounts) {
+        // Already sparse — no-op succeeds without rewriting the file.
+        return new Response("OK", { status: 200 });
+      }
+      if (agentParam) {
+        delete tmuxState.ttydRestartCounts[agentParam];
+        if (Object.keys(tmuxState.ttydRestartCounts).length === 0) {
+          // Keep persisted shape sparse so future reads see undefined.
+          delete tmuxState.ttydRestartCounts;
+        }
+      } else {
+        // Slot-wide reset → drop the entire field.
+        delete tmuxState.ttydRestartCounts;
+      }
+      writeTmuxSlotState(tmuxState, harnessDir());
+      return new Response("OK", { status: 200 });
     }
 
     // API: clear a slot as done

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1031,3 +1031,144 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     expect(after).not.toMatch(/^status: ready$/m);
   });
 });
+
+// task-7476a03a — slot ttyd flap-suppression. /api/ttyd-reset is the
+// recovery endpoint posted by the Terminals tab on full page reload.
+describe("dashboard HTTP /api/ttyd-reset", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+
+  function tmuxStatePath(slot: number): string {
+    return join(harnessDir(), "orchestration", `tmux-slot-${slot}.json`);
+  }
+
+  function seedTmuxState(slot: number, state: object): void {
+    const dir = join(harnessDir(), "orchestration");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(tmuxStatePath(slot), JSON.stringify(state));
+  }
+
+  test("400 for missing or out-of-range slot", async () => {
+    const handler = await makeHandler();
+    for (const url of [
+      "http://x/api/ttyd-reset",
+      "http://x/api/ttyd-reset?slot=0",
+      "http://x/api/ttyd-reset?slot=7",
+      "http://x/api/ttyd-reset?slot=abc",
+    ]) {
+      const resp = await handler(new Request(url, { method: "POST" }));
+      // Invariant: every malformed slot must hit 400 — silently dropping a
+      // bad request would leave the user thinking the reset succeeded.
+      // Mutation: replacing /^[1-6]$/ with /^\d+$/ allows slot=7 (200), failing.
+      expect(resp.status).toBe(400);
+    }
+  });
+
+  test("404 when no tmux-slot file exists for that slot", async () => {
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/ttyd-reset?slot=2", { method: "POST" }));
+    expect(resp.status).toBe(404);
+  });
+
+  test("agent-targeted reset deletes the named key and drops the field when the map empties", async () => {
+    seedTmuxState(3, {
+      slot: 3,
+      ttydPids: { coder: 1234, reviewer: 1235 },
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: 1700000000, backoffUntil: Number.MAX_SAFE_INTEGER },
+      },
+      orchestration: { stateFile: "orch.json", mode: "pair", pid: process.pid },
+    });
+
+    const handler = await makeHandler();
+    const resp = await handler(
+      new Request("http://x/api/ttyd-reset?slot=3&agent=coder", { method: "POST" }),
+    );
+    expect(resp.status).toBe(200);
+
+    const persisted = JSON.parse(readFileSync(tmuxStatePath(3), "utf-8"));
+    // Invariant: emptying the per-agent map drops the entire field so the
+    // sparse-shape contract holds. Mutation: changing the inner-`delete`
+    // path to skip the empty-check would leave `ttydRestartCounts: {}` on
+    // disk and the assertion below fails.
+    expect(persisted.ttydRestartCounts).toBeUndefined();
+    // Other fields untouched.
+    expect(persisted.ttydPids).toEqual({ coder: 1234, reviewer: 1235 });
+    expect(persisted.orchestration.pid).toBe(process.pid);
+  });
+
+  test("agent-targeted reset preserves remaining sibling counters", async () => {
+    seedTmuxState(4, {
+      slot: 4,
+      ttydPids: { coder: 1234, reviewer: 1235 },
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: 1700000000, backoffUntil: Number.MAX_SAFE_INTEGER },
+        reviewer: { count: 3, firstRestartAt: 1700000050 },
+      },
+    });
+
+    const handler = await makeHandler();
+    const resp = await handler(
+      new Request("http://x/api/ttyd-reset?slot=4&agent=coder", { method: "POST" }),
+    );
+    expect(resp.status).toBe(200);
+
+    const persisted = JSON.parse(readFileSync(tmuxStatePath(4), "utf-8"));
+    expect(persisted.ttydRestartCounts).toBeDefined();
+    expect(persisted.ttydRestartCounts.coder).toBeUndefined();
+    expect(persisted.ttydRestartCounts.reviewer).toEqual({ count: 3, firstRestartAt: 1700000050 });
+  });
+
+  test("slot-wide reset (no agent param) drops the entire field", async () => {
+    seedTmuxState(5, {
+      slot: 5,
+      ttydPids: { coder: 1234, reviewer: 1235 },
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: 1700000000, backoffUntil: Number.MAX_SAFE_INTEGER },
+        reviewer: { count: 3, firstRestartAt: 1700000050 },
+      },
+    });
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/ttyd-reset?slot=5", { method: "POST" }));
+    expect(resp.status).toBe(200);
+
+    const persisted = JSON.parse(readFileSync(tmuxStatePath(5), "utf-8"));
+    expect(persisted.ttydRestartCounts).toBeUndefined();
+  });
+
+  test("200 no-op when the slot exists but has no flap counters yet", async () => {
+    seedTmuxState(6, { slot: 6, ttydPids: {} });
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/ttyd-reset?slot=6", { method: "POST" }));
+    expect(resp.status).toBe(200);
+
+    const persisted = JSON.parse(readFileSync(tmuxStatePath(6), "utf-8"));
+    expect(persisted.ttydRestartCounts).toBeUndefined();
+    expect(persisted.ttydPids).toEqual({});
+  });
+
+  test("round-trips through readTmuxSlotState — counter is gone after reset", async () => {
+    seedTmuxState(1, {
+      slot: 1,
+      ttydPids: {},
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: 1700000000, backoffUntil: Number.MAX_SAFE_INTEGER },
+      },
+    });
+
+    const handler = await makeHandler();
+    await handler(new Request("http://x/api/ttyd-reset?slot=1", { method: "POST" }));
+
+    const { readTmuxSlotState } = await import("./adapters/tmux-adapter.ts");
+    const round = readTmuxSlotState(1, harnessDir());
+    expect(round).not.toBeNull();
+    expect(round!.ttydRestartCounts).toBeUndefined();
+  });
+});

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -1507,14 +1507,20 @@ describe("ensureTtydAlive — flap suppression", () => {
     expect(persisted.ttydRestartCounts!.coder!.backoffUntil).toBeUndefined();
   });
 
-  test("a >300s quiet period resets the counter to count:1 instead of crossing threshold", async () => {
-    // count=9 already accumulated, but firstRestartAt is 301s old → the
-    // window-reset path must fire BEFORE the threshold check, otherwise
-    // nextCount=10 would prematurely escalate.
+  test("quiet > 5 min since the LAST restart resets to count:1 even when firstRestartAt is recent", async () => {
+    // The reset is gated on lastRestartAt, not firstRestartAt. Seed a
+    // fixture where firstRestartAt is recent (50 s ago) but lastRestartAt
+    // is old (301 s ago). The reset must fire because nothing has
+    // restarted in 5+ min — even though the incident itself is young.
+    //
+    // Mutation: gating on `now - prev.firstRestartAt` (the prior bug)
+    // sees `50 ≤ 300` → no reset → enters threshold check → nextCount=10
+    // → emits ttyd_flapping. This test's `expect(types).toEqual(["ttyd_restarted"])`
+    // would then fail.
     seedSlot(4, {
       ttydPids: { coder: 99999999 },
       ttydRestartCounts: {
-        coder: { count: 9, firstRestartAt: nowSeconds - 301 },
+        coder: { count: 9, firstRestartAt: nowSeconds - 50, lastRestartAt: nowSeconds - 301 },
       },
     });
     const state = makeTmuxState(4);
@@ -1523,14 +1529,71 @@ describe("ensureTtydAlive — flap suppression", () => {
     await ensureTtydAlive(state);
 
     const types = eventTypes();
-    // Invariant: window-reset wins over threshold-cross when quiet > 5min.
-    // Mutation: swapping the order of the window-reset and threshold checks
-    // would emit ttyd_flapping here instead of ttyd_restarted.
     expect(types).toEqual(["ttyd_restarted"]);
     const persisted = readSlot(4)!;
     expect(persisted.ttydRestartCounts!.coder!.count).toBe(1);
     expect(persisted.ttydRestartCounts!.coder!.firstRestartAt).toBe(nowSeconds);
+    expect(persisted.ttydRestartCounts!.coder!.lastRestartAt).toBe(nowSeconds);
     expect(persisted.ttydRestartCounts!.coder!.backoffUntil).toBeUndefined();
+  });
+
+  test("active flap whose firstRestartAt is older than 5 min does NOT reset when lastRestartAt is recent", async () => {
+    // The reviewer's concrete falsifier (round-2 REQUEST_CHANGES): a
+    // record at count=9 with firstRestartAt=600s ago AND lastRestartAt=11s
+    // ago is an ACTIVE flap, not a stale incident. The reset MUST NOT
+    // fire here; the next poll must cross the threshold and emit
+    // ttyd_flapping.
+    //
+    // Mutation: gating on firstRestartAt (`now - 600 > 300` → reset) would
+    // produce types=["ttyd_restarted"] and count=1. The strict
+    // `expect(types).toEqual(["ttyd_flapping"])` plus
+    // `expect(... .count).toBe(10)` below fail under that mutation.
+    seedSlot(7, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        coder: { count: 9, firstRestartAt: nowSeconds - 600, lastRestartAt: nowSeconds - 11 },
+      },
+    });
+    const state = makeTmuxState(7);
+
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    const types = eventTypes();
+    // (now - firstRestartAt) = 600 — exactly at the window edge, satisfies
+    // the threshold's `≤ TTYD_FLAP_WINDOW_S`.
+    expect(types).toEqual(["ttyd_flapping"]);
+    const persisted = readSlot(7)!;
+    expect(persisted.ttydRestartCounts!.coder!.count).toBe(10);
+    expect(persisted.ttydRestartCounts!.coder!.backoffUntil).toBe(Number.MAX_SAFE_INTEGER);
+    // Reviewer's concrete falsifier from REQUEST_CHANGES: the buggy gate
+    // would have lost lastRestartAt=11; the fixed gate keeps it.
+    expect(persisted.ttydRestartCounts!.coder!.lastRestartAt).toBe(nowSeconds - 11);
+  });
+
+  test("legacy record without lastRestartAt falls back to firstRestartAt for the quiet gate", async () => {
+    // Back-compat: records persisted before the lastRestartAt field was
+    // added must still load. For a legacy count==1 record they coincide;
+    // for higher counts, behaviour is acceptable (the next restart will
+    // stamp lastRestartAt and the gate becomes precise).
+    seedSlot(8, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        // No lastRestartAt — pre-fix shape.
+        coder: { count: 1, firstRestartAt: nowSeconds - 301 },
+      },
+    });
+    const state = makeTmuxState(8);
+
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    // Fallback (firstRestartAt) > 300 → reset to a fresh record that NOW
+    // includes lastRestartAt.
+    const persisted = readSlot(8)!;
+    expect(persisted.ttydRestartCounts!.coder!.count).toBe(1);
+    expect(persisted.ttydRestartCounts!.coder!.firstRestartAt).toBe(nowSeconds);
+    expect(persisted.ttydRestartCounts!.coder!.lastRestartAt).toBe(nowSeconds);
   });
 
   test("ttyd_flapping payload includes restart_count, window_seconds, and the per-agent log path", async () => {

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -1357,7 +1357,6 @@ describe("ensureTtydAlive — flap suppression", () => {
   let nowSeconds = 1700000000;
   let pidCounter = 5000;
 
-  function setNow(epoch: number): void { nowSeconds = epoch; }
   function advance(seconds: number): void { nowSeconds += seconds; }
 
   function seedSlot(slot: number, init: Partial<tmuxAdapter.TmuxSlotState> = {}): void {

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -3,7 +3,10 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { isAgentDone } from "./phases.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
-import { refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery } from "./runner.ts";
+import { ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests } from "./runner.ts";
+import * as tmuxAdapter from "../adapters/tmux-adapter.ts";
+import * as t3codeServer from "../t3code/server.ts";
+import * as orchUtil from "./util.ts";
 import * as wfr from "./wrong-filename-recovery.ts";
 import * as peerSync from "./peer-sync.ts";
 import * as events from "../events.ts";
@@ -1335,5 +1338,225 @@ describe("runWrongFilenameRecovery — runner integration", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+// task-7476a03a — flap-suppression state machine. With processAlive forced
+// false and a controlled clock, the machine must (1) emit ttyd_restarted
+// while count < 10 in the 10-min window, (2) emit exactly one ttyd_flapping
+// at the threshold and stop calling startTtyd, (3) be silent on subsequent
+// polls while suppressed, (4) restart freshly after the record is deleted,
+// and (5) reset the counter rather than escalate after a >5-min quiet gap.
+describe("ensureTtydAlive — flap suppression", () => {
+  let tmpDir = "";
+  let harness = "";
+  let processAliveSpy: ReturnType<typeof spyOn>;
+  let nowSpy: ReturnType<typeof spyOn>;
+  let startTtydSpy: ReturnType<typeof spyOn>;
+  let emitSpy: ReturnType<typeof spyOn>;
+  let nowSeconds = 1700000000;
+  let pidCounter = 5000;
+
+  function setNow(epoch: number): void { nowSeconds = epoch; }
+  function advance(seconds: number): void { nowSeconds += seconds; }
+
+  function seedSlot(slot: number, init: Partial<tmuxAdapter.TmuxSlotState> = {}): void {
+    mkdirSync(join(harness, "orchestration"), { recursive: true });
+    const state: tmuxAdapter.TmuxSlotState = {
+      slot,
+      ttydPids: { coder: 99999999 },
+      ...init,
+    };
+    writeFileSync(
+      join(harness, "orchestration", `tmux-slot-${slot}.json`),
+      JSON.stringify(state),
+    );
+  }
+
+  function readSlot(slot: number): tmuxAdapter.TmuxSlotState | null {
+    return tmuxAdapter.readTmuxSlotState(slot, harness);
+  }
+
+  function makeTmuxState(slot: number) {
+    return makeState({
+      slot,
+      backend: "tmux",
+      taskId: "task-7476a03a",
+      harnessDir: harness,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
+      ],
+    });
+  }
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    harness = join(tmpDir, "harness");
+    mkdirSync(harness, { recursive: true });
+    nowSeconds = 1700000000;
+    pidCounter = 5000;
+    processAliveSpy = spyOn(t3codeServer, "processAlive").mockImplementation(() => false);
+    nowSpy = spyOn(orchUtil, "nowEpoch").mockImplementation(() => nowSeconds);
+    // Spy startTtyd so we never actually spawn bash/ttyd.
+    startTtydSpy = spyOn(tmuxAdapter, "startTtyd").mockImplementation(() => ++pidCounter);
+    emitSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    __resetTtydCheckGateForTests();
+  });
+
+  afterEach(() => {
+    processAliveSpy.mockRestore();
+    nowSpy.mockRestore();
+    startTtydSpy.mockRestore();
+    emitSpy.mockRestore();
+    __resetTtydCheckGateForTests();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function eventTypes(): string[] {
+    return emitSpy.mock.calls.map((call: unknown[]) => {
+      const arg = call[0] as { event_type?: string } | undefined;
+      return arg?.event_type ?? "";
+    });
+  }
+
+  test("9 below-threshold polls emit ttyd_restarted, the 10th poll within 600s emits exactly one ttyd_flapping with no startTtyd call", async () => {
+    seedSlot(1);
+    const state = makeTmuxState(1);
+
+    // Drive 10 polls. Advance 31s between calls so the 30-s gate passes
+    // each time. firstRestartAt stays inside the 10-min window through
+    // poll 10 (9 * 31s = 279s ≤ 600).
+    for (let i = 0; i < 10; i++) {
+      __resetTtydCheckGateForTests(); // bypass the module-scoped 30s gate per call
+      await ensureTtydAlive(state);
+      advance(31);
+    }
+
+    const types = eventTypes();
+    const restarts = types.filter((t) => t === "ttyd_restarted").length;
+    const flapping = types.filter((t) => t === "ttyd_flapping").length;
+    // Invariant: 9 successful restarts (counts 1..9), then exactly one
+    // flap event at count=10. Mutation: changing `count + 1 >= THRESHOLD`
+    // to `count >= THRESHOLD` makes restarts==10 and flapping==0 on the
+    // tenth call (it would cross at the 11th instead).
+    expect(restarts).toBe(9);
+    expect(flapping).toBe(1);
+    // Threshold-crossing poll must NOT call startTtyd. AC: "do NOT call
+    // startTtyd". 9 restarts === 9 spawn invocations.
+    expect(startTtydSpy.mock.calls.length).toBe(9);
+
+    // Persisted shape: backoffUntil sentinel set on the agent's record.
+    const persisted = readSlot(1);
+    expect(persisted!.ttydRestartCounts!.coder!.backoffUntil).toBe(Number.MAX_SAFE_INTEGER);
+    expect(persisted!.ttydRestartCounts!.coder!.count).toBe(10);
+  });
+
+  test("subsequent polls while suppressed are silent — no processAlive, no startTtyd, no emitEvent", async () => {
+    // Pre-seed give-up state directly so the test isolates the short-circuit branch.
+    seedSlot(2, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: nowSeconds - 100, backoffUntil: Number.MAX_SAFE_INTEGER },
+      },
+    });
+    const state = makeTmuxState(2);
+
+    // Reset call counters AFTER the seed (we want to count only what
+    // happens during the suppressed poll, not the test setup).
+    processAliveSpy.mockClear();
+    startTtydSpy.mockClear();
+    emitSpy.mockClear();
+
+    advance(31);
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    // Invariant: give-up branch short-circuits BEFORE processAlive. Mutation:
+    // dropping the `if (prev?.backoffUntil === SENTINEL) continue;` guard
+    // makes processAlive get called and a fresh ttyd_restarted gets emitted.
+    expect(processAliveSpy.mock.calls.length).toBe(0);
+    expect(startTtydSpy.mock.calls.length).toBe(0);
+    expect(emitSpy.mock.calls.length).toBe(0);
+  });
+
+  test("deleting the agent's record restarts ttyd freshly without re-emitting ttyd_flapping", async () => {
+    // Start from give-up state, simulate the /api/ttyd-reset effect by
+    // deleting the agent's record and persisting.
+    seedSlot(3, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        coder: { count: 10, firstRestartAt: nowSeconds - 100, backoffUntil: Number.MAX_SAFE_INTEGER },
+      },
+    });
+    // Edit on disk so readTmuxSlotState picks up the cleared shape next poll.
+    const initial = readSlot(3)!;
+    delete initial.ttydRestartCounts!.coder;
+    tmuxAdapter.writeTmuxSlotState(initial, harness);
+
+    const state = makeTmuxState(3);
+    advance(31);
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    const types = eventTypes();
+    expect(types).toEqual(["ttyd_restarted"]);
+    // No re-emission of ttyd_flapping — the prior incident is closed.
+    expect(types.includes("ttyd_flapping")).toBe(false);
+
+    const persisted = readSlot(3)!;
+    expect(persisted.ttydRestartCounts!.coder!.count).toBe(1);
+    expect(persisted.ttydRestartCounts!.coder!.backoffUntil).toBeUndefined();
+  });
+
+  test("a >300s quiet period resets the counter to count:1 instead of crossing threshold", async () => {
+    // count=9 already accumulated, but firstRestartAt is 301s old → the
+    // window-reset path must fire BEFORE the threshold check, otherwise
+    // nextCount=10 would prematurely escalate.
+    seedSlot(4, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        coder: { count: 9, firstRestartAt: nowSeconds - 301 },
+      },
+    });
+    const state = makeTmuxState(4);
+
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    const types = eventTypes();
+    // Invariant: window-reset wins over threshold-cross when quiet > 5min.
+    // Mutation: swapping the order of the window-reset and threshold checks
+    // would emit ttyd_flapping here instead of ttyd_restarted.
+    expect(types).toEqual(["ttyd_restarted"]);
+    const persisted = readSlot(4)!;
+    expect(persisted.ttydRestartCounts!.coder!.count).toBe(1);
+    expect(persisted.ttydRestartCounts!.coder!.firstRestartAt).toBe(nowSeconds);
+    expect(persisted.ttydRestartCounts!.coder!.backoffUntil).toBeUndefined();
+  });
+
+  test("ttyd_flapping payload includes restart_count, window_seconds, and the per-agent log path", async () => {
+    seedSlot(5, {
+      ttydPids: { coder: 99999999 },
+      ttydRestartCounts: {
+        coder: { count: 9, firstRestartAt: nowSeconds - 60 },
+      },
+    });
+    const state = makeTmuxState(5);
+    __resetTtydCheckGateForTests();
+    await ensureTtydAlive(state);
+
+    const flapCalls = emitSpy.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { event_type?: string } | undefined)?.event_type === "ttyd_flapping",
+    );
+    expect(flapCalls.length).toBe(1);
+    const payload = flapCalls[0][0] as Record<string, unknown>;
+    // Diff anchor — proposal AC enumerates each of these literal fields.
+    expect(payload.event_type).toBe("ttyd_flapping");
+    expect(payload.slot).toBe(5);
+    expect(payload.agent).toBe("coder");
+    expect(payload.restart_count).toBe(10);
+    expect(payload.window_seconds).toBe(600);
+    const expectedLog = tmuxAdapter.ttydLogPath(5, "coder");
+    expect(String(payload.message)).toContain(expectedLog);
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -28,7 +28,7 @@ import { setSlotLivenessOnData } from "../slots/index.ts";
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
-import { agentPortRole, readTmuxSlotState, startTtyd, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentPortRole, readTmuxSlotState, startTtyd, ttydLogPath, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { readSlotState, processAlive } from "../t3code/server.ts";
 import { recoverWrongFilename } from "./wrong-filename-recovery.ts";
 
@@ -51,6 +51,16 @@ const HUNG_IDLE_RUNNING_THRESHOLD_S = 180;
 const HUNG_NUDGE_COOLDOWN_S = 90;
 /** Seconds between ttyd liveness checks in the poll loop. */
 const TTYD_HEALTH_CHECK_INTERVAL_S = 30;
+/** Hard threshold window for ttyd flap detection — 10 minutes. */
+const TTYD_FLAP_WINDOW_S = 600;
+/** Restarts within TTYD_FLAP_WINDOW_S before the runner gives up. */
+const TTYD_FLAP_THRESHOLD = 10;
+/** Quiet period that resets the flap counter — a transient blip after this
+ *  much idle time starts a fresh count, not an escalation. */
+const TTYD_FLAP_QUIET_RESET_S = 300;
+/** backoffUntil sentinel that encodes the give-up state without a separate
+ *  boolean field — keeps TmuxSlotState.ttydRestartCounts shape on disk. */
+const TTYD_GIVE_UP_SENTINEL = Number.MAX_SAFE_INTEGER;
 
 // --- Verification gate constants and types ---
 type VerificationDecision = "advance" | "redispatch" | "hold" | "skip";
@@ -690,7 +700,14 @@ export async function detectAndNudgeHungAgents(
 
 let lastTtydCheckAt = 0;
 
-async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
+/** Test-only: reset the module-scoped 30-s gate so unit tests can drive
+ *  consecutive `ensureTtydAlive` calls without faking the clock-floor.
+ *  Production callers never need this. */
+export function __resetTtydCheckGateForTests(): void {
+  lastTtydCheckAt = 0;
+}
+
+export async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
   if (state.backend !== "tmux") return;
   const now = nowEpoch();
   if (now - lastTtydCheckAt < TTYD_HEALTH_CHECK_INTERVAL_S) return;
@@ -703,16 +720,69 @@ async function ensureTtydAlive(state: OrchestrationState): Promise<void> {
   let changed = false;
   for (let i = 0; i < state.agents.length; i++) {
     const agent = state.agents[i]!;
-    const pid = tmuxState.ttydPids[agent.name];
+    const records = (tmuxState.ttydRestartCounts ??= {});
+    const prev = records[agent.name];
 
-    // Check if PID is alive
+    // Give-up state — skip processAlive AND startTtyd. AC requires no
+    // further events, no respawn, no liveness churn while suppressed.
+    if (prev?.backoffUntil === TTYD_GIVE_UP_SENTINEL) continue;
+
+    const pid = tmuxState.ttydPids[agent.name];
     const alive = pid ? processAlive(pid) : false;
     if (alive) continue;
 
-    // Dead or missing — restart
     const role = agentPortRole(agent, i);
+
+    // Window-reset path: no record, or last restart > 5 min ago. A
+    // long-quiet flap was a transient blip; start a fresh count.
+    if (!prev || (now - prev.firstRestartAt) > TTYD_FLAP_QUIET_RESET_S) {
+      const newPid = startTtyd(state.slot, agent.name, role, state.taskId);
+      tmuxState.ttydPids[agent.name] = newPid;
+      records[agent.name] = { count: 1, firstRestartAt: now };
+      changed = true;
+      emitEvent({
+        event_type: "ttyd_restarted",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.taskId,
+        agent: agent.name,
+        pid: newPid,
+        message: `${agent.name}: ttyd died (was pid ${pid ?? "none"}), restarted as pid ${newPid}`,
+      });
+      continue;
+    }
+
+    const nextCount = prev.count + 1;
+
+    // Threshold-cross — single emission of ttyd_flapping, no respawn. The
+    // sentinel makes the next poll short-circuit at the give-up branch
+    // above (so this event fires exactly once per flap incident).
+    if (nextCount >= TTYD_FLAP_THRESHOLD && (now - prev.firstRestartAt) <= TTYD_FLAP_WINDOW_S) {
+      records[agent.name] = {
+        count: nextCount,
+        firstRestartAt: prev.firstRestartAt,
+        backoffUntil: TTYD_GIVE_UP_SENTINEL,
+      };
+      changed = true;
+      emitEvent({
+        event_type: "ttyd_flapping",
+        source: "orchestration",
+        scope: "slot",
+        slot: state.slot,
+        task: state.taskId,
+        agent: agent.name,
+        restart_count: nextCount,
+        window_seconds: TTYD_FLAP_WINDOW_S,
+        message: `${agent.name}: ttyd flapping (${nextCount} restarts within ${now - prev.firstRestartAt}s) — see ${ttydLogPath(state.slot, agent.name)}`,
+      });
+      continue;
+    }
+
+    // Below threshold — restart and increment within the current window.
     const newPid = startTtyd(state.slot, agent.name, role, state.taskId);
     tmuxState.ttydPids[agent.name] = newPid;
+    records[agent.name] = { count: nextCount, firstRestartAt: prev.firstRestartAt };
     changed = true;
     emitEvent({
       event_type: "ttyd_restarted",

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -733,12 +733,17 @@ export async function ensureTtydAlive(state: OrchestrationState): Promise<void> 
 
     const role = agentPortRole(agent, i);
 
-    // Window-reset path: no record, or last restart > 5 min ago. A
-    // long-quiet flap was a transient blip; start a fresh count.
-    if (!prev || (now - prev.firstRestartAt) > TTYD_FLAP_QUIET_RESET_S) {
+    // Window-reset path: no record, or quiet > 5 min since the LAST
+    // restart (not the first — that would misclassify an active flap
+    // whose incident started > 5 min ago as "quiet"). Legacy records
+    // without lastRestartAt fall back to firstRestartAt; this is correct
+    // for the count==1 case where they coincide and acceptable for
+    // higher counts because the next restart re-stamps lastRestartAt.
+    const lastRestartAt = prev?.lastRestartAt ?? prev?.firstRestartAt;
+    if (!prev || (now - lastRestartAt!) > TTYD_FLAP_QUIET_RESET_S) {
       const newPid = startTtyd(state.slot, agent.name, role, state.taskId);
       tmuxState.ttydPids[agent.name] = newPid;
-      records[agent.name] = { count: 1, firstRestartAt: now };
+      records[agent.name] = { count: 1, firstRestartAt: now, lastRestartAt: now };
       changed = true;
       emitEvent({
         event_type: "ttyd_restarted",
@@ -762,6 +767,7 @@ export async function ensureTtydAlive(state: OrchestrationState): Promise<void> 
       records[agent.name] = {
         count: nextCount,
         firstRestartAt: prev.firstRestartAt,
+        lastRestartAt: prev.lastRestartAt,
         backoffUntil: TTYD_GIVE_UP_SENTINEL,
       };
       changed = true;
@@ -782,7 +788,7 @@ export async function ensureTtydAlive(state: OrchestrationState): Promise<void> 
     // Below threshold — restart and increment within the current window.
     const newPid = startTtyd(state.slot, agent.name, role, state.taskId);
     tmuxState.ttydPids[agent.name] = newPid;
-    records[agent.name] = { count: nextCount, firstRestartAt: prev.firstRestartAt };
+    records[agent.name] = { count: nextCount, firstRestartAt: prev.firstRestartAt, lastRestartAt: now };
     changed = true;
     emitEvent({
       event_type: "ttyd_restarted",

--- a/templates/dashboard/terminals-reset.js
+++ b/templates/dashboard/terminals-reset.js
@@ -1,0 +1,40 @@
+// task-7476a03a — slot ttyd flap-suppression recovery hook.
+//
+// Posts /api/ttyd-reset?slot=<n> for each active slot exactly once per
+// page lifetime. Cmd-Shift-R reloads the document → re-evaluates the
+// module → fresh closure with resetSent=false → reset re-fires once.
+// The 30-s setInterval in terminals.html keeps the same module instance,
+// so resetSent stays true and the reset does NOT re-fire on routine
+// refreshes. This is what turns "force reload" into the recovery gesture.
+//
+// Failure modes (both warn-only — never reject the returned promise so
+// the calling render path is unblocked):
+//   1. fetch() rejects (network unreachable / CORS / abort)
+//   2. fetch() resolves with !resp.ok (4xx/5xx)
+let resetSent = false;
+
+// Test-only escape hatch — module-private state needs a way to be reset
+// between unit tests so each can observe the once-only invariant.
+export function __resetForTests() { resetSent = false; }
+
+/**
+ * @param {number[]} activeSlots
+ * @param {typeof fetch} [fetchImpl]
+ */
+export async function maybeResetTtydCounters(activeSlots, fetchImpl) {
+  if (resetSent) return;
+  resetSent = true;
+  const f = fetchImpl ?? fetch;
+  await Promise.allSettled(
+    (activeSlots || []).map(async (slot) => {
+      try {
+        const resp = await f(`/api/ttyd-reset?slot=${slot}`, { method: 'POST' });
+        if (!resp.ok) {
+          console.warn('ttyd-reset non-2xx', slot, resp.status, resp.statusText);
+        }
+      } catch (err) {
+        console.warn('ttyd-reset failed', slot, err);
+      }
+    }),
+  );
+}

--- a/templates/dashboard/terminals-reset.test.ts
+++ b/templates/dashboard/terminals-reset.test.ts
@@ -1,0 +1,107 @@
+// task-7476a03a — terminals-reset.js regression coverage. Pins the
+// once-per-page-lifetime invariant and warn-only error handling for both
+// network rejections and non-2xx responses.
+
+import { describe, expect, test, beforeEach, spyOn } from "bun:test";
+
+import {
+  __resetForTests,
+  maybeResetTtydCounters,
+} from "./terminals-reset.js";
+
+type FetchCall = { url: string; init?: { method?: string } };
+
+function makeFetchSpy(impl: (url: string, init?: { method?: string }) => Promise<Response>) {
+  const calls: FetchCall[] = [];
+  const fn = ((url: string, init?: { method?: string }) => {
+    calls.push({ url, init });
+    return impl(url, init);
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+describe("maybeResetTtydCounters — once per page lifetime", () => {
+  test("first call posts /api/ttyd-reset?slot=N for each active slot; second call is a no-op", async () => {
+    const { fn, calls } = makeFetchSpy(async () => new Response("OK", { status: 200 }));
+
+    await maybeResetTtydCounters([1, 2, 3], fn);
+    expect(calls.length).toBe(3);
+    expect(calls.map((c) => c.url).sort()).toEqual([
+      "/api/ttyd-reset?slot=1",
+      "/api/ttyd-reset?slot=2",
+      "/api/ttyd-reset?slot=3",
+    ]);
+    for (const c of calls) expect(c.init?.method).toBe("POST");
+
+    // Invariant: subsequent calls within the same module lifetime add
+    // zero new fetch invocations regardless of the args. Mutation:
+    // commenting out `if (resetSent) return;` makes calls.length jump.
+    await maybeResetTtydCounters([1, 2, 3], fn);
+    await maybeResetTtydCounters([4, 5], fn);
+    expect(calls.length).toBe(3);
+  });
+
+  test("first call with [] still flips resetSent so a follow-up with non-empty slots is a no-op", async () => {
+    const { fn, calls } = makeFetchSpy(async () => new Response("OK", { status: 200 }));
+    await maybeResetTtydCounters([], fn);
+    expect(calls.length).toBe(0);
+    // Invariant from proposal AC: "first call may see zero active slots;
+    // should mark itself done for that page lifetime".
+    await maybeResetTtydCounters([1, 2], fn);
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("maybeResetTtydCounters — warn-only failure handling", () => {
+  test("rejected fetch resolves through Promise.allSettled and warns to console", async () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fn = (async () => { throw new Error("network down"); }) as unknown as typeof fetch;
+      // Must not throw — render path depends on this resolving.
+      await maybeResetTtydCounters([1, 2], fn);
+      // Both slots produced one warn entry each. Mutation: removing the
+      // try/catch around `await f(...)` would cause an unhandled rejection
+      // and Promise.allSettled would still resolve, but the test's "warn
+      // count = slot count" assertion would fail.
+      expect(warnSpy.mock.calls.length).toBe(2);
+      const messages = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      expect(messages.every((m: string) => m === "ttyd-reset failed")).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("non-2xx response logs status code via console.warn (no throw)", async () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fn = makeFetchSpy(async () => new Response("oops", { status: 503, statusText: "Service Unavailable" })).fn;
+      await maybeResetTtydCounters([1], fn);
+      // Invariant: a 5xx response (resp.ok === false) must trigger a warn.
+      // Mutation: removing the `if (!resp.ok) console.warn(...)` branch
+      // makes warnSpy.mock.calls.length === 0 and this assertion fails.
+      expect(warnSpy.mock.calls.length).toBe(1);
+      const args = warnSpy.mock.calls[0] as unknown[];
+      expect(String(args[0])).toBe("ttyd-reset non-2xx");
+      expect(args[1]).toBe(1);
+      expect(args[2]).toBe(503);
+      expect(args[3]).toBe("Service Unavailable");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("a 2xx response does NOT warn", async () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fn = makeFetchSpy(async () => new Response("OK", { status: 200 })).fn;
+      await maybeResetTtydCounters([1, 2], fn);
+      expect(warnSpy.mock.calls.length).toBe(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/templates/dashboard/terminals.html
+++ b/templates/dashboard/terminals.html
@@ -63,7 +63,11 @@
     <div class="terminal-grid">
         <!-- Populated by JS from data/terminals.json -->
     </div>
-    <script>
+    <script type="module">
+        // task-7476a03a — Terminals tab posts /api/ttyd-reset once per page
+        // lifetime so a Cmd-Shift-R reload clears any ttyd flap-suppression.
+        import { maybeResetTtydCounters } from './terminals-reset.js';
+
         function showError(msg) {
             const grid = document.querySelector('.terminal-grid');
             grid.classList.add('error');
@@ -83,6 +87,8 @@
                 }
                 const data = await resp.json();
                 clearError();
+                // Fire-and-forget — render must not block on reset.
+                maybeResetTtydCounters(data.activeSlots || []);
                 renderTerminals(data.terminals || [], data.activeSlots || []);
                 document.getElementById('last-update').textContent =
                     'Last update: ' + new Date().toLocaleTimeString();


### PR DESCRIPTION
## Summary

Refs proposal: `docs/proposals/slot-ttyd-observability-flap-suppression.md` (task-7476a03a).

Slot ttyd processes were spawning with stdout/stderr ignored, so when ttyd died the runner restarted it without leaving any error trace on disk — slot 1 had accrued **1258 `ttyd_restarted` events** vs slot 2's **1**, with no diagnostic signal. This PR delivers two pieces of infrastructure so the next investigator can finally see why ttyds die and the runaway respawn churn stops on its own:

1. **Observability** — `startTtyd` now appends ttyd output to `~/Library/Logs/ludics-slot-{N}-{agent}-ttyd.log` (with `/tmp` fallback), via `bash -c "exec ttyd … >>'<log>' 2>&1"` wrapped by `setsidWrap`. The `exec` keeps `proc.pid` pointing at ttyd so `processAlive` semantics are unchanged. Mirrors `src/mag.ts`'s existing precedent and picks up macOS `newsyslog` rotation for free. POSIX single-quote escaping (`'` → `'\''`) handles HOMEs containing apostrophes (e.g. `/Users/O'Connor`).
2. **Flap-suppression** — `ensureTtydAlive` tracks per-agent restart cadence in `TmuxSlotState.ttydRestartCounts` and escalates after **10 restarts within a 10-minute window**: a single `ttyd_flapping` event is emitted (with `restart_count`, `window_seconds`, and the absolute log path), and the runner stops calling both `processAlive` and `startTtyd` for that agent until recovery. Quiet-reset gate consults `lastRestartAt` (not `firstRestartAt`) so an active flap whose first incident is older than 5 minutes is correctly classified as ongoing rather than "quiet".
3. **Recovery** — new `POST /api/ttyd-reset?slot=N&agent=X` endpoint clears the per-agent counter; `templates/dashboard/terminals.html` now imports a `terminals-reset.js` module that fires the reset once per page lifetime, so a Cmd-Shift-R on the Terminals tab becomes the "un-suppress" gesture.

The *root cause* of slot 1's flap is explicitly out of scope — fix that once the new logs reveal it.

## Commits

1. `a3766fa feat(tmux): capture slot ttyd output to per-agent log files`
2. `a7d8030 feat(runner): add flap suppression to ensureTtydAlive`
3. `a1aad30 feat(dashboard): add POST /api/ttyd-reset to clear flap counters`
4. `95248d9 feat(terminals): post /api/ttyd-reset on full page reload`
5. `ad49dbb fix(runner): gate ttyd flap quiet-reset on last restart, not first` (round-2 reviewer fix)
6. `6b5c06b fix(tmux): escape apostrophes in ttyd bash-c paths` (Codex P2 fix)

## Files changed

- `src/adapters/tmux-adapter.ts` — `ttydLogPath`, `buildTtydSpawnArgs` with `shellSingleQuote` escape, optional `ttydRestartCounts`/`lastRestartAt` fields, read-boundary normalization in `readTmuxSlotState`.
- `src/orchestration/runner.ts` — full backoff state machine (window-reset on `lastRestartAt`, threshold check, single-emission `ttyd_flapping`, give-up branch); `ensureTtydAlive` now exported.
- `src/dashboard-server.ts` — `POST /api/ttyd-reset` (400/404/200, sparse-shape preservation).
- `templates/dashboard/terminals.html` + new `templates/dashboard/terminals-reset.js` — module-scoped `resetSent` flag, warn-only handling for both fetch rejects and non-2xx.
- Regression tests landed in the same round across `tmux-adapter.test.ts`, `runner.lifecycle.test.ts`, `dashboard.test.ts`, and a new `terminals-reset.test.ts`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run build` compiles standalone binary
- [x] `bun test` — **2067 pass / 2 fail** (same vendored-bundle baseline as `d0fe5ad`; no net-new failures)
- [x] Round-trip fidelity: `ttydRestartCounts` (with and without `lastRestartAt`) round-trips byte-faithfully via `readTmuxSlotState`/`writeTmuxSlotState`
- [x] Two boundary tests pin the `lastRestartAt` semantics — fail closed under any regression to a single-timestamp gate
- [x] Apostrophe-escape regression test seeds `mkdtempSync(".../O'Connor")` HOME and asserts the bash command contains the `'\''` escape; verified end-to-end that the escaped path is parseable by bash
- [ ] Manual smoke (post-merge): kill `$(pgrep -f "ttyd.*--port 7681")`, observe new log file growing in `~/Library/Logs/`, then loop-kill 10× in 9 minutes and observe exactly one `ttyd_flapping` event in `events.jsonl`
- [ ] Manual smoke (post-merge): force-reload the Terminals tab while suppressed and confirm the next 30-s poll restarts the dead ttyd

🤖 Generated with [Claude Code](https://claude.com/claude-code)