### PR TITLE
feat(lint): add lint:no-nul-bytes guard for tracked text files (gh-ludics-503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint — no mock.module() in tests
         run: bun run lint:no-mock-module
 
+      - name: Lint — no NUL bytes in tracked text files
+        run: bun run lint:no-nul-bytes
+
       - name: Lint worker/orchestrator contracts
         run: bun run lint:contracts
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:vendor-sync": "bun run scripts/lint-vendor-sync.ts",
     "lint:state-migration": "bun run scripts/lint-state-migration.ts",
     "lint:no-mock-module": "bun run scripts/lint-no-mock-module.ts",
+    "lint:no-nul-bytes": "bun run scripts/lint-no-nul-bytes.ts",
     "lint:no-shadow-util": "bun run scripts/lint-no-shadow-util.ts",
     "smoke": "bun run scripts/smoke.ts"
   },

--- a/scripts/lint-no-nul-bytes.test.ts
+++ b/scripts/lint-no-nul-bytes.test.ts
@@ -1,0 +1,270 @@
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "bun";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runLint } from "./lint-no-nul-bytes.ts";
+
+function makeFixture(files: Record<string, string | Buffer>): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(join(tmpdir(), "lint-no-nul-bytes-"));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+// NUL bytes are constructed via Buffer.from([0]) rather than appearing as a
+// literal in this source — both because the lint we ship would flag this
+// file otherwise (AC #2 final bullet) and because keeping the test source
+// itself clean is exactly the post-fix invariant the lint pins.
+const NUL = Buffer.from([0]);
+
+describe("runLint", () => {
+  test("exitCode 0 with empty offenders on a clean ASCII fixture", () => {
+    const { root, cleanup } = makeFixture({
+      "src/foo.ts": "export const x = 1;\n",
+      "docs/notes.md": "# Notes\n\nPlain ASCII content.\n",
+      "config.json": '{"name":"x"}\n',
+      "ci.yaml": "name: ci\n",
+      "ci.yml": "name: ci\n",
+      "ui/page.tsx": "export default function P() { return null; }\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(0);
+      expect(result.offenders).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("exitCode 1 with offender paths when a .ts file contains a NUL byte", () => {
+    const dirty = Buffer.concat([
+      Buffer.from("export const NEVER = /^"),
+      NUL,
+      Buffer.from("NEVER_MATCH/;\n"),
+    ]);
+    const { root, cleanup } = makeFixture({
+      "src/dirty.ts": dirty,
+      "src/clean.ts": "export const ok = 1;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(1);
+      expect(result.offenders).toEqual(["src/dirty.ts"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-ASCII UTF-8 (em-dash, accents) is clean — invariant is NUL-only, not ASCII-only", () => {
+    // AC #2 explicit case: an over-eager rewrite toward an ASCII-only check
+    // would flag valid multibyte UTF-8. Em-dash `—` is 0xE2 0x80 0x94 in
+    // UTF-8; accented `é` is 0xC3 0xA9. Neither byte is 0x00, so both must
+    // pass.
+    const { root, cleanup } = makeFixture({
+      "docs/non-ascii.md": "# Title — subtitle\n\nCafé, naïve, façade — résumé.\n",
+      "src/non-ascii.ts": "// éàü — ASCII-printable replacement is /^__NEVER__$/\nexport const s = 'café';\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(0);
+      expect(result.offenders).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("scans every advertised text extension (.ts, .tsx, .md, .json, .yaml, .yml)", () => {
+    // Each extension gets its own NUL-bearing fixture so a missing entry in
+    // TEXT_EXTENSIONS would surface as a missing offender.
+    const dirty = Buffer.concat([Buffer.from("prefix"), NUL, Buffer.from("suffix\n")]);
+    const { root, cleanup } = makeFixture({
+      "a.ts": dirty,
+      "b.tsx": dirty,
+      "c.md": dirty,
+      "d.json": dirty,
+      "e.yaml": dirty,
+      "f.yml": dirty,
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(1);
+      expect(result.offenders).toEqual([
+        "a.ts",
+        "b.tsx",
+        "c.md",
+        "d.json",
+        "e.yaml",
+        "f.yml",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("ignores NUL bytes in non-listed extensions (e.g. .png)", () => {
+    // Extension policy is the boundary between "tracked text" and "anything
+    // else" — a binary fixture under a non-listed extension must not be
+    // flagged.
+    const dirty = Buffer.concat([Buffer.from("PNG"), NUL, NUL, Buffer.from("data")]);
+    const { root, cleanup } = makeFixture({
+      "assets/icon.png": dirty,
+      "src/clean.ts": "export const ok = 1;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(0);
+      expect(result.offenders).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("scans dot-directories (matches GNU grep -r semantics; codex P2 on PR #468)", () => {
+    const dirty = Buffer.concat([Buffer.from("hidden"), NUL, Buffer.from("\n")]);
+    const { root, cleanup } = makeFixture({
+      "src/.hidden/dirty.ts": dirty,
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(1);
+      expect(result.offenders).toEqual(["src/.hidden/dirty.ts"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips node_modules/, bin/, dist/, .git/", () => {
+    const dirty = Buffer.concat([Buffer.from("vendored"), NUL, Buffer.from("\n")]);
+    const { root, cleanup } = makeFixture({
+      "node_modules/pkg/index.ts": dirty,
+      "bin/build.ts": dirty,
+      "dist/out.js.ts": dirty,
+      ".git/HEAD.md": dirty,
+      "src/clean.ts": "export const ok = 1;\n",
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(0);
+      expect(result.offenders).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("aggregates multiple offenders and sorts paths", () => {
+    const dirty = Buffer.concat([Buffer.from("x"), NUL, Buffer.from("\n")]);
+    const { root, cleanup } = makeFixture({
+      "src/zeta.ts": dirty,
+      "src/alpha.md": dirty,
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(1);
+      expect(result.offenders).toEqual(["src/alpha.md", "src/zeta.ts"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns exit 0 against an empty fixture", () => {
+    const { root, cleanup } = makeFixture({});
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(0);
+      expect(result.offenders).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("catches a NUL byte past the leading 8KB (whole-file scan, not git's heuristic window)", () => {
+    // git's text/binary detection only inspects the first ~8KB of a blob, so
+    // a NUL byte deeper in a long file may render textually in some tools
+    // but still trip `git diff --numstat`. The lint scans the whole file.
+    const padding = Buffer.alloc(16384, 0x41); // 16KB of 'A'
+    const dirty = Buffer.concat([padding, NUL, Buffer.from("trailing\n")]);
+    const { root, cleanup } = makeFixture({
+      "src/long.ts": dirty,
+    });
+    try {
+      const result = runLint(root);
+      expect(result.exitCode).toBe(1);
+      expect(result.offenders).toEqual(["src/long.ts"]);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI integration — drive the real script against tmp-fixture roots so the
+// `import.meta.main` exit-code branches are observable.
+// ---------------------------------------------------------------------------
+
+describe("CLI integration", () => {
+  test("exits 0 against a tmp fixture with no offenders (drives import.meta.main)", () => {
+    const { root, cleanup } = makeFixture({
+      "src/clean.ts": "export const x = 1;\n",
+    });
+    try {
+      const result = spawnSync({
+        cmd: ["bun", "run", join(import.meta.dir, "lint-no-nul-bytes.ts"), root],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (result.exitCode !== 0) {
+        console.error(result.stderr.toString());
+        console.error(result.stdout.toString());
+      }
+      expect(result.exitCode).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("exits non-zero against a tmp fixture with an offender", () => {
+    const dirty = Buffer.concat([Buffer.from("/^"), NUL, Buffer.from("NEVER/\n")]);
+    const { root, cleanup } = makeFixture({
+      "src/dirty.ts": dirty,
+    });
+    try {
+      const result = spawnSync({
+        cmd: ["bun", "run", join(import.meta.dir, "lint-no-nul-bytes.ts"), root],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(result.exitCode).not.toBe(0);
+      // stderr should name the offending repo-relative path so reviewers can
+      // act on it without re-running the lint locally.
+      expect(result.stderr.toString()).toContain("src/dirty.ts");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("exits 0 against the real repo (no current offenders, including docs/swe-textbook.shape.test.ts)", () => {
+    // AC #5: real-repo passes. The historical offender
+    // docs/swe-textbook.shape.test.ts (15767 bytes, 0 NUL bytes today) is
+    // part of the scanned set; if it ever regresses, this assertion fails.
+    const result = spawnSync({
+      cmd: ["bun", "run", join(import.meta.dir, "lint-no-nul-bytes.ts")],
+      cwd: join(import.meta.dir, ".."),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (result.exitCode !== 0) {
+      console.error(result.stderr.toString());
+      console.error(result.stdout.toString());
+    }
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/scripts/lint-no-nul-bytes.ts
+++ b/scripts/lint-no-nul-bytes.ts
@@ -1,0 +1,129 @@
+#!/usr/bin/env bun
+/**
+ * lint-no-nul-bytes.ts
+ *
+ * CI lint: tracked text files (`.ts`, `.tsx`, `.md`, `.json`, `.yaml`, `.yml`)
+ * must not contain a NUL byte (`0x00`). A literal NUL inside a TypeScript
+ * source file (e.g. a `/^\0NEVER_MATCH/` regex sentinel) flips git's
+ * text/binary detection — `git diff --numstat` reports `- -` and the file
+ * becomes opaque in PR review. The historical offender was
+ * `docs/swe-textbook.shape.test.ts`; commit `9f911db` replaced the
+ * NUL-bearing closer with a `sliceToEnd(body, opener)` helper. This lint
+ * pins the post-fix invariant so it cannot regress silently.
+ *
+ * Update the `TEXT_EXTENSIONS` set when introducing a new tracked text
+ * extension (e.g. `.toml`, `.html`). The check is whole-file, so a NUL byte
+ * past the first ~8KB is also caught (git's heuristic only inspects the
+ * leading bytes).
+ *
+ * Exit code:
+ *   0 — every scanned file is NUL-free
+ *   1 — one or more offending files found (paths printed to stderr)
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from "fs";
+import { join, relative, sep } from "path";
+
+const TEXT_EXTENSIONS = new Set([".ts", ".tsx", ".md", ".json", ".yaml", ".yml"]);
+
+// Build-output and vendored trees that aren't part of the repo's source. We
+// don't skip dot-directories in general — that matches the GNU-grep
+// semantics documented in `lint-no-mock-module.ts` (codex P2 on PR #468) so
+// an offending file under e.g. `src/.something/` cannot hide. `.git/` is
+// listed explicitly because git's object store contains pack files that
+// happen to have no scanned extension today, and we'd rather be defensive
+// than rely on the extension filter.
+const SKIP_DIR_NAMES = new Set(["node_modules", "bin", "dist", ".git"]);
+
+function hasTextExtension(name: string): boolean {
+  for (const ext of TEXT_EXTENSIONS) {
+    if (name.endsWith(ext)) return true;
+  }
+  return false;
+}
+
+/** Recursively walk `dir` and return every text-extension file (absolute paths). */
+export function listTextFiles(dir: string): string[] {
+  const out: string[] = [];
+  if (!existsSync(dir)) return out;
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(cur);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (SKIP_DIR_NAMES.has(entry)) continue;
+      const full = join(cur, entry);
+      let st;
+      try {
+        st = statSync(full);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(full);
+      else if (st.isFile() && hasTextExtension(entry)) out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+export interface RunLintResult {
+  exitCode: number;
+  /** Repo-relative paths (forward slashes) of files containing a NUL byte. */
+  offenders: string[];
+}
+
+/**
+ * Scan every text-extension file under `root` for a NUL byte. Returns the
+ * offending repo-relative paths and an exitCode of 1 if any are found.
+ */
+export function runLint(root: string): RunLintResult {
+  const offenders: string[] = [];
+  for (const abs of listTextFiles(root)) {
+    let bytes: Buffer;
+    try {
+      bytes = readFileSync(abs);
+    } catch {
+      continue;
+    }
+    if (bytes.includes(0)) {
+      offenders.push(relative(root, abs).split(sep).join("/"));
+    }
+  }
+  offenders.sort();
+  return { exitCode: offenders.length > 0 ? 1 : 0, offenders };
+}
+
+if (import.meta.main) {
+  // Optional first positional arg overrides the root directory, which lets
+  // tests exercise the real CLI exit-code paths against a tmp fixture.
+  const argRoot = process.argv[2];
+  const root = argRoot ? argRoot : join(import.meta.dir, "..");
+  const { exitCode, offenders } = runLint(root);
+
+  if (exitCode === 0) {
+    console.log("✅  No NUL bytes in tracked text files.");
+    process.exit(0);
+  }
+
+  console.error(
+    `\n❌  ${offenders.length} text file${offenders.length === 1 ? "" : "s"} contain${offenders.length === 1 ? "s" : ""} a NUL byte:`,
+  );
+  for (const f of offenders) {
+    console.error(`     - ${f}`);
+  }
+  console.error(
+    "\n     A NUL byte flips git's text/binary detection (`git diff --numstat` reports `- -`).",
+  );
+  console.error(
+    "     If a regex sentinel needs to 'never match,' use an ASCII-printable token like",
+  );
+  console.error(
+    "     /^__NEVER_MATCH_SENTINEL__$/ or refactor to a `sliceToEnd(body, opener)` helper.\n",
+  );
+  process.exit(1);
+}

--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -12,7 +12,7 @@ Reviewer guidance from prior round:
 
 Commit in small batches (4-6 files), and include a regression test alongside each behavior change in the same batch — deferring the test to a follow-up round tends to drift into abandonment. Build, lint, and run targeted tests before signaling done.
 
-Before modifying any symbol, re-run a project-wide grep for it — the plan's occurrence list may have missed an inline reimplementation (regex pattern, copy-pasted logic, string literal) that the same change needs to reach. Handle new hits in this round rather than deferring. See [exhaustive occurrence search](../../docs/orchestration-patterns.md#exhaustive-occurrence-search) for the variants to look for.
+Before modifying any symbol, re-run a project-wide grep for it — the plan's occurrence list may have missed an inline reimplementation (regex pattern, copy-pasted logic, string literal) that the same change needs to reach. Handle new hits in this round rather than deferring. See [exhaustive occurrence search](../../docs/orchestration-patterns.md#exhaustive-occurrence-search) for the variants to look for. Avoid embedded control bytes in regex sentinels; if a closer's job is "match nothing," refactor to a `sliceToEnd`-style helper instead of a NUL-bearing literal (the `lint:no-nul-bytes` CI step pins this invariant).
 
 Documented interfaces drift when the code behind them changes — config schemas drift from their reference doc, CLI USAGE strings drift from the README. When you touch one side, update the other in the same round so CI can confirm the pair; see [CI drift files](../../docs/orchestration-patterns.md#ci-drift-files) for the known pairs and their lint scripts.
 


### PR DESCRIPTION
## Summary

Closes #503. Adds `lint:no-nul-bytes`, a regression guard against the bug
that flipped `docs/swe-textbook.shape.test.ts` to binary (a `/^\0NEVER_MATCH/`
regex sentinel embedded a NUL byte). The bug was already fixed on `main`
in 9f911db via a `sliceToEnd(body, opener)` helper; this PR pins the
post-fix invariant — *no NUL bytes in tracked text files* — so it cannot
regress silently.

- `scripts/lint-no-nul-bytes.ts` — walks `.ts`/`.tsx`/`.md`/`.json`/`.yaml`/`.yml`
  from the repo root (skipping `node_modules/`, `bin/`, `dist/`, `.git/`;
  scanning dot-dirs to match GNU `grep -r` semantics, per the existing
  `lint-no-mock-module.ts` codex-P2 comment), exports `runLint(root)`,
  exits 1 with stderr-listed paths on offenders.
- `scripts/lint-no-nul-bytes.test.ts` — 13 tests covering the test triple
  (positive offender / clean baseline / non-ASCII UTF-8 clean),
  per-extension coverage, dot-dir + skip-dir behaviour, a `>8KB`-deep NUL
  catch past git's heuristic window, and CLI integration via `bun run`
  with a real-repo exit-0 check. NUL bytes are written via
  `Buffer.from([0])`, never as a literal in source.
- `package.json` + `.github/workflows/ci.yml` — register and wire the
  step alongside the other `lint:*` entries.
- `skills/orchestration/pair-coder-work.md` — one-line note referencing
  the new lint, near the existing regex-reimplementation paragraph.

## AC walkthrough

1. **Lint script** — `scripts/lint-no-nul-bytes.ts` matches every required
   property (recursive walk with overridable root, advertised extension
   set, skip list, stderr offender output, exit 0/1, exported
   `runLint(root)`).
2. **Test triple** — `runLint` block has the three required cases plus
   per-extension coverage, dot-dir, skip-dir, sort/aggregation, and
   `>8KB` whole-file scan; `CLI integration` block spawns the script via
   `bun run` and checks the real-repo exit-0 path.
3. **package.json** — `lint:no-nul-bytes` slotted alphabetically between
   `lint:no-mock-module` and `lint:no-shadow-util`.
4. **CI wiring** — `Lint — no NUL bytes in tracked text files` step
   added between `lint:no-mock-module` and `lint:contracts`.
5. **Real-repo passes** — `bun run lint:no-nul-bytes` exits 0 today; the
   real-repo CLI integration test pins this and includes the historical
   offender `docs/swe-textbook.shape.test.ts` (15767 bytes, 0 NUL bytes)
   in the scanned set.
6. **Coder-prompt note** — added to `pair-coder-work.md` at the
   regex-reimplementation paragraph (line 15), terse one-liner per the
   "review scaffolding is sufficient" memory.

## Test plan

- [x] `bun run lint:no-nul-bytes` exits 0 against `main`
- [x] `bun test scripts/lint-no-nul-bytes.test.ts` — 13/13 pass
- [x] `bun run typecheck`
- [x] Sibling drift lints (`lint:cli-readme`, `lint:contracts`,
      `lint:skill-cli-refs`) still pass after the skill markdown edit
- [ ] CI green on the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)