### PR TITLE
fix(dashboard): reject slotted-task abandon at /api/stale-abandon and /api/deferred-abandon

### DIFF
--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -424,7 +424,11 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       }
     }
 
-    // API: abandon a deferred task (clear slot if assigned, set abandoned)
+    // API: abandon a deferred task. Slotted deferred tasks are rejected
+    // with 409 — the user must clear the slot first (slot operations'
+    // terminal transitions handle displaced-task recovery via
+    // task-4028c493). tasksAbandon's slot-aware path is preserved for
+    // the CLI caller `ludics tasks abandon <id>`.
     if (pathname === "/api/deferred-abandon") {
       const taskParam = url.searchParams.get("task");
       if (!taskParam || !TASK_ID_RE.test(taskParam)) {
@@ -433,6 +437,13 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       try {
         const resolved = resolveTaskFile(taskParam);
         if ("error" in resolved) return resolved.error;
+        const slotNum = findSlotForTask(taskParam);
+        if (slotNum !== null) {
+          return new Response(
+            JSON.stringify({ error: `task is in slot ${slotNum}; use slot operations to change state` }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          );
+        }
         await tasksAbandon(taskParam, { source: "dashboard", scope: "task" });
         lastGenerated = 0;
         return new Response(JSON.stringify({ status: "abandoned" }), {
@@ -471,26 +482,12 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       }
     }
 
-    // API: abandon a stale task. We bypass tasksAbandon and do the abandon
-    // flow inline because (a) tasksAbandon's terminal-status guard rejects
-    // status: stale, and (b) the de-stale-then-abandon sequence does not
-    // compose with tasksAbandon's slot-aware path — for a slotted task,
-    // tasksAbandon delegates to slotClear -> taskUpdateForSlotClear, whose
-    // `expectedFrom` for `abandoned` is [in-progress, deferred, preempted];
-    // a freshly-de-staled task is `ready`, so the status flip silently
-    // no-ops while the endpoint reports success (Codex PR #476 review).
-    //
-    // Inline order:
-    //  1. transitionStatus(stale → abandoned) — atomic, returns false if
-    //     the task is no longer stale (raced with another writer).
-    //  2. Mirror tasksAbandon's frontmatter cleanup (completed timestamp,
-    //     remove deferred_launch/approved).
-    //  3. If slotted, clear the slot's runtime state with finalStatus
-    //     "ready" so taskUpdateForSlotClear's `expectedFrom` (which now
-    //     would see status=abandoned, not in [in-progress, deferred])
-    //     silently leaves the already-correct frontmatter alone. The
-    //     console.error inside taskUpdateForSlotClear is informational.
-    //  4. Emit task_abandon event to mirror tasksAbandon's observability.
+    // API: abandon a stale task. Slotted stale tasks are rejected with
+    // 409 — the user must clear the slot first (slot operations' terminal
+    // transitions handle displaced-task recovery via task-4028c493). For
+    // unslotted stale tasks we bypass tasksAbandon and do the abandon
+    // flow inline because tasksAbandon's terminal-status guard rejects
+    // status: stale.
     if (pathname === "/api/stale-abandon") {
       const taskParam = url.searchParams.get("task");
       if (!taskParam || !TASK_ID_RE.test(taskParam)) {
@@ -500,6 +497,14 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         const resolved = resolveTaskFile(taskParam);
         if ("error" in resolved) return resolved.error;
         const taskFile = resolved.path;
+
+        const slotNum = findSlotForTask(taskParam);
+        if (slotNum !== null) {
+          return new Response(
+            JSON.stringify({ error: `task is in slot ${slotNum}; use slot operations to change state` }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          );
+        }
 
         const ok = transitionStatus(taskFile, "stale", "abandoned");
         if (!ok) {
@@ -513,20 +518,13 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         removeFrontmatterField(taskFile, "deferred_launch");
         removeFrontmatterField(taskFile, "approved");
 
-        const slotNum = findSlotForTask(taskParam);
-        if (slotNum !== null) {
-          await slotClear(slotNum, "ready");
-        }
-
         emitEvent({
           event_type: "task_abandon",
           source: "dashboard",
           scope: "task",
           task: taskParam,
           status: "abandoned",
-          message: slotNum !== null
-            ? `abandoned from slot ${slotNum} (stale → abandoned)`
-            : "abandoned (stale → abandoned, no slot)",
+          message: "abandoned (stale → abandoned)",
         });
 
         lastGenerated = 0;

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -488,6 +488,14 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
     // unslotted stale tasks we bypass tasksAbandon and do the abandon
     // flow inline because tasksAbandon's terminal-status guard rejects
     // status: stale.
+    //
+    // The findSlotForTask / transitionStatus pair is check-then-act; a
+    // task could in principle be slotted between the two calls. Per
+    // proposal § Race notes (task-ad39a394) this is accepted as
+    // best-effort: no production path slots a stale task post-check
+    // (the staleness sweeper never targets in-progress, slot-assign
+    // paths reject non-ready/deferred statuses for stale tasks). The
+    // same applies symmetrically to /api/deferred-abandon below.
     if (pathname === "/api/stale-abandon") {
       const taskParam = url.searchParams.get("task");
       if (!taskParam || !TASK_ID_RE.test(taskParam)) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -999,36 +999,80 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     expect(resp.status).toBe(400);
   });
 
-  test("POST /api/stale-abandon on a slotted stale task ends with status: abandoned (not silently left at ready)", async () => {
-    // Harness condition: a `stale` task is also assigned to a slot. Codex
-    // round-2 review noted that the de-stale-then-abandon composition is
-    // unsafe: tasksAbandon for a slotted task delegates to slotClear ->
-    // taskUpdateForSlotClear, whose abandoned `expectedFrom` is
-    // [in-progress, deferred, preempted] — `ready` is NOT in that list, so
-    // the freshly-de-staled task silently stays at `ready` while the
-    // endpoint still returns `{"status":"abandoned"}`. The fix lifts that
-    // gate; this test pins the invariant.
+  test("POST /api/stale-abandon on a slotted stale task returns 409 and does not mutate task or slot", async () => {
+    // Harness condition: a `stale` task is also assigned to slot 1
+    // (writeSlotJson(1, { task: "task-slotted-stale" })). Without the
+    // 409 pre-check, the handler would flip status to abandoned and
+    // clear the slot. With the 409 pre-check, neither happens.
     const file = writeTask("task-slotted-stale", "stale");
-    // Mark the task as assigned to slot 1 so findSlotForTask picks it up.
-    const { writeSlotJson, emptySlotData } = await import("./slots/json.ts");
+    const before = readFileSync(file, "utf-8");
+    const { writeSlotJson, emptySlotData, readSlotJson } = await import("./slots/json.ts");
     const slotData = { ...emptySlotData(1), task: "task-slotted-stale", process: "tmux:s1" };
     writeSlotJson(1, slotData);
 
     const handler = await makeHandler();
     const resp = await handler(new Request("http://x/api/stale-abandon?task=task-slotted-stale"));
+    // Invariant: response is 409 with the slot number in the error body.
+    // Mutation: drop the findSlotForTask pre-check and the response is
+    // 200, the assertions below all flip.
+    expect(resp.status).toBe(409);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toContain("slot 1");
+    expect(body.error).toContain("use slot operations");
+    // Invariant: task remains stale — no `completed` written, no status flip.
+    const after = readFileSync(file, "utf-8");
+    expect(after).toBe(before);
+    expect(after).toContain("status: stale");
+    expect(after).not.toContain("status: abandoned");
+    expect(after).not.toContain("completed:");
+    // Invariant: slot's `task` field is unchanged.
+    expect(readSlotJson(1).task).toBe("task-slotted-stale");
+  });
+
+  test("POST /api/deferred-abandon de-defers and abandons a non-slotted deferred task", async () => {
+    // Harness condition: deferred task with no slot assignment.
+    // tasksAbandon's terminal-status guard accepts `deferred`, so the
+    // existing flow runs end-to-end and produces status: abandoned.
+    const file = writeTask("task-deferred-abandon", "deferred");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/deferred-abandon?task=task-deferred-abandon"));
     expect(resp.status).toBe(200);
     const body = await resp.json() as { status: string };
     expect(body.status).toBe("abandoned");
-    // Invariant: file MUST end at status: abandoned, not silently stay at
-    // some intermediate state while the endpoint reports success.
-    // Mutation: revert /api/stale-abandon to delegate to tasksAbandon
-    // after a `stale → ready` flip and this assertion fails because
-    // taskUpdateForSlotClear's `expectedFrom` does not include `ready`,
-    // so the slotted task silently keeps the intermediate `ready` while
-    // the endpoint returns 200 (the exact Codex PR #476 review finding).
+    // Invariant: task transitions to abandoned. Mutation: drop the
+    // tasksAbandon call and this assertion fails (status would still
+    // read deferred).
+    expect(readFileSync(file, "utf-8")).toContain("status: abandoned");
+  });
+
+  test("POST /api/deferred-abandon on a slotted deferred task returns 409 and does not mutate task or slot", async () => {
+    // Harness condition: a `deferred` task is also assigned to slot 1.
+    // Without the 409 pre-check, the handler would delegate to
+    // tasksAbandon, which clears the slot and flips status to abandoned.
+    const file = writeTask("task-slotted-deferred", "deferred");
+    const before = readFileSync(file, "utf-8");
+    const { writeSlotJson, emptySlotData, readSlotJson } = await import("./slots/json.ts");
+    const slotData = { ...emptySlotData(1), task: "task-slotted-deferred", process: "tmux:s1" };
+    writeSlotJson(1, slotData);
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/deferred-abandon?task=task-slotted-deferred"));
+    // Invariant: response is 409 with the slot number.
+    // Mutation: drop the findSlotForTask pre-check and the response
+    // becomes 200 (or 500 from tasksAbandon's slot-clear path) and the
+    // assertions below flip.
+    expect(resp.status).toBe(409);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toContain("slot 1");
+    expect(body.error).toContain("use slot operations");
+    // Invariant: task remains deferred (no status flip).
     const after = readFileSync(file, "utf-8");
-    expect(after).toContain("status: abandoned");
-    expect(after).not.toMatch(/^status: ready$/m);
+    expect(after).toBe(before);
+    expect(after).toContain("status: deferred");
+    expect(after).not.toContain("status: abandoned");
+    // Invariant: slot's `task` field is unchanged.
+    expect(readSlotJson(1).task).toBe("task-slotted-deferred");
   });
 });
 

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -963,10 +963,11 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
   });
 
   test("POST /api/stale-abandon de-stales then abandons, ending in status: abandoned", async () => {
-    // Harness condition: task starts at status: stale. The endpoint composes
-    // transitionStatus(stale -> ready) + tasksAbandon. If either step is
-    // skipped or the order is reversed, tasksAbandon's terminal-status guard
-    // (which now includes stale) throws and the response status flips to 500.
+    // Harness condition: task starts at status: stale, no slot. The handler
+    // calls transitionStatus(stale → abandoned) inline (it bypasses
+    // tasksAbandon because tasksAbandon's terminal-status guard rejects
+    // status: stale). If the inline transitionStatus is skipped or its
+    // expectedFrom/to are wrong, the file does not end up at abandoned.
     const file = writeTask("task-stale-abandon", "stale");
 
     const handler = await makeHandler();
@@ -975,7 +976,7 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     const body = await resp.json() as { status: string };
     expect(body.status).toBe("abandoned");
     // Invariant: file ends up status: abandoned. Mutation: drop the
-    // tasksAbandon call and the file would still read status: ready.
+    // transitionStatus call and the file would still read status: stale.
     expect(readFileSync(file, "utf-8")).toContain("status: abandoned");
   });
 
@@ -1006,9 +1007,17 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     // clear the slot. With the 409 pre-check, neither happens.
     const file = writeTask("task-slotted-stale", "stale");
     const before = readFileSync(file, "utf-8");
-    const { writeSlotJson, emptySlotData, readSlotJson } = await import("./slots/json.ts");
-    const slotData = { ...emptySlotData(1), task: "task-slotted-stale", process: "tmux:s1" };
+    const { writeSlotJson, emptySlotData, slotJsonPath } = await import("./slots/json.ts");
+    const slotData = {
+      ...emptySlotData(1),
+      task: "task-slotted-stale",
+      process: "tmux:s1",
+      liveness: "alive" as const,
+      session: "sess-stale",
+    };
     writeSlotJson(1, slotData);
+    const slotFile = slotJsonPath(1);
+    const slotBefore = readFileSync(slotFile, "utf-8");
 
     const handler = await makeHandler();
     const resp = await handler(new Request("http://x/api/stale-abandon?task=task-slotted-stale"));
@@ -1025,8 +1034,11 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     expect(after).toContain("status: stale");
     expect(after).not.toContain("status: abandoned");
     expect(after).not.toContain("completed:");
-    // Invariant: slot's `task` field is unchanged.
-    expect(readSlotJson(1).task).toBe("task-slotted-stale");
+    // Invariant: slot JSON is byte-identical (no field — task, process,
+    // liveness, session, or anything else — was mutated). Mutation: any
+    // residual slotClear or in-place field write would change the file
+    // bytes and fail this assertion, even if `task` was left intact.
+    expect(readFileSync(slotFile, "utf-8")).toBe(slotBefore);
   });
 
   test("POST /api/deferred-abandon de-defers and abandons a non-slotted deferred task", async () => {
@@ -1052,9 +1064,17 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     // tasksAbandon, which clears the slot and flips status to abandoned.
     const file = writeTask("task-slotted-deferred", "deferred");
     const before = readFileSync(file, "utf-8");
-    const { writeSlotJson, emptySlotData, readSlotJson } = await import("./slots/json.ts");
-    const slotData = { ...emptySlotData(1), task: "task-slotted-deferred", process: "tmux:s1" };
+    const { writeSlotJson, emptySlotData, slotJsonPath } = await import("./slots/json.ts");
+    const slotData = {
+      ...emptySlotData(1),
+      task: "task-slotted-deferred",
+      process: "tmux:s1",
+      liveness: "alive" as const,
+      session: "sess-deferred",
+    };
     writeSlotJson(1, slotData);
+    const slotFile = slotJsonPath(1);
+    const slotBefore = readFileSync(slotFile, "utf-8");
 
     const handler = await makeHandler();
     const resp = await handler(new Request("http://x/api/deferred-abandon?task=task-slotted-deferred"));
@@ -1071,8 +1091,11 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     expect(after).toBe(before);
     expect(after).toContain("status: deferred");
     expect(after).not.toContain("status: abandoned");
-    // Invariant: slot's `task` field is unchanged.
-    expect(readSlotJson(1).task).toBe("task-slotted-deferred");
+    // Invariant: slot JSON is byte-identical (tasksAbandon's slot-aware
+    // path would clear `task`, `process`, `liveness`, `session`, etc. —
+    // any of those mutations would change the file bytes and fail this
+    // assertion, even if a future regression somehow preserved `task`).
+    expect(readFileSync(slotFile, "utf-8")).toBe(slotBefore);
   });
 });
 


### PR DESCRIPTION
## Summary

UI-boundary defense-in-depth for task-ad39a394. Two dashboard abandon endpoints currently accept slotted tasks and silently clear the slot reservation. This PR makes both endpoints return **409** before any state mutation when `findSlotForTask(taskParam) !== null`, forcing the user to clear the slot (whose terminal transitions handle displaced-task recovery via task-4028c493).

- `/api/stale-abandon`: 409 pre-check; the post-mutation `slotClear` block is removed (unreachable now), the block-comment is trimmed of the `"ready"` `expectedFrom` workaround paragraph, and the `task_abandon` event message collapses to the constant `"abandoned (stale → abandoned)"`.
- `/api/deferred-abandon`: surgical 409 pre-check before delegating to `tasksAbandon`.
- `tasksAbandon`'s own slot-aware path is preserved for the CLI caller `ludics tasks abandon <id>`.
- `/api/task-dismiss` is intentionally not extended — its existing status guard restricts input to `needs-confirmation`, which is never slotted by construction.

## Commits

- `4b1d305` fix(dashboard): 409 pre-check on both endpoints; remove slotClear block; collapse event message; invert slotted-stale test; add deferred-abandon test pair.
- `84b6f04` test(dashboard): replace single-field `readSlotJson(1).task` checks with byte-identity of `slot-N.json` (round-1 reviewer ask); refresh stale "drop the tasksAbandon call" comment.
- `17872dd` docs(dashboard): note accepted check-then-act race per proposal § Race notes (Codex P2 inline; design decision now documented in-place).

## Test plan

- [x] Invert existing slotted-stale test to pin 409 + byte-identity of task file + **byte-identity of slot JSON file** (snapshots `readFileSync(slotJsonPath(1), "utf-8")` before/after; populated `process`, `liveness`, `session` make the check non-vacuous).
- [x] Add regression pair for `/api/deferred-abandon` (slotted → 409 + byte-identity of task and slot JSON; non-slotted → 200 + abandoned).
- [x] Existing non-slotted `/api/stale-abandon` regression still passes; stale "drop the tasksAbandon call" comment refreshed to reference `transitionStatus` (the actual code path now).
- [x] `bun run typecheck`, `bun run lint`, `bun run lint:cli-readme` all clean.
- [x] `bun test src/dashboard.test.ts`: 69 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)