### PR TITLE
lint: test-spawn-coverage — mechanize cli_exit_code_needs_spawn trip-wire (task-f534e799)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Lint skill body shell variables
         run: bun run lint:skill-shell
 
+      - name: Lint — test spawn coverage
+        run: bun run lint:test-spawn-coverage
+
       - name: Lint config reference drift
         run: bun run lint:config-reference
 

--- a/docs/proposals/lint-test-spawn-coverage.md
+++ b/docs/proposals/lint-test-spawn-coverage.md
@@ -151,10 +151,11 @@ for the test-coverage discipline.
       - **Floor-count meta-test** (SILENT-DRIFT guard, sibling to
         `lint-skill-cli-refs.test.ts`'s pattern): the number of `test|it
         ("exits 0|1|\d+|non-zero …")` rows in the live `scripts/*.test.ts`
-        set is at least the count observed at proposal time (≥ 35 rows
-        across ≥ 12 files — verified count: 35 trigger rows in 12 files
-        as of HEAD `6b2121a`). If a future refactor drops the trigger
-        recognizer to zero matches, this assertion fires.
+        set is at least the count observed at implementation time (≥ 30
+        rows across ≥ 10 files — verified count via the lint's own
+        recognizer at HEAD `ce4b106`: 31 trigger rows in 10 files). If a
+        future refactor drops the trigger recognizer to zero matches,
+        this assertion fires.
 - [ ] `scripts/lint-test-spawn-coverage.test.ts` itself complies with the
       lint's own contract: its `describe("CLI exit code", …)` block (or
       equivalent) MUST contain `Bun.spawnSync` and assert on `proc.exitCode`
@@ -230,13 +231,15 @@ Sibling-shape models (verified on current `main`, HEAD `6b2121a`,
   second-occurrence note and the specific trip-wire grep recipe). This
   proposal mechanizes the grep recipe.
 
-Existing exit-shape test inventory (verified on HEAD `6b2121a`,
-2026-05-10): 35 trigger-matching rows across 12 `scripts/*.test.ts` files.
-All currently comply with the spawn requirement except for the two
-`describe("runCli", …)` rows in `scripts/lint-no-shadow-util.test.ts`
-(lines 198, 233) which use the injectable-IO `runCli({ writeErr, writeOut,
-… })` pattern. Those two rows receive `// lint:allow-no-spawn` pragmas as
-part of this PR (per the AC above).
+Existing exit-shape test inventory (verified at implementation time
+against the lint's own `findTriggers` recognizer, HEAD `ce4b106`): 31
+trigger-matching rows across 10 `scripts/*.test.ts` files. All currently
+comply with the spawn requirement except for the two `describe("runCli",
+…)` rows in `scripts/lint-no-shadow-util.test.ts` which use the
+injectable-IO `runCli({ writeErr, writeOut, … })` pattern. Those two
+rows receive `// lint:allow-no-spawn` pragmas as part of this PR (per
+the AC above). The proposal-time count of "35 rows in 12 files" was an
+agent estimate; the lint's recognizer is authoritative.
 
 The runner.lifecycle false-positive class is structurally avoided by Q1
 (in-scope: `scripts/*.test.ts` only — `src/orchestration/runner.lifecycle.

--- a/docs/proposals/lint-test-spawn-coverage.md
+++ b/docs/proposals/lint-test-spawn-coverage.md
@@ -151,9 +151,11 @@ for the test-coverage discipline.
       - **Floor-count meta-test** (SILENT-DRIFT guard, sibling to
         `lint-skill-cli-refs.test.ts`'s pattern): the number of `test|it
         ("exits 0|1|\d+|non-zero …")` rows in the live `scripts/*.test.ts`
-        set is at least the count observed at proposal time (≥ 35 rows
-        across ≥ 12 files — verified count: 35 trigger rows in 12 files
-        as of HEAD `6b2121a`). If a future refactor drops the trigger
+        set is at least the count observed at implementation time (≥ 30
+        rows across ≥ 10 files — verified count via the lint's own
+        `findTriggers` recognizer at HEAD `6b2121a`: 31 trigger rows in
+        10 files; the proposal-time estimate of 35 / 12 was an
+        unverified agent count). If a future refactor drops the trigger
         recognizer to zero matches, this assertion fires.
 - [ ] `scripts/lint-test-spawn-coverage.test.ts` itself complies with the
       lint's own contract: its `describe("CLI exit code", …)` block (or
@@ -230,13 +232,16 @@ Sibling-shape models (verified on current `main`, HEAD `6b2121a`,
   second-occurrence note and the specific trip-wire grep recipe). This
   proposal mechanizes the grep recipe.
 
-Existing exit-shape test inventory (verified on HEAD `6b2121a`,
-2026-05-10): 35 trigger-matching rows across 12 `scripts/*.test.ts` files.
-All currently comply with the spawn requirement except for the two
-`describe("runCli", …)` rows in `scripts/lint-no-shadow-util.test.ts`
-(lines 198, 233) which use the injectable-IO `runCli({ writeErr, writeOut,
-… })` pattern. Those two rows receive `// lint:allow-no-spawn` pragmas as
-part of this PR (per the AC above).
+Existing exit-shape test inventory (verified on HEAD `6b2121a` via the
+lint's own `findTriggers` recognizer): 31 trigger-matching rows across
+10 `scripts/*.test.ts` files. All currently comply with the spawn
+requirement except for the two `describe("runCli", …)` rows in
+`scripts/lint-no-shadow-util.test.ts` (lines 198, 233) which use the
+injectable-IO `runCli({ writeErr, writeOut, … })` pattern. Those two
+rows receive `// lint:allow-no-spawn` pragmas as part of this PR (per
+the AC above). (The proposal-draft text originally cited "35 / 12";
+that count was an unverified agent estimate corrected here against the
+recognizer's actual output.)
 
 The runner.lifecycle false-positive class is structurally avoided by Q1
 (in-scope: `scripts/*.test.ts` only — `src/orchestration/runner.lifecycle.

--- a/docs/proposals/lint-test-spawn-coverage.md
+++ b/docs/proposals/lint-test-spawn-coverage.md
@@ -151,11 +151,10 @@ for the test-coverage discipline.
       - **Floor-count meta-test** (SILENT-DRIFT guard, sibling to
         `lint-skill-cli-refs.test.ts`'s pattern): the number of `test|it
         ("exits 0|1|\d+|non-zero …")` rows in the live `scripts/*.test.ts`
-        set is at least the count observed at implementation time (≥ 30
-        rows across ≥ 10 files — verified count via the lint's own
-        recognizer at HEAD `ce4b106`: 31 trigger rows in 10 files). If a
-        future refactor drops the trigger recognizer to zero matches,
-        this assertion fires.
+        set is at least the count observed at proposal time (≥ 35 rows
+        across ≥ 12 files — verified count: 35 trigger rows in 12 files
+        as of HEAD `6b2121a`). If a future refactor drops the trigger
+        recognizer to zero matches, this assertion fires.
 - [ ] `scripts/lint-test-spawn-coverage.test.ts` itself complies with the
       lint's own contract: its `describe("CLI exit code", …)` block (or
       equivalent) MUST contain `Bun.spawnSync` and assert on `proc.exitCode`
@@ -231,15 +230,13 @@ Sibling-shape models (verified on current `main`, HEAD `6b2121a`,
   second-occurrence note and the specific trip-wire grep recipe). This
   proposal mechanizes the grep recipe.
 
-Existing exit-shape test inventory (verified at implementation time
-against the lint's own `findTriggers` recognizer, HEAD `ce4b106`): 31
-trigger-matching rows across 10 `scripts/*.test.ts` files. All currently
-comply with the spawn requirement except for the two `describe("runCli",
-…)` rows in `scripts/lint-no-shadow-util.test.ts` which use the
-injectable-IO `runCli({ writeErr, writeOut, … })` pattern. Those two
-rows receive `// lint:allow-no-spawn` pragmas as part of this PR (per
-the AC above). The proposal-time count of "35 rows in 12 files" was an
-agent estimate; the lint's recognizer is authoritative.
+Existing exit-shape test inventory (verified on HEAD `6b2121a`,
+2026-05-10): 35 trigger-matching rows across 12 `scripts/*.test.ts` files.
+All currently comply with the spawn requirement except for the two
+`describe("runCli", …)` rows in `scripts/lint-no-shadow-util.test.ts`
+(lines 198, 233) which use the injectable-IO `runCli({ writeErr, writeOut,
+… })` pattern. Those two rows receive `// lint:allow-no-spawn` pragmas as
+part of this PR (per the AC above).
 
 The runner.lifecycle false-positive class is structurally avoided by Q1
 (in-scope: `scripts/*.test.ts` only — `src/orchestration/runner.lifecycle.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:cli-subcommands": "bun run scripts/lint-cli-subcommands.ts",
     "lint:skill-cli-refs": "bun run scripts/lint-skill-cli-refs.ts",
     "lint:skill-shell": "bun run scripts/lint-skill-shell.ts",
+    "lint:test-spawn-coverage": "bun run scripts/lint-test-spawn-coverage.ts",
     "lint:config-reference": "bun run scripts/lint-config-reference.ts",
     "lint:contracts": "bun run scripts/lint-contracts.ts",
     "lint:hooks": "bun run scripts/lint-hooks.ts",

--- a/scripts/lint-no-shadow-util.test.ts
+++ b/scripts/lint-no-shadow-util.test.ts
@@ -195,6 +195,7 @@ function writeUtil(srcDir: string): string {
 }
 
 describe("runCli", () => {
+  // lint:allow-no-spawn
   test("exits 0 on a clean tree (only util.ts defines the helpers)", () => {
     const root = makeTempTree();
     try {
@@ -230,6 +231,7 @@ describe("runCli", () => {
     }
   });
 
+  // lint:allow-no-spawn
   test("exits 1 with path:line on a planted shadow", () => {
     const root = makeTempTree();
     try {

--- a/scripts/lint-test-spawn-coverage.test.ts
+++ b/scripts/lint-test-spawn-coverage.test.ts
@@ -1,0 +1,607 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { join } from "path";
+import {
+  IN_SCOPE_GLOBS,
+  collectInScopeFiles,
+  countTriggerRows,
+  findDescribeBlocks,
+  findMatchingBrace,
+  findSpawnIndices,
+  findTriggers,
+  hasPragmaAbove,
+  lintCorpus,
+  lintFile,
+  spawnCoversTrigger,
+} from "./lint-test-spawn-coverage.ts";
+
+const root = join(import.meta.dir, "..");
+
+// The lint scans `scripts/*.test.ts` — including this file. To prevent the
+// synthetic-source fixtures below from being seen as real triggers when the
+// lint reads this file's bytes, we interpolate the keywords from uppercase
+// constants. The trigger regex is case-sensitive and matches lowercase
+// `test|it` only, so `${TEST}(...` in the source bytes does NOT match,
+// while at runtime the strings resolve to lowercase `test(...` for the
+// recognizer to find as intended. (Without this, the live-corpus assertion
+// would fail with dozens of self-induced violations.)
+const TEST = "test";
+const IT = "it";
+
+// ---------------------------------------------------------------------------
+// IN_SCOPE_GLOBS — single literal, scoped to scripts/*.test.ts only
+// ---------------------------------------------------------------------------
+
+describe("IN_SCOPE_GLOBS", () => {
+  test("is exactly scripts/*.test.ts (no src/, templates/, docs/ extension)", () => {
+    expect(IN_SCOPE_GLOBS).toEqual(["scripts/*.test.ts"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findMatchingBrace — balanced-brace walker (skips strings, templates, comments)
+// ---------------------------------------------------------------------------
+
+describe("findMatchingBrace", () => {
+  test("finds the matching `}` for a flat block", () => {
+    const src = "x = { foo: 1 }";
+    const start = src.indexOf("{");
+    expect(findMatchingBrace(src, start)).toBe(src.lastIndexOf("}"));
+  });
+
+  test("skips `{` / `}` inside double-quoted strings", () => {
+    const src = 'x = { s: "{not a brace}" }';
+    const start = src.indexOf("{");
+    expect(findMatchingBrace(src, start)).toBe(src.length - 1);
+  });
+
+  test("skips `{` / `}` inside template literals (and substitution interiors)", () => {
+    const src = "x = { s: `${a}` }";
+    const start = src.indexOf("{");
+    expect(findMatchingBrace(src, start)).toBe(src.length - 1);
+  });
+
+  test("skips `{` / `}` inside line and block comments", () => {
+    const src = "x = { // }\n /* } */ y: 1 }";
+    const start = src.indexOf("{");
+    expect(findMatchingBrace(src, start)).toBe(src.length - 1);
+  });
+
+  test("returns -1 when startIdx is not `{`", () => {
+    expect(findMatchingBrace("abc", 0)).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findDescribeBlocks — describe(…) callsite discovery
+// ---------------------------------------------------------------------------
+
+describe("findDescribeBlocks", () => {
+  test("locates a single describe block with body offsets", () => {
+    const src = ['describe("a", () => {', "  const x = 1;", "});"].join("\n");
+    const blocks = findDescribeBlocks(src);
+    expect(blocks).toHaveLength(1);
+    expect(src[blocks[0]!.bodyStart]).toBe("{");
+    expect(src[blocks[0]!.bodyEnd]).toBe("}");
+  });
+
+  test("locates nested describes (each registered separately)", () => {
+    const src = [
+      'describe("outer", () => {',
+      '  describe("inner", () => {',
+      "    const x = 1;",
+      "  });",
+      "});",
+    ].join("\n");
+    const blocks = findDescribeBlocks(src);
+    expect(blocks).toHaveLength(2);
+    const [first, second] = blocks;
+    const outer = first!.bodyEnd > second!.bodyEnd ? first! : second!;
+    const inner = outer === first ? second! : first!;
+    expect(outer.bodyStart < inner.bodyStart).toBe(true);
+    expect(outer.bodyEnd > inner.bodyEnd).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findTriggers — recognizer narrowness
+// ---------------------------------------------------------------------------
+
+describe("findTriggers — Q2 narrowness", () => {
+  test(`recognizes ${TEST}("exits 0|1|non-zero …")`, () => {
+    const src = [
+      `${TEST}("exits 0 on a clean tree", () => {});`,
+      `${TEST}("exits 1 with a violation", () => {});`,
+      `${TEST}("exits non-zero on bad input", () => {});`,
+    ].join("\n");
+    const triggers = findTriggers(src);
+    expect(triggers).toHaveLength(3);
+    expect(triggers.map((t) => t.testName)).toEqual([
+      "exits 0 on a clean tree",
+      "exits 1 with a violation",
+      "exits non-zero on bad input",
+    ]);
+  });
+
+  test(`recognizes ${IT}("exits 0 …") alongside test (Q4 alias)`, () => {
+    const src = `${IT}("exits 0 against an empty fixture", () => {});`;
+    const triggers = findTriggers(src);
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]!.testName).toBe("exits 0 against an empty fixture");
+  });
+
+  test(`does NOT recognize "exits after grace window …" (no leading numeric)`, () => {
+    // Mutation evidence: if the recognizer were widened to `exits\s+\w+`,
+    // this assertion fires. Falsifies the runner.lifecycle false-positive
+    // class structurally.
+    const src = `${TEST}("exits after grace window when tmux sibling state is missing", () => {});`;
+    expect(findTriggers(src)).toEqual([]);
+  });
+
+  test(`does NOT recognize "exits early when …"`, () => {
+    const src = `${TEST}("exits early when t3code sibling state has a mismatched PID", () => {});`;
+    expect(findTriggers(src)).toEqual([]);
+  });
+
+  test(`does NOT recognize "returns exit 0 …" synonym (intentional narrow scope)`, () => {
+    const src = `${TEST}("returns exit 0 against an empty fixture", () => {});`;
+    expect(findTriggers(src)).toEqual([]);
+  });
+
+  test(`does NOT recognize "fails CI when …" synonym`, () => {
+    const src = `${TEST}("fails CI when descriptor is missing", () => {});`;
+    expect(findTriggers(src)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSpawnIndices — Q3 allowlist
+// ---------------------------------------------------------------------------
+
+describe("findSpawnIndices — Q3 allowlist", () => {
+  test("matches Bun.spawnSync(", () => {
+    expect(findSpawnIndices("const p = Bun.spawnSync({});")).toHaveLength(1);
+  });
+
+  test("matches Bun.spawn( (async form)", () => {
+    expect(findSpawnIndices("const p = Bun.spawn({});")).toHaveLength(1);
+  });
+
+  test("matches Bun.$", () => {
+    expect(findSpawnIndices("await Bun.$`ls`;")).toHaveLength(1);
+  });
+
+  test("matches execFileSync(", () => {
+    expect(findSpawnIndices("execFileSync('git', []);")).toHaveLength(1);
+  });
+
+  test("matches execSync(", () => {
+    expect(findSpawnIndices("execSync('git status');")).toHaveLength(1);
+  });
+
+  test("matches standalone spawnSync( (Node-style import)", () => {
+    expect(
+      findSpawnIndices(
+        'import { spawnSync } from "child_process";\nspawnSync("ls", []);',
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  test("matches standalone spawn( (Node-style import)", () => {
+    expect(
+      findSpawnIndices(
+        'import { spawn } from "child_process";\nspawn("ls", []);',
+      ).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasPragmaAbove — escape-hatch logic
+// ---------------------------------------------------------------------------
+
+describe("hasPragmaAbove", () => {
+  test("returns true when pragma is on the line immediately above", () => {
+    const src = [
+      "// lint:allow-no-spawn",
+      `${TEST}("exits 1 when foo", () => {});`,
+    ].join("\n");
+    const idx = src.indexOf(`${TEST}(`);
+    expect(hasPragmaAbove(src, idx)).toBe(true);
+  });
+
+  test("returns true with intervening blank lines", () => {
+    const src = [
+      "// lint:allow-no-spawn",
+      "",
+      "",
+      `${TEST}("exits 1 when foo", () => {});`,
+    ].join("\n");
+    const idx = src.indexOf(`${TEST}(`);
+    expect(hasPragmaAbove(src, idx)).toBe(true);
+  });
+
+  test("returns false when other code is between pragma and trigger", () => {
+    const src = [
+      "// lint:allow-no-spawn",
+      "const x = 1;",
+      `${TEST}("exits 1 when foo", () => {});`,
+    ].join("\n");
+    const idx = src.indexOf(`${TEST}(`);
+    expect(hasPragmaAbove(src, idx)).toBe(false);
+  });
+
+  test("returns false when no pragma is above", () => {
+    const src = [
+      `describe('x', () => {`,
+      `${TEST}("exits 1 when foo", () => {});`,
+      "});",
+    ].join("\n");
+    const idx = src.indexOf(`${TEST}(`);
+    expect(hasPragmaAbove(src, idx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnCoversTrigger — ancestor-only scope rule
+// ---------------------------------------------------------------------------
+
+describe("spawnCoversTrigger", () => {
+  test("file-scope spawn always covers any trigger (no enclosing describe)", () => {
+    expect(spawnCoversTrigger(0, 100, [])).toBe(true);
+  });
+
+  test("ancestor-describe spawn covers nested-describe trigger", () => {
+    const blocks = [{ bodyStart: 0, bodyEnd: 100 }];
+    expect(spawnCoversTrigger(5, 50, blocks)).toBe(true);
+  });
+
+  test("sibling-describe spawn does NOT cover trigger in another describe", () => {
+    const blocks = [
+      { bodyStart: 0, bodyEnd: 50 },
+      { bodyStart: 60, bodyEnd: 100 },
+    ];
+    expect(spawnCoversTrigger(5, 70, blocks)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintFile — full AC matrix
+// ---------------------------------------------------------------------------
+
+describe("lintFile — AC matrix", () => {
+  test("Positive — flagged: in-process resolver inside CLI exit code describe", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when foo", () => {`,
+      `    const result = runLint([]);`,
+      `    expect(result.exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 1 when foo");
+    expect(violations[0]!.line).toBe(2);
+  });
+
+  test("Positive — flagged for it(...) (Q4 alias)", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${IT}("exits 0 against an empty fixture", () => {`,
+      `    expect(runLint([]).exitCode).toBe(0);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 0 against an empty fixture");
+  });
+
+  test("Negative — describe contains Bun.spawnSync (PR #518 round-2 shape)", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when bar", () => {`,
+      `    const proc = Bun.spawnSync({});`,
+      `    expect(proc.exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — describe contains Bun.$", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when baz", async () => {`,
+      "    await Bun.$`bun run scripts/lint.ts`;",
+      `    expect(true).toBe(true);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — describe contains Bun.spawn( (async form, Q3 sync+async)", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when qux", async () => {`,
+      `    const proc = Bun.spawn({});`,
+      `    await proc.exited;`,
+      `    expect(proc.exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — describe contains execFileSync from child_process", () => {
+    const src = [
+      `import { execFileSync } from "child_process";`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when qq", () => {`,
+      `    const out = execFileSync('bun', ['run']);`,
+      `    expect(out).toBeTruthy();`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — describe contains standalone spawnSync from child_process", () => {
+    const src = [
+      `import { spawnSync } from "child_process";`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when ww", () => {`,
+      `    const proc = spawnSync('bun', []);`,
+      `    expect(proc.status).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — test.each(...) is intentionally NOT recognized (v1 scope)", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}.each([[1], [2]])("exits 1 when %p", (n) => {`,
+      `    expect(n).toBeGreaterThan(0);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test(`Negative — trigger excludes "exits after grace window …" (Q2)`, () => {
+    // Mutation evidence: even with zero spawns in the enclosing describe,
+    // an "exits after …"-style runner test does NOT fire. Falsifies the
+    // runner.lifecycle false-positive class structurally — if the
+    // recognizer were widened to `exits\s+\w+`, this assertion flips.
+    const src = [
+      `describe("runner lifecycle", () => {`,
+      `  ${TEST}("exits after grace window when tmux sibling state is missing", () => {`,
+      `    const out = runOrchestration({});`,
+      `    expect(out.phase).toBe('ended');`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test(`Negative — trigger excludes "returns exit 0 …" synonym`, () => {
+    const src = [
+      `describe("CLI", () => {`,
+      `  ${TEST}("returns exit 0 against an empty fixture", () => {`,
+      `    expect(runLint([]).exitCode).toBe(0);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — pragma suppresses the immediately-following row", () => {
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  // lint:allow-no-spawn`,
+      `  ${TEST}("exits 1 when no spawn", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Positive — pragma does NOT suppress a non-immediately-following row", () => {
+    // Mutation evidence: if the pragma were treated as a block-wide
+    // suppressor, the assertion `length === 1` and the second-test name
+    // check below would fail. The pragma's single-row scope is what's
+    // being enforced here.
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  // lint:allow-no-spawn`,
+      `  ${TEST}("exits 1 when first", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `  ${TEST}("exits 0 when second", () => {`,
+      `    expect(runLint([]).exitCode).toBe(0);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 0 when second");
+  });
+
+  test("Negative — nested describes, ancestor describe contains Bun.spawnSync", () => {
+    const src = [
+      `describe("outer", () => {`,
+      `  const proc = Bun.spawnSync({});`,
+      `  describe("inner", () => {`,
+      `    ${TEST}("exits 1 when nested", () => {`,
+      `      expect(proc.exitCode).toBe(1);`,
+      `    });`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Negative — top-level test with file-body spawn (no enclosing describe)", () => {
+    const src = [
+      `const proc = Bun.spawnSync({});`,
+      `${TEST}("exits 1 when top level", () => {`,
+      `  expect(proc.exitCode).toBe(1);`,
+      `});`,
+    ].join("\n");
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("Positive — sibling-describe spawn does NOT cover a trigger in another describe", () => {
+    // Falsifies a too-lenient "any spawn anywhere in the file is enough"
+    // implementation. The spawn lives inside a sibling describe; the
+    // trigger lives in a different describe with no spawn. Per Q4-extended
+    // scope rule, this MUST flag.
+    const src = [
+      `describe("smoke", () => {`,
+      `  const proc = Bun.spawnSync({});`,
+      `  ${TEST}("exits 0 when smoke", () => {`,
+      `    expect(proc.exitCode).toBe(0);`,
+      `  });`,
+      `});`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when foo", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 1 when foo");
+  });
+
+  test("violation row carries file, line, and full test-name literal", () => {
+    const src = [
+      `// header line 1`,
+      `// header line 2`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when fabricated", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("a.test.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.file).toBe("a.test.ts");
+    expect(violations[0]!.line).toBe(4);
+    expect(violations[0]!.testName).toBe("exits 1 when fabricated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live-corpus smoke + floor-count meta-test
+// ---------------------------------------------------------------------------
+
+describe("live corpus", () => {
+  test("running the lint over the live scripts/*.test.ts set yields zero violations", () => {
+    // After the pragma applications mandated by the AC, the live tree
+    // MUST be clean. If a future PR introduces an unwrapped exits-named
+    // test without a spawn or pragma, this assertion fires.
+    const files = collectInScopeFiles(root);
+    const violations = lintCorpus(files, (rel) =>
+      readFileSync(join(root, rel), "utf-8"),
+    );
+    expect(violations).toEqual([]);
+  });
+
+  test("floor-count: at least 30 trigger rows across at least 10 files (silent-drift guard)", () => {
+    // SILENT-DRIFT WARNING: a refactor that consolidates exit-code tests
+    // behind a helper or renames them would let this lint pass vacuously
+    // (zero triggers ⇒ zero violations). This floor-count assertion fires
+    // if the trigger recognizer drops to near-zero matches against the
+    // live `scripts/*.test.ts` set.
+    const files = collectInScopeFiles(root);
+    const { totalRows, filesWithRows } = countTriggerRows(files, (rel) =>
+      readFileSync(join(root, rel), "utf-8"),
+    );
+    expect(totalRows).toBeGreaterThanOrEqual(30);
+    expect(filesWithRows).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI exit-code contract — the lint's own self-test must spawn the CLI
+// (otherwise it would fail its own check, which is the right invariant).
+// Mirrors the failure-path tamper-and-restore harness in
+// scripts/lint-skill-shell.test.ts.
+// ---------------------------------------------------------------------------
+
+describe("CLI exit code", () => {
+  const scriptPath = join(root, "scripts", "lint-test-spawn-coverage.ts");
+
+  test("exits 0 against the live corpus (post-PR pragma applications)", () => {
+    const proc = Bun.spawnSync({
+      cmd: ["bun", "run", scriptPath],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("✅");
+  });
+
+  test("exits 1 with the AC stderr shape on a tampered in-scope test file", () => {
+    // Harness condition: temporarily plant a synthetic test file under
+    // scripts/ that contains a violating exits-named row with no spawn
+    // in its describe block. Spawn the CLI, then unlink.
+    //
+    // Invariant being enforced: the AC's CLI-surface wording — exit 1 on
+    // any violation, with stderr matching the expected shape (❌ summary
+    // + per-violation `file:line test("…")` row + remediation prompt
+    // naming the three fixes). Mutation-testing this path catches a
+    // future refactor that drops `process.exit(1)`, swallows the ❌
+    // summary, omits the test-name literal, or drops a remediation phrase.
+    const target = join(
+      root,
+      "scripts",
+      "__lint_test_spawn_coverage_probe__.test.ts",
+    );
+    const probe = [
+      `import { describe, test, expect } from "bun:test";`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when probe fires", () => {`,
+      `    expect(1).toBe(1);`,
+      `  });`,
+      `});`,
+      ``,
+    ].join("\n");
+    try {
+      writeFileSync(target, probe);
+      const proc = Bun.spawnSync({
+        cmd: ["bun", "run", scriptPath],
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(proc.exitCode).toBe(1);
+      const stderr = proc.stderr.toString();
+      // ❌ summary line — without it, the violation list is unattributed.
+      expect(stderr).toContain("❌");
+      // Per-violation row shape: `<file>:<line> test("<name>")`.
+      expect(stderr).toContain(
+        "scripts/__lint_test_spawn_coverage_probe__.test.ts",
+      );
+      expect(stderr).toContain(`test("exits 1 when probe fires")`);
+      // Remediation prompt — anchor on each of the three sanctioned
+      // fixes so a future edit that strips one path is caught.
+      expect(stderr).toContain("Bun.spawnSync");
+      expect(stderr).toContain("rename the test");
+      expect(stderr).toContain("// lint:allow-no-spawn");
+    } finally {
+      try {
+        unlinkSync(target);
+      } catch {
+        // best-effort cleanup — if unlink fails the next run will overwrite.
+      }
+    }
+  });
+});

--- a/scripts/lint-test-spawn-coverage.test.ts
+++ b/scripts/lint-test-spawn-coverage.test.ts
@@ -247,13 +247,39 @@ describe("hasPragmaAbove", () => {
 // ---------------------------------------------------------------------------
 
 describe("spawnCoversTrigger", () => {
-  test("file-scope spawn always covers any trigger (no enclosing describe)", () => {
+  test("file-scope spawn covers a top-level trigger (both at file scope)", () => {
     expect(spawnCoversTrigger(0, 100, [])).toBe(true);
   });
 
-  test("ancestor-describe spawn covers nested-describe trigger", () => {
+  test("file-scope spawn does NOT cover a describe-internal trigger", () => {
+    // Reviewer's blocking case (round 1): the AC explicitly says
+    // "Top-level test(...) rows with no enclosing describe use the file
+    // body as their 'describe body'" — meaning file-body spawns ONLY
+    // cover top-level triggers. A trigger inside a describe is NOT
+    // covered by a file-scope spawn (only by spawns inside its describe
+    // chain). Mutation evidence: under a "containers(spawn) ⊆
+    // containers(trigger)"-only rule (which my round-1 implementation
+    // had), this assertion would return true — an over-lenient cover.
+    const blocks = [{ bodyStart: 50, bodyEnd: 100 }];
+    // spawn at idx 5 (file scope, before block), trigger at idx 70 (inside block).
+    expect(spawnCoversTrigger(5, 70, blocks)).toBe(false);
+  });
+
+  test("same-describe spawn covers a same-describe trigger", () => {
     const blocks = [{ bodyStart: 0, bodyEnd: 100 }];
     expect(spawnCoversTrigger(5, 50, blocks)).toBe(true);
+  });
+
+  test("ancestor-describe spawn covers nested-describe trigger", () => {
+    // Outer describe contains inner; spawn lives in outer's body
+    // (between the outer's open and the inner's open). Trigger lives in
+    // inner. Per AC: ancestor describe bodies count toward coverage.
+    const blocks = [
+      { bodyStart: 0, bodyEnd: 100 }, // outer
+      { bodyStart: 30, bodyEnd: 80 }, // inner
+    ];
+    // spawn at idx 10 (in outer, before inner opens), trigger at 50 (in inner)
+    expect(spawnCoversTrigger(10, 50, blocks)).toBe(true);
   });
 
   test("sibling-describe spawn does NOT cover trigger in another describe", () => {
@@ -262,6 +288,15 @@ describe("spawnCoversTrigger", () => {
       { bodyStart: 60, bodyEnd: 100 },
     ];
     expect(spawnCoversTrigger(5, 70, blocks)).toBe(false);
+  });
+
+  test("describe-nested spawn does NOT cover a top-level trigger", () => {
+    // Symmetric of the file-scope-spawn-covers-describe-internal bug:
+    // a spawn buried inside a describe block is not "at file scope" and
+    // therefore can't cover a sibling top-level test row.
+    const blocks = [{ bodyStart: 50, bodyEnd: 100 }];
+    // spawn at idx 70 (inside block), trigger at idx 5 (top level, outside block).
+    expect(spawnCoversTrigger(70, 5, blocks)).toBe(false);
   });
 });
 
@@ -456,6 +491,33 @@ describe("lintFile — AC matrix", () => {
     expect(lintFile("synthetic.ts", src)).toEqual([]);
   });
 
+  test("Positive — file-scope spawn does NOT cover trigger inside describe", () => {
+    // Reviewer round-1 blocking case (verbatim fixture). The AC says
+    // "Top-level test(...) rows with no enclosing describe use the file
+    // body as their 'describe body'" — meaning file-body spawns ONLY
+    // cover top-level triggers. This fixture has a file-scope
+    // Bun.spawnSync({}) and a trigger inside a `describe("CLI exit
+    // code", …)` whose body has no spawn. Under the round-1
+    // implementation, lintFile returned [] (no violation, incorrect).
+    // Under the round-2 implementation, this fires.
+    //
+    // Mutation evidence: reverting `spawnCoversTrigger` to the
+    // round-1 "containers(spawn) ⊆ containers(trigger)"-only rule
+    // makes `expect(violations).toHaveLength(1)` fail (it would
+    // return 0).
+    const src = [
+      `const proc = Bun.spawnSync({});`,
+      `describe("CLI exit code", () => {`,
+      `  ${TEST}("exits 1 when in-process", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 1 when in-process");
+  });
+
   test("Positive — sibling-describe spawn does NOT cover a trigger in another describe", () => {
     // Falsifies a too-lenient "any spawn anywhere in the file is enough"
     // implementation. The spawn lives inside a sibling describe; the
@@ -519,6 +581,14 @@ describe("live corpus", () => {
     // (zero triggers ⇒ zero violations). This floor-count assertion fires
     // if the trigger recognizer drops to near-zero matches against the
     // live `scripts/*.test.ts` set.
+    //
+    // AC-vs-reality note: the proposal text says "≥ 35 rows across ≥ 12
+    // files (verified count: 35 / 12 as of HEAD 6b2121a)". The lint's
+    // own `findTriggers` recognizer — the authoritative count — yields
+    // 31 / 10 against that same SHA, so the proposal's literal floor is
+    // unsatisfiable. The reality-based floor of 30 / 10 used here keeps
+    // the silent-drift invariant honest. Proposal-text correction is
+    // tracked under task-5083844f (status: needs-confirmation).
     const files = collectInScopeFiles(root);
     const { totalRows, filesWithRows } = countTriggerRows(files, (rel) =>
       readFileSync(join(root, rel), "utf-8"),

--- a/scripts/lint-test-spawn-coverage.test.ts
+++ b/scripts/lint-test-spawn-coverage.test.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import {
   IN_SCOPE_GLOBS,
   collectInScopeFiles,
+  computeCodeMask,
   countTriggerRows,
   findDescribeBlocks,
   findMatchingBrace,
@@ -157,6 +158,140 @@ describe("findTriggers — Q2 narrowness", () => {
 // ---------------------------------------------------------------------------
 // findSpawnIndices — Q3 allowlist
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// computeCodeMask + non-code masking — codex P1/P2 regression coverage
+// ---------------------------------------------------------------------------
+
+describe("computeCodeMask + non-code masking (codex P1/P2)", () => {
+  test("masks // line-comment bytes", () => {
+    const src = "const x = 1; // foo Bun.spawnSync({})\nconst y = 2;";
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(1);
+  });
+
+  test("masks /* block-comment */ bytes", () => {
+    const src = "const x = 1; /* Bun.spawnSync({}) */ const y = 2;";
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(1);
+  });
+
+  test("masks bytes inside double-quoted strings", () => {
+    const src = `const s = "Bun.spawnSync({})";`;
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(1);
+  });
+
+  test("masks bytes inside single-quoted strings", () => {
+    const src = `const s = 'Bun.spawnSync({})';`;
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(1);
+  });
+
+  test("masks bytes inside backtick template body", () => {
+    const src = "const s = `Bun.spawnSync({}) and stuff`;";
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(1);
+  });
+
+  test("does NOT mask bytes inside ${...} substitution (substitution interior is code)", () => {
+    const src = "const s = `prefix ${Bun.spawnSync({}).exitCode} suffix`;";
+    const mask = computeCodeMask(src);
+    const idx = src.indexOf("Bun.spawnSync");
+    expect(mask[idx]).toBe(0);
+  });
+
+  test("survives a regex literal containing string-like chars (no stuck-state)", () => {
+    // The lint-template-safety.test.ts file contains
+    //   `return /(?:\\?\\?|:|\\|\\|)\\s*""(?!")|.../.test(rhs);`
+    // — without regex-literal handling, the walker treated `""` as a
+    // string opener/closer and fell into a stuck-state that flipped the
+    // mask for the rest of the file. Regression test for the live-corpus
+    // case where line 725 of lint-template-safety.test.ts (a real
+    // `test("exits 0 …")` call) was being masked.
+    const src = [
+      `function looksFunny(rhs) {`,
+      `  return /(?:\\?\\?|:|\\|\\|)\\s*""(?!")|(?:\\?\\?|:|\\|\\|)\\s*''(?!')/.test(rhs);`,
+      `}`,
+      `describe("after regex", () => {`,
+      `  test("exits 0 against a clean tree", () => {`,
+      `    const proc = Bun.spawnSync({});`,
+      `    expect(proc.exitCode).toBe(0);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const mask = computeCodeMask(src);
+    // The describe and test calls AFTER the regex must be at code position.
+    const describeIdx = src.indexOf("describe(\"after");
+    const testIdx = src.indexOf(`test("exits 0`);
+    expect(mask[describeIdx]).toBe(0);
+    expect(mask[testIdx]).toBe(0);
+    // And findTriggers / lintFile should treat the trigger as covered.
+    expect(lintFile("synthetic.ts", src)).toEqual([]);
+  });
+
+  test("findSpawnIndices ignores spawn tokens in comments (codex P1)", () => {
+    // Without mask: this would return 1 match. With mask: 0.
+    const src = "// TODO: use Bun.spawnSync(...) here\nconst x = 1;";
+    expect(findSpawnIndices(src)).toEqual([]);
+  });
+
+  test("findSpawnIndices ignores spawn tokens in string fixtures (codex P1)", () => {
+    const src = 'const note = "Bun.spawnSync prose"; const x = 1;';
+    expect(findSpawnIndices(src)).toEqual([]);
+  });
+
+  test("findTriggers ignores trigger literals in template-body fixture text", () => {
+    // Mirrors the codex-P1 concern in the trigger direction. A bare
+    // backtick-quoted prose mention of `test("exits 1 ...")` is not a
+    // real test row.
+    const src = "const docs = `see test(\"exits 1 when foo\") in spec`;";
+    expect(findTriggers(src)).toEqual([]);
+  });
+
+  test("lintFile does NOT swallow a violation when an in-comment spawn token appears in the same describe (codex P1 end-to-end)", () => {
+    // Without mask filtering, the comment mention `// Bun.spawnSync(...)`
+    // would count as a covering spawn and the in-process trigger would
+    // pass lint silently. With the mask, it correctly flags the
+    // violation. Mutation evidence: removing the mask filter from
+    // findSpawnIndices makes this assertion fail (returns []).
+    const src = [
+      `describe("CLI exit code", () => {`,
+      `  // TODO: replace runLint() with Bun.spawnSync(...) at some point`,
+      `  ${TEST}("exits 1 when in-process", () => {`,
+      `    expect(runLint([]).exitCode).toBe(1);`,
+      `  });`,
+      `});`,
+    ].join("\n");
+    const violations = lintFile("synthetic.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.testName).toBe("exits 1 when in-process");
+  });
+
+  test("findMatchingBrace handles ${\"{\"} substitution-string with brace (codex P2)", () => {
+    // Without the mask-aware brace walker, the inner `"{"` would
+    // unbalance the substitution-depth counter and the outer brace
+    // walk would either return -1 or a wrong index. With the mask,
+    // strings inside the substitution are masked and their braces are
+    // skipped.
+    const src = [
+      `const x = {`,
+      "  s: `${\"{\"}`,",
+      `  v: 1,`,
+      `};`,
+    ].join("\n");
+    const start = src.indexOf("{");
+    const end = findMatchingBrace(src, start);
+    // The matching `}` should be the one before `;` — i.e. end matches
+    // the outer block, not -1, and is at the LAST `}` in the source.
+    expect(end).toBe(src.lastIndexOf("}"));
+  });
+});
 
 describe("findSpawnIndices — Q3 allowlist", () => {
   test("matches Bun.spawnSync(", () => {

--- a/scripts/lint-test-spawn-coverage.ts
+++ b/scripts/lint-test-spawn-coverage.ts
@@ -1,0 +1,366 @@
+#!/usr/bin/env bun
+/**
+ * lint-test-spawn-coverage.ts (task-f534e799)
+ *
+ * Mechanizes the trip-wire grep from `feedback_cli_exit_code_needs_spawn.md`
+ * (originally captured from gh-ludics-439; second occurrence flagged in the
+ * PR #518 / task-9329e350 retrospective): a test named
+ * `test("exits 0|1|N|non-zero …")` (or `it(…)`) inside a `describe(…)` block
+ * is asserting on a CLI surface contract — exit code, stderr/stdout shape,
+ * remediation prompt. A correct test for that contract must spawn the actual
+ * CLI binary; an in-process resolver assertion (`runLint(...)`,
+ * `lintCorpus(...)`, etc.) is the gh-ludics-439 / PR #518 anti-pattern.
+ *
+ * In-scope file set: `scripts/*.test.ts` only (Q1 boundary). `src/**`,
+ * `templates/**`, etc. are out of scope. Trigger recognizer fires only on
+ * `exits 0|1|N|non-zero` (Q2 tightening) — `exits after …` / `exits early
+ * …`-style runner-lifecycle tests (which assert on an in-process function's
+ * return, not a CLI exit code) do not match.
+ *
+ * Spawn allowlist (Q3): `Bun.spawnSync(`, `Bun.spawn(`, `Bun.$`,
+ * `execFileSync(`, `execSync(`, `spawnSync(`, `spawn(`. The Node-style
+ * standalone forms accept an imported `spawnSync` / `spawn` from
+ * `child_process`.
+ *
+ * Scope rule (Q4-extended): a trigger fires only if its nearest enclosing
+ * `describe(…)` body, its ancestor describe bodies, and the file body
+ * (collectively) contain no spawn-allowlist match. Sibling describes
+ * outside the ancestor chain do not count toward coverage.
+ *
+ * Escape hatch (Q5): a `// lint:allow-no-spawn` line comment immediately
+ * above a trigger row (intervening blank lines allowed; no other code)
+ * suppresses that one trigger. The pragma scope is the immediately-
+ * following `test(`/`it(` call only.
+ */
+
+import { readFileSync } from "fs";
+import { Glob } from "bun";
+import { join } from "path";
+
+const root = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// In-scope file set
+// ---------------------------------------------------------------------------
+
+export const IN_SCOPE_GLOBS: ReadonlyArray<string> = ["scripts/*.test.ts"];
+
+export function collectInScopeFiles(rootDir: string): string[] {
+  const out: string[] = [];
+  for (const pattern of IN_SCOPE_GLOBS) {
+    const glob = new Glob(pattern);
+    for (const match of glob.scanSync({ cwd: rootDir, onlyFiles: true })) {
+      out.push(match);
+    }
+  }
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Recognizers
+// ---------------------------------------------------------------------------
+
+// Trigger: `test("exits 0|1|N|non-zero …")` or `it(...)`. Captures the full
+// quoted name body (group 1) for the violation snippet. Uses an inner
+// non-greedy `[^"]*` so the regex anchors on a single quoted string.
+const TRIGGER_RE =
+  /(?:test|it)\s*\(\s*"(exits\s+(?:0|1|\d+|non-zero)\b[^"]*)"/g;
+
+// Spawn allowlist (single anchored expression matching any of the forms).
+// `Bun.spawn(` matches both sync (`Bun.spawnSync(`) and async (`Bun.spawn(`)
+// shapes via the optional `Sync` capture. `\bspawn(` / `\bspawnSync(`
+// accept Node-style standalone imports from `child_process`.
+const SPAWN_RE =
+  /Bun\.spawn(?:Sync)?\(|Bun\.\$|execFileSync\s*\(|execSync\s*\(|\bspawnSync\s*\(|\bspawn\s*\(/g;
+
+const PRAGMA_LITERAL = "// lint:allow-no-spawn";
+
+// ---------------------------------------------------------------------------
+// describe(…) block discovery — balanced-brace walk
+// ---------------------------------------------------------------------------
+
+export interface DescribeBlock {
+  /** Character offset of the opening `{` of the describe body. */
+  readonly bodyStart: number;
+  /** Character offset of the matching closing `}`. */
+  readonly bodyEnd: number;
+}
+
+// Match the opening shape `describe("...", () => {` (or function form / async
+// / single bareword arg). The match's terminal char is `{` — the body open.
+const DESCRIBE_OPEN_RE =
+  /\bdescribe\s*\(\s*(?:"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|'(?:[^'\\]|\\.)*')\s*,\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_$][\w$]*|function\s*\*?\s*[a-zA-Z_$]?\w*\s*\([^)]*\))\s*(?:=>)?\s*\{/g;
+
+/**
+ * Walk balanced braces starting from `startIdx` (which must be a `{`),
+ * skipping over string literals (single, double, backtick template),
+ * template-substitution `${…}` interiors, and `//` / `/* …`/ comments.
+ * Returns the index of the matching `}`, or -1 if not found.
+ */
+export function findMatchingBrace(source: string, startIdx: number): number {
+  if (source[startIdx] !== "{") return -1;
+  let depth = 0;
+  let i = startIdx;
+  while (i < source.length) {
+    const c = source[i]!;
+    const next = source[i + 1];
+    if (c === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (
+        i < source.length - 1 &&
+        !(source[i] === "*" && source[i + 1] === "/")
+      ) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      const q = c;
+      i++;
+      while (i < source.length && source[i] !== q) {
+        if (source[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        i++;
+      }
+      i++;
+      continue;
+    }
+    if (c === "`") {
+      i++;
+      while (i < source.length && source[i] !== "`") {
+        if (source[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (source[i] === "$" && source[i + 1] === "{") {
+          i += 2;
+          let subDepth = 1;
+          while (i < source.length && subDepth > 0) {
+            const cc = source[i]!;
+            if (cc === "{") subDepth++;
+            else if (cc === "}") subDepth--;
+            i++;
+          }
+          continue;
+        }
+        i++;
+      }
+      i++;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+export function findDescribeBlocks(source: string): DescribeBlock[] {
+  const out: DescribeBlock[] = [];
+  DESCRIBE_OPEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = DESCRIBE_OPEN_RE.exec(source)) !== null) {
+    const bodyStart = m.index + m[0].length - 1;
+    const bodyEnd = findMatchingBrace(source, bodyStart);
+    if (bodyEnd === -1) continue;
+    out.push({ bodyStart, bodyEnd });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Trigger / spawn / pragma scanning
+// ---------------------------------------------------------------------------
+
+export interface TriggerMatch {
+  /** Character offset of the start of the `test|it` keyword. */
+  readonly idx: number;
+  /** 1-indexed line number containing the trigger. */
+  readonly line: number;
+  /** The full quoted test-name literal (between the surrounding `"` chars). */
+  readonly testName: string;
+}
+
+export function findTriggers(source: string): TriggerMatch[] {
+  const out: TriggerMatch[] = [];
+  TRIGGER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = TRIGGER_RE.exec(source)) !== null) {
+    out.push({
+      idx: m.index,
+      line: lineOf(source, m.index),
+      testName: m[1]!,
+    });
+  }
+  return out;
+}
+
+export function findSpawnIndices(source: string): number[] {
+  const out: number[] = [];
+  SPAWN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SPAWN_RE.exec(source)) !== null) out.push(m.index);
+  return out;
+}
+
+function lineOf(source: string, idx: number): number {
+  let line = 1;
+  for (let i = 0; i < idx && i < source.length; i++) {
+    if (source[i] === "\n") line++;
+  }
+  return line;
+}
+
+/**
+ * Returns true if the trigger row is preceded — allowing intervening blank
+ * lines but no other code — by a `// lint:allow-no-spawn` line comment.
+ */
+export function hasPragmaAbove(source: string, triggerIdx: number): boolean {
+  const lineStart = source.lastIndexOf("\n", triggerIdx - 1) + 1;
+  if (lineStart === 0) return false;
+  let cursor = lineStart - 1;
+  while (cursor > 0) {
+    const prevLineEnd = cursor;
+    const prevLineStart = source.lastIndexOf("\n", cursor - 1) + 1;
+    const prevLine = source.slice(prevLineStart, prevLineEnd);
+    const trimmed = prevLine.trim();
+    if (trimmed === "") {
+      cursor = prevLineStart - 1;
+      continue;
+    }
+    return trimmed === PRAGMA_LITERAL;
+  }
+  return false;
+}
+
+/**
+ * For a spawn at `spawnIdx` to count as coverage for a trigger at
+ * `triggerIdx`, every describe block whose body contains the spawn must
+ * also contain the trigger — i.e. the spawn lives in an ancestor (or the
+ * same) describe of the trigger, or at file scope. Sibling/non-ancestor
+ * describes' spawns are filtered out.
+ */
+export function spawnCoversTrigger(
+  spawnIdx: number,
+  triggerIdx: number,
+  blocks: ReadonlyArray<DescribeBlock>,
+): boolean {
+  for (const b of blocks) {
+    const spawnIn = b.bodyStart < spawnIdx && spawnIdx < b.bodyEnd;
+    if (!spawnIn) continue;
+    const triggerIn = b.bodyStart < triggerIdx && triggerIdx < b.bodyEnd;
+    if (!triggerIn) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Per-file lint
+// ---------------------------------------------------------------------------
+
+export interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly testName: string;
+}
+
+export function lintFile(file: string, source: string): Violation[] {
+  const blocks = findDescribeBlocks(source);
+  const triggers = findTriggers(source);
+  const spawns = findSpawnIndices(source);
+  const out: Violation[] = [];
+  for (const t of triggers) {
+    if (hasPragmaAbove(source, t.idx)) continue;
+    const covered = spawns.some((s) => spawnCoversTrigger(s, t.idx, blocks));
+    if (covered) continue;
+    out.push({ file, line: t.line, testName: t.testName });
+  }
+  return out;
+}
+
+export function lintCorpus(
+  files: ReadonlyArray<string>,
+  readSource: (relPath: string) => string,
+): Violation[] {
+  const all: Violation[] = [];
+  for (const file of files) {
+    const src = readSource(file);
+    all.push(...lintFile(file, src));
+  }
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Trigger-row count helper (for the floor-count meta-test)
+// ---------------------------------------------------------------------------
+
+export function countTriggerRows(
+  files: ReadonlyArray<string>,
+  readSource: (relPath: string) => string,
+): { totalRows: number; filesWithRows: number } {
+  let totalRows = 0;
+  let filesWithRows = 0;
+  for (const file of files) {
+    const src = readSource(file);
+    const triggers = findTriggers(src);
+    if (triggers.length > 0) {
+      totalRows += triggers.length;
+      filesWithRows++;
+    }
+  }
+  return { totalRows, filesWithRows };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — mirrors lint-skill-shell.ts / lint-skill-cli-refs.ts shape
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const files = collectInScopeFiles(root);
+  const violations = lintCorpus(files, (rel) =>
+    readFileSync(join(root, rel), "utf-8"),
+  );
+  const triggerCount = countTriggerRows(files, (rel) =>
+    readFileSync(join(root, rel), "utf-8"),
+  ).totalRows;
+  if (violations.length === 0) {
+    console.log(
+      `✅  All ${triggerCount} exits-named tests in ${files.length} scripts/*.test.ts files spawn the CLI in their describe block.`,
+    );
+    process.exit(0);
+  }
+  const plural = violations.length === 1 ? "" : "s";
+  console.error(
+    `\n❌  ${violations.length} test("exits …") row${plural} do not spawn the CLI in their describe block:\n`,
+  );
+  for (const v of violations) {
+    console.error(`     - ${v.file}:${v.line} test("${v.testName}")`);
+  }
+  console.error(
+    `\n   Each row above names a test whose name promises CLI-level\n` +
+      `   coverage (exit code, stderr/stdout shape, remediation prompt) but\n` +
+      `   whose enclosing describe block does not call any of\n` +
+      `   Bun.spawnSync, Bun.spawn, Bun.$, execFileSync, execSync,\n` +
+      `   spawnSync, or spawn. Fix by either:\n` +
+      `     (a) rewrite to spawn the CLI via Bun.spawnSync and assert on\n` +
+      `         proc.exitCode / proc.stderr / proc.stdout (mirroring the\n` +
+      `         tamper-and-restore harness in scripts/lint-skill-shell.test.ts), or\n` +
+      `     (b) rename the test if it is genuinely asserting on an\n` +
+      `         in-process function's exit-code-shaped return (e.g.\n` +
+      `         "returns exit-code 0 …"), or\n` +
+      `     (c) add // lint:allow-no-spawn on the line immediately above the\n` +
+      `         test row if the in-process pattern is intentional and the\n` +
+      `         test name's CLI promise has been re-read.\n`,
+  );
+  process.exit(1);
+}

--- a/scripts/lint-test-spawn-coverage.ts
+++ b/scripts/lint-test-spawn-coverage.ts
@@ -245,21 +245,38 @@ export function hasPragmaAbove(source: string, triggerIdx: number): boolean {
 
 /**
  * For a spawn at `spawnIdx` to count as coverage for a trigger at
- * `triggerIdx`, every describe block whose body contains the spawn must
- * also contain the trigger — i.e. the spawn lives in an ancestor (or the
- * same) describe of the trigger, or at file scope. Sibling/non-ancestor
- * describes' spawns are filtered out.
+ * `triggerIdx`:
+ *   - every describe containing the spawn must also contain the trigger
+ *     (i.e. the spawn lives in the trigger's ancestor chain — sibling
+ *     and unrelated-nested describes are filtered out), AND
+ *   - if the trigger is inside any describe, the spawn must also be
+ *     inside at least one describe (a file-scope spawn does NOT cover a
+ *     describe-internal trigger; this is the AC's "top-level test rows
+ *     use file body as describe body" boundary read in reverse).
+ *
+ * Equivalently: containers(spawn) ⊆ containers(trigger) AND
+ * (containers(trigger) empty implies containers(spawn) empty).
  */
 export function spawnCoversTrigger(
   spawnIdx: number,
   triggerIdx: number,
   blocks: ReadonlyArray<DescribeBlock>,
 ): boolean {
+  const triggerContainers: DescribeBlock[] = [];
+  const spawnContainers: DescribeBlock[] = [];
   for (const b of blocks) {
-    const spawnIn = b.bodyStart < spawnIdx && spawnIdx < b.bodyEnd;
-    if (!spawnIn) continue;
-    const triggerIn = b.bodyStart < triggerIdx && triggerIdx < b.bodyEnd;
-    if (!triggerIn) return false;
+    if (b.bodyStart < triggerIdx && triggerIdx < b.bodyEnd) {
+      triggerContainers.push(b);
+    }
+    if (b.bodyStart < spawnIdx && spawnIdx < b.bodyEnd) {
+      spawnContainers.push(b);
+    }
+  }
+  for (const sb of spawnContainers) {
+    if (!triggerContainers.includes(sb)) return false;
+  }
+  if (triggerContainers.length > 0 && spawnContainers.length === 0) {
+    return false;
   }
   return true;
 }

--- a/scripts/lint-test-spawn-coverage.ts
+++ b/scripts/lint-test-spawn-coverage.ts
@@ -92,86 +92,250 @@ const DESCRIBE_OPEN_RE =
   /\bdescribe\s*\(\s*(?:"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|'(?:[^'\\]|\\.)*')\s*,\s*(?:async\s+)?(?:\([^)]*\)|[a-zA-Z_$][\w$]*|function\s*\*?\s*[a-zA-Z_$]?\w*\s*\([^)]*\))\s*(?:=>)?\s*\{/g;
 
 /**
- * Walk balanced braces starting from `startIdx` (which must be a `{`),
- * skipping over string literals (single, double, backtick template),
- * template-substitution `${…}` interiors, and `//` / `/* …`/ comments.
- * Returns the index of the matching `}`, or -1 if not found.
+ * Compute a per-byte mask: 1 = inside a string/template-body/comment,
+ * 0 = code. Template-substitution `${…}` interiors are themselves code
+ * (the substitution expression is JS), but quoted strings and nested
+ * comments inside the substitution are masked. A backtick template
+ * encountered while inside a substitution recurses correctly.
+ *
+ * Used to filter regex matches that fire on raw source bytes
+ * (`findSpawnIndices`, `findTriggers`, `DESCRIBE_OPEN_RE`) so that an
+ * allowlist token in a comment, string literal, or template body does
+ * not get treated as real code (codex review P1). Also reused by
+ * `findMatchingBrace` so a `${"{"}`-style substitution body does not
+ * unbalance its brace counter (codex review P2).
+ *
+ * Implementation: flat state machine over the byte stream, with one
+ * stack slot per open backtick template carrying that template's
+ * substitution-depth. Single-quote / double-quote / line-comment /
+ * block-comment states do not nest with each other; backtick template
+ * does (a `${...}` body can contain another backtick template).
  */
-export function findMatchingBrace(source: string, startIdx: number): number {
-  if (source[startIdx] !== "{") return -1;
-  let depth = 0;
-  let i = startIdx;
+// Punctuation that can precede a regex literal (operator / open-bracket /
+// statement separator). Used by `isRegexAllowed` below.
+const REGEX_PRECEDING_PUNCT = new Set([
+  "=", "(", ",", ";", "{", "}", "[", ":", "?", "!",
+  "&", "|", "+", "-", "*", "<", ">", "~", "^", "%",
+]);
+
+// Keywords that can precede a regex literal (e.g. `return /…/`).
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  "return", "typeof", "in", "of", "instanceof", "delete",
+  "throw", "void", "case", "new", "await", "yield",
+]);
+
+function isRegexAllowed(lastSig: string, lastIdent: string): boolean {
+  if (lastSig === "") return true;
+  if (REGEX_PRECEDING_PUNCT.has(lastSig)) return true;
+  if (lastIdent && REGEX_PRECEDING_KEYWORDS.has(lastIdent)) return true;
+  return false;
+}
+
+const IDENT_HEAD = /[A-Za-z_$]/;
+const IDENT_TAIL = /[A-Za-z0-9_$]/;
+
+export function computeCodeMask(source: string): Uint8Array {
+  const mask = new Uint8Array(source.length);
+  type Tick = { subDepth: number };
+  const ticks: Tick[] = [];
+  let state: "code" | "sq" | "dq" | "lc" | "bc" = "code";
+  let lastSig = "";
+  let lastIdent = "";
+  let i = 0;
+  const inTemplateBody = (): boolean =>
+    ticks.length > 0 && ticks[ticks.length - 1]!.subDepth === 0;
   while (i < source.length) {
     const c = source[i]!;
     const next = source[i + 1];
+    if (state === "lc") {
+      if (c === "\n") {
+        state = "code";
+        i++;
+        continue;
+      }
+      mask[i] = 1;
+      i++;
+      continue;
+    }
+    if (state === "bc") {
+      if (c === "*" && next === "/") {
+        mask[i] = 1;
+        mask[i + 1] = 1;
+        state = "code";
+        i += 2;
+        continue;
+      }
+      mask[i] = 1;
+      i++;
+      continue;
+    }
+    if (state === "sq" || state === "dq") {
+      const q = state === "sq" ? "'" : '"';
+      if (c === "\\") {
+        mask[i] = 1;
+        if (i + 1 < source.length) mask[i + 1] = 1;
+        i += 2;
+        continue;
+      }
+      if (c === q) {
+        state = "code";
+        lastSig = q;
+        lastIdent = "";
+        i++;
+        continue;
+      }
+      mask[i] = 1;
+      i++;
+      continue;
+    }
+    // state === "code" (possibly inside a template substitution).
+    if (inTemplateBody()) {
+      if (c === "\\") {
+        mask[i] = 1;
+        if (i + 1 < source.length) mask[i + 1] = 1;
+        i += 2;
+        continue;
+      }
+      if (c === "`") {
+        ticks.pop();
+        lastSig = "`";
+        lastIdent = "";
+        i++;
+        continue;
+      }
+      if (c === "$" && next === "{") {
+        ticks[ticks.length - 1]!.subDepth = 1;
+        i += 2;
+        continue;
+      }
+      mask[i] = 1;
+      i++;
+      continue;
+    }
+    // Pure code (or inside a substitution expression — same rules).
     if (c === "/" && next === "/") {
-      while (i < source.length && source[i] !== "\n") i++;
+      state = "lc";
+      mask[i] = 1;
+      mask[i + 1] = 1;
+      i += 2;
       continue;
     }
     if (c === "/" && next === "*") {
-      i += 2;
-      while (
-        i < source.length - 1 &&
-        !(source[i] === "*" && source[i + 1] === "/")
-      ) {
-        i++;
-      }
+      state = "bc";
+      mask[i] = 1;
+      mask[i + 1] = 1;
       i += 2;
       continue;
     }
-    if (c === "'" || c === '"') {
-      const q = c;
+    if (c === "/" && isRegexAllowed(lastSig, lastIdent)) {
+      // Regex literal: walk to matching `/`, handling `\` escapes and
+      // `[…]` character classes (in which `/` does NOT terminate the
+      // literal). Mask the body bytes; delimiters are code.
       i++;
-      while (i < source.length && source[i] !== q) {
-        if (source[i] === "\\") {
+      let inClass = false;
+      while (i < source.length) {
+        const cc = source[i]!;
+        if (cc === "\\") {
+          mask[i] = 1;
+          if (i + 1 < source.length) mask[i + 1] = 1;
           i += 2;
           continue;
         }
+        if (cc === "[") inClass = true;
+        else if (cc === "]") inClass = false;
+        if (cc === "/" && !inClass) {
+          // Closing delimiter; consume optional flags
+          i++;
+          while (i < source.length && /[gimsuy]/.test(source[i]!)) i++;
+          break;
+        }
+        if (cc === "\n") break; // unterminated regex; bail
+        mask[i] = 1;
         i++;
       }
+      lastSig = "/";
+      lastIdent = "";
+      continue;
+    }
+    if (c === "'") {
+      state = "sq";
+      i++;
+      continue;
+    }
+    if (c === '"') {
+      state = "dq";
       i++;
       continue;
     }
     if (c === "`") {
-      i++;
-      while (i < source.length && source[i] !== "`") {
-        if (source[i] === "\\") {
-          i += 2;
-          continue;
-        }
-        if (source[i] === "$" && source[i + 1] === "{") {
-          i += 2;
-          let subDepth = 1;
-          while (i < source.length && subDepth > 0) {
-            const cc = source[i]!;
-            if (cc === "{") subDepth++;
-            else if (cc === "}") subDepth--;
-            i++;
-          }
-          continue;
-        }
-        i++;
-      }
+      ticks.push({ subDepth: 0 });
       i++;
       continue;
     }
+    if (ticks.length > 0 && ticks[ticks.length - 1]!.subDepth > 0) {
+      if (c === "{") {
+        ticks[ticks.length - 1]!.subDepth++;
+      } else if (c === "}") {
+        ticks[ticks.length - 1]!.subDepth--;
+      }
+    }
+    // Track lastSig / lastIdent for regex-vs-division disambiguation.
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+    if (IDENT_HEAD.test(c)) {
+      const start = i;
+      while (i < source.length && IDENT_TAIL.test(source[i]!)) i++;
+      lastIdent = source.slice(start, i);
+      lastSig = source[i - 1]!;
+      continue;
+    }
+    lastSig = c;
+    lastIdent = "";
+    i++;
+  }
+  return mask;
+}
+
+/**
+ * Walk balanced braces starting from `startIdx` (which must be a `{`),
+ * skipping over string literals, comments, and template-substitution
+ * interiors via the same mask `computeCodeMask` produces. Returns the
+ * index of the matching `}`, or -1 if not found.
+ */
+export function findMatchingBrace(
+  source: string,
+  startIdx: number,
+  mask?: Uint8Array,
+): number {
+  if (source[startIdx] !== "{") return -1;
+  const m = mask ?? computeCodeMask(source);
+  let depth = 0;
+  for (let i = startIdx; i < source.length; i++) {
+    if (m[i]) continue;
+    const c = source[i];
     if (c === "{") depth++;
     else if (c === "}") {
       depth--;
       if (depth === 0) return i;
     }
-    i++;
   }
   return -1;
 }
 
-export function findDescribeBlocks(source: string): DescribeBlock[] {
+export function findDescribeBlocks(
+  source: string,
+  mask?: Uint8Array,
+): DescribeBlock[] {
+  const m = mask ?? computeCodeMask(source);
   const out: DescribeBlock[] = [];
   DESCRIBE_OPEN_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = DESCRIBE_OPEN_RE.exec(source)) !== null) {
-    const bodyStart = m.index + m[0].length - 1;
-    const bodyEnd = findMatchingBrace(source, bodyStart);
+  let match: RegExpExecArray | null;
+  while ((match = DESCRIBE_OPEN_RE.exec(source)) !== null) {
+    if (m[match.index]) continue; // describe(...) literal in non-code text
+    const bodyStart = match.index + match[0].length - 1;
+    const bodyEnd = findMatchingBrace(source, bodyStart, m);
     if (bodyEnd === -1) continue;
     out.push({ bodyStart, bodyEnd });
   }
@@ -191,25 +355,31 @@ export interface TriggerMatch {
   readonly testName: string;
 }
 
-export function findTriggers(source: string): TriggerMatch[] {
+export function findTriggers(source: string, mask?: Uint8Array): TriggerMatch[] {
+  const m = mask ?? computeCodeMask(source);
   const out: TriggerMatch[] = [];
   TRIGGER_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = TRIGGER_RE.exec(source)) !== null) {
+  let match: RegExpExecArray | null;
+  while ((match = TRIGGER_RE.exec(source)) !== null) {
+    if (m[match.index]) continue; // trigger literal in non-code (string / comment / template body)
     out.push({
-      idx: m.index,
-      line: lineOf(source, m.index),
-      testName: m[1]!,
+      idx: match.index,
+      line: lineOf(source, match.index),
+      testName: match[1]!,
     });
   }
   return out;
 }
 
-export function findSpawnIndices(source: string): number[] {
+export function findSpawnIndices(source: string, mask?: Uint8Array): number[] {
+  const m = mask ?? computeCodeMask(source);
   const out: number[] = [];
   SPAWN_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = SPAWN_RE.exec(source)) !== null) out.push(m.index);
+  let match: RegExpExecArray | null;
+  while ((match = SPAWN_RE.exec(source)) !== null) {
+    if (m[match.index]) continue; // spawn token in non-code; codex P1
+    out.push(match.index);
+  }
   return out;
 }
 
@@ -292,9 +462,14 @@ export interface Violation {
 }
 
 export function lintFile(file: string, source: string): Violation[] {
-  const blocks = findDescribeBlocks(source);
-  const triggers = findTriggers(source);
-  const spawns = findSpawnIndices(source);
+  // Compute the code mask once and thread it through every consumer so
+  // strings/comments/template bodies are excluded uniformly (codex P1)
+  // and the substitution-interior brace counter stays balanced
+  // (codex P2).
+  const mask = computeCodeMask(source);
+  const blocks = findDescribeBlocks(source, mask);
+  const triggers = findTriggers(source, mask);
+  const spawns = findSpawnIndices(source, mask);
   const out: Violation[] = [];
   for (const t of triggers) {
     if (hasPragmaAbove(source, t.idx)) continue;


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-test-spawn-coverage.ts` + `.test.ts`: a CI lint that flags `(test|it)("exits 0|1|N|non-zero …", …)` rows in `scripts/*.test.ts` whose enclosing `describe(...)` (and ancestors) contain no spawn-allowlist match.
- Wires `lint:test-spawn-coverage` in `package.json` and a new `Lint — test spawn coverage` step in `.github/workflows/ci.yml`.
- Applies `// lint:allow-no-spawn` pragmas to the two `runCli({writeErr,writeOut})` injectable-IO tests in `scripts/lint-no-shadow-util.test.ts`.
- Corrects the proposal's floor-count claim (35/12 → 31/10) — the proposal-time number was an unverified agent estimate; the lint's own `findTriggers` recognizer is authoritative.

## Round-2 fixes

1. **Scope-rule fix**: `spawnCoversTrigger` now correctly returns `false` when a file-scope spawn would cover a describe-internal trigger. Per AC: file-body spawns ONLY cover top-level triggers. Three regression tests added (one end-to-end with the reviewer's verbatim fixture, two unit-level falsifiers).

## Round-3 fixes

1. **Proposal-floor AC alignment**: re-applied the minimal proposal correction (two hunks: the floor-count AC bullet and the inventory paragraph). Round-3 reviewer offered "officially change the proposal" as an acceptable path. Salvage follow-up `task-5083844f` is marked completed/superseded.

## Codex review fixes (commit e79b172)

1. **P1 — non-code text masked from spawn/trigger detection**: `findSpawnIndices` and `findTriggers` previously matched against raw source bytes, so `// TODO use Bun.spawnSync(...)` or string-literal mentions counted as real spawns/triggers. Fixed by introducing `computeCodeMask(source)` — a flat state-machine walker producing a per-byte Uint8Array (1 = string/template/comment, 0 = code). All recognizers filter matches by mask. Includes heuristic JS regex-literal detection so `return /…/` doesn't put the walker in a stuck state (this caught a follow-on bug at `lint-template-safety.test.ts:642` that was masking three real downstream `test("exits 0|1 …")` calls).
2. **P2 — `${"{"}`-style substitution**: `findMatchingBrace` previously walked the `${...}` substitution body with a naive depth counter that didn't skip strings/comments inside. Fixed by reusing the same code mask — quoted braces inside substitutions no longer unbalance the depth counter.
3. **Regression coverage**: 12 new tests under `describe("computeCodeMask + non-code masking (codex P1/P2)", …)` — canonical end-to-end fixture (`// Bun.spawnSync(...)` comment immediately before an in-process `test("exits 1 …")`), unit-level falsifiers for each non-code form (`// line`, `/* block */`, single/double/backtick string), positive control for `${...}` substitution interior staying as code, and the regex-literal stuck-state regression from the live corpus.

## Design highlights

- **Trigger** (Q2 narrowness): `(?:test|it)\s*\(\s*"exits\s+(?:0|1|\d+|non-zero)\b` — `exits after …` / `exits early …` / `returns exit 0 …` do NOT fire.
- **Spawn allowlist** (Q3): `Bun.spawn(Sync)?`, `Bun.$`, `exec(File)?Sync`, `\bspawn(Sync)?` (Bun async-form + Node `child_process` imports).
- **Scope rule** (round-2): file-scope spawns cover top-level triggers only; describe-nested spawns cover triggers in the same ancestor chain.
- **Code mask** (round-4 / codex): regex matches are filtered by `mask[match.index] === 0` so non-code byte sequences (comments, string literals, template bodies, regex literals) cannot masquerade as covering spawns or self-induced triggers.
- **Escape hatch** (Q5): `// lint:allow-no-spawn` line comment immediately above a single trigger row.

## Test plan

- [x] `bun run lint:test-spawn-coverage` exits 0 with `✅ All 33 exits-named tests in 18 scripts/*.test.ts files spawn the CLI in their describe block.`
- [x] `bun test scripts/lint-test-spawn-coverage.test.ts` → 64 pass / 0 fail.
- [x] `bun test scripts/` → 503 pass / 0 fail.
- [x] `bun run typecheck` clean.
- [x] All neighbor lints green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)