### PR TITLE
task-7a5e2add: commit proposals on default branch + preserve worktree on resume

### DIFF
--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -106,13 +106,49 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 
 <!-- section:commit-push -->
 8. **Commit and push**:
-   Strip the `<project_path>/` prefix from `<proposals_path>` to get the repo-relative path:
+   Strip the `<project_path>/` prefix from `<proposals_path>` to get the repo-relative path.
+
+   The shared `~/<repo-name>` checkout's HEAD is unspecified state — a prior
+   slot or session may have left it on a stale orchestration branch. Switch
+   to the project's default branch and fast-forward it *before* staging, so
+   the proposal commit lands on the branch from which the orchestration
+   runner forks per-agent worktrees. Resolve the default-branch name the
+   same way `defaultMainBranch` does in `src/orchestration/worktrees.ts`
+   (do not hard-code `"main"` — projects on `master`/`trunk` are covered):
+
    ```bash
    cd <project_path>
+   default_branch=$(
+     git symbolic-ref --quiet --short refs/remotes/origin/HEAD \
+       | sed 's|^origin/||'
+   )
+   default_branch=${default_branch:-main}
+   git checkout "$default_branch"      # fail-loud: stop on uncommitted changes / detached HEAD
+   git pull --ff-only origin "$default_branch"
    git add <proposals_path_relative>/<feature>.md
    git commit -m "proposal: <title>"
-   git push
+   if ! git push origin "$default_branch"; then
+     git pull --rebase origin "$default_branch"
+     git push origin "$default_branch"   # one retry for concurrent-push race; fail-loud after
+   fi
    ```
+
+   **Fail-loud on operator-state corruption.** If `git checkout
+   "$default_branch"` cannot succeed (uncommitted changes on the prior
+   branch, detached HEAD that cannot be left, etc.), stop and emit
+   `status: "error"` with the diagnostic message from git. Do not commit on
+   a different branch. Do not stash, reset, or otherwise paper over the
+   stale state — the operator's prior checkout state is theirs to recover.
+
+   **Concurrent-push race is handled with one retry, not fail-loud.** A push
+   that fails because the remote tip advanced (another slot pushed in the
+   same window) is recovered with a single `git pull --rebase origin
+   "$default_branch" && git push origin "$default_branch"`. A second
+   failure is fail-loud (`status: "error"`).
+
+   The push targets the named branch explicitly (`git push origin
+   "$default_branch"`) — do not fall back to a bare `git push` that relies
+   on the working tree's prior HEAD or upstream tracking.
 
 <!-- section:update-frontmatter -->
 9. **Update task frontmatter**: Set `proposal: <proposals_path_relative>/<feature-name>.md`

--- a/skills/ludics-revise-proposal-worker.md
+++ b/skills/ludics-revise-proposal-worker.md
@@ -123,12 +123,52 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
 6. **Commit and push**:
 
    **File-based mode**:
+
+   The shared `~/<repo-name>` checkout's HEAD is unspecified state — a prior
+   slot or session may have left it on a stale orchestration branch. Switch
+   to the project's default branch and fast-forward it *before* staging, so
+   the proposal-revision commit lands on the branch from which the
+   orchestration runner forks per-agent worktrees. Resolve the
+   default-branch name the same way `defaultMainBranch` does in
+   `src/orchestration/worktrees.ts` (do not hard-code `"main"` — projects
+   on `master`/`trunk` are covered):
+
    ```bash
    cd <project_path>
+   default_branch=$(
+     git symbolic-ref --quiet --short refs/remotes/origin/HEAD \
+       | sed 's|^origin/||'
+   )
+   default_branch=${default_branch:-main}
+   git checkout "$default_branch"      # fail-loud: stop on uncommitted changes / detached HEAD
+   git pull --ff-only origin "$default_branch"
    git add "$proposal_rel"          # repo-relative path computed in the detect-mode section
    git commit -m "proposal: revise <title>"
-   git push
+   if ! git push origin "$default_branch"; then
+     git pull --rebase origin "$default_branch"
+     git push origin "$default_branch"   # one retry for concurrent-push race; fail-loud after
+   fi
    ```
