### PR TITLE
draft-proposal-worker: AC verification reachability subsection (task-a8415073)

### DIFF
--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -79,6 +79,34 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    GitHub issue, task context, and resolved questions. Each criterion should be
    verifiable. Do NOT invent requirements beyond what the user stated or implied.
 
+   ### AC verification reachability — find/grep over commit-SHA when the path is outside project git context
+
+   When an AC's named path sits outside `git -C <project_path>`'s introspection
+   reach, the AC's primary evidence must use tooling reachable from the project
+   worktree (find/grep), not a commit-SHA from the unreachable subtree.
+
+   Why: `git -C <subpath>` walks parents looking for a `.git` directory and
+   returns "not a git repository" when none is found, so an AC that demands a
+   SHA from that subtree is self-contradicting at verification time.
+   Precipitating instance: `gh-ludics-478` round 1 (PR #491) generated such an
+   AC against `~/.claude/projects/-*/memory/`; commit `b4f5a92` reconciled it
+   by switching to find/grep evidence with optional secondary harness-side SHA.
+
+   Worked example (memory subtree, `~/.claude/projects/-*/memory/`):
+   - Pre-state: `find ~/.claude/projects/-*/memory -name '<file>'` → expected hits.
+   - Post-state: the same `find` invocation → expected empty.
+   - Index update: `grep -F '<slug>' <project>/memory/MEMORY.md` → expected no match.
+   - Optional secondary evidence: the harness-side keepalive-commit SHA, only
+     if the harness sync has run; not load-bearing. See `CLAUDE.md` /
+     `MEMORY.md` for the harness-side tracking detail — do not inline that
+     mechanism here.
+
+   The same rule applies to other paths outside the project's git context:
+   cache dirs, generated artefacts, and parent-symlinked trees (where the
+   symlink target's git context is unreachable from the symlink path) follow
+   the same pattern. Add future instances as new bullets under this
+   subsection rather than spawning new subsections.
+
    ## Context
    How things work now. Key files and code pointers by function/type/symbol
    name — not line numbers, which drift as other PRs merge before implementation.

--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -95,7 +95,10 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    Worked example (memory subtree, `~/.claude/projects/-*/memory/`):
    - Pre-state: `find ~/.claude/projects/-*/memory -name '<file>'` → expected hits.
    - Post-state: the same `find` invocation → expected empty.
-   - Index update: `grep -F '<slug>' <project>/memory/MEMORY.md` → expected no match.
+   - Index update: `grep -F '<slug>' ~/.claude/projects/-*/memory/MEMORY.md`
+     → expected no match. Target the memory-subtree `MEMORY.md` directly (the
+     `~/.claude/projects/-<encoded-project>/memory/MEMORY.md` path), not a
+     project-local `<project>/memory/MEMORY.md`, which does not exist.
    - Optional secondary evidence: the harness-side keepalive-commit SHA, only
      if the harness sync has run; not load-bearing. See `CLAUDE.md` /
      `MEMORY.md` for the harness-side tracking detail — do not inline that

--- a/skills/ludics-draft-proposal-worker.md
+++ b/skills/ludics-draft-proposal-worker.md
@@ -92,13 +92,19 @@ Follow the conventions in [worker-conventions.md](worker-conventions.md).
    AC against `~/.claude/projects/-*/memory/`; commit `b4f5a92` reconciled it
    by switching to find/grep evidence with optional secondary harness-side SHA.
 
-   Worked example (memory subtree, `~/.claude/projects/-*/memory/`):
-   - Pre-state: `find ~/.claude/projects/-*/memory -name '<file>'` → expected hits.
+   Worked example (memory subtree, `~/.claude/projects/-*/memory/` — where
+   `-*` is the structural-shape glob; substitute `-<encoded-project>` in
+   actual verification commands so the check stays scoped to the current
+   project rather than aggregating across every project's memory tree):
+   - Pre-state: `find ~/.claude/projects/-<encoded-project>/memory -name '<file>'` → expected hits.
    - Post-state: the same `find` invocation → expected empty.
-   - Index update: `grep -F '<slug>' ~/.claude/projects/-*/memory/MEMORY.md`
-     → expected no match. Target the memory-subtree `MEMORY.md` directly (the
-     `~/.claude/projects/-<encoded-project>/memory/MEMORY.md` path), not a
-     project-local `<project>/memory/MEMORY.md`, which does not exist.
+   - Index update: `grep -F '<slug>' ~/.claude/projects/-<encoded-project>/memory/MEMORY.md`
+     → expected no match. Use the project-scoped path (Claude Code encodes
+     the project root into the directory slug, e.g. `-Users-lukstafi-ludics`);
+     a literal `~/.claude/projects/-*/memory/MEMORY.md` would shell-glob
+     across every project's memory index and produce false positives or
+     negatives from unrelated projects. The project-local
+     `<project>/memory/MEMORY.md` does not exist either, so do not use it.
    - Optional secondary evidence: the harness-side keepalive-commit SHA, only
      if the harness sync has run; not load-bearing. See `CLAUDE.md` /
      `MEMORY.md` for the harness-side tracking detail — do not inline that


### PR DESCRIPTION
## Summary

- Adds `### AC verification reachability — find/grep over commit-SHA when the path is outside project git context` subsection inside `skills/ludics-draft-proposal-worker.md`'s proposal-template fenced block.
- Rule: when an AC's named path sits outside `git -C <project_path>`'s introspection reach, the AC's primary evidence must use tooling reachable from the project worktree (find/grep), not a commit-SHA from the unreachable subtree.
- Worked example covers the memory subtree (`~/.claude/projects/-*/memory/`) with project-scoped find pre/post + concrete `grep -F '<slug>' ~/.claude/projects/-<encoded-project>/memory/MEMORY.md` + optional secondary keepalive-commit SHA. Generalises to cache dirs, generated artefacts, and parent-symlinked trees.
- Cites `gh-ludics-478` round 1 (PR #491) and commit `b4f5a92` as the precipitating instance.
- Skill-template-only change; pre-existing AC-template prose preserved.

Proposal: `docs/proposals/task-a8415073-ac-verification-reachability.md` (already on main as `6b2121a`).

Round-by-round:
- `d515a33` — initial subsection.
- `5b2cf4a` — round-2 fix: retargeted the worked-example index-check grep at the memory subtree's `MEMORY.md` (was project-local non-existent path).
- `607c896` — round-3 codex fix: scoped the worked-example commands to `~/.claude/projects/-<encoded-project>/memory/...` so verification doesn't shell-glob across every project's memory tree. Heading still uses `-*/memory/` as the structural-shape descriptor; inline note explains the wildcard-vs-encoded-project distinction.

## AC Verification

- AC1 — `grep -F` of full heading literal returns 1 hit. ✓
- AC2 — `awk` over `\`\`\`markdown` … `\`\`\`` fenced block contains the new heading. ✓
- AC3 — subsection body contains `gh-ludics-478` AND `b4f5a92`. ✓
- AC4 — find/grep = 5 hits, MEMORY.md = 4, optional|secondary = 2 in body; concrete grep targets `~/.claude/projects/-<encoded-project>/memory/MEMORY.md` (project-scoped). ✓
- AC5 — `cache` / `generated` / `parent-symlinked` present AND `same pattern` stated. ✓
- AC6 — `CLAUDE.md` AND `MEMORY.md` referenced; no `harness/claude-memory` or `keepalive checkpoint` literals (link-by-reference only). ✓
- AC7 — `git diff --name-only main...HEAD` matches none of `^(src/|scripts/|.*\.test\.ts$)`. ✓
- AC8 — only `skills/ludics-draft-proposal-worker.md` under `skills/`; no `docs/ac-rigor-reference.md` change. ✓
- AC9 — `Each criterion should be` AND `Do NOT invent requirements` still present in the worker skill. ✓

## Test plan

- [x] All 9 AC falsifiers re-run locally and pass on `607c896`.
- [x] No code changes — skill markdown only, no test/build target affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)