### PR TITLE
fix(orchestration): runner reclaims stale sibling-PID lock (gh-ludics-509)

### DIFF
--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -111,6 +111,30 @@ This skill is invoked when:
      - Severity: warning on `agent_hung_detected`, critical on
        `agent_hung_force_settle` (escalation already happened — the
        agent was force-settled).
+   - Auto-resume cluster layer (gh-ludics-509; event-driven): scan the
+     same post-baseline tail of `journal/events.jsonl` for
+     `orchestration_auto_resume_failed` records. Sustained clusters
+     for the same slot indicate a wedged auto-resume loop where every
+     keepalive tick spawns a runner that immediately exits — the
+     symptom of a stale sibling-PID lock. The runner's self-heal
+     (gh-ludics-509) closes the original failure mode; this rule
+     surfaces *future* regressions of the same shape within minutes
+     instead of hours. Threshold: ≥3 events for the same slot within
+     the last 30 minutes.
+     ```bash
+     NOW_EPOCH=$(date +%s)
+     WINDOW_START=$((NOW_EPOCH - 1800))   # 30 minutes
+     tail -n +"$TAIL_FROM" "$EVENTS_FILE" \
+       | grep -F '"event_type":"orchestration_auto_resume_failed"' \
+       | jq -c --argjson cutoff "$WINDOW_START" \
+           'select(.epoch >= $cutoff) | {slot, ts, message}' \
+       | jq -s 'group_by(.slot) | map(select(length >= 3))' || true
+     ```
+     - For each cluster, report: slot, count of events in the window,
+       first/last timestamp, last `message`.
+     - Build stable issue key: `auto-resume-stuck:<slot>`
+     - Severity: warning (the runner self-heals; the cluster signals
+       a pattern worth investigating, not an immediate emergency).
 
 <!-- section:check-queue -->
 3. **Check queue health**:

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -1347,8 +1347,9 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
   test("exits early when tmux sibling state has a mismatched PID", async () => {
     const state = makeState({ slot: 4, backend: "tmux", phase: "work" }, peerSyncDir);
     const wrongPid = process.pid + 1;
+    const tmuxSlotPath = join(harness, "orchestration", "tmux-slot-4.json");
     writeFileSync(
-      join(harness, "orchestration", "tmux-slot-4.json"),
+      tmuxSlotPath,
       JSON.stringify({
         orchestration: { pid: wrongPid, stateFile: "x", mode: "pair" },
         sessionNames: { coder: "s", reviewer: "r" },
@@ -1368,6 +1369,11 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       errSpy.mockRestore();
       aliveSpy.mockRestore();
     }
+    // AC2 invariant: a live mismatch must NOT rewrite the sibling state.
+    // (A mutation that wrote `process.pid` and then logged/returned would
+    // still fire the "PID mismatch" log above; this assertion catches it.)
+    const persisted = JSON.parse(readFileSync(tmuxSlotPath, "utf-8"));
+    expect(persisted.orchestration.pid).toBe(wrongPid);
   });
 
   test("PID mismatch exits immediately even during the startup grace window", async () => {
@@ -1375,10 +1381,12 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
     // conflict (parent always writes our own pid) and must exit without waiting.
     process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "60000";
     const state = makeState({ slot: 8, backend: "tmux", phase: "work" }, peerSyncDir);
+    const wrongPid = process.pid + 1;
+    const tmuxSlotPath = join(harness, "orchestration", "tmux-slot-8.json");
     writeFileSync(
-      join(harness, "orchestration", "tmux-slot-8.json"),
+      tmuxSlotPath,
       JSON.stringify({
-        orchestration: { pid: process.pid + 1, stateFile: "x", mode: "pair" },
+        orchestration: { pid: wrongPid, stateFile: "x", mode: "pair" },
         sessionNames: { coder: "s", reviewer: "r" },
         ttydPids: {},
       }),
@@ -1396,13 +1404,17 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       errSpy.mockRestore();
       aliveSpy.mockRestore();
     }
+    // AC2 invariant: live mismatch must NOT rewrite the sibling state.
+    const persisted = JSON.parse(readFileSync(tmuxSlotPath, "utf-8"));
+    expect(persisted.orchestration.pid).toBe(wrongPid);
   });
 
   test("exits early when t3code sibling state has a mismatched PID", async () => {
     const state = makeState({ slot: 5, backend: "t3code", phase: "work" }, peerSyncDir);
     const wrongPid = process.pid + 1;
+    const t3codeSlotPath = join(harness, "t3code", "slot-5.json");
     writeFileSync(
-      join(harness, "t3code", "slot-5.json"),
+      t3codeSlotPath,
       JSON.stringify({
         orchestration: { pid: wrongPid, stateFile: "x", mode: "pair" },
         threads: [],
@@ -1418,6 +1430,9 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       errSpy.mockRestore();
       aliveSpy.mockRestore();
     }
+    // AC2 invariant: live mismatch must NOT rewrite the sibling state.
+    const persisted = JSON.parse(readFileSync(t3codeSlotPath, "utf-8"));
+    expect(persisted.orchestration.pid).toBe(wrongPid);
   });
 
   // ------------------------------------------------------------------------
@@ -1459,15 +1474,25 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
     };
 
     let errMessages: string[] = [];
+    let transitionCalls = 0;
     try {
       await runOrchestration(state, transport);
       // Capture spy state BEFORE mockRestore (bun:test wipes call history).
       errMessages = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      transitionCalls = transitionSpy.mock.calls.length;
     } finally {
       aliveSpy.mockRestore();
       transitionSpy.mockRestore();
       errSpy.mockRestore();
     }
+
+    // AC1 phase-completion invariant: the runner falls through into
+    // enterPhase / pollUntilDone / evaluateTransition (NOT just return after
+    // emitEvent). If a hypothetical mutation added `return;` after the
+    // reclaim emitEvent, evaluateTransition would never be called and
+    // state.phase would remain "setup".
+    expect(transitionCalls).toBeGreaterThan(0);
+    expect(state.phase).toBe("done");
 
     // AC1: sibling state file rewritten with our pid.
     const persisted = JSON.parse(
@@ -1531,14 +1556,21 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
     };
 
     let errMessages: string[] = [];
+    let transitionCalls = 0;
     try {
       await runOrchestration(state, transport);
       errMessages = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+      transitionCalls = transitionSpy.mock.calls.length;
     } finally {
       aliveSpy.mockRestore();
       transitionSpy.mockRestore();
       errSpy.mockRestore();
     }
+
+    // AC3 phase-completion invariant (parallel to AC1): the runner falls
+    // through into evaluateTransition rather than returning after emitEvent.
+    expect(transitionCalls).toBeGreaterThan(0);
+    expect(state.phase).toBe("done");
 
     // AC3: read back via readSlotState (round-trip through the t3code reader).
     const persisted = t3codeServer.readSlotState(SLOT, harness);

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach, spyOn, setDefaultTimeout
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { isAgentDone } from "./phases.ts";
+import * as phases from "./phases.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
 import { ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests } from "./runner.ts";
 import * as tmuxAdapter from "../adapters/tmux-adapter.ts";
@@ -1354,6 +1355,9 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
         ttydPids: {},
       }),
     );
