### PR TITLE
docs(swe-textbook): name same-retro-distinct-headline ASSUMPTION GAP (#506)

### DIFF
--- a/docs/swe-textbook.md
+++ b/docs/swe-textbook.md
@@ -69,6 +69,22 @@ fi
 echo "append"
 ```
 
+**Known soft-spot — `ASSUMPTION GAP` escalation.** The disjunctive guard
+above (`headline OR retro`) returns `skip-duplicate` whenever a new entry
+shares either key with any existing entry. The case it silently
+collapses: a new entry whose `Precipitating retro:` matches an existing
+entry's, but whose headline and `Filter decision:` describe a materially
+distinct lesson. Under the bare contract the caller would amend the
+matched entry's `Second occurrence:` line and drop the new lesson. When
+the caller runs inside an orchestrated coder/reviewer pair, the right
+move is to surface the choice in the merged plan with an
+`⚠️ ASSUMPTION GAP: …` marker (per `pair-coder-plan-merge.md`) so the
+reviewer sees and rules on the divergence at plan-merge time. When the
+caller is a one-shot Mag invocation of `/ludics-feedback-digest` (no
+merged plan), the equivalent discipline is to surface the choice in the
+digest's result JSON and commit message rather than silently routing
+through `skip-duplicate`.
+
 ---
 
 ### "Issue is updated" means an actual GH-side comment, not a one-way docs cite


### PR DESCRIPTION
## Summary

- Adds one ASSUMPTION GAP paragraph to `docs/swe-textbook.md`'s `## Capture Idempotency` section, between the bash snippet's closing fence and the `---` divider.
- Names the soft-spot in the disjunctive (`headline OR retro`) guard: a new entry sharing a `Precipitating retro:` with an existing-but-unrelated entry (different headline, different `Filter decision:`) is silently collapsed to `skip-duplicate` and would be dropped via `Second occurrence:` amendment.
- Points orchestrated callers to the `⚠️ ASSUMPTION GAP:` plan-merge escalation; points one-shot Mag invocations of `/ludics-feedback-digest` to the surrogate-surfacing path (result JSON / commit message).

Bash snippet is byte-identical to HEAD; no skill, reviewer prompt, or template files touched.

Closes #506.

## AC walk-through

- **AC1**: One paragraph inserted between the bash closing fence and the `---` divider; no other section modified.
- **AC2**: Paragraph contains, in order, `ASSUMPTION GAP` → `Precipitating retro:` → `Filter decision:` → `plan-merge`; no incident strings (`gh-ludics-497`, `gh-ludics-496`, `task-a670cdbf`, `Entries A/B`, `Entries C/D`).
- **AC3**: Contains both `result JSON` and `commit message` for the un-orchestrated caller path.
- **AC4**: `git diff HEAD~ -- docs/swe-textbook.md` shows additions only outside the fenced bash block — `grep -Fq "### \${ENTRY_HEADLINE}"`, `grep -Fq "\${PRECIPITATING_RETRO}"`, `echo "skip-duplicate"`, `echo "append"`, and surrounding `if`/`then`/`fi` lines unchanged.
- **AC5**: `bun test docs/swe-textbook.shape.test.ts` → 26 pass / 0 fail; no edits to the shape test.
- **AC6**: `git diff --name-only main...HEAD` lists exactly `docs/swe-textbook.md`.
- **AC7**: No skill body gained a `swe-textbook` substring (no skill files touched).

## Test plan

- [x] `bun test docs/swe-textbook.shape.test.ts` — 26/26 green
- [x] Diff inspection — additions only between bash closing fence and `---`
- [ ] Reviewer cross-check at PR HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)