### PR TITLE
feat(lint): surface two-fix heuristic on pinned warning-count failures (gh-ludics-497)

### DIFF
--- a/docs/swe-textbook.md
+++ b/docs/swe-textbook.md
@@ -169,3 +169,19 @@ prompts because the doctrine is most useful as guidance to humans
 writing proposals, not as a rule enforced at every coder turn. The
 mechanical lint from the sibling entry above closes the same
 failure mode for the specific case of `OrchestrationConfig` fields.
+
+### Cherry-picking one named lint into pair-coder-work.md is editorially inconsistent
+
+Description: Named-lint enumeration in `pair-coder-work.md` is editorially inconsistent unless you name **all** repo-wide gates; cherry-picking one (`lint:test-isolation`) advertises it as special. The competent-SWE filter applies — the other lints (`bun run lint`, `bun run typecheck`, `bun run lint:contracts`, etc.) are not enumerated either. The skill says "Build, lint, and run targeted tests before signaling done" without naming individual scripts; adding one named lint inverts that established editorial stance.
+
+Precipitating retro: `task-a670cdbf` round-2 review of PR #493; aggregated via `/ludics-feedback-digest` 2026-05-04 (gh-ludics-497 issue body action 1).
+
+Filter decision: Under the competent-SWE filter this is doctrine ("remind coders to run X") and would be skipped from a `/ludics-process-suggestions` run. Captured here rather than promoted to always-loaded agent prompts because surfacing the failure message at the moment of trip (gh-ludics-497 action 2c) accomplishes the ergonomic goal without naming the lint in a checklist.
+
+### "Optional pre-commit hook" feedback-digest items must verify the infra exists
+
+Description: Feedback-digest items proposing optional pre-commit hook integration if a Husky setup exists should verify the infrastructure is present before treating as in-scope. Introducing Husky is a separate decision affecting every commit on every machine; not a workflow-feedback fix. The verification pattern: `ls .husky` plus a `package.json` grep for `"husky"` / `"lint-staged"` keys — both empty means the proposal's "if exists" antecedent is false and the action is captured-as-doctrine rather than executed.
+
+Precipitating retro: `task-a670cdbf` round-2 review of PR #493; aggregated via `/ludics-feedback-digest` 2026-05-04 (gh-ludics-497 issue body action 3).
+
+Filter decision: Under the competent-SWE filter this is doctrine — verifying infrastructure preconditions before acting on a conditional suggestion is general engineering hygiene. Captured here because the failure mode is asymmetric: feedback-digest aggregation tends to bundle "if X exists, also do Y" suggestions without checking X, and a competent reviewer can still miss that the antecedent never held.

--- a/scripts/lint-contracts.test.ts
+++ b/scripts/lint-contracts.test.ts
@@ -10,6 +10,7 @@ import {
   lintPair,
   hasOrchestratorRoutingSection,
   runCli,
+  formatContractsHeuristic,
 } from "./lint-contracts.ts";
 
 // ---------------------------------------------------------------------------
@@ -514,11 +515,11 @@ describe("integration", () => {
       writeOut: () => {},
     });
     expect(result.errorCount).toBe(0);
-    // When this fails: either a new skill pair introduced a worker/orchestrator
-    // field-contract drift (regression — fix the pair) OR a matcher improvement
-    // found new real-world hits (coverage upgrade — justify and update the
-    // count).
-    expect(result.warningCount).toBe(0);
+    const expectedWarningCount = 0;
+    if (result.warningCount !== expectedWarningCount) {
+      throw new Error(formatContractsHeuristic(result.warningCount));
+    }
+    expect(result.warningCount).toBe(expectedWarningCount);
   });
 
   // Floor-count guards for the two regex-over-markdown extractors

--- a/scripts/lint-contracts.ts
+++ b/scripts/lint-contracts.ts
@@ -22,6 +22,18 @@ import { join, basename } from "path";
 const root = join(import.meta.dir, "..");
 const skillsDir = join(root, "skills");
 
+/**
+ * Failure-message heuristic surfaced by the integration test's
+ * guarded throw when the pinned contracts warning count drifts.
+ * Distinct from the test-isolation heuristic: contracts-lint
+ * failure mode is field-contract drift (regression — fix the
+ * pair) OR matcher coverage upgrade (justify and update the
+ * count). gh-ludics-497.
+ */
+export function formatContractsHeuristic(warningCount: number): string {
+  return `(${warningCount} warnings — either a new skill pair introduced a worker/orchestrator field-contract drift (regression — fix the pair), OR a matcher improvement found new real-world hits (coverage upgrade — justify and update the pinned count in scripts/lint-contracts.test.ts).`;
+}
+
 // ---------------------------------------------------------------------------
 // Pure extractors (exported for tests)
 // ---------------------------------------------------------------------------

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -13,6 +13,7 @@ import {
   listTestFiles,
   runCli,
   RULE_3_TARGETS,
+  formatWarningCountHeuristic,
 } from "./lint-test-isolation.ts";
 
 // ---------------------------------------------------------------------------
@@ -790,6 +791,55 @@ describe("runCli", () => {
       cleanup();
     }
   });
+
+  test("CLI summary appends heuristic when warningCount > 0 (gh-ludics-497 AC2 positive)", () => {
+    // Rule-3 fixture produces exactly one warning, no errors. Exercises the
+    // success-summary branch in runCli with warningCount > 0 so the heuristic
+    // body is appended to the writeOut sink.
+    const { dir, cleanup } = makeRepoFixture({
+      "src/r3.test.ts": "import { harnessDir } from './config.ts';\n",
+      "src/config.ts": "export function harnessDir(){}",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.exitCode).toBe(0);
+      expect(r.errorCount).toBe(0);
+      expect(r.warningCount).toBe(1);
+      const summary = r.out.join("\n");
+      expect(summary).toContain("✅  No test-isolation anti-patterns detected");
+      expect(summary).toContain(
+        "wrap with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts",
+      );
+      expect(summary).toContain(
+        "bump the pinned count in scripts/lint-test-isolation.test.ts",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("CLI summary omits heuristic when warningCount === 0 (gh-ludics-497 AC2 negative)", () => {
+    // Clean fixture — zero-warning success summary must remain byte-identical
+    // to the pre-gh-ludics-497 output so any downstream success-grep keeps
+    // matching.
+    const { dir, cleanup } = makeRepoFixture({
+      "src/safe.test.ts": [
+        "import { foo } from './foo.ts';",
+        "beforeEach(() => { process.env.LUDICS_HARNESS_DIR = '/tmp/x'; });",
+      ].join("\n"),
+      "src/foo.ts": "export const foo = 1;",
+    });
+    try {
+      const r = driveRunCli(dir);
+      expect(r.warningCount).toBe(0);
+      const summary = r.out.join("\n");
+      expect(summary).toBe("✅  No test-isolation anti-patterns detected.");
+      expect(summary).not.toContain("withSyntheticHarness");
+      expect(summary).not.toContain("bump the pinned count");
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -806,11 +856,11 @@ describe("integration", () => {
       writeOut: () => {},
     });
     expect(result.errorCount).toBe(0);
-    // When this fails: either a new test introduced an unhandled isolation
-    // anti-pattern (regression — fix the test) OR a matcher improvement
-    // found new real-world hits (coverage upgrade — justify and update the
-    // count).
-    expect(result.warningCount).toBe(20);
+    const expectedWarningCount = 20;
+    if (result.warningCount !== expectedWarningCount) {
+      throw new Error(formatWarningCountHeuristic(result.warningCount));
+    }
+    expect(result.warningCount).toBe(expectedWarningCount);
   });
 });
 

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -54,6 +54,19 @@ const SCAN_EXCLUDE = new Set<string>([
   "src/test-utils.ts",
 ]);
 
+/**
+ * Failure-message heuristic surfaced by both the CLI summary
+ * (when warningCount > 0) and the integration test's guarded
+ * throw. Names `withSyntheticHarness` (positive recommendation —
+ * actually isolates the harness env) and the pin-bump fallback.
+ * If `withSyntheticHarness` is renamed in src/test-utils.ts,
+ * update RULE_3_TARGETS / hasIsolationSetup AND this string in
+ * the same PR (gh-ludics-497).
+ */
+export function formatWarningCountHeuristic(warningCount: number): string {
+  return `(${warningCount} warnings — to silence a new test: wrap with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts (preferred — actually isolates the harness env), OR bump the pinned count in scripts/lint-test-isolation.test.ts (only for pure-unit tests with no harness needs).`;
+}
+
 // ---------------------------------------------------------------------------
 // Issue shape
 // ---------------------------------------------------------------------------
@@ -470,11 +483,13 @@ export function runCli(options: RunCliOptions = {}): RunCliResult {
   }
 
   if (errorCount === 0) {
-    const suffix =
-      warningCount > 0
-        ? ` (${warningCount} warning${warningCount === 1 ? "" : "s"})`
-        : "";
-    writeOut(`✅  No test-isolation anti-patterns detected${suffix}.`);
+    if (warningCount > 0) {
+      writeOut(
+        `✅  No test-isolation anti-patterns detected ${formatWarningCountHeuristic(warningCount)}`,
+      );
+    } else {
+      writeOut(`✅  No test-isolation anti-patterns detected.`);
+    }
     return { exitCode: 0, errorCount, warningCount, issues };
   }
   writeErr(


### PR DESCRIPTION
## Summary

- Adds `formatWarningCountHeuristic(n)` in `scripts/lint-test-isolation.ts` and wires it into both the CLI summary (when `warningCount > 0`) and the pinned-count integration test as a guarded throw before `expect(...).toBe(20)`. Bun's failure surface now prints the actionable heuristic ("wrap with `withSyntheticHarness(beforeEach, afterEach)` OR bump the pin") ahead of the numeric matcher diff.
- Mirrors the same idiom on the sibling lint-contracts pin via `formatContractsHeuristic(n)`, with distinct wording (no `withSyntheticHarness` mention; AC4 invariant).
- Captures two filter-rejected doctrine items (named-lint enumeration; optional pre-commit hook) as `docs/swe-textbook.md` entries per Capture Idempotency.
- Zero-warning CLI summary preserved byte-identical to today (AC2 negative invariant).

Closes #497.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 2245 pass / 0 fail (was 2243 at baseline; +2 from AC2 positive/negative tests)
- [x] `bun run lint:test-isolation` summary on live tree:
  `✅  No test-isolation anti-patterns detected (20 warnings — to silence a new test: wrap with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts (preferred — actually isolates the harness env), OR bump the pinned count in scripts/lint-test-isolation.test.ts (only for pure-unit tests with no harness needs).`
- [x] `bun run lint:contracts` summary unchanged byte-for-byte
- [x] `bun run lint` clean
- [x] AC1 verifier: `git grep -F "wrap with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts"` finds the literal in exactly one production source (`scripts/lint-test-isolation.ts` formatter body) plus one test-side `toContain` literal, no copy-paste in the integration-throw site
- [x] AC4 verifier: `git grep -F "withSyntheticHarness" -- scripts/lint-contracts.ts scripts/lint-contracts.test.ts` returns zero hits
- [x] AC5 verifier: both new headlines (`### Cherry-picking one named lint…` and `### "Optional pre-commit hook"…`) present in `docs/swe-textbook.md` with required `Description: / Precipitating retro: / Filter decision:` fields
- [x] AC7/AC8/AC9/AC10 invariants: branch diff covers exactly five files (`scripts/lint-{test-isolation,contracts}{,.test}.ts` + `docs/swe-textbook.md`); no edits under `src/coder/**`, `src/reviewer/**`, `src/orchestration/**`, agent-loaded skills, `.husky/**`, or `package.json`'s husky/lint-staged keys

## Post-merge

Per AC6, comment on issue #497 with the merged-PR link plus the two `docs/swe-textbook.md` anchor IDs (verify literal slugger output via `gh api -H "Accept: application/vnd.github.html" repos/lukstafi/ludics/contents/docs/swe-textbook.md?ref=<merge-sha>` before pinning slugs), then close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)