### PR TITLE
AC self-check imperative reads the proposal, not the task-file bullets (gh-ludics-505)

### DIFF
--- a/skills/orchestration/pair-coder-work.md
+++ b/skills/orchestration/pair-coder-work.md
@@ -40,13 +40,18 @@ Cross-cutting cleanups in unrelated files (whole-file reformatting, dead-code sw
 **Acceptance Criteria self-check.** Before writing the done status, verify every acceptance criterion is satisfied. Produce a visible checklist — don't just think it through. AC drift is the long-tail failure mode of this workflow.
 
 {{#IF PROPOSAL_PATH}}
-1. Re-read `{{PROPOSAL_PATH}}` in the project repo for the authoritative acceptance criteria.
+1. Re-read `{{PROPOSAL_PATH}}` in the project repo — its `## Acceptance Criteria` section is the authoritative AC list. Count the bullets there; that count is the length of the `## AC Verification` checklist you must produce, and walk every one of them. Do not substitute the task-file summary below — when the proposal expands the task-file's N bullets into M > N ACs, the proposal prevails and you walk all M.
 {{/IF}}
 {{#UNLESS PROPOSAL_PATH}}
 1. Re-read the task spec above (from context) for the acceptance criteria — no proposal file exists for this task.
 {{/UNLESS}}
 {{#IF TASK_AC}}
+{{#IF PROPOSAL_PATH}}
+Task-file ACs (non-authoritative coarsened reference — for context only; the proposal's `## Acceptance Criteria` is the checklist):
+{{/IF}}
+{{#UNLESS PROPOSAL_PATH}}
 Task acceptance criteria from the task file:
+{{/UNLESS}}
 
 {{TASK_AC}}
 {{/IF}}


### PR DESCRIPTION
## Summary

- Restructures the `**Acceptance Criteria self-check.**` block in `skills/orchestration/pair-coder-work.md` so the proposal is the authoritative imperative (count its bullets, walk all of them) rather than a path to re-read alongside the inlined task-file checklist.
- Reframes the inlined `{{TASK_AC}}` block, when a proposal exists, as a "non-authoritative coarsened reference — for context only; the proposal's `## Acceptance Criteria` is the checklist."
- Leaves the no-proposal branch (`{{#UNLESS PROPOSAL_PATH}}`) functionally unchanged.

Closes #505. Tracks `docs/proposals/ac-self-check-proposal-authoritative.md`.

## AC Verification

- **AC1** (proposal as single imperative when `PROPOSAL_PATH` set): the `{{#IF PROPOSAL_PATH}}` step now reads "Re-read `{{PROPOSAL_PATH}}` … its `## Acceptance Criteria` section is the authoritative AC list. Count the bullets there; that count is the length of the `## AC Verification` checklist you must produce, and walk every one of them." Invariant: rendered output names the proposal as authoritative and instructs counting + walking — not a re-read followed by walking the inlined bullets. Harness: existing test `pair-coder-work: AC self-check references PROPOSAL_PATH when set …` (`src/orchestration/skills.test.ts:1804`) instantiates `PROPOSAL_PATH: "docs/proposals/my-feature.md"` and asserts the literal substring is rendered.
- **AC2** (TASK_AC reframed as non-authoritative): nested `{{#IF PROPOSAL_PATH}}` inside `{{#IF TASK_AC}}` so when a proposal is set, the heading reads "Task-file ACs (non-authoritative coarsened reference — for context only; the proposal's `## Acceptance Criteria` is the checklist):". Invariant: surrounding prose explicitly tells the coder the bullets are not the checklist.
- **AC3** (no-proposal branch unchanged): `{{#UNLESS PROPOSAL_PATH}}` still says "Re-read the task spec above (from context) for the acceptance criteria — no proposal file exists for this task." and the TASK_AC block, when no proposal exists, still reads "Task acceptance criteria from the task file:" — semantically unchanged. Harness: `pair-coder-work: unconditional AC self-check + no-proposal fallback renders when PROPOSAL_PATH is empty` (`src/orchestration/skills.test.ts:1788`) instantiates `PROPOSAL_PATH: ""` and asserts both substrings; passes.
- **AC4** (wikilinks preserved): `[AC self-check]`, `[harness instantiation]`, `[mutation evidence]`, `[pre-assertion harness probe]` all live in the long verification paragraph, untouched by the edit (the diff replaces only the conditional steps + the TASK_AC heading).
- **AC5** (`## AC Verification` heading + `{{WORKFLOW_FEEDBACK_FILE}}` unchanged): both live in the untouched verification paragraph. Harness: `pair-coder-work: AC self-check references WORKFLOW_FEEDBACK_FILE and the visible-checklist heading` (`src/orchestration/skills.test.ts:1819`) asserts the rendered output contains `## AC Verification`, the substituted `WORKFLOW_FEEDBACK_FILE` value, and `visible checklist`; passes.
- **AC6** (no new prescriptive scaffolding): no new wikilinks, no new "before you signal done, also do X / Y / Z" subsection, no new reference doc, no inline restatement of rigor families. The edit is reordering + reframing + exactly one short stinger naming the proposal-vs-task-file delta ("when the proposal expands the task-file's N bullets into M > N ACs, the proposal prevails and you walk all M") — exactly what AC6 explicitly permits.
- **AC7** (existing render tests pass without modification): `bun test src/orchestration/skills.test.ts src/orchestration/state.harnessdir.test.ts src/orchestration/phases.test.ts scripts/lint-template-safety.test.ts` → 322 pass, 0 fail.
- **AC8** (build + tests green): `bun run typecheck`, `bun run build`, `bun run lint:skill-cli-refs`, and `bun run lint:template-safety` all pass.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test src/orchestration/skills.test.ts` (115 pass, 0 fail)
- [x] `bun test` across all skill/template-related test files (322 pass, 0 fail)
- [x] `bun run lint:skill-cli-refs`
- [x] `bun run lint:template-safety`

🤖 Generated with [Claude Code](https://claude.com/claude-code)