+    // gh-ludics-509: ensure the seeded wrong PID is treated as live so the
+    // reclaim path doesn't fire (defends against host PID-recycling flakes).
+    const aliveSpy = spyOn(t3codeServer, "processAlive").mockImplementation(() => true);
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
     try {
       await runOrchestration(state, stubTransport());
@@ -1362,12 +1366,13 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       expect(msgs.some((m: string) => m.includes(String(process.pid)))).toBe(true);
     } finally {
       errSpy.mockRestore();
+      aliveSpy.mockRestore();
     }
   });
 
   test("PID mismatch exits immediately even during the startup grace window", async () => {
-    // Grace only covers missing-file races; a PID mismatch is a real conflict
-    // (parent always writes our own pid) and must exit without waiting.
+    // Grace only covers missing-file races; a live PID mismatch is a real
+    // conflict (parent always writes our own pid) and must exit without waiting.
     process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "60000";
     const state = makeState({ slot: 8, backend: "tmux", phase: "work" }, peerSyncDir);
     writeFileSync(
@@ -1378,6 +1383,7 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
         ttydPids: {},
       }),
     );
+    const aliveSpy = spyOn(t3codeServer, "processAlive").mockImplementation(() => true);
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
     const before = Date.now();
     try {
@@ -1388,6 +1394,7 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       expect(msgs.some((m: string) => m.includes("PID mismatch"))).toBe(true);
     } finally {
       errSpy.mockRestore();
+      aliveSpy.mockRestore();
     }
   });
 
@@ -1401,6 +1408,7 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
         threads: [],
       }),
     );
+    const aliveSpy = spyOn(t3codeServer, "processAlive").mockImplementation(() => true);
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
     try {
       await runOrchestration(state, stubTransport());
@@ -1408,7 +1416,152 @@ describe("runOrchestration self-guard (task-72a318c3)", () => {
       expect(msgs.some((m: string) => m.includes("PID mismatch"))).toBe(true);
     } finally {
       errSpy.mockRestore();
+      aliveSpy.mockRestore();
     }
+  });
+
+  // ------------------------------------------------------------------------
+  // gh-ludics-509: stale sibling-PID lock reclaim — runner self-heals when
+  // the recorded sibling pid is dead (the bug that wedged slot 1 in setup).
+  // ------------------------------------------------------------------------
+
+  test("reclaims stale tmux sibling lock when recorded PID is dead", async () => {
+    const DEAD_PID = 2147483647; // sentinel; AC1 falsifier seed.
+    const SLOT = 11;
+    writeFileSync(
+      join(harness, "orchestration", `tmux-slot-${SLOT}.json`),
+      JSON.stringify({
+        slot: SLOT,
+        orchestration: { pid: DEAD_PID, stateFile: "x", mode: "pair" },
+        sessionNames: { coder: "s" },
+        ttydPids: {},
+      }),
+    );
+    // Empty-agents `setup` phase — completes one phase deterministically:
+    // enterPhase returns at the setup early-return; allAgentsDone is true on
+    // empty participants; evaluateTransition is mocked to "done" so the
+    // while-loop exits cleanly. No `.catch(() => {})`. No timeout race.
+    const state = makeState(
+      { slot: SLOT, backend: "tmux", phase: "setup", agents: [] },
+      peerSyncDir,
+    );
+
+    const aliveSpy = spyOn(t3codeServer, "processAlive")
+      .mockImplementation((p: number) => p !== DEAD_PID);
+    const transitionSpy = spyOn(phases, "evaluateTransition").mockReturnValue("done");
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const transport: OrchestrationTransport = {
+      async sendTurn() { return "cmd-stub"; },
+      async refreshAgentTransportState() { /* no-op */ },
+      async sendEnter() { /* no-op */ },
+      async interruptAgent() { /* no-op */ },
+    };
+
+    let errMessages: string[] = [];
+    try {
+      await runOrchestration(state, transport);
+      // Capture spy state BEFORE mockRestore (bun:test wipes call history).
+      errMessages = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    } finally {
+      aliveSpy.mockRestore();
+      transitionSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+
+    // AC1: sibling state file rewritten with our pid.
+    const persisted = JSON.parse(
+      readFileSync(join(harness, "orchestration", `tmux-slot-${SLOT}.json`), "utf-8"),
+    );
+    expect(persisted.orchestration.pid).toBe(process.pid);
+    // Negative control on the spread: untouched fields survive.
+    expect(persisted.sessionNames.coder).toBe("s");
+    expect(persisted.orchestration.mode).toBe("pair");
+
+    // AC4: journal event emitted with the expected fields.
+    const eventsPath = join(harness, "journal", "events.jsonl");
+    expect(existsSync(eventsPath)).toBe(true);
+    const journal = readFileSync(eventsPath, "utf-8")
+      .trim().split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const reclaim = journal.find((e) => e.event_type === "orchestration_lock_reclaimed");
+    expect(reclaim).toBeDefined();
+    expect(reclaim!.slot).toBe(SLOT);
+    expect(reclaim!.deadPid).toBe(DEAD_PID);
+    expect(reclaim!.newPid).toBe(process.pid);
+    expect(reclaim!.backend).toBe("tmux");
+
+    // The reclaim console log fired; the live-mismatch exit log did NOT.
+    expect(errMessages.some((m) =>
+      m.includes("reclaiming stale lock")
+      && m.includes(String(DEAD_PID))
+      && m.includes(String(process.pid))
+    )).toBe(true);
+    expect(errMessages.some((m) =>
+      m.includes("PID mismatch") && m.includes("exiting")
+    )).toBe(false);
+  });
+
+  test("reclaims stale t3code sibling lock when recorded PID is dead", async () => {
+    const DEAD_PID = 2147483647;
+    const SLOT = 12;
+    writeFileSync(
+      join(harness, "t3code", `slot-${SLOT}.json`),
+      JSON.stringify({
+        slot: SLOT,
+        threads: [],
+        orchestration: { pid: DEAD_PID, stateFile: "x", mode: "pair" },
+      }),
+    );
+    const state = makeState(
+      { slot: SLOT, backend: "t3code", phase: "setup", agents: [] },
+      peerSyncDir,
+    );
+
+    const aliveSpy = spyOn(t3codeServer, "processAlive")
+      .mockImplementation((p: number) => p !== DEAD_PID);
+    const transitionSpy = spyOn(phases, "evaluateTransition").mockReturnValue("done");
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    const transport: OrchestrationTransport = {
+      async sendTurn() { return "cmd-stub"; },
+      async refreshAgentTransportState() { /* no-op */ },
+      async sendEnter() { /* no-op */ },
+      async interruptAgent() { /* no-op */ },
+    };
+
+    let errMessages: string[] = [];
+    try {
+      await runOrchestration(state, transport);
+      errMessages = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    } finally {
+      aliveSpy.mockRestore();
+      transitionSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+
+    // AC3: read back via readSlotState (round-trip through the t3code reader).
+    const persisted = t3codeServer.readSlotState(SLOT, harness);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.orchestration?.pid).toBe(process.pid);
+    expect(persisted!.threads).toEqual([]);
+
+    // AC4: journal event with backend === "t3code".
+    const eventsPath = join(harness, "journal", "events.jsonl");
+    const journal = readFileSync(eventsPath, "utf-8")
+      .trim().split("\n")
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+    const reclaim = journal.find((e) => e.event_type === "orchestration_lock_reclaimed");
+    expect(reclaim).toBeDefined();
+    expect(reclaim!.slot).toBe(SLOT);
+    expect(reclaim!.deadPid).toBe(DEAD_PID);
+    expect(reclaim!.newPid).toBe(process.pid);
+    expect(reclaim!.backend).toBe("t3code");
+
+    expect(errMessages.some((m) => m.includes("reclaiming stale lock"))).toBe(true);
+    expect(errMessages.some((m) =>
+      m.includes("PID mismatch") && m.includes("exiting")
+    )).toBe(false);
   });
 });
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -30,7 +30,7 @@ import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 import { agentPortRole, readTmuxSlotState, startTtyd, ttydLogPath, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
-import { readSlotState, processAlive } from "../t3code/server.ts";
+import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts";
 import { recoverWrongFilename } from "./wrong-filename-recovery.ts";
 
 // --- Settled-no-signal detection constants ---
@@ -2395,8 +2395,13 @@ export async function runOrchestration(
   // tmux-slot-<N>.json / t3code/slot-<N>.json only AFTER
   // startOrchestrationProcess returns (~500ms wait), so the child runner can
   // reach its first guard check before the parent has finished bookkeeping.
-  // Only the "file missing" branch gets a grace; a PID mismatch is always a
-  // real conflict (the parent always writes our own pid) and exits immediately.
+  // Branch shape:
+  //   - missing file: startup grace, then exit if still missing
+  //   - live PID mismatch: real conflict, exit immediately (a live sibling owns the lock)
+  //   - dead PID mismatch (gh-ludics-509): stale lock from a prior crashed runner;
+  //     reclaim it (rewrite the field with our own pid, emit an event) and proceed
+  //   - missing/null recordedPid: malformed ownership; treat as live mismatch and exit
+  //     (no AC asks for reclaim of malformed sibling state — fail-closed is safer).
   const runnerStartMs = Date.now();
   const startupGraceMs = Number(process.env.LUDICS_RUNNER_STARTUP_GRACE_MS ?? "5000");
 
@@ -2421,11 +2426,60 @@ export async function runOrchestration(
         );
         return;
       }
-      if (sibling.orchestration?.pid !== process.pid) {
-        console.error(
-          `ludics: runner slot ${state.slot}: sibling PID mismatch (expected ${process.pid}, got ${sibling.orchestration?.pid}) — exiting`,
-        );
-        return;
+      const recordedPid = sibling.orchestration?.pid;
+      if (recordedPid !== process.pid) {
+        if (typeof recordedPid === "number" && !processAlive(recordedPid)) {
+          // Stale sibling-PID lock (gh-ludics-509): the recorded pid is dead,
+          // so the previous runner crashed without clearing the lock. Reclaim
+          // it by rewriting the sibling state with our own pid, then fall
+          // through to enterPhase. Atomic-rename writes mean concurrent
+          // reclaimers self-heal — the loser sees a live mismatch on its
+          // next iteration and exits cleanly.
+          console.error(
+            `ludics: runner slot ${state.slot}: reclaiming stale lock from dead pid ${recordedPid} (now ${process.pid})`,
+          );
+          if (state.backend === "tmux") {
+            // Cast OK: state.backend === "tmux" was used to read this very file.
+            const tmuxSibling = sibling as NonNullable<ReturnType<typeof readTmuxSlotState>>;
+            writeTmuxSlotState(
+              {
+                ...tmuxSibling,
+                slot: state.slot,
+                ttydPids: tmuxSibling.ttydPids ?? {},
+                orchestration: { ...tmuxSibling.orchestration!, pid: process.pid },
+              },
+              dir,
+            );
+          } else {
+            const t3Sibling = sibling as NonNullable<ReturnType<typeof readSlotState>>;
+            writeSlotState(
+              {
+                ...t3Sibling,
+                slot: state.slot,
+                threads: t3Sibling.threads ?? [],
+                orchestration: { ...t3Sibling.orchestration!, pid: process.pid },
+              },
+              dir,
+            );
+          }
+          emitEvent({
+            event_type: "orchestration_lock_reclaimed",
+            source: "orchestration",
+            scope: "slot",
+            slot: state.slot,
+            task: state.taskId,
+            deadPid: recordedPid,
+            newPid: process.pid,
+            backend: state.backend,
+            message: `reclaimed stale sibling lock from dead pid ${recordedPid}`,
+          });
+        } else {
+          // Live sibling owns the lock (or recordedPid is malformed/missing) — exit.
+          console.error(
+            `ludics: runner slot ${state.slot}: sibling PID mismatch (expected ${process.pid}, got ${recordedPid}) — exiting`,
+          );
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- The orchestration runner's startup self-guard now reclaims a stale sibling-PID lock when the recorded pid is dead, so a single mid-setup runner crash cannot wedge a slot in an indefinite restart loop.
- New `ludics-health-check` rule flags ≥3 `orchestration_auto_resume_failed` events for the same slot within 30 minutes (stable issue key `auto-resume-stuck:<slot>`) — surfaces any future regression of the same shape within minutes.
- Closes #509.

## Implementation

- `src/orchestration/runner.ts`: guard at `runOrchestration` startup grows a `processAlive(recordedPid)` check. Dead → rewrite `orchestration.pid` via the backend-routed writer (`writeTmuxSlotState`/`writeSlotState`), emit `orchestration_lock_reclaimed`, fall through to `enterPhase`. Live (or missing/malformed) → existing exit-on-mismatch.
- `src/orchestration/runner.lifecycle.test.ts`: two new positive reclaim tests (tmux + t3code) using a real `OrchestrationTransport` impl + `phases.evaluateTransition → "done"` spy that completes one phase deterministically without `.catch(() => {})` swallowing. Existing PID-mismatch trio reinforced with a defensive `processAlive → true` spy. **Round-2 review uplift (commit 5d0642c)**: positive tests now assert `transitionCalls > 0` and `state.phase === "done"` so a hypothetical `return;` after the `emitEvent` would fail the phase-completion invariant; negative-control trio now also asserts the sibling state file's `orchestration.pid` is still the seeded `wrongPid` so a hypothetical write-then-log mutation would fail the AC2 no-rewrite invariant. Both mutations were tested locally — see commit body.
- `skills/ludics-health-check.md`: cluster-detection sub-rule under `<!-- section:check-orchestration -->`, reusing the existing `PREV_EVENTS_LINES`/`TAIL_FROM` baseline anchor.

## Test plan

- [x] `bun test` — 2260 pass / 0 fail (5488 expect() calls; +7 from this round's strengthened invariants)
- [x] `bun test src/orchestration/runner.lifecycle.test.ts` — 79 pass / 0 fail (196 expect() calls)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] AC5 falsifier probes: `grep -F '"event_type":"orchestration_auto_resume_failed"' skills/ludics-health-check.md` returns ≥1 hit; `grep -F 'auto-resume-stuck:' skills/ludics-health-check.md` returns ≥1 hit; the prose names `≥3` and `30 minutes` literally and adjacently.
- [x] Mutation evidence (round 2):
  - `return;` after `emitEvent({ event_type: "orchestration_lock_reclaimed", ... })` → both new positive tests fail on `expect(transitionCalls).toBeGreaterThan(0)` (received 0).
  - Adding `writeTmuxSlotState(...)` in the live-exit branch → both tmux negative-control tests fail on `expect(persisted.orchestration.pid).toBe(wrongPid)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)