### PR TITLE
notify: guard ntfy.sh curl behind shouldSuppressNtfy() (task-87d4b17e)

### DIFF
--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -109,3 +109,151 @@ describe("notify state-file atomic writes", () => {
     expect(typeof parsed.created).toBe("number");
   });
 });
+
+import { spyOn } from "bun:test";
+import * as spawnModule from "./spawn.ts";
+
+describe("notify ntfy.sh suppression under bun test", () => {
+  let tmpDir: string;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_BUN_TEST = process.env.BUN_TEST;
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ludics-notify-suppress-"));
+    mkdirSync(join(tmpDir, "journal"), { recursive: true });
+    process.env.LUDICS_HARNESS_DIR = tmpDir;
+    // Set BUN_TEST explicitly: bun-test does not always populate it. The
+    // guard's primary signal is BUN_TEST; assert from the test that the
+    // value the suppression check sees matches what the runner / wrapper
+    // would set in production-test invocations.
+    process.env.BUN_TEST = "1";
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    if (ORIGINAL_BUN_TEST === undefined) delete process.env.BUN_TEST;
+    else process.env.BUN_TEST = ORIGINAL_BUN_TEST;
+    if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  test("notifyAgents writes to journal but does NOT invoke safeSyncOutput under BUN_TEST", async () => {
+    expect(process.env.BUN_TEST).toBeTruthy();
+
+    const spawnSpy = spyOn(spawnModule, "safeSyncOutput");
+    const { notifyAgents } = await import("./notify.ts");
+    let calls = 0;
+    try {
+      notifyAgents("suppression-probe-message", 1, "suppression-probe-title");
+      calls = spawnSpy.mock.calls.length;
+    } finally {
+      spawnSpy.mockRestore();
+    }
+    expect(calls).toBe(0);
+    const log = readFileSync(join(tmpDir, "journal", "notifications.jsonl"), "utf-8");
+    expect(log).toContain("suppression-probe-message");
+  });
+
+  test("shouldSuppressNtfy negative control: returns false when BUN_TEST and NODE_ENV are cleared", async () => {
+    const { shouldSuppressNtfy } = await import("./notify.ts");
+    const savedBunTest = process.env.BUN_TEST;
+    const savedNodeEnv = process.env.NODE_ENV;
+    let observed: boolean | null = null;
+    try {
+      delete process.env.BUN_TEST;
+      delete process.env.NODE_ENV;
+      observed = shouldSuppressNtfy();
+    } finally {
+      if (savedBunTest === undefined) delete process.env.BUN_TEST;
+      else process.env.BUN_TEST = savedBunTest;
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedNodeEnv;
+    }
+    expect(observed).toBe(false);
+  });
+
+  test("shouldSuppressNtfy returns true under BUN_TEST=1 and under NODE_ENV=test", async () => {
+    const { shouldSuppressNtfy } = await import("./notify.ts");
+    const savedBunTest = process.env.BUN_TEST;
+    const savedNodeEnv = process.env.NODE_ENV;
+    let withBunTest: boolean | null = null;
+    let withNodeEnv: boolean | null = null;
+    let withZero: boolean | null = null;
+    try {
+      delete process.env.NODE_ENV;
+      process.env.BUN_TEST = "1";
+      withBunTest = shouldSuppressNtfy();
+
+      delete process.env.BUN_TEST;
+      process.env.NODE_ENV = "test";
+      withNodeEnv = shouldSuppressNtfy();
+
+      delete process.env.NODE_ENV;
+      process.env.BUN_TEST = "0";
+      withZero = shouldSuppressNtfy();
+    } finally {
+      if (savedBunTest === undefined) delete process.env.BUN_TEST;
+      else process.env.BUN_TEST = savedBunTest;
+      if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = savedNodeEnv;
+    }
+    expect(withBunTest).toBe(true);
+    expect(withNodeEnv).toBe(true);
+    expect(withZero).toBe(false);
+  });
+
+  test("notifyPublishMessage returns synthesised 200 without calling safeSyncOutput under BUN_TEST", async () => {
+    expect(process.env.BUN_TEST).toBeTruthy();
+
+    const spawnSpy = spyOn(spawnModule, "safeSyncOutput");
+    const { notifyPublishMessage } = await import("./notify.ts");
+    let result: { httpCode: string; stderr: string; body: string } | null = null;
+    let calls = 0;
+    try {
+      result = notifyPublishMessage(
+        "lukstafi-agents",
+        "publish-probe-message",
+        "real-bearer-token",
+        "publish-probe-title",
+        3,
+        "memo,task-87d4b17e",
+        [],
+      );
+      calls = spawnSpy.mock.calls.length;
+    } finally {
+      spawnSpy.mockRestore();
+    }
+    expect(calls).toBe(0);
+    expect(result).toEqual({ httpCode: "200", stderr: "", body: "" });
+  });
+
+  test("notifyPublishFile returns synthesised 200 without calling safeSyncOutput under BUN_TEST", async () => {
+    expect(process.env.BUN_TEST).toBeTruthy();
+
+    const spawnSpy = spyOn(spawnModule, "safeSyncOutput");
+    const { notifyPublishFile } = await import("./notify.ts");
+    let result: { httpCode: string; stderr: string; body: string } | null = null;
+    let calls = 0;
+    try {
+      result = notifyPublishFile(
+        "lukstafi-agents",
+        "/dev/null",
+        "probe.md",
+        "real-bearer-token",
+        "publish-file-probe-title",
+        "publish-file-probe-message",
+        3,
+        "memo,task-87d4b17e",
+        [],
+      );
+      calls = spawnSpy.mock.calls.length;
+    } finally {
+      spawnSpy.mockRestore();
+    }
+    expect(calls).toBe(0);
+    expect(result).toEqual({ httpCode: "200", stderr: "", body: "" });
+  });
+});

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, appendFileSync, writeFileSync, mkdirSync, sta
 import { basename, join, resolve } from "path";
 import { loadConfigSync, harnessDir, slotsCount } from "./config.ts";
 import { isPlainObject, writeJsonFile, writeJsonFileCompact } from "./json.ts";
-import { safeSyncOutput } from "./spawn.ts";
+import * as spawnModule from "./spawn.ts";
 import { queueRequest } from "./queue.ts";
 import { emitEvent } from "./events.ts";
 import { readAllSlotJson } from "./slots/json.ts";
@@ -32,9 +32,36 @@ function getToken(): string {
   return config.notifications?.token ?? "";
 }
 
+/**
+ * Return true when running under a test runner that should not actually
+ * publish to ntfy.sh. Suppresses the network call but preserves the
+ * upstream `notifyLog` write so test assertions on
+ * `notifications.jsonl` keep working.
+ *
+ * See task-87d4b17e: without this guard, the lifecycle tests on
+ * `slot = 11`/`12` reached `https://ntfy.sh/lukstafi-agents` for real
+ * because `loadConfigSync` resolves the user's real config.yaml even
+ * when `LUDICS_HARNESS_DIR` is a tmp directory.
+ *
+ * Two env vars: `BUN_TEST` (set by `bun test` automatically) is the
+ * primary signal; `NODE_ENV === "test"` is belt-and-braces for any
+ * future migration off the Bun runner or wrapper scripts that set
+ * NODE_ENV explicitly.
+ *
+ * @internal exported for tests only
+ */
+export function shouldSuppressNtfy(): boolean {
+  const bunTest = process.env.BUN_TEST;
+  if (bunTest && bunTest !== "0") return true;
+  if (process.env.NODE_ENV === "test") return true;
+  return false;
+}
+
 function notifySend(topic: string, message: string, priority: number, title: string, tags: string): void {
   if (!topic) throw new Error("notify: topic required");
   if (!message) throw new Error("notify: message required");
+
+  if (shouldSuppressNtfy()) return;
 
   const curlArgs = [
     "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
@@ -48,7 +75,7 @@ function notifySend(topic: string, message: string, priority: number, title: str
   if (token) curlArgs.push("-H", `Authorization: Bearer ${token}`);
   curlArgs.push(`https://ntfy.sh/${topic}`);
 
-  const result = safeSyncOutput(curlArgs);
+  const result = spawnModule.safeSyncOutput(curlArgs);
   const httpCode = result.stdout;
   if (httpCode !== "200") {
     console.error(`ludics: ntfy.sh notification failed (HTTP ${httpCode}), logged locally`);
@@ -273,7 +300,8 @@ function proposalInlineMessage(summary: string, proposalText: string, attachment
   return `Full proposal attached as ${attachmentName}.`;
 }
 
-function notifyPublishMessage(
+/** @internal exported for tests only */
+export function notifyPublishMessage(
   topic: string,
   message: string,
   token: string,
@@ -282,6 +310,8 @@ function notifyPublishMessage(
   tags: string,
   actions: Array<Record<string, unknown>>,
 ) : { httpCode: string; stderr: string; body: string } {
+  if (shouldSuppressNtfy()) return { httpCode: "200", stderr: "", body: "" };
+
   const curlArgs = [
     "curl", "-sS", "-w", "\n%{http_code}",
     "-X", "POST",
@@ -294,7 +324,7 @@ function notifyPublishMessage(
   if (token) curlArgs.push("-H", `Authorization: Bearer ${token}`);
   curlArgs.push(`https://ntfy.sh/${topic}`);
 
-  const result = safeSyncOutput(curlArgs, { trim: false });
+  const result = spawnModule.safeSyncOutput(curlArgs, { trim: false });
   const stdout = result.stdout;
   const splitAt = stdout.lastIndexOf("\n");
   const body = splitAt >= 0 ? stdout.slice(0, splitAt).trim() : "";
@@ -306,7 +336,8 @@ function notifyPublishMessage(
   };
 }
 
-function notifyPublishFile(
+/** @internal exported for tests only */
+export function notifyPublishFile(
   topic: string,
   filePath: string,
   filename: string,
@@ -317,6 +348,8 @@ function notifyPublishFile(
   tags: string,
   actions: Array<Record<string, unknown>>,
 ) : { httpCode: string; stderr: string; body: string } {
+  if (shouldSuppressNtfy()) return { httpCode: "200", stderr: "", body: "" };
+
   const curlArgs = [
     "curl", "-sS", "-w", "\n%{http_code}",
     "-X", "PUT",
@@ -331,7 +364,7 @@ function notifyPublishFile(
   if (token) curlArgs.push("-H", `Authorization: Bearer ${token}`);
   curlArgs.push(`https://ntfy.sh/${topic}`);
 
-  const result = safeSyncOutput(curlArgs, { trim: false });
+  const result = spawnModule.safeSyncOutput(curlArgs, { trim: false });
   const stdout = result.stdout;
   const splitAt = stdout.lastIndexOf("\n");
   const body = splitAt >= 0 ? stdout.slice(0, splitAt).trim() : "";


### PR DESCRIPTION
## Summary

- Adds `shouldSuppressNtfy()` helper in `src/notify.ts`, gated on `BUN_TEST` (Bun's test sentinel) and `NODE_ENV === "test"` (belt-and-braces). Three curl-emitting sites consult it after `notifyLog` and before `safeSyncOutput`: `notifySend`, `notifyPublishMessage`, `notifyPublishFile`. The two publish helpers return synthesised `{ httpCode: "200", stderr: "", body: "" }` so `notifyProposal` / `notifySessionConclusion` callers don't trip the HTTP-failure path or fall back to file attachment.
- Tests in `src/notify.test.ts` cover the positive control (`notifyAgents` writes to journal but invokes `safeSyncOutput` 0 times), negative control (helper returns `false` when both env vars are cleared), all three env arms (`BUN_TEST=1`, `NODE_ENV=test`, `BUN_TEST=0`), and direct synthesised-success assertions for `notifyPublishMessage` and `notifyPublishFile`.

## Root cause

`bun test` was issuing real HTTPS POSTs to `https://ntfy.sh/<topic>`. The user's 2026-05-10 notification (`Slot 11 [feat]: setup → done (round 1)`) traced to lifecycle tests on `slot=11`/`12` that mock `evaluateTransition → "done"` and run `runOrchestration` end-to-end. `notifyAgents → notifySend` had no test-mode guard, and `loadConfigSync` resolves the user's *real* `config.yaml` even when `LUDICS_HARNESS_DIR` points at a tmp dir, so the curl reached real ntfy.sh with the real bearer token. Local journal had no matching entry because the tmp `LUDICS_HARNESS_DIR` was discarded in `afterEach`.

## Mutation evidence

Replacing the helper body with `return false;` flips 4 tests PASS → FAIL:
- `notifyAgents writes to journal but does NOT invoke safeSyncOutput under BUN_TEST` (calls === 1 instead of 0)
- `shouldSuppressNtfy returns true under BUN_TEST=1 and under NODE_ENV=test` (`withBunTest` is `false`)
- `notifyPublishMessage returns synthesised 200 without calling safeSyncOutput under BUN_TEST` (calls === 1)
- `notifyPublishFile returns synthesised 200 without calling safeSyncOutput under BUN_TEST` (calls === 1)

Restored helper passes all 11 notify-suite tests.

## Refactor

`import { safeSyncOutput } from "./spawn.ts"` → `import * as spawnModule from "./spawn.ts"` so `spyOn(spawnModule, "safeSyncOutput")` reliably intercepts. `notifyPublishMessage` and `notifyPublishFile` are now exported with `@internal` markers (mirroring the pattern already used for `sessionConclusionStateFile` etc.) so the tests exercise them directly rather than through `notifyProposal`'s dashboard URL plumbing.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` passes (2397 tests, 0 failures)
- [x] `bun test src/orchestration/runner.lifecycle.test.ts` still passes — the slot=11/12 lifecycle tests work unchanged
- [x] Mutation-evidence test (helper neutered to `return false`) flips 4 tests PASS → FAIL; restored helper passes
- [ ] Manual: subscribing to `https://ntfy.sh/lukstafi-agents` from another terminal during `bun test src/orchestration/runner.lifecycle.test.ts` should produce **no** "Slot 11 [feat]: phase" notification (cannot verify from this sandbox; the AC marks this as PR-notes confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)