### PR TITLE
docs(runner): document operator workaround for malformed pid lock

### DIFF
--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -2402,6 +2402,18 @@ export async function runOrchestration(
   //     reclaim it (rewrite the field with our own pid, emit an event) and proceed
   //   - missing/null recordedPid: malformed ownership; treat as live mismatch and exit
   //     (no AC asks for reclaim of malformed sibling state — fail-closed is safer).
+  //
+  // Operator workaround for a stuck slot whose pid field has been cleared
+  // (e.g. someone deleted the field thinking that "removes the lock"):
+  // restore `orchestration.pid` in tmux-slot-<N>.json / t3code/slot-<N>.json
+  // to a known-dead integer (any pid not in `ps`), then re-run
+  // `ludics slot <N> resume`. The next runner will hit the dead-pid branch
+  // above and reclaim the lock cleanly. Do NOT clear the field — the runner
+  // intentionally fails closed on undefined to avoid clobbering a sibling
+  // whose write lost a race. (Encountered 2026-05-09 while unblocking
+  // slot 1 post-merge of gh-ludics-509; if recurrence motivates
+  // auto-reclaim of the malformed-pid case, file a sibling AC and update
+  // this comment.)
   const runnerStartMs = Date.now();
   const startupGraceMs = Number(process.env.LUDICS_RUNNER_STARTUP_GRACE_MS ?? "5000");
 


### PR DESCRIPTION
## Summary

- Adds a paragraph to the branch-shape comment block in `src/orchestration/runner.ts` (right after the live/dead/malformed enumeration) describing the operator workaround for a stuck slot whose pid field has been cleared.
- Explains the gotcha: clearing the pid field thinking it "removes the lock" falls through to the live-mismatch exit branch, not the reclaim branch. Restore the field to any known-dead integer (a pid not in `ps`) instead.
- Adds a forward-pointer: if recurrence motivates auto-reclaim of the malformed-pid case, file a sibling AC and update the comment.

## Background

Encountered 2026-05-09 while unblocking slot 1 post-merge of gh-ludics-509 (PR #512). The merged fix's branch shape is:
- live PID match → continue
- recordedPid is a number AND dead → reclaim
- anything else (undefined, null, non-number) → fail-closed exit

Comment line 2403 already states "fail-closed is safer", but doesn't tell an operator what to do when they've already cleared the field. This commit fills in that gap.

No code change. Doc-only.

## Test plan
- [ ] Comment renders cleanly (review only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)