### PR TITLE
feat(lint): adapter-call-site lint for mag.orchestration YAML keys (gh-ludics-496)

### DIFF
--- a/docs/swe-textbook.md
+++ b/docs/swe-textbook.md
@@ -97,3 +97,75 @@ the "obvious-to-experienced-engineer" bucket and be discarded from a
 competent engineers under deadline pressure (the contracted artifact
 lives on the *other* side of the fence). Captured here rather than
 skipped silently.
+
+### New OrchestrationConfig fields require parse+merge in adapter init
+
+Description: A typed configuration object that drives runtime
+behaviour usually has four independent surfaces a new field has to
+land on: the interface declaration, the in-code default, any
+backfill the persistent-state migrator applies to old records, and
+the parse+merge step the initialisation path performs against the
+user-facing YAML. The first three are easy to spot — they live next
+to each other in the same file or test — and a typed compiler will
+flag drift between them. The fourth is the most distant from the
+field declaration and the least visible to the type checker: if the
+init path never reads the YAML key, the documented config is
+silently inert and the field always takes its default. Adding a
+shared parser called from each init consumer is the cheapest way to
+keep the fourth surface visible. The pattern: a single helper named
+after the value it produces, called from each adapter's existing
+config-load consumer, fed into the partial-config record that the
+defaults function consumes — so the adapter knows to read the YAML,
+the parser knows the shape, and the merge knows the precedence.
+Test the parser as a unit; integration coverage at the call sites
+catches regressions there.
+
+Precipitating retro: `task-a670cdbf` round-2 review of PR #493
+(settled-no-signal / hung-detection split). The reviewer's blocking
+line: the new `mag.orchestration.substantive_stall.*` YAML keys
+were documented and runtime-honoured, but neither adapter init
+extracted them from the YAML — so the keys were silently inert
+until the round-2 fix shipped a shared
+`parseSubstantiveStallOverrides` parser called from both adapter
+call sites.
+
+Filter decision: Under the competent-SWE filter this is an
+"obvious-to-experienced-engineer" doctrine reminder — wiring up the
+read site is part of the same change as adding the field, by
+definition. Captured here rather than promoted to always-loaded
+agent prompts because the failure mode survives competent engineers
+under deadline pressure when the four surfaces sit in different
+files. The same precipitating retro is closed mechanically by the
+adapter-call-site lint shipped in gh-ludics-496, which makes the
+typed-default-plus-backfill checkbox no longer sufficient.
+
+### "Adapter init reads YAML" is a separate AC for OrchestrationConfig field additions
+
+Description: When an acceptance criteria list enumerates the surfaces
+that have to change for a new typed config field — interface,
+default, migration backfill — the adapter init path's read of the
+user-facing YAML is easy to bundle into the umbrella line "config
+field exists". That bundling lets a typed-interface-plus-default
+checkbox count as completion even when the YAML is silently
+ignored. The remedy is to give the init-side read its own AC,
+phrased as a behavioural property at the user-visible boundary
+("setting the YAML key to a non-default value produces the
+non-default behaviour"), distinct from any structural AC about the
+type or the default. The behavioural framing makes the AC
+falsifiable by an end-to-end test that sets the YAML and observes
+the runtime, not by an inspection of the type declaration.
+
+Precipitating retro: `task-a670cdbf` round-2 review of PR #493. The
+proposal's AC list bundled the YAML-read step into "config field
+exists"; round-1 implementation satisfied the structural ACs without
+satisfying the behavioural one, and the gap surfaced only at
+round-2 review.
+
+Filter decision: Under the competent-SWE filter this is also
+"obvious-to-experienced-engineer" doctrine — separate ACs for
+separate surfaces is general AC-writing hygiene. Captured here
+rather than promoted to AC templates loaded by always-on agent
+prompts because the doctrine is most useful as guidance to humans
+writing proposals, not as a rule enforced at every coder turn. The
+mechanical lint from the sibling entry above closes the same
+failure mode for the specific case of `OrchestrationConfig` fields.

--- a/docs/swe-textbook.shape.test.ts
+++ b/docs/swe-textbook.shape.test.ts
@@ -308,6 +308,51 @@ describe("skills/worker-conventions.md (AC4d field-contract reference)", () => {
   });
 });
 
+// gh-ludics-496 textbook entries (AC9 of that proposal). Pins both new
+// `### …` blocks and their shared `task-a670cdbf` precipitating retro.
+// Mutation: drop either entry → assertion fails on the headline literal;
+// drop the retro citation → assertion fails on `task-a670cdbf`.
+describe("docs/swe-textbook.md (gh-ludics-496 entries)", () => {
+  const body = read(TEXTBOOK_PATH);
+
+  const ENTRY_A_HEADLINE =
+    "### New OrchestrationConfig fields require parse+merge in adapter init";
+  const ENTRY_B_HEADLINE =
+    '### "Adapter init reads YAML" is a separate AC for OrchestrationConfig field additions';
+
+  test("entry A — present with all four labelled fields and the retro", () => {
+    const entryA = slice(
+      body,
+      new RegExp("^" + ENTRY_A_HEADLINE.replace(/[+]/g, "\\+")),
+      new RegExp(
+        "^" + ENTRY_B_HEADLINE.replace(/[.*+?^${}()|[\]\\"]/g, "\\$&"),
+      ),
+    );
+    expect(entryA).toContain("Description:");
+    expect(entryA).toContain("Precipitating retro:");
+    expect(entryA).toContain("Filter decision:");
+    expect(entryA).toContain("task-a670cdbf");
+  });
+
+  test("entry B — present with all four labelled fields and the retro", () => {
+    const entryB = sliceToEnd(
+      body,
+      new RegExp(
+        "^" + ENTRY_B_HEADLINE.replace(/[.*+?^${}()|[\]\\"]/g, "\\$&"),
+      ),
+    );
+    expect(entryB).toContain("Description:");
+    expect(entryB).toContain("Precipitating retro:");
+    expect(entryB).toContain("Filter decision:");
+    expect(entryB).toContain("task-a670cdbf");
+  });
+
+  test("both headlines literally present in the textbook body", () => {
+    expect(body).toContain(ENTRY_A_HEADLINE);
+    expect(body).toContain(ENTRY_B_HEADLINE);
+  });
+});
+
 describe("AC7 — negative control on agent-loaded prompts", () => {
   test("no `skills/**.md` outside the AC7 allowlist mentions `swe-textbook`", () => {
     // Harness: walk every .md file under skills/ and check the

--- a/scripts/lint-config-helpers.test.ts
+++ b/scripts/lint-config-helpers.test.ts
@@ -1,12 +1,14 @@
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "bun";
-import { readFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import {
   extractInterfaceBody,
   parseFieldDeclarations,
   extractInterfacePaths,
   extractMagPathsFromSource,
+  extractAdapterReadKeysFromSource,
   flattenYamlPaths,
   collectArrayPaths,
   comparePaths,
@@ -332,6 +334,110 @@ describe("extractMagPathsFromSource floor count", () => {
     const repoRoot = join(import.meta.dir, "..");
     const set = extractMagPathsFromSource(join(repoRoot, "src"));
     expect(set.size).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractAdapterReadKeysFromSource (gh-ludics-496)
+//
+// Same DRY-refactor-safety failure-mode as extractMagPathsFromSource (see
+// SILENT-DRIFT WARNING in scripts/lint-config-helpers.ts). The floor-count
+// tests below pin the live extractor against an inadvertent collapse of
+// `orchCfg?.<key>` literals behind a helper. Failure here means **either**:
+//   (a) a DRY refactor collapsed call sites — register the new helper in
+//       extractAdapterReadKeysFromSource, then re-run this test; or
+//   (b) keys were intentionally removed — lower the floor and note here.
+// Today t3code yields 11 distinct keys (floor 9 with slack); tmux yields
+// 8 (floor 6 with slack).
+// ---------------------------------------------------------------------------
+
+describe("extractAdapterReadKeysFromSource", () => {
+  function withTmpFile<T>(body: string, fn: (path: string) => T): T {
+    const dir = mkdtempSync(join(tmpdir(), "extract-orch-keys-"));
+    const path = join(dir, "adapter.ts");
+    writeFileSync(path, body);
+    try {
+      return fn(path);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("(a) positive — recognises orchCfg?.<key> and orchCfg.<key>", () => {
+    const src = [
+      "const m = orchCfg?.coder_model as string | undefined;",
+      "const t = orchCfg?.phase_timeouts;",
+      "const a = orchCfg.legacy_alias;",
+      "",
+    ].join("\n");
+    withTmpFile(src, (path) => {
+      const set = extractAdapterReadKeysFromSource(path);
+      expect(set.size).toBe(3);
+      expect(set.has("coder_model")).toBe(true);
+      expect(set.has("phase_timeouts")).toBe(true);
+      expect(set.has("legacy_alias")).toBe(true);
+    });
+  });
+
+  test("(b) negative — source without orchCfg returns empty set", () => {
+    const src = "const x = otherCfg?.coder_model;\nexport {};\n";
+    withTmpFile(src, (path) => {
+      const set = extractAdapterReadKeysFromSource(path);
+      expect(set.size).toBe(0);
+    });
+  });
+
+  test("(b') comments do not count — // and /* */ mentions ignored", () => {
+    // Mutation: drop the comment-strip in extractAdapterReadKeysFromSource
+    // → this test's `set.size === 0` flips to 3 (three comment hits).
+    const src = [
+      "// orchCfg.commented_line",
+      "/* orchCfg?.commented_block */",
+      "/**",
+      " * orchCfg?.jsdoc_mention",
+      " */",
+      "export {};",
+      "",
+    ].join("\n");
+    withTmpFile(src, (path) => {
+      const set = extractAdapterReadKeysFromSource(path);
+      expect(set.size).toBe(0);
+    });
+  });
+
+  test("(c) floor count — live src/adapters/t3code.ts yields >= 9 keys", () => {
+    const repoRoot = join(import.meta.dir, "..");
+    const set = extractAdapterReadKeysFromSource(
+      join(repoRoot, "src", "adapters", "t3code.ts"),
+    );
+    expect(set.size).toBeGreaterThanOrEqual(9);
+  });
+
+  test("(d) floor count — live src/adapters/tmux-adapter.ts yields >= 6 keys", () => {
+    const repoRoot = join(import.meta.dir, "..");
+    const set = extractAdapterReadKeysFromSource(
+      join(repoRoot, "src", "adapters", "tmux-adapter.ts"),
+    );
+    expect(set.size).toBeGreaterThanOrEqual(6);
+  });
+
+  test("(e) motivating keys — t3code reads phase_timeouts AND substantive_stall", () => {
+    // Pins the precise failure mode the lint exists to prevent: if either
+    // motivating key drops out of the live extractor, the new lint stops
+    // covering its own precipitating class (task-a670cdbf).
+    const repoRoot = join(import.meta.dir, "..");
+    const set = extractAdapterReadKeysFromSource(
+      join(repoRoot, "src", "adapters", "t3code.ts"),
+    );
+    expect(set.has("phase_timeouts")).toBe(true);
+    expect(set.has("substantive_stall")).toBe(true);
+  });
+
+  test("(f) self-test floor — missing file returns empty set, no throw", () => {
+    const set = extractAdapterReadKeysFromSource(
+      join(tmpdir(), "definitely-does-not-exist-" + Date.now() + ".ts"),
+    );
+    expect(set.size).toBe(0);
   });
 });
 

--- a/scripts/lint-config-helpers.ts
+++ b/scripts/lint-config-helpers.ts
@@ -251,6 +251,81 @@ export function extractMagPathsFromSource(sourceDir: string): Set<string> {
 }
 
 // ---------------------------------------------------------------------------
+// Adapter Source Grep (gh-ludics-496)
+// ---------------------------------------------------------------------------
+
+// SILENT-DRIFT WARNING (gh-ludics-496):
+// `extractAdapterReadKeysFromSource` is a regex-over-source extractor.
+// Its safety claim — "every documented `mag.orchestration.<leaf>` YAML
+// key is read by at least one adapter" — depends on the literal access
+// patterns below appearing at the call sites. A "DRY-only" refactor
+// that wraps any of these patterns behind a new helper, table, or loop
+// *deletes* the literals from source. The regex still runs, just with
+// fewer hits, and the lint passes silently with reduced coverage.
+//
+// If you introduce a new helper that reads `orchCfg?.<key>` (or
+// sibling), add a matching regex pattern below AND keep the
+// floor-count tests in scripts/lint-config-helpers.test.ts
+// ("extractAdapterReadKeysFromSource floor count") in sync.
+//
+// The floor-count tests are the mechanical guard that catches the
+// next instance of this silent-drift class. A second guard
+// (zero-match self-test) lives in scripts/lint-config-reference.ts:
+// when either adapter file's extractor returns the empty set, the
+// whole lint fails with a distinct error so a complete refactor
+// cannot make the lint silently green.
+//
+// Recognised patterns (mirror in the test's failure-mode comment):
+//   - orchCfg?.property        (primary; every current call site)
+//   - orchCfg.property         (non-optional variant; defensive)
+//
+// Comment forms (e.g. `// orchCfg.foo`, `/* orchCfg.bar */`) are
+// stripped before matching so a comment mention does not silently
+// satisfy coverage for an unimplemented key.
+
+/**
+ * Extract first-segment keys read from `orchCfg` in a single adapter
+ * source file. Strips JSDoc / block / line comments before scanning so
+ * a comment mention of `orchCfg.<key>` does not falsely satisfy
+ * coverage. Returns the empty set when the file is missing or
+ * unreadable — the caller (runLint) turns that into a self-test
+ * error rather than an exception.
+ */
+export function extractAdapterReadKeysFromSource(
+  adapterFile: string,
+): Set<string> {
+  let source: string;
+  try {
+    source = readFileSync(adapterFile, "utf-8");
+  } catch {
+    return new Set();
+  }
+
+  // Strip comments so `// orchCfg.future_key` does not satisfy coverage.
+  // Mirror parseFieldDeclarations' three-step strip (JSDoc, block, line).
+  const cleaned = source
+    .replace(/\/\*\*[\s\S]*?\*\//g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
+
+  const keys = new Set<string>();
+  // Pattern 1: orchCfg?.key (primary)
+  const p1 = /\borchCfg\?\.(\w+)/g;
+  // Pattern 2: orchCfg.key (non-optional variant; defensive)
+  const p2 = /\borchCfg\.(\w+)/g;
+
+  for (const pattern of [p1, p2]) {
+    pattern.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(cleaned)) !== null) {
+      keys.add(m[1]);
+    }
+  }
+
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
 // YAML Flattener
 // ---------------------------------------------------------------------------
 

--- a/scripts/lint-config-reference.test.ts
+++ b/scripts/lint-config-reference.test.ts
@@ -5,12 +5,27 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { runLint } from "./lint-config-reference.ts";
 
+// gh-ludics-496: the new adapter-call-site direction in runLint always
+// reads `src/adapters/{t3code,tmux-adapter}.ts`; an absent file or one
+// without any `orchCfg?.<key>` literals trips `inertSelfTestErrors` and
+// forces exit 1. Tests that don't exercise the new direction get a
+// minimal non-empty stub in each adapter file by default so pre-existing
+// assertions (TS↔YAML drift, harness-subset) remain isolated. The new
+// adapter-direction tests override these defaults by passing their own
+// `src/adapters/*.ts` entries in `files`.
+const ADAPTER_STUB = "const _ = orchCfg?.foo;\n";
+
 function makeFixture(files: Record<string, string>): {
   root: string;
   cleanup: () => void;
 } {
+  const merged: Record<string, string> = {
+    "src/adapters/t3code.ts": ADAPTER_STUB,
+    "src/adapters/tmux-adapter.ts": ADAPTER_STUB,
+    ...files,
+  };
   const root = mkdtempSync(join(tmpdir(), "lint-config-reference-"));
-  for (const [rel, body] of Object.entries(files)) {
+  for (const [rel, body] of Object.entries(merged)) {
     const abs = join(root, rel);
     mkdirSync(join(abs, ".."), { recursive: true });
     writeFileSync(abs, body);
@@ -223,5 +238,140 @@ describe("CLI integration", () => {
       console.error(result.stdout.toString());
     }
     expect(result.exitCode).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runLint — adapter-call-site direction (gh-ludics-496)
+//
+// Each test extends the fixture with explicit `src/adapters/*.ts` content
+// to override the ADAPTER_STUB defaults. The fixture's TS interface
+// declares `mag.orchestration` as opaque (Record<string, unknown>) so the
+// existing TS↔YAML direction tolerates the new YAML keys without raising
+// a `missingFromTs` false-positive — the documented carve-out at
+// scripts/lint-config-reference.ts skips `mag.X.Y` paths in that
+// direction.
+// ---------------------------------------------------------------------------
+
+const TS_INTERFACE_WITH_ORCH = [
+  "export interface LudicsFullConfig {",
+  "  state_repo: string;",
+  "  state_path: string;",
+  "  staleThresholdSeconds: number;",
+  "  slots?: { count?: number };",
+  "  mag?: { orchestration?: Record<string, unknown> };",
+  "}",
+  "",
+].join("\n");
+
+function yamlWithOrch(block: string): string {
+  return [
+    "state_repo: org/repo",
+    "state_path: harness",
+    "slots:",
+    "  count: 6",
+    "mag:",
+    "  orchestration:",
+    block,
+    "",
+  ].join("\n");
+}
+
+describe("runLint — adapter-call-site direction (gh-ludics-496)", () => {
+  test("AC8 happy path — documented key read by t3code → no inert keys, exit 0", () => {
+    const { root, cleanup } = makeFixture({
+      "src/config.ts": TS_INTERFACE_WITH_ORCH,
+      "templates/config.reference.yaml": yamlWithOrch("    foo: 1"),
+      "templates/harness/config.yaml": HARNESS_YAML_SUBSET,
+      "src/adapters/t3code.ts": "const x = orchCfg?.foo;\n",
+      "src/adapters/tmux-adapter.ts": "const y = orchCfg?.bar;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.inertYamlKeys).toEqual([]);
+      expect(result.inertSelfTestErrors).toEqual([]);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("AC8 inert key — documented key not read by either adapter → exit 1", () => {
+    const { root, cleanup } = makeFixture({
+      "src/config.ts": TS_INTERFACE_WITH_ORCH,
+      "templates/config.reference.yaml": yamlWithOrch("    bar: 1"),
+      "templates/harness/config.yaml": HARNESS_YAML_SUBSET,
+      "src/adapters/t3code.ts": "const x = orchCfg?.foo;\n",
+      "src/adapters/tmux-adapter.ts": "const y = orchCfg?.foo;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.inertYamlKeys).toContain("bar");
+      expect(result.exitCode).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("AC3 disjunctive — tmux-only read covers a key absent from t3code → exit 0", () => {
+    const { root, cleanup } = makeFixture({
+      "src/config.ts": TS_INTERFACE_WITH_ORCH,
+      "templates/config.reference.yaml": yamlWithOrch("    baz: 1"),
+      "templates/harness/config.yaml": HARNESS_YAML_SUBSET,
+      "src/adapters/t3code.ts": "const x = orchCfg?.qux;\n",
+      "src/adapters/tmux-adapter.ts": "const y = orchCfg?.baz;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.inertYamlKeys).toEqual([]);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("AC5 self-test — both adapter sources have zero orchCfg literals → exit 1 with inertSelfTestErrors", () => {
+    const { root, cleanup } = makeFixture({
+      "src/config.ts": TS_INTERFACE_WITH_ORCH,
+      "templates/config.reference.yaml": yamlWithOrch("    foo: 1"),
+      "templates/harness/config.yaml": HARNESS_YAML_SUBSET,
+      "src/adapters/t3code.ts": "// empty module\nexport {};\n",
+      "src/adapters/tmux-adapter.ts": "// empty module\nexport {};\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.inertSelfTestErrors).toContain("src/adapters/t3code.ts");
+      expect(result.inertSelfTestErrors).toContain("src/adapters/tmux-adapter.ts");
+      expect(result.exitCode).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("AC4 nested-block — first-segment read covers nested leaves (substantive_stall.*)", () => {
+    // Mutation: drop the `orchCfg?.substantive_stall` literal from both
+    // adapter stubs → `substantive_stall` flips to inert and exit code
+    // becomes 1. Pins both AC4 (first-segment granularity) and the
+    // precise failure mode the proposal exists to prevent
+    // (task-a670cdbf round-2 reviewer caught the inverse).
+    const nestedYaml = [
+      "    substantive_stall:",
+      "      settled_no_signal_seconds: 60",
+      "      threshold_seconds: 1200",
+    ].join("\n");
+    const { root, cleanup } = makeFixture({
+      "src/config.ts": TS_INTERFACE_WITH_ORCH,
+      "templates/config.reference.yaml": yamlWithOrch(nestedYaml),
+      "templates/harness/config.yaml": HARNESS_YAML_SUBSET,
+      "src/adapters/t3code.ts": "const ss = orchCfg?.substantive_stall;\n",
+      "src/adapters/tmux-adapter.ts": "const ss = orchCfg?.substantive_stall;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.inertYamlKeys).toEqual([]);
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanup();
+    }
   });
 });

--- a/scripts/lint-config-reference.ts
+++ b/scripts/lint-config-reference.ts
@@ -20,6 +20,7 @@ import YAML from "yaml";
 import {
   extractInterfacePaths,
   extractMagPathsFromSource,
+  extractAdapterReadKeysFromSource,
   flattenYamlPaths,
   collectArrayPaths,
   comparePaths,
@@ -33,7 +34,34 @@ export interface RunLintResult {
   missingFromTs: string[];
   /** Harness paths not present in the reference YAML. */
   harnessExtras: string[];
+  /**
+   * mag.orchestration.<leaf> YAML keys not read by either adapter
+   * (silently inert). Empty when every documented leaf has an
+   * adapter read site, or is listed in `IGNORE_ADAPTER_READ`.
+   * Distinct from `inertSelfTestErrors` so a complete extractor
+   * miss is not misdiagnosed as every YAML key being inert.
+   */
+  inertYamlKeys: string[];
+  /**
+   * Adapter source files for which `extractAdapterReadKeysFromSource`
+   * returned the empty set — a self-test against silent regex drift.
+   * Non-empty means the literal `orchCfg?.<key>` access patterns the
+   * extractor depends on may have been DRY-refactored behind a
+   * helper, so the lint can no longer protect anything.
+   */
+  inertSelfTestErrors: string[];
 }
+
+/**
+ * mag.orchestration.<leaf> keys intentionally not read by any
+ * adapter (e.g., a future YAML key consumed only by a CLI command).
+ * One-line per-entry rationale required when adding an entry —
+ * silent escape hatches defeat the whole lint.
+ *
+ * Initially empty: gh-ludics-496 verified every current leaf is
+ * covered by at least one adapter read site.
+ */
+const IGNORE_ADAPTER_READ = new Set<string>();
 
 /**
  * Run the bidirectional drift check against an arbitrary repo root. Reads
@@ -139,14 +167,61 @@ export function runLint(root: string): RunLintResult {
   }
   harnessExtras.sort();
 
+  // 8. Direction 4 (gh-ludics-496): every documented leaf under
+  //    `mag.orchestration:` in the reference YAML must have at least
+  //    one literal read site in `src/adapters/t3code.ts` OR
+  //    `src/adapters/tmux-adapter.ts`. Disjunctive because
+  //    `default_mode` / `default_coder` / `default_reviewer` are
+  //    t3code-only concepts. First-segment granularity:
+  //    `phase_timeouts` covers `phase_timeouts.work` etc.,
+  //    `substantive_stall` covers its inner leaves, because the
+  //    adapters spread the whole record / pass it into a shared
+  //    parser.
+  const orchBlock =
+    yamlObj &&
+    typeof yamlObj === "object" &&
+    yamlObj.mag &&
+    typeof yamlObj.mag === "object"
+      ? (yamlObj.mag as Record<string, unknown>).orchestration
+      : undefined;
+  const documentedOrchKeys =
+    orchBlock && typeof orchBlock === "object"
+      ? Object.keys(orchBlock as Record<string, unknown>)
+      : [];
+
+  const t3codeAdapterPath = join(root, "src", "adapters", "t3code.ts");
+  const tmuxAdapterPath = join(root, "src", "adapters", "tmux-adapter.ts");
+  const tCovered = extractAdapterReadKeysFromSource(t3codeAdapterPath);
+  const mCovered = extractAdapterReadKeysFromSource(tmuxAdapterPath);
+
+  const inertYamlKeys: string[] = [];
+  for (const k of documentedOrchKeys) {
+    if (IGNORE_ADAPTER_READ.has(k)) continue;
+    if (tCovered.has(k)) continue;
+    if (mCovered.has(k)) continue;
+    inertYamlKeys.push(k);
+  }
+  inertYamlKeys.sort();
+
+  const inertSelfTestErrors: string[] = [];
+  if (tCovered.size === 0) inertSelfTestErrors.push("src/adapters/t3code.ts");
+  if (mCovered.size === 0) inertSelfTestErrors.push("src/adapters/tmux-adapter.ts");
+  inertSelfTestErrors.sort();
+
   const errors =
-    missingFromYaml.length + missingFromTs.length + harnessExtras.length;
+    missingFromYaml.length +
+    missingFromTs.length +
+    harnessExtras.length +
+    inertYamlKeys.length +
+    inertSelfTestErrors.length;
 
   return {
     exitCode: errors > 0 ? 1 : 0,
     missingFromYaml,
     missingFromTs,
     harnessExtras,
+    inertYamlKeys,
+    inertSelfTestErrors,
   };
 }
 
@@ -181,6 +256,28 @@ if (import.meta.main) {
     );
     for (const p of result.harnessExtras) {
       console.error(`     - ${p}`);
+    }
+  }
+
+  if (result.inertYamlKeys.length > 0) {
+    console.error(
+      "\n❌  config.reference.yaml documents mag.orchestration keys " +
+        "not read by either adapter (silently inert):",
+    );
+    for (const k of result.inertYamlKeys) {
+      console.error(`     - mag.orchestration.${k}`);
+    }
+  }
+
+  if (result.inertSelfTestErrors.length > 0) {
+    console.error(
+      "\n❌  Adapter-source extractor returned zero keys for these " +
+        "files — the literal `orchCfg?.<key>` patterns may have been " +
+        "DRY-refactored behind a helper. Re-extend " +
+        "scripts/lint-config-helpers.ts:extractAdapterReadKeysFromSource:",
+    );
+    for (const f of result.inertSelfTestErrors) {
+      console.error(`     - ${f}`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Extends `lint:config-reference` with a fourth direction that asserts every documented `mag.orchestration.<leaf>` key in `templates/config.reference.yaml` has at least one literal read site in `src/adapters/t3code.ts` **or** `src/adapters/tmux-adapter.ts` — closing the silent-inert-key class flagged by PR #493 round-2.
- New `extractAdapterReadKeysFromSource` helper in `scripts/lint-config-helpers.ts` strips comments before regex so `// orchCfg.future_key` mentions cannot satisfy coverage. Floor-count + zero-match self-test guards mirror the gh-ludics-406 SILENT-DRIFT doctrine.
- Captures two competent-SWE-filter learnings to `docs/swe-textbook.md` (write-side memory; AC11/AC12 negative controls keep the file out of always-loaded coder/reviewer prompts).

Closes #496.

## Test plan

- [x] `bun test scripts/lint-config-helpers.test.ts` — 32 pass (6 new under `extractAdapterReadKeysFromSource`)
- [x] `bun test scripts/lint-config-reference.test.ts` — 13 pass (5 new under the adapter-call-site direction)
- [x] `bun test docs/swe-textbook.shape.test.ts` — 26 pass (3 new under the gh-ludics-496-entries describe block)
- [x] `bun run lint:config-reference` against the live tree — exit 0, no inert keys, no self-test errors
- [x] `bun run typecheck` — clean
- [x] `bun test` — 2243 pass / 0 fail (baseline 2228 + 15 new)
- [x] AC11/AC12 scope checks: forbidden-glob diff and `git grep -F "swe-textbook"` in agent-loaded skills both empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)