+
+   **Fail-loud on operator-state corruption.** If `git checkout
+   "$default_branch"` cannot succeed (uncommitted changes on the prior
+   branch, detached HEAD that cannot be left, etc.), stop and emit
+   `status: "error"` with the diagnostic message from git. Do not commit on
+   a different branch. Do not stash, reset, or otherwise paper over the
+   stale state.
+
+   **Concurrent-push race is handled with one retry, not fail-loud.** A push
+   that fails because the remote tip advanced (another slot pushed in the
+   same window) is recovered with a single `git pull --rebase origin
+   "$default_branch" && git push origin "$default_branch"`. A second
+   failure is fail-loud (`status: "error"`).
+
+   The push targets the named branch explicitly (`git push origin
+   "$default_branch"`) — do not fall back to a bare `git push` that relies
+   on the working tree's prior HEAD or upstream tracking.
+
+   The harness-side block below (`cd "$LUDICS_STATE_PATH"`) is unchanged —
+   the harness repo only has `main` and is not at risk.
    Then commit any task file changes (notes, criteria) written in the edit-task section:
    ```bash
    cd "$LUDICS_STATE_PATH"

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask } from "./t3code.ts";
+import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -510,5 +510,67 @@ describe("selectOrchestrationFlags — tiny effort", () => {
     const { args } = selectOrchestrationFlags("tiny", fakeConfig);
     expect(args).toContain("--solo --coder codex");
     expect(args).not.toContain(":claude-sonnet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope (3a) cold-start CWD invariant — t3code backend.
+// (`proposal-commit-on-main-and-worktree-resume`.)
+//
+// Pins that an agent's `DesiredThreadConfig` (the payload dispatched to the
+// t3code server's `thread.create`) carries `worktreePath: agent.worktreePath`
+// — i.e. the per-agent path returned by `createWorktrees` flows unchanged
+// to the boundary the t3code server stores on the thread, which then drives
+// the spawned agent's CWD.
+//
+// Asserting at the boundary is sufficient: the t3code server-side handling
+// of `worktreePath` is out of scope for this task. Subsequent-turn CWD is
+// not asserted because `T3CodeTransport.sendTurn` dispatches against the
+// stored thread without ever sending a different worktreePath.
+// ---------------------------------------------------------------------------
+
+describe("t3code adapter cold-start DesiredThreadConfig", () => {
+  test("orchestrated DesiredThreadConfig carries the agent's worktreePath unchanged at the thread.create boundary", () => {
+    // Each agent in duo mode gets a distinct per-agent worktree from
+    // createWorktrees; the AC pins that worktreePath flows into the
+    // dispatched DesiredThreadConfig per agent without aliasing or
+    // collapsing onto the slot's primary worktree.
+    const coderAgent = {
+      name: "coder",
+      role: "coder",
+      model: "claude-sonnet-4-6",
+      provider: "claude-code" as const,
+      branch: "ludics/task-cs/coder",
+      worktreePath: "/tmp/proj-task-cs-coder",
+    };
+    const reviewerAgent = {
+      name: "reviewer",
+      role: "reviewer",
+      model: "gpt-5.4",
+      provider: "codex" as const,
+      branch: "ludics/task-cs/reviewer",
+      worktreePath: "/tmp/proj-task-cs-reviewer",
+    };
+
+    const slot = 7;
+    const opts = { runtimeMode: "full-access" as const, interactionMode: "default" as const };
+
+    const desiredCoder = buildOrchestratedDesiredThreadConfig(coderAgent, slot, "task-cs", opts);
+    const desiredReviewer = buildOrchestratedDesiredThreadConfig(reviewerAgent, slot, "task-cs", opts);
+
+    // The named-seam invariant: each per-agent DesiredThreadConfig's
+    // worktreePath equals the agent's per-agent worktree. Mutation:
+    // collapsing the runner's per-agent loop to use a single workspace
+    // root would make these expectations diverge.
+    expect(desiredCoder.worktreePath).toBe("/tmp/proj-task-cs-coder");
+    expect(desiredReviewer.worktreePath).toBe("/tmp/proj-task-cs-reviewer");
+    expect(desiredCoder.worktreePath).not.toBe(desiredReviewer.worktreePath);
+
+    // Branch and provider are also per-agent — sanity that the helper
+    // does not silently ignore agent fields.
+    expect(desiredCoder.branch).toBe("ludics/task-cs/coder");
+    expect(desiredReviewer.branch).toBe("ludics/task-cs/reviewer");
+    expect(desiredCoder.provider).toBe("claude-code");
+    expect(desiredReviewer.provider).toBe("codex");
   });
 });

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -107,6 +107,35 @@ function normalizeWorkspacePath(ctx: AdapterContext): string {
 }
 
 /** Build orchestrated thread title — delegates to shared slotSessionName convention */
+/**
+ * Build the {@link DesiredThreadConfig} dispatched to the t3code server for a
+ * single orchestration agent. Extracted as a named export so a regression
+ * test can pin the cold-start invariant — the `worktreePath` field on the
+ * payload MUST equal the agent's per-agent worktree path returned by
+ * `createWorktrees` — without standing up a t3code-server fixture.
+ *
+ * Pinned by `proposal-commit-on-main-and-worktree-resume` scope (3a):
+ * the t3code-side handling of `worktreePath` (project resolution, thread
+ * creation, CWD enforcement) is out of scope; the boundary asserted here
+ * is the value the runner constructs and dispatches.
+ */
+export function buildOrchestratedDesiredThreadConfig(
+  agent: { name: string; role?: string | null; model: string; provider?: T3ProviderKind; branch: string; worktreePath: string },
+  slot: number,
+  taskId: string | undefined,
+  options: { runtimeMode: T3RuntimeMode; interactionMode: T3InteractionMode },
+): DesiredThreadConfig {
+  return {
+    worktreePath: agent.worktreePath,
+    title: orchestratedThreadTitle(slot, agent.role ?? agent.name, taskId),
+    model: agent.model,
+    provider: agent.provider,
+    runtimeMode: options.runtimeMode,
+    interactionMode: options.interactionMode,
+    branch: agent.branch,
+  };
+}
+
 export function orchestratedThreadTitle(slot: number, role: string, taskId?: string): string {
   return slotSessionName(slot, role, taskId);
 }
@@ -951,15 +980,12 @@ async function startOrchestratedThreads(
     const projectId = await ensureProject(client, snapshot, projectDir, defaultModelSelection);
     const created: T3CodeThreadRecord[] = [];
     for (const agent of agents) {
-      const desired: DesiredThreadConfig = {
-        worktreePath: agent.worktreePath,
-        title: orchestratedThreadTitle(ctx.slot, agent.role ?? agent.name, ctx.taskId),
-        model: agent.model,
-        provider: agent.provider,
-        runtimeMode: options.runtimeMode,
-        interactionMode: options.interactionMode,
-        branch: agent.branch,
-      };
+      const desired = buildOrchestratedDesiredThreadConfig(
+        agent,
+        ctx.slot,
+        ctx.taskId,
+        { runtimeMode: options.runtimeMode, interactionMode: options.interactionMode },
+      );
       created.push(
         await ensureThread(
           client,

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -457,3 +457,67 @@ describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", (
     expect(round!.ttydRestartCounts!.coder!.lastRestartAt).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Scope (3a) cold-start CWD invariant — tmux backend.
+// (`proposal-commit-on-main-and-worktree-resume`.)
+//
+// Pins that an agent launched at cold-start has its tmux session born inside
+// the agent's per-agent worktree path returned from `createWorktrees`. The
+// chain is `setupOrchestratedSlot` →
+// `createTmuxAgentSession(slot, name, agent.worktreePath, taskId)` →
+// `tmuxNewSession(name, cwd)`. The test spies on the inner `tmuxNewSession`
+// and asserts the `cwd` argument equals `agent.worktreePath` per agent.
+//
+// Subsequent-turn CWD is not asserted: `TmuxTransport.sendTurn` injects
+// prompts without `cd`, so the cold-start CWD is preserved by construction.
+// ---------------------------------------------------------------------------
+
+describe("tmux adapter cold-start CWD", () => {
+  test("createTmuxAgentSession threads agent.worktreePath into tmuxNewSession's cwd argument for each duo agent", async () => {
+    const tmuxMod = await import("./tmux.ts");
+    const { spyOn } = await import("bun:test");
+
+    const captured: Array<{ name: string; cwd: string | undefined }> = [];
+    const newSessionSpy = spyOn(tmuxMod, "tmuxNewSession").mockImplementation((name: string, cwd?: string) => {
+      captured.push({ name, cwd });
+    });
+    const hasSessionSpy = spyOn(tmuxMod, "tmuxHasSession").mockReturnValue(false);
+    // Avoid the post-create `tmux set-option ... mouse off` shelling out
+    // to a real tmux binary that may or may not be installed.
+    const safeSpawnMod = await import("../spawn.ts");
+    const safeSpy = spyOn(safeSpawnMod, "safeSyncOutput").mockReturnValue({
+      ok: true, exitCode: 0, stdout: "", stderr: "", timedOut: false,
+    });
+
+    try {
+      const { createTmuxAgentSession } = await import("./tmux-adapter.ts");
+
+      // Simulate the per-agent loop in setupOrchestratedSlot: each
+      // `agent` carries its worktreePath from `createWorktrees`. The
+      // assertion is that the path threads unchanged into tmuxNewSession.
+      const agents = [
+        { name: "coder", worktreePath: "/tmp/proj-task-s9-coder" },
+        { name: "reviewer", worktreePath: "/tmp/proj-task-s9-reviewer" },
+      ];
+      for (const a of agents) {
+        createTmuxAgentSession(9, a.name, a.worktreePath, "task-coldstart");
+      }
+
+      // Per-agent invariant: each tmuxNewSession call's cwd argument is
+      // the agent's worktreePath. Mutation: replacing
+      // `agent.worktreePath` with `repo` in the call site at
+      // `setupOrchestratedSlot` makes both assertions fail.
+      expect(captured).toHaveLength(2);
+      expect(captured[0]!.cwd).toBe("/tmp/proj-task-s9-coder");
+      expect(captured[1]!.cwd).toBe("/tmp/proj-task-s9-reviewer");
+      // Distinct sessions per agent — duo mode never collapses two
+      // agents into one session.
+      expect(captured[0]!.name).not.toBe(captured[1]!.name);
+    } finally {
+      newSessionSpy.mockRestore();
+      hasSessionSpy.mockRestore();
+      safeSpy.mockRestore();
+    }
+  });
+});

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -462,62 +462,144 @@ describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", (
 // Scope (3a) cold-start CWD invariant — tmux backend.
 // (`proposal-commit-on-main-and-worktree-resume`.)
 //
-// Pins that an agent launched at cold-start has its tmux session born inside
-// the agent's per-agent worktree path returned from `createWorktrees`. The
-// chain is `setupOrchestratedSlot` →
-// `createTmuxAgentSession(slot, name, agent.worktreePath, taskId)` →
-// `tmuxNewSession(name, cwd)`. The test spies on the inner `tmuxNewSession`
-// and asserts the `cwd` argument equals `agent.worktreePath` per agent.
+// Pins that an agent launched at cold-start has its tmux session born
+// inside the agent's per-agent worktree path returned from
+// `createWorktrees`. The load-bearing chain in `setupOrchestratedSlot` is
+//   for each agent:
+//     createTmuxAgentSession(slot, agent.name, agent.worktreePath, taskId)
+//       → tmuxNewSession(name, cwd)
+// — and the per-agent loop now lives in the named helper
+// `startTmuxAgentSessionsForOrchestratedSlot` so the test exercises the
+// same body `setupOrchestratedSlot` calls. A real `createWorktrees(..., "duo")`
+// produces distinct duo paths; the spy on `tmuxNewSession` sees those exact
+// paths per agent. A mutation in the helper that swaps `agent.worktreePath`
+// for `peerSyncDir` (or any other slot-shared path) flips the test
+// PASS→FAIL — verified locally.
 //
 // Subsequent-turn CWD is not asserted: `TmuxTransport.sendTurn` injects
 // prompts without `cd`, so the cold-start CWD is preserved by construction.
 // ---------------------------------------------------------------------------
 
+import { createWorktrees, cleanupWorktrees } from "../orchestration/worktrees.ts";
+import type { AgentConfig } from "../orchestration/state.ts";
+
+const TMUX_TMP = join(import.meta.dir, ".test-tmp-tmux-cwd");
+
+function initRepo(repo: string): void {
+  mkdirSync(repo, { recursive: true });
+  Bun.spawnSync(["git", "init", "-b", "main"], { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "config", "user.email", "test@example.com"], { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "config", "user.name", "Test User"], { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  writeFileSync(join(repo, "README.md"), "init\n");
+  Bun.spawnSync(["git", "add", "README.md"], { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+  Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+}
+
 describe("tmux adapter cold-start CWD", () => {
-  test("createTmuxAgentSession threads agent.worktreePath into tmuxNewSession's cwd argument for each duo agent", async () => {
+  test("setupOrchestratedSlot per-agent loop sees distinct duo worktree paths from createWorktrees as tmuxNewSession cwd", async () => {
+    if (!Bun.which("git")) return;
     const tmuxMod = await import("./tmux.ts");
     const { spyOn } = await import("bun:test");
 
+    // Driving the same helper `setupOrchestratedSlot` calls (rather than
+    // a hand-built agent fixture) guarantees that any future refactor of
+    // the per-agent loop is also exercised by this test.
+    const { startTmuxAgentSessionsForOrchestratedSlot } = await import("./tmux-adapter.ts");
+
+    rmSync(TMUX_TMP, { recursive: true, force: true });
+    mkdirSync(TMUX_TMP, { recursive: true });
+    const repo = join(TMUX_TMP, "repo-cwd");
+    initRepo(repo);
+
+    // Real createWorktrees with mode "duo" — produces two distinct
+    // per-agent worktree paths and registers the branches with git.
+    const setup = createWorktrees(
+      repo,
+      "task-coldstart",
+      [{ name: "coder" }, { name: "reviewer" }],
+      "main",
+      9,
+      "duo",
+    );
+    expect(setup.agentWorktrees.coder).not.toBe(setup.agentWorktrees.reviewer);
+    expect(setup.agentWorktrees.coder).not.toBe(setup.peerSyncDir);
+    expect(setup.agentWorktrees.reviewer).not.toBe(setup.peerSyncDir);
+
+    // Spy on the inner tmux primitives BEFORE the helper runs.
     const captured: Array<{ name: string; cwd: string | undefined }> = [];
     const newSessionSpy = spyOn(tmuxMod, "tmuxNewSession").mockImplementation((name: string, cwd?: string) => {
       captured.push({ name, cwd });
     });
     const hasSessionSpy = spyOn(tmuxMod, "tmuxHasSession").mockReturnValue(false);
-    // Avoid the post-create `tmux set-option ... mouse off` shelling out
-    // to a real tmux binary that may or may not be installed.
+    // bootAgentCli routes through tmuxSendCommand; mock so it doesn't
+    // shell out to a tmux that may not be installed.
+    const sendCommandSpy = spyOn(tmuxMod, "tmuxSendCommand").mockImplementation(() => true);
+    // Avoid the post-create `tmux set-option ... mouse off` shelling out.
     const safeSpawnMod = await import("../spawn.ts");
     const safeSpy = spyOn(safeSpawnMod, "safeSyncOutput").mockReturnValue({
       ok: true, exitCode: 0, stdout: "", stderr: "", timedOut: false,
     });
 
     try {
-      const { createTmuxAgentSession } = await import("./tmux-adapter.ts");
-
-      // Simulate the per-agent loop in setupOrchestratedSlot: each
-      // `agent` carries its worktreePath from `createWorktrees`. The
-      // assertion is that the path threads unchanged into tmuxNewSession.
-      const agents = [
-        { name: "coder", worktreePath: "/tmp/proj-task-s9-coder" },
-        { name: "reviewer", worktreePath: "/tmp/proj-task-s9-reviewer" },
+      // Mirror the AgentConfig shape `setupOrchestratedSlot` constructs
+      // at tmux-adapter.ts: each agent's worktreePath is sourced from
+      // setup.agentWorktrees[agent.name] returned by createWorktrees.
+      const agents: AgentConfig[] = [
+        {
+          name: "coder",
+          provider: "claude-code",
+          role: "coder",
+          model: "claude-sonnet-4-6",
+          branch: setup.branches.coder!,
+          worktreePath: setup.agentWorktrees.coder!,
+        },
+        {
+          name: "reviewer",
+          provider: "codex",
+          role: "reviewer",
+          model: "gpt-5.4",
+          branch: setup.branches.reviewer!,
+          worktreePath: setup.agentWorktrees.reviewer!,
+        },
       ];
-      for (const a of agents) {
-        createTmuxAgentSession(9, a.name, a.worktreePath, "task-coldstart");
-      }
+
+      // Drive the exact helper that `setupOrchestratedSlot` invokes per
+      // round (`tmux-adapter.ts:594-597`). startTtyd is disabled so the
+      // test does not depend on a real ttyd binary; the AC scope is the
+      // tmux session's CWD, not ttyd lifecycle.
+      startTmuxAgentSessionsForOrchestratedSlot(
+        9, agents, setup.peerSyncDir, "task-coldstart", false,
+      );
 
       // Per-agent invariant: each tmuxNewSession call's cwd argument is
-      // the agent's worktreePath. Mutation: replacing
-      // `agent.worktreePath` with `repo` in the call site at
-      // `setupOrchestratedSlot` makes both assertions fail.
+      // the agent's distinct per-agent worktree path returned from
+      // createWorktrees — NOT the slot-shared peerSyncDir or the project
+      // dir. Mutation: replacing `agent.worktreePath` with
+      // `peerSyncDir` (or `setup.rootWorktree`, or `repo`) in the loop
+      // body collapses both calls onto a single path, which fails the
+      // distinct-paths assertion below.
       expect(captured).toHaveLength(2);
-      expect(captured[0]!.cwd).toBe("/tmp/proj-task-s9-coder");
-      expect(captured[1]!.cwd).toBe("/tmp/proj-task-s9-reviewer");
-      // Distinct sessions per agent — duo mode never collapses two
-      // agents into one session.
-      expect(captured[0]!.name).not.toBe(captured[1]!.name);
+      const byAgent = new Map(captured.map((c) => [c.name, c.cwd]));
+      // Distinct: each per-agent session's cwd matches that agent's
+      // worktree, not aliased to a shared path.
+      const coderSessionName = captured[0]!.name;
+      const reviewerSessionName = captured[1]!.name;
+      expect(byAgent.get(coderSessionName)).toBe(setup.agentWorktrees.coder!);
+      expect(byAgent.get(reviewerSessionName)).toBe(setup.agentWorktrees.reviewer!);
+      expect(byAgent.get(coderSessionName)).not.toBe(byAgent.get(reviewerSessionName));
+      // Defensive: neither cwd is the shared peerSyncDir / projectDir —
+      // pins the negative case the reviewer's mutation aimed at.
+      expect(byAgent.get(coderSessionName)).not.toBe(setup.peerSyncDir);
+      expect(byAgent.get(coderSessionName)).not.toBe(repo);
+      expect(byAgent.get(reviewerSessionName)).not.toBe(setup.peerSyncDir);
+      expect(byAgent.get(reviewerSessionName)).not.toBe(repo);
     } finally {
       newSessionSpy.mockRestore();
       hasSessionSpy.mockRestore();
+      sendCommandSpy.mockRestore();
       safeSpy.mockRestore();
+      cleanupWorktrees(repo, "task-coldstart", [{ name: "coder" }, { name: "reviewer" }], 9, "duo");
+      rmSync(TMUX_TMP, { recursive: true, force: true });
     }
   });
 });

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -250,8 +250,16 @@ function resolveAgentThinkingEffort(
 // tmux window + ttyd setup
 // ---------------------------------------------------------------------------
 
-/** Create a dedicated tmux session for an agent. One session per agent for full isolation. */
-function createTmuxAgentSession(slot: number, agentName: string, cwd: string, taskId?: string): void {
+/**
+ * Create a dedicated tmux session for an agent. One session per agent for full isolation.
+ *
+ * Exported as a test seam: regression tests for the cold-start CWD
+ * invariant (`proposal-commit-on-main-and-worktree-resume` scope (3a))
+ * spy on the inner `tmuxNewSession` and assert that the `cwd` argument
+ * threaded through this function matches the agent's per-agent worktree
+ * path returned by `createWorktrees`.
+ */
+export function createTmuxAgentSession(slot: number, agentName: string, cwd: string, taskId?: string): void {
   const sessionName = tmuxSessionName(slot, agentName, taskId);
   // Kill existing session if present (stale from prior run)
   if (tmuxHasSession(sessionName)) {

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -251,6 +251,42 @@ function resolveAgentThinkingEffort(
 // ---------------------------------------------------------------------------
 
 /**
+ * Per-agent loop body extracted from `setupOrchestratedSlot` so the
+ * cold-start CWD invariant is testable without standing up the full
+ * AdapterContext / config / state-persistence pipeline.
+ *
+ * For each agent, this is the canonical "born inside the worktree"
+ * sequence: a fresh tmux session whose CWD is `agent.worktreePath`
+ * (the per-agent path returned from `createWorktrees`), an optional ttyd
+ * for browser access, then the persistent agent-CLI boot.
+ *
+ * Pinned by `proposal-commit-on-main-and-worktree-resume` scope (3a):
+ * a regression test in `src/adapters/tmux-adapter.test.ts` builds an
+ * `agents` array from a real `createWorktrees(..., "duo")` setup and
+ * asserts that each call to `tmuxNewSession` sees the matching
+ * per-agent path. A mutation here that swaps `agent.worktreePath` for
+ * `peerSyncDir` (or any other slot-shared path) flips that test PASS→FAIL.
+ */
+export function startTmuxAgentSessionsForOrchestratedSlot(
+  slot: number,
+  agents: AgentConfig[],
+  peerSyncDir: string,
+  taskId: string | undefined,
+  startTtydEnabled: boolean,
+): Record<string, number> {
+  const ttydPids: Record<string, number> = {};
+  for (let i = 0; i < agents.length; i++) {
+    const agent = agents[i]!;
+    createTmuxAgentSession(slot, agent.name, agent.worktreePath, taskId);
+    const role = agentPortRole(agent, i);
+    if (startTtydEnabled) ttydPids[agent.name] = startTtyd(slot, agent.name, role, taskId);
+    // Boot persistent interactive agent CLI in the session
+    bootAgentCli(slot, agent, peerSyncDir, "setup", taskId);
+  }
+  return ttydPids;
+}
+
+/**
  * Create a dedicated tmux session for an agent. One session per agent for full isolation.
  *
  * Exported as a test seam: regression tests for the cold-start CWD
@@ -592,15 +628,9 @@ async function start(ctx: AdapterContext): Promise<string> {
   writeAgentMarkerFiles(setup.peerSyncDir, setup.agentWorktrees);
 
   // --- tmux-specific setup: create sessions + ttyd + boot agent CLIs ---
-  const ttydPids: Record<string, number> = {};
-  for (let i = 0; i < agents.length; i++) {
-    const agent = agents[i]!;
-    createTmuxAgentSession(ctx.slot, agent.name, agent.worktreePath, taskId);
-    const role = agentPortRole(agent, i);
-    if (ctx.startTtyd !== false) ttydPids[agent.name] = startTtyd(ctx.slot, agent.name, role, taskId);
-    // Boot persistent interactive agent CLI in the session
-    bootAgentCli(ctx.slot, agent, setup.peerSyncDir, "setup", taskId);
-  }
+  const ttydPids = startTmuxAgentSessionsForOrchestratedSlot(
+    ctx.slot, agents, setup.peerSyncDir, taskId, ctx.startTtyd !== false,
+  );
 
   // --- Build orchestration state (no t3code threadIds) ---
   const state: OrchestrationState = {

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1076,3 +1076,192 @@ describe("purgeOrphanDirIfRecoverable", () => {
     expect(existsSync(join(path, ".peer-sync"))).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Scope (2): per-agent branches inherit commits placed on main BEFORE
+// createWorktrees runs. Pins the invariant that paired with scope (1)
+// guarantees the proposal commit reaches both coder and reviewer in duo mode.
+// (`proposal-commit-on-main-and-worktree-resume`.)
+// ---------------------------------------------------------------------------
+
+describe("createWorktrees forks per-agent branches from the default branch", () => {
+  test("duo mode: commits placed on main before createWorktrees are visible on every per-agent branch", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "fork-from-main");
+    initRepo(repo);
+
+    // Place a "proposal" commit on main BEFORE createWorktrees runs.
+    // This is the canonical scope-(1)-then-(2) sequence: proposal on
+    // default branch first, then orchestration forks per-agent worktrees.
+    writeFileSync(join(repo, "PROPOSAL.md"), "proposal body\n");
+    run(["git", "add", "PROPOSAL.md"], repo);
+    run(["git", "commit", "-m", "proposal: scope-2 fixture"], repo);
+
+    const setup = createWorktrees(
+      repo,
+      "fork-feat",
+      [{ name: "coder" }, { name: "reviewer" }],
+      "main",
+      9,
+      "duo",
+    );
+
+    // Per-agent branches must inherit the proposal commit, so the file
+    // exists in each per-agent worktree's checkout.
+    for (const agent of ["coder", "reviewer"]) {
+      const wt = setup.agentWorktrees[agent]!;
+      expect(existsSync(join(wt, "PROPOSAL.md"))).toBe(true);
+      expect(readFileSync(join(wt, "PROPOSAL.md"), "utf-8")).toBe("proposal body\n");
+      // Branch is forked, not shared.
+      expect(setup.branches[agent]).not.toBe(setup.branches.root);
+    }
+    // Root worktree also carries the commit.
+    expect(existsSync(join(setup.rootWorktree, "PROPOSAL.md"))).toBe(true);
+
+    cleanupWorktrees(repo, "fork-feat", [{ name: "coder" }, { name: "reviewer" }], 9, "duo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope (3b): resume short-circuit preserves worktree directory contents.
+// (`proposal-commit-on-main-and-worktree-resume`.)
+// ---------------------------------------------------------------------------
+
+describe("addWorktree resume short-circuit", () => {
+  test("re-creating an existing worktree+branch preserves uncommitted scratch and branch HEAD", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "resume-shortcircuit");
+    initRepo(repo);
+
+    // First call: cold-start. createWorktrees materialises the worktrees
+    // and forks per-agent branches from main.
+    const taskId = "resume-feat";
+    const agents = [{ name: "coder" }, { name: "reviewer" }];
+    const slot = 11;
+    const first = createWorktrees(repo, taskId, agents, "main", slot, "duo");
+
+    // Capture the branch HEADs and write uncommitted scratch into one of
+    // the worktrees, simulating an agent's mid-round work-in-progress.
+    const headsBefore: Record<string, string> = {};
+    for (const agent of ["coder", "reviewer"]) {
+      const wt = first.agentWorktrees[agent]!;
+      headsBefore[agent] = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+        cwd: wt, stdout: "pipe", stderr: "pipe",
+        env: process.env as Record<string, string>,
+      }).stdout.toString().trim();
+    }
+    const scratchPath = join(first.agentWorktrees.coder!, "SCRATCH-WIP.txt");
+    writeFileSync(scratchPath, "agent uncommitted work\n");
+
+    // Second call: simulates resume / restart of the slot. Same args, same
+    // stem — addWorktree should short-circuit instead of removing+re-adding.
+    const second = createWorktrees(repo, taskId, agents, "main", slot, "duo");
+
+    // Identity: worktree paths must be the same.
+    expect(second.rootWorktree).toBe(first.rootWorktree);
+    expect(second.agentWorktrees.coder).toBe(first.agentWorktrees.coder);
+    expect(second.agentWorktrees.reviewer).toBe(first.agentWorktrees.reviewer);
+
+    // Invariant: uncommitted scratch survives the resume (the property the
+    // short-circuit exists to enforce — `git worktree remove --force`
+    // would have wiped this file).
+    expect(existsSync(scratchPath)).toBe(true);
+    expect(readFileSync(scratchPath, "utf-8")).toBe("agent uncommitted work\n");
+
+    // Invariant: branches are not reset. (addWorktree never ran `git
+    // reset`, but pin it here for the short-circuit path explicitly so a
+    // future refactor cannot silently introduce a reset.)
+    for (const agent of ["coder", "reviewer"]) {
+      const wt = second.agentWorktrees[agent]!;
+      const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], {
+        cwd: wt, stdout: "pipe", stderr: "pipe",
+        env: process.env as Record<string, string>,
+      }).stdout.toString().trim();
+      expect(head).toBe(headsBefore[agent]!);
+    }
+
+    cleanupWorktrees(repo, "resume-feat", [{ name: "coder" }, { name: "reviewer" }], 11, "duo");
+  });
+
+  test("falls through to teardown-and-recreate when the directory exists but git does NOT register it (orphan)", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "shortcircuit-fallthrough-orphan");
+    initRepo(repo);
+
+    // Pre-seed the canonical worktree path with allow-list scaffolding but
+    // no git registration — same shape as the orphan-recovery test, which
+    // is exactly the "directory exists but registration disagrees" case
+    // the short-circuit must NOT short-circuit.
+    const stem = orchWorktreeStem("shortcircuit-fallthrough-orphan", "task-fallthrough", 4);
+    const orphanPath = join(dirname(repo), stem);
+    seedOrphanLayout(orphanPath);
+
+    // Pre-condition: dir exists, no git registration.
+    expect(existsSync(orphanPath)).toBe(true);
+    const preList = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(preList).not.toContain(`worktree ${orphanPath}`);
+
+    // createWorktrees must fall through to the orphan-recovery path,
+    // not short-circuit on directory-exists alone.
+    const setup = createWorktrees(repo, "task-fallthrough", [{ name: "coder" }], "main", 4, "pair");
+    expect(setup.rootWorktree).toBe(orphanPath);
+    const postList = Bun.spawnSync(["git", "worktree", "list", "--porcelain"], {
+      cwd: repo, stdout: "pipe", stderr: "pipe",
+      env: process.env as Record<string, string>,
+    }).stdout.toString();
+    expect(postList).toContain(`worktree ${orphanPath}`);
+
+    cleanupWorktrees(repo, "task-fallthrough", [{ name: "coder" }], 4, "pair");
+  });
+
+  test("falls through when the registered branch differs from the requested branch", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "shortcircuit-fallthrough-branch");
+    initRepo(repo);
+
+    // First, materialise a worktree on branch `wrong-branch` at the
+    // canonical orchestration path.
+    const stem = orchWorktreeStem("shortcircuit-fallthrough-branch", "task-fb", 5);
+    const path = join(dirname(repo), stem);
+    run(["git", "branch", "wrong-branch"], repo);
+    run(["git", "worktree", "add", path, "wrong-branch"], repo);
+    expect(existsSync(path)).toBe(true);
+
+    // Now ask createWorktrees to materialise a pair-mode worktree at the
+    // same path, but for a different branch (the canonical
+    // `ludics/task-fb-s5/root`). The short-circuit MUST decline because
+    // the registered branch differs — short-circuiting would silently
+    // leave the worktree on `wrong-branch`.
+    //
+    // The teardown-and-recreate path (`git worktree remove --force` then
+    // `git worktree add path branch`) handles this case correctly.
+    const setup = createWorktrees(repo, "task-fb", [{ name: "coder" }], "main", 5, "pair");
+    expect(setup.rootWorktree).toBe(path);
+
+    // Worktree must now be on the canonical orchestration branch, not on
+    // `wrong-branch` — proving the short-circuit fell through.
+    const head = Bun.spawnSync(
+      ["git", "symbolic-ref", "--short", "HEAD"],
+      { cwd: path, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> },
+    ).stdout.toString().trim();
+    expect(head).toBe(setup.branches.root);
+    expect(head).not.toBe("wrong-branch");
+
+    cleanupWorktrees(repo, "task-fb", [{ name: "coder" }], 5, "pair");
+    safeRun(["git", "branch", "-D", "wrong-branch"], repo);
+  });
+});
+
+function safeRun(cmd: string[], cwd: string): void {
+  Bun.spawnSync(cmd, {
+    cwd, stdout: "pipe", stderr: "pipe",
+    env: process.env as Record<string, string>,
+  });
+}

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, purgeOrphanDirIfRecoverable, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -1256,6 +1256,103 @@ describe("addWorktree resume short-circuit", () => {
 
     cleanupWorktrees(repo, "task-fb", [{ name: "coder" }], 5, "pair");
     safeRun(["git", "branch", "-D", "wrong-branch"], repo);
+  });
+
+});
+
+// Regression for Codex P2 reviewer note on PR #519: `git worktree list
+// --porcelain` can emit `prunable <reason>` (not just bare `prunable`),
+// so an exact-equality check on `prunable` lets the short-circuit
+// silently accept a stale registration. parseRegisteredWorktreeMatches
+// is the pure helper extracted so this can be tested directly without
+// having to manufacture the messy on-disk state.
+describe("parseRegisteredWorktreeMatches: prunable-with-reason rejection", () => {
+  const PATH = "/tmp/wt-path";
+  const BRANCH = "ludics/task-x/coder";
+
+  test("returns true for a clean registered record matching path + branch", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/${BRANCH}`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(true);
+  });
+
+  test("returns false when the record carries a bare `prunable` line (existing behaviour)", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/${BRANCH}`,
+      `prunable`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(false);
+  });
+
+  // Load-bearing assertion for the Codex P2 fix: a real-world git
+  // emission shape (`prunable gitdir file points to non-existent
+  // location`) must be rejected, not accepted. Mutation: reverting the
+  // prefix-match in parseRegisteredWorktreeMatches to a literal
+  // `=== "prunable"` makes this assertion flip from false→true.
+  test("returns false when the record carries a `prunable <reason>` line (Codex P2 reviewer fix)", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/${BRANCH}`,
+      `prunable gitdir file points to non-existent location`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(false);
+  });
+
+  // Defence-in-depth: leading whitespace on the prunable line should
+  // also be rejected. Some git versions / locales may indent.
+  test("returns false when the prunable line has leading whitespace", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/${BRANCH}`,
+      `  prunable some reason`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(false);
+  });
+
+  // Negative control: a line that merely contains the substring
+  // "prunable" but is not the prunable marker (e.g. a hypothetical
+  // future record field) must NOT trigger rejection — exact prefix
+  // match, not substring match.
+  test("does NOT reject lines that merely contain 'prunable' as a substring", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/${BRANCH}`,
+      `# this comment mentions prunable but is not the marker`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(true);
+  });
+
+  test("returns false when the record's branch differs from the requested branch", () => {
+    const porcelain = [
+      `worktree ${PATH}`,
+      `HEAD abc123`,
+      `branch refs/heads/different-branch`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(false);
+  });
+
+  test("returns false when path is not registered at all", () => {
+    const porcelain = [
+      `worktree /tmp/some-other`,
+      `HEAD abc123`,
+      `branch refs/heads/some-other`,
+      ``,
+    ].join("\n");
+    expect(parseRegisteredWorktreeMatches(porcelain, PATH, BRANCH)).toBe(false);
   });
 });
 

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -229,6 +229,40 @@ function worktreeExists(projectDir: string, path: string): boolean {
   return list.split("\n").some((line) => line === `worktree ${path}`);
 }
 
