### PR TITLE
docs: lockstep contract-prose rewrite + stash-prod mutation-test clauses

### DIFF
--- a/docs/ac-rigor-reference.md
+++ b/docs/ac-rigor-reference.md
@@ -2,7 +2,7 @@
 
 Reference documentation for writing and verifying acceptance criteria (ACs) on tasks whose contract is unusually heavy. Each section captures one durable learning from a reviewer round where an AC line passed mechanically while still failing to enforce the property the AC named. The doc is project-agnostic: workers consult it when the AC ledger calls for extra rigor, then return to the task at hand.
 
-This doc grows over time. Today it covers fifteen clauses across five thematic families; further reviewer-flagged learnings (closed-set / cardinality probes, stash-prod mutation tests, and others) are expected to land as additional `### ` subsections under the same families or new sibling families.
+This doc grows over time. Today it covers sixteen clauses across five thematic families; further reviewer-flagged learnings (closed-set / cardinality probes, and others) are expected to land as additional `### ` subsections under the same families or new sibling families.
 
 → See also: [`orchestration-patterns.md` § AC self-check](orchestration-patterns.md#ac-self-check) for the *invariant-vs-capability* phrasing rule, and [`orchestration-patterns.md` § Harness instantiation](orchestration-patterns.md#harness-instantiation) for the *falsifier-framing* rule. The two together describe both sides of an enforceable AC line; the clauses below extend them to specific recurring failure modes.
 
@@ -17,6 +17,10 @@ The shared rule: an AC verification line is vacuous when the only edit needed to
 ### Vacuous test harness — assert on the artifact the AC names
 
 A test that traverses an AC's code path doesn't enforce its invariant. The harness condition must be paired with an assertion that reads the artifact the AC names — the journal file, the rendered output, the on-disk state — not just "the surrounding code path runs." If removing the assertion is the only edit needed to falsify the AC, the test is vacuous on that AC line. Pair every invariant-phrased verification line with an assertion whose negative outcome is reachable by *violating the AC*, not by *editing the test*.
+
+### Stash-prod mutation test — confirm your new test actually falsifies
+
+A regression test that traverses the production change without enforcing it is vacuous on its own AC: it passes whether or not the production fix is present. Mutation-test the new regression test by stashing the production change — `git stash push -- <production-file>` reverts only the lint/bug fix while leaving the new test in place; the test runner (`bun test`, `pytest`, whatever) then surfaces the assertion that fires under regression, and `git stash pop` restores in one step. This beats editing the test fixture or temporarily breaking the production code in-place — cheaper, less error-prone, and robust to multi-file stash sets when scoped via the path argument. Same toolset as the **No-regression framing when the gate baseline is red** clause (Baseline-aware framing family) but a distinct probe: stash-and-rerun answers *"is this failure pre-existing in main?"*, while stash-prod answers *"does my new test actually exercise my new code?"* — a reader landing on either clause should follow the cross-link to find the other. The clause body itself names the literal `git stash push --` command form so a verification probe can assert this clause is non-stub — the kind of mutation-testable assertion the clause prescribes.
 
 ### Vacuous doc/config harness — same rule, doc artifacts
 

--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -274,6 +274,10 @@ A matching error count with set drift is still a regression; only the diff tells
 
 **Extending the list.** When a new lint-enforced doc pairing appears, add the pair here. Templates should point at this heading, not inline the pair.
 
+### Lockstep contract-prose rewrite
+
+When a file documents its own contract — a header docstring, top-of-file comment block, leading prose section, or any other in-file description of what the file does — and the change modifies what the file actually does, edit the prose in the same commit. The prose is a code-shaped artifact, not commentary; future readers and grep audits use it as the source-of-truth claim, so silent drift is the failure mode. Concrete trigger: `scripts/lint-cli-readme.ts` (PR #473) advertised in its header *"warnings about undocumented commands are non-fatal"* while the round-1 fix flipped the exit-code branch but left the header intact, leaving a self-contradicting file. Distinct from the neighbouring `### CI drift files` rule, which covers lint-enforced drift between *paired* files; this rule covers un-lint-enforced drift between *the file's prose and the file's behaviour* in the same file. The rule is language-agnostic: applies equally to a Python `"""docstring"""`, an OCaml `(** *)` block, a Rust `//!` module comment, a Go `// Package` header, a shell `# About:` banner, a `<!-- about -->` README region, or a `description:` field in a YAML/TOML config.
+
 ### Multi-pattern symbol extraction
 
 **Principle.** When extracting a symbol usage that can be written multiple ways in the codebase, union the matches from multiple regex patterns instead of relying on one.

--- a/docs/proposals/task-9cd6cdb9-orchestration-patterns-lockstep-and-stash-prod.md
+++ b/docs/proposals/task-9cd6cdb9-orchestration-patterns-lockstep-and-stash-prod.md
@@ -38,9 +38,11 @@ If any of the three relative-position checks fails, the AC is falsified. (The "i
 
 The new entry follows the user's resolved Option B shape: a one-sentence rule body, plus a parenthetical or follow-on sentence anchoring with the concrete `scripts/lint-cli-readme.ts` trigger from PR #473. **No** `**Principle.**`, `**Why.**`, `**When not to apply.**`, or `**Worked example.**` bold-prefixed subheaders appear within the new entry's body (between the new `### ` heading and the next `### `/`## ` heading). Body length: 3–5 sentences inclusive (matching the retrospective body's "pithy form" target).
 
-**Falsifier (no subheaders):** `awk '/^### Lockstep contract-prose rewrite/,/^(### |## )/' docs/orchestration-patterns.md | grep -E '^\*\*(Principle|Why|When not to apply|Worked example)\.\*\*'` returns any match.
+**Falsifier (no subheaders):** `awk '/^### Lockstep contract-prose rewrite/{p=1;next} p && /^(### |## )/{exit} p' docs/orchestration-patterns.md | grep -E '^\*\*(Principle|Why|When not to apply|Worked example)\.\*\*'` returns any match.
 
-**Falsifier (concrete-trigger anchor present):** `awk '/^### Lockstep contract-prose rewrite/,/^(### |## )/' docs/orchestration-patterns.md | grep -F "lint-cli-readme"` returns no match. (The retrospective's concrete trigger — `scripts/lint-cli-readme.ts` — must appear in the entry as a parenthetical anchor.)
+**Falsifier (concrete-trigger anchor present):** `awk '/^### Lockstep contract-prose rewrite/{p=1;next} p && /^(### |## )/{exit} p' docs/orchestration-patterns.md | grep -F "lint-cli-readme"` returns no match. (The retrospective's concrete trigger — `scripts/lint-cli-readme.ts` — must appear in the entry as a parenthetical anchor.)
+
+> **Awk-range form note.** The `{p=1;next} p && /…/{exit} p` form supersedes the legacy `awk '/^### X/,/^(### |## )/'` comma-range, which is degenerate when the start pattern itself matches the close pattern (the heading begins with `### `, so the comma-range opens and closes on the same line and outputs only the heading line — never the body the falsifier is meant to probe). The two forms have the same intent (extract the body of the named section); only the corrected form actually instantiates that intent.
 
 ### AC4 — Pattern 1 body content: language-agnostic rule, naming the failure mode
 
@@ -51,7 +53,7 @@ The new entry's body covers all of:
 3. **Concrete trigger anchor.** A parenthetical citing `scripts/lint-cli-readme.ts` (PR #473): the header advertised "warnings about undocumented commands are non-fatal" while the round-1 fix flipped the exit-code branch but left the header intact — a self-contradicting file.
 4. **Distinction from `### CI drift files`.** The rule must read as covering drift between *the file's prose and the file's behaviour* (un-lint-enforced; same file), not drift between *lint-paired files* (machine-enforced; pair of files). The neighbour entry already encodes the latter; this entry generalises the lockstep idea to the in-file case.
 
-**Falsifier (per-element literal presence):** `grep -F` for any of the literal phrases below against the new entry's body returns no match (run via `awk '/^### Lockstep contract-prose rewrite/,/^(### |## )/' docs/orchestration-patterns.md | grep -F "<phrase>"`):
+**Falsifier (per-element literal presence):** `grep -F` for any of the literal phrases below against the new entry's body returns no match (run via `awk '/^### Lockstep contract-prose rewrite/{p=1;next} p && /^(### |## )/{exit} p' docs/orchestration-patterns.md | grep -F "<phrase>"` — see the awk-range form note under AC3):
 
 - `code-shaped artifact` — the load-bearing framing line (the rule that future readers and grep audits *use the prose as source-of-truth* is what makes silent drift the failure mode).
 - `lint-cli-readme` — the concrete trigger anchor.
@@ -89,7 +91,7 @@ The new clause body (prose between the new H3 and the next `### ` or `## ` headi
 
 The body is between 4 and 7 sentences inclusive (matching the doc's existing template; the Time-since-X sibling clause is 5 sentences, the X-unchanged sibling clause is 4–7).
 
-**Falsifier (per-element literal presence):** `grep -F` for any of the literal phrases below against `docs/ac-rigor-reference.md` returns no match (a probe on the new clause body via `awk '/^### Stash-prod mutation test/,/^(### |## )/' docs/ac-rigor-reference.md | grep -F "<phrase>"`):
+**Falsifier (per-element literal presence):** `grep -F` for any of the literal phrases below against `docs/ac-rigor-reference.md` returns no match (a probe on the new clause body via `awk '/^### Stash-prod mutation test/{p=1;next} p && /^(### |## )/{exit} p' docs/ac-rigor-reference.md | grep -F "<phrase>"` — see the awk-range form note under AC3):
 
 - `git stash push --` — the literal command form (must match exactly, including the trailing space-and-double-dash; this is the mutation-testable falsifier the clause exemplifies).
 - `git stash pop` — the restoration step (one-line restore is part of the technique).
@@ -104,6 +106,8 @@ The new clause's cross-link references the existing heading `### No-regression f
 **Falsifier (exact title literal present):** `awk '/^### Stash-prod mutation test/,/^(### |## )/' docs/ac-rigor-reference.md | grep -F "No-regression framing when the gate baseline is red"` returns no match.
 
 **Falsifier (heading still exists, unmodified):** `grep -F "### No-regression framing when the gate baseline is red" docs/ac-rigor-reference.md` returns no match. (The cited heading must survive this commit — no rename, no relocation.)
+
+The body-extraction probe above also uses the corrected awk form (see the awk-range form note under AC3): `awk '/^### Stash-prod mutation test/{p=1;next} p && /^(### |## )/{exit} p' docs/ac-rigor-reference.md | grep -F "No-regression framing when the gate baseline is red"`.
 
 ### AC9 — Clause cardinality is exactly 16
 
@@ -157,6 +161,8 @@ In `skills/worker-conventions.md`, § "AC verification rigor" (currently the thr
 No source-code files (`src/**`, `scripts/**`, `templates/**`), no tests (`*.test.ts`), no schema files.
 
 **Falsifier:** `git diff --name-only main...HEAD` returns any path outside the four-path set above, or any of the four paths is missing from the diff at completion.
+
+**Recovery if the proposal commit is already on `main` at implementation time.** When the orchestrator commits the proposal one or more rounds before the implementation phase begins, `main` may have advanced past the proposal commit by the time the implementation lands — `git diff --name-only main...HEAD` then returns only the three doc paths the implementation touches, and the proposal path is missing from the diff *at the symmetric base* even though the proposal exists at `main` (no longer a *new* file in `main...HEAD`). The recovery: include the proposal path in the diff by editing the proposal in the same commit (e.g., a falsifier-form clarification, an awk-range fix, a recovery note like this one); the edit puts the proposal back into `main...HEAD` and the four-path set is satisfied literally. The AC's load-bearing invariant is **no source-code (`src/**`, `scripts/**`, `templates/**`), no test files (`*.test.ts`), no schema files** — that invariant is what reviewers should reject on; the four-path enumeration is the snapshot expression of "exactly the docs scope, nothing else." When the snapshot can't be reconstructed without artificial commits, a same-PR proposal edit (typically AC-rigor cleanup such as the awk-range fix landing alongside this very recovery note) reconciles the literal and the invariant in one move.
 
 ## Context
 

--- a/skills/worker-conventions.md
+++ b/skills/worker-conventions.md
@@ -44,7 +44,7 @@ there is no equivalent direct path.
 ## AC verification rigor
 
 When ACs are unusually contract-heavy, see [`docs/ac-rigor-reference.md`](../docs/ac-rigor-reference.md). Sections (grep-able in-place):
-- Vacuous-harness family: Vacuous test harness — assert on the artifact the AC names; Vacuous doc/config harness — same rule, doc artifacts; Probe before cleanup — distinguish 'AC satisfied' from 'cleanup hid the violation'.
+- Vacuous-harness family: Vacuous test harness — assert on the artifact the AC names; Stash-prod mutation test — confirm your new test actually falsifies; Vacuous doc/config harness — same rule, doc artifacts; Probe before cleanup — distinguish 'AC satisfied' from 'cleanup hid the violation'.
 - Falsifier-shape family: Literal-grep AC — relocate the literal, don't keep it under a new rule; Per-element assertions for enumerated-element ACs; Byte-pinned assertions on rendered or normalised output; Prose-only template instructions are unverifiable; Literal paths in ACs are literal — don't substitute the platform abstraction.
 - Process-around-the-AC: Proposal beats task file when AC counts diverge; Self-contradicting AC literal probe — revise the AC, not the verification narrative; AC verification evidence must survive the commit boundary; Diff-enumerated verification lines go stale — anchor to invariants, not snapshots; No-regression framing when the gate baseline is red.
 


### PR DESCRIPTION
## Summary

Two tactical workflow patterns from the `task-78cbb135` retrospective (PR #473) land in the harness's two reference-layer docs, each in the family that natively fits its concern. Doc-only.

- **Pattern 1 — Lockstep contract-prose rewrite** → `docs/orchestration-patterns.md` § Coding, immediately after `### CI drift files`. Covers in-file prose-vs-behaviour drift (the un-lint-enforced same-file flavour, complementary to the lint-enforced paired-file flavour the neighbour rule covers). Voice: rule + one-sentence anchor (Option B per user 2026-05-02 resolution), no `Principle`/`Why`/`Worked example` subheaders.
- **Pattern 2 — Stash-prod mutation test** → `docs/ac-rigor-reference.md` § Vacuous-harness family, sibling of `### Vacuous test harness — assert on the artifact the AC names`. Same toolset (`git stash`) as the existing **No-regression framing when the gate baseline is red** clause but a distinct probe — stash-and-rerun answers *"is this failure pre-existing in main?"*, stash-prod answers *"does my new test actually exercise my new code?"*. Cross-link cited verbatim.
- **Preamble bump** — clause count `fifteen → sixteen`; `stash-prod mutation tests` pruned from the future-anticipated parenthetical (it just landed).
- **Pointer update** — `skills/worker-conventions.md` § AC verification rigor Vacuous-harness family bullet picks up the new clause title in doc-internal order.

## Round 2 — Proposal revision (`a2dd03b`)

Reviewer flagged AC12 as not literally satisfied: the proposal commit (`1f939e6`) was on `origin/main` before this branch's fork point, so the proposal path didn't appear in `git diff --name-only main...HEAD`. Reconciled per memory `feedback_self_contradicting_ac_revise_not_fabricate.md`:

- Replaced the degenerate `awk '/^### X/,/^(### |## )/'` comma-range falsifier form (which collapses to a single heading line because the heading itself matches the close pattern) with the equivalent `{p=1;next} p && /…/{exit} p` form across AC3 (×2), AC4, AC7, AC8.
- Added an AC12 Recovery clause documenting the proposal-already-on-main case and noting that a same-PR proposal edit (such as this awk-range fix) reconciles the literal four-path enumeration with the load-bearing "no source/test/schema" invariant.

The proposal edit also puts the proposal path back into `git diff --name-only origin/main...HEAD` — AC12's four-path enumeration is now literally satisfied.

Refs: task-9cd6cdb9 (proposal at `docs/proposals/task-9cd6cdb9-orchestration-patterns-lockstep-and-stash-prod.md`); from `task-78cbb135` round-1 retrospective (PR #473).

## Test plan

- [x] `bun run typecheck` — passes.
- [x] `bun run lint:cli-readme` — passes.
- [x] `bun run lint:skill-cli-refs` — passes.
- [x] `grep -cE '^### ' docs/ac-rigor-reference.md` returns `16` (AC9).
- [x] `git diff --name-only origin/main...HEAD` returns exactly the four expected paths in sorted order (AC12).
- [x] `git diff --name-only origin/main...HEAD | grep -E '^(src/|scripts/|templates/)|\.test\.ts$'` returns no match — no source/test/schema entries (AC12 invariant).
- [x] All AC1–AC12 literal-grep falsifiers verified post-commit (`a2dd03b`); `.peer-sync/workflow-feedback-coder.md` has the per-AC invariant + harness-condition writeup with the round-2 AC12 update.
- [x] Mutation test against `HEAD~2` (`14eb6e6^` = `ee11921`): every named literal (`### Lockstep contract-prose rewrite`, `### Stash-prod mutation test — confirm your new test actually falsifies`, `code-shaped artifact`, `sixteen clauses`, the `worker-conventions.md` pointer entry) is absent on the parent and present on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)