+/**
+ * True iff `path` is registered with git as a worktree AND that registration's
+ * branch line is `branch refs/heads/<branch>`. Used by the resume short-circuit
+ * in {@link addWorktree} — the directory existing on disk is not enough; git
+ * must agree (a) that the directory IS the worktree and (b) that it tracks
+ * the named branch. Any other shape (different path, different branch,
+ * detached HEAD, prunable record) falls through to the teardown-and-recreate
+ * path.
+ */
+function registeredWorktreeMatches(projectDir: string, path: string, branch: string): boolean {
+  const list = maybeGit(projectDir, ["worktree", "list", "--porcelain"]);
+  if (!list) return false;
+  // `git worktree list --porcelain` emits records separated by blank lines,
+  // each beginning with `worktree <path>`. Find the record for `path` and
+  // verify its `branch` line equals `refs/heads/<branch>`.
+  const records = list.split(/\n\n+/);
+  for (const record of records) {
+    const lines = record.split("\n");
+    const head = lines[0];
+    if (head !== `worktree ${path}`) continue;
+    if (lines.includes("prunable")) return false;
+    return lines.includes(`branch refs/heads/${branch}`);
+  }
+  return false;
+}
+
+/** True iff the local branch ref `refs/heads/<branch>` exists in `projectDir`. */
+function branchRefExists(projectDir: string, branch: string): boolean {
+  return safeSyncOutput(
+    ["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+    { cwd: projectDir },
+  ).ok;
+}
+
 function removeIfRegistered(projectDir: string, path: string): void {
   if (worktreeExists(projectDir, path)) {
     maybeGit(projectDir, ["worktree", "remove", "--force", path]);
@@ -289,6 +323,32 @@ export function deleteBranches(projectDir: string, branches: string[]): void {
 }
 
 function addWorktree(projectDir: string, path: string, branch: string, base: string): void {
+  // Resume short-circuit: when the worktree directory still exists on disk,
+  // the branch ref still exists in projectDir, AND git's own registration
+  // agrees that this directory tracks this branch, leave everything alone.
+  // No removeIfRegistered, no `git worktree add`, no filesystem touch — so any
+  // uncommitted scratch the user (or a mid-round agent) left in the worktree
+  // survives the call.
+  //
+  // Conservative: any inconsistency (registered path differs, registered
+  // branch differs, prunable record, detached HEAD, missing branch ref)
+  // falls through to the existing teardown-and-recreate path so the
+  // orphan-recovery branch below remains the recovery seam for unusual
+  // states.
+  //
+  // Paired with scope (1) of `proposal-commit-on-main-and-worktree-resume`:
+  // the proposal commit is reliably on the project's default branch before
+  // `createWorktrees` runs, so per-agent branches inherit it on first
+  // creation, and a later resume preserves whatever the agents have done
+  // since.
+  if (
+    existsSync(path) &&
+    branchRefExists(projectDir, branch) &&
+    registeredWorktreeMatches(projectDir, path, branch)
+  ) {
+    return;
+  }
+
   removeIfRegistered(projectDir, path);
 
   // Orphan recovery: directory exists but git no longer registers it as a worktree
@@ -409,6 +469,16 @@ export function createWorktrees(
   const branches: Record<string, string> = {
     root: orchBranchName(taskId, slot, "root"),
   };
+  // Invariant (paired with scope (1) of `proposal-commit-on-main-and-worktree-resume`):
+  // every per-agent and root branch is forked from `mainBranch` (resolved by
+  // `defaultMainBranch(projectDir)` unless the caller passes a different
+  // value). In duo mode the coder and reviewer never share a branch, so the
+  // proposal commit reaches them only if it is already on `mainBranch` at
+  // the moment `addWorktree` runs — which is what the worker-skill edits in
+  // `skills/ludics-{draft,revise}-proposal-worker.md` step "Commit and push"
+  // guarantee. Do not change the `mainBranch` argument here without also
+  // re-validating that the worker still commits the proposal on the same
+  // branch.
   addWorktree(projectDir, rootWorktree, branches.root, mainBranch);
 
   const agentWorktrees: Record<string, string> = {};
@@ -420,7 +490,9 @@ export function createWorktrees(
       agentWorktrees[agent.name] = rootWorktree;
     }
   } else {
-    // Duo mode: each agent gets its own worktree and branch
+    // Duo mode: each agent gets its own worktree and branch.
+    // Each per-agent branch is forked from `mainBranch` (see invariant
+    // comment on the root `addWorktree` call above).
     for (const agent of agents) {
       const path = join(parentDir, `${stem}-${slugify(agent.name)}`);
       const branch = orchBranchName(taskId, slot, slugify(agent.name));

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -241,15 +241,38 @@ function worktreeExists(projectDir: string, path: string): boolean {
 function registeredWorktreeMatches(projectDir: string, path: string, branch: string): boolean {
   const list = maybeGit(projectDir, ["worktree", "list", "--porcelain"]);
   if (!list) return false;
-  // `git worktree list --porcelain` emits records separated by blank lines,
-  // each beginning with `worktree <path>`. Find the record for `path` and
-  // verify its `branch` line equals `refs/heads/<branch>`.
-  const records = list.split(/\n\n+/);
+  return parseRegisteredWorktreeMatches(list, path, branch);
+}
+
+/**
+ * Pure helper extracted from {@link registeredWorktreeMatches} for testability.
+ * Given a `git worktree list --porcelain` body, return whether `path` is
+ * registered, not prunable, and tracks `refs/heads/<branch>`.
+ *
+ * `git worktree list --porcelain` emits records separated by blank lines,
+ * each beginning with `worktree <path>`.
+ *
+ * The `prunable` marker can appear bare (`prunable`) or with an attached
+ * reason (`prunable gitdir file points to non-existent location`), so
+ * match by prefix on the trimmed line — exact-equality matching would
+ * miss the with-reason form and let the short-circuit accept a stale
+ * registration. (Codex P2 reviewer note on PR #519.)
+ */
+export function parseRegisteredWorktreeMatches(
+  porcelain: string,
+  path: string,
+  branch: string,
+): boolean {
+  if (!porcelain) return false;
+  const records = porcelain.split(/\n\n+/);
   for (const record of records) {
     const lines = record.split("\n");
     const head = lines[0];
     if (head !== `worktree ${path}`) continue;
-    if (lines.includes("prunable")) return false;
+    if (lines.some((line) => {
+      const trimmed = line.trim();
+      return trimmed === "prunable" || trimmed.startsWith("prunable ");
+    })) return false;
     return lines.includes(`branch refs/heads/${branch}`);
   }
   return false;


### PR DESCRIPTION
## Summary

Closes the four scopes of [`docs/proposals/proposal-commit-on-main-and-worktree-resume.md`](docs/proposals/proposal-commit-on-main-and-worktree-resume.md):

- **Scope (1)** — `skills/ludics-{draft,revise}-proposal-worker.md` now resolve the project's default branch via `git symbolic-ref … origin/HEAD` (matching `defaultMainBranch`), `checkout`/fast-forward it before staging, and `git push origin <default-branch>` after the commit. `git checkout` failures are fail-loud (operator-state corruption); a failed push retries once with `git pull --rebase`, then fail-loud (concurrent-push race).
- **Scope (2)** — invariant comment at the `addWorktree(..., mainBranch)` call sites + a regression test (`createWorktrees forks per-agent branches from the default branch`) showing pre-existing main commits reach every per-agent worktree in duo mode.
- **Scope (3a)** — regression tests for both backends pin that an agent's cold-start CWD is `setup.agentWorktrees[agent.name]`. tmux: the `setupOrchestratedSlot` per-agent loop is extracted into the new export `startTmuxAgentSessionsForOrchestratedSlot`; the test drives that helper with agents built from a real duo `createWorktrees` and asserts each `tmuxNewSession` call's `cwd` equals the matching per-agent worktree (mutation tested: `agent.worktreePath` → `peerSyncDir`/`"/tmp/shared"` both flip PASS→FAIL). t3code: assert at the `DesiredThreadConfig` boundary via the new `buildOrchestratedDesiredThreadConfig` helper extracted from `startOrchestratedThreads`.
- **Scope (3b)** — `addWorktree` short-circuits when the directory, branch ref, AND `git worktree list` registration all agree, leaving everything alone (so uncommitted scratch survives a slot restart). Inconsistency — orphan dirs, mismatched branches, **prunable records (bare or with reason)**, registered-path mismatch — falls through to the existing teardown-and-recreate path, so the orphan-recovery branch is unaffected.

## Round 2 update

Addresses reviewer blocker on round 1 (scope 3a tmux): the prior test exercised `createTmuxAgentSession` directly, which only proved that function passes its own argument through. Round 2 extracts the `setupOrchestratedSlot` per-agent loop into `startTmuxAgentSessionsForOrchestratedSlot` and drives the test through that helper, with real duo `createWorktrees` paths and negative assertions against `peerSyncDir`/`projectDir`. Mutation evidence verified locally for both `peerSyncDir` and a fixed `/tmp/shared` substitution.

## Round 3 update — Codex P2 inline comment

`registeredWorktreeMatches` rejected `prunable` records only when the line was exactly `"prunable"`, but `git worktree list --porcelain` commonly emits `prunable <reason>` (e.g. `prunable gitdir file points to non-existent location`). Fixed by matching trimmed lines via `=== "prunable" || startsWith("prunable ")`. Extracted the porcelain-parsing logic into a pure helper `parseRegisteredWorktreeMatches(porcelain, path, branch)` so the bug class is testable directly. Added 7 unit tests (clean match, bare prunable, prunable-with-reason, leading-whitespace prunable, substring-only prunable negative control, branch mismatch, unregistered path). Mutation evidence: reverting the fix flips the prunable-with-reason and leading-whitespace assertions PASS→FAIL.

## Commits

- `86a0332` worker-skills: commit proposals on the project's default branch (scope 1)
- `80c79fd` worktrees: short-circuit resume when directory + branch + registration agree (scopes 2 + 3b)
- `eac372f` adapters: pin cold-start CWD invariant for tmux + t3code (scope 3a)
- `de7f9dd` tmux-adapter: extract per-agent loop helper, drive cold-start CWD test through it (round-2 reviewer blocker)
- `f0bf250` worktrees: short-circuit treats 'prunable <reason>' records as mismatches (round-3 Codex P2)

## Test plan

- [x] `bun test` — 2277 pass / 0 fail (was 2270 pre-round-3; +7 prunable-rejection tests)
- [x] `bun run typecheck` clean
- [x] `bun run build` produces `bin/ludics`
- [x] `bun run lint` clean (eslint)
- [x] `bun run lint:cli-readme`, `lint:cli-subcommands`, `lint:skill-cli-refs`, `lint:contracts`, `lint:state-migration`, `lint:no-mock-module` all pass
- [x] Mutation evidence:
  - replacing `registeredWorktreeMatches(...)` with `false` flips the scratch-survives assertion PASS→FAIL
  - replacing `agent.worktreePath` with `peerSyncDir` (or `/tmp/shared`) inside `startTmuxAgentSessionsForOrchestratedSlot` flips the cold-start CWD assertion PASS→FAIL
  - reverting the prunable-prefix match to `lines.includes("prunable")` flips two of the new prunable-rejection assertions false→true
- [x] AC self-check: see [`.peer-sync/workflow-feedback-coder.md`](.peer-sync/workflow-feedback-coder.md) (16 verification lines mapped 1:1 to the proposal AC bullets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)