### PR TITLE
task-b43bd578: dashboard top-bar provider-role toggle (coder/reviewer/none)

### DIFF
--- a/docs/proposals/task-b43bd578-dashboard-provider-role-toggle.md
+++ b/docs/proposals/task-b43bd578-dashboard-provider-role-toggle.md
@@ -127,6 +127,28 @@ current values to the client.
     in `T3ProviderKind`, the toggle will pick which two providers form the
     duo pair.
 
+13a. **Null role semantics in the N=2 universe (limitation).** With the
+    current `PROVIDERS = {claude-code, codex}` universe, the toggle
+    persists an explicit `coder: null` or `reviewer: null` selection in
+    `config.yaml` and round-trips it through
+    `dashboard/data/orchestration-defaults.json` so the UI remembers the
+    user's choice across reloads (AC 10 + AC 11). However, the existing
+    auto-fill read sites (`selectOrchestrationFlags` in
+    `src/adapters/t3code.ts` and `expandDuoSlots` in
+    `src/slots/duo-expand.ts`) coerce explicit YAML `null` to the
+    hard-coded literal fallback (`claude-code` for coder, `codex` for
+    reviewer), identical to the unset case. Therefore in the N=2
+    universe, picking "none" has no observable effect on which provider
+    auto-fill actually uses. This mirrors AC 13's analogous limitation
+    for duo mode and is deferred to the future N≥3 provider-extension
+    task (the same task that extends `T3ProviderKind`, the shared
+    `PROVIDERS` constant, and the per-provider plumbing in
+    `selectOrchestrationFlags`). A regression test in
+    `src/orchestration-defaults.test.ts` pins `selectOrchestrationFlags`
+    and `expandDuoSlots` returning the literal fallback when
+    `default_coder: null` / `default_reviewer: null` are configured, so a
+    future "make null real" change must update both tests deliberately.
+
 14. **Tests — invariant + cascade.** New unit tests cover the cascade rule
     independently of the UI: extract the pure transformation
     `applyRoleChange(state, provider, role) → state'` into a testable

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -178,3 +178,106 @@ projects:
     expect(_peekPriorityProjectsCache()).toBe(beforeRewrite);
   });
 });
+
+// ---------------------------------------------------------------------------
+// task-b43bd578 — writeOrchestrationDefaults round-trip + null persistence.
+// ---------------------------------------------------------------------------
+
+describe("writeOrchestrationDefaults", () => {
+  test("sets both keys under mag.orchestration", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    // Overwrite the beforeEach config with a minimal fixture that
+    // exercises the round-trip behaviour (already exists at LUDICS_CONFIG).
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_mode: pair\n");
+    writeOrchestrationDefaults({ coder: "codex", reviewer: "claude-code" });
+    const raw = readFileSync(configPath, "utf-8");
+    expect(raw).toMatch(/default_coder:\s*codex/);
+    expect(raw).toMatch(/default_reviewer:\s*claude-code/);
+  });
+
+  test("persists null as YAML 'null' (does NOT delete the key)", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_mode: pair\n    default_coder: claude-code\n    default_reviewer: codex\n");
+    writeOrchestrationDefaults({ coder: null, reviewer: "codex" });
+    const raw = readFileSync(configPath, "utf-8");
+    // The key is still present (NOT deleted) — explicit YAML null.
+    expect(raw).toMatch(/default_coder:\s*null/);
+    expect(raw).toMatch(/default_reviewer:\s*codex/);
+    // Cross-check via the YAML parser that key-presence holds.
+    const YAML = (await import("yaml")).default;
+    const parsed = YAML.parse(raw) as { mag: { orchestration: Record<string, unknown> } };
+    expect("default_coder" in parsed.mag.orchestration).toBe(true);
+    expect(parsed.mag.orchestration.default_coder).toBeNull();
+  });
+
+  test("preserves adjacent comment + sibling default_mode verbatim", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const configPath = process.env.LUDICS_CONFIG!;
+    const sentinel = "# DO-NOT-REFLOW sentinel comment task-b43bd578";
+    const original = `state_repo: owner/ludics-state
+state_path: harness
+mag:
+  orchestration:
+    default_mode: pair  ${sentinel}
+    queue_dir: queue
+`;
+    writeFileSync(configPath, original);
+    writeOrchestrationDefaults({ coder: "codex", reviewer: "claude-code" });
+    const after = readFileSync(configPath, "utf-8");
+    // Sentinel comment on the unchanged adjacent key survives.
+    expect(after).toContain(sentinel);
+    // Sibling key default_mode value is preserved.
+    expect(after).toMatch(/default_mode:\s*pair/);
+    // Unrelated sibling `queue_dir` survives.
+    expect(after).toMatch(/queue_dir:\s*queue/);
+  });
+
+  test("uses atomicWriteFileSync (no partial-write window)", async () => {
+    const { spyOn } = await import("bun:test");
+    const jsonMod = await import("./json.ts");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\n");
+    const spy = spyOn(jsonMod, "atomicWriteFileSync");
+    let callsForConfig: { path: string; content: string }[] = [];
+    try {
+      writeOrchestrationDefaults({ coder: "codex", reviewer: "claude-code" });
+      // Capture calls BEFORE mockRestore (bun:test mockRestore wipes history).
+      callsForConfig = spy.mock.calls
+        .filter((c) => typeof c[0] === "string" && c[0] === configPath)
+        .map((c) => ({ path: c[0] as string, content: c[1] as string }));
+    } finally {
+      spy.mockRestore();
+    }
+    expect(callsForConfig.length).toBe(1);
+    expect(callsForConfig[0]!.content).toMatch(/default_coder:\s*codex/);
+    expect(callsForConfig[0]!.content).toMatch(/default_reviewer:\s*claude-code/);
+  });
+
+  test("round-trip fidelity: write then re-parse yields exactly the written state", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const { effectiveDefaultsFromConfig } = await import("./orchestration-defaults.ts");
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\n");
+    for (const state of [
+      { coder: "claude-code" as const, reviewer: "codex" as const },
+      { coder: "codex" as const, reviewer: "claude-code" as const },
+      { coder: null, reviewer: "codex" as const },
+      { coder: "claude-code" as const, reviewer: null },
+      { coder: null, reviewer: null },
+    ]) {
+      writeOrchestrationDefaults(state);
+      const raw = readFileSync(configPath, "utf-8");
+      const YAML = (await import("yaml")).default;
+      const parsed = YAML.parse(raw) as { mag?: { orchestration?: Record<string, unknown> } };
+      const round = effectiveDefaultsFromConfig(parsed.mag?.orchestration);
+      expect(round).toEqual(state);
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,8 +3,9 @@
 import { existsSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
 import YAML from "yaml";
-import { isPlainObject } from "./json.ts";
+import { atomicWriteFileSync, isPlainObject } from "./json.ts";
 import { PRIORITY_INCREASE, priorityValue } from "./tasks/markdown.ts";
+import type { Provider } from "./orchestration-defaults.ts";
 
 const DEFAULT_STALE_THRESHOLD = 86400; // 24 hours
 
@@ -565,3 +566,28 @@ export function milestoneKey(
   if (enabledProjects.has(project) && milestone) return milestone;
   return "\uFFFF";
 }
+
+// --- Orchestration defaults writer (task-b43bd578) ---
+//
+// Persists the dashboard role-switcher's choice to
+// mag.orchestration.default_coder / default_reviewer in config.yaml.
+//
+// Uses YAML.parseDocument + setIn + toString to preserve unrelated keys,
+// ordering, and comments on the rest of the file. Explicit null values
+// are persisted as YAML `null` (not deleted) so the dashboard can
+// distinguish present-null from absent on reload (AC 9, AC 10, AC 11).
+export function writeOrchestrationDefaults(state: {
+  coder: Provider | null;
+  reviewer: Provider | null;
+}): void {
+  const configPath = resolveConfigPath();
+  if (!existsSync(configPath)) {
+    throw new Error(`config not found: ${configPath} (run: ludics init)`);
+  }
+  const text = readFileSync(configPath, "utf-8");
+  const doc = YAML.parseDocument(text);
+  doc.setIn(["mag", "orchestration", "default_coder"], state.coder);
+  doc.setIn(["mag", "orchestration", "default_reviewer"], state.reviewer);
+  atomicWriteFileSync(configPath, doc.toString());
+}
+

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -19,6 +19,8 @@ import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./ma
 import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
 import { resolveSkillCommand } from "./skill-queue-registry.ts";
 import { handleClusterRequest } from "./cluster-http.ts";
+import { validatePayload } from "./orchestration-defaults.ts";
+import { writeOrchestrationDefaults } from "./config.ts";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html",
@@ -682,6 +684,45 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         });
       } catch (e) {
         return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: persist dashboard role-switcher state to config.yaml (task-b43bd578)
+    if (pathname === "/api/orchestration-defaults") {
+      if (req.method !== "POST") {
+        return new Response(
+          JSON.stringify({ error: "method not allowed" }),
+          { status: 405, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "invalid JSON" }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      const result = validatePayload(body);
+      if (!result.ok) {
+        return new Response(
+          JSON.stringify({ error: result.error }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      try {
+        writeOrchestrationDefaults({ coder: result.coder, reviewer: result.reviewer });
+        lastGenerated = 0; // force regeneration on next data request
+        return new Response(
+          JSON.stringify({ coder: result.coder, reviewer: result.reviewer }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      } catch (e) {
+        return new Response(
+          JSON.stringify({ error: e instanceof Error ? e.message : String(e) }),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+        );
       }
     }
 

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1327,3 +1327,156 @@ describe("dashboardGenerate writes orchestration-defaults.json — task-b43bd578
     expect(after).toEqual({ coder: "codex", reviewer: "claude-code" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// task-b43bd578 — POST /api/orchestration-defaults endpoint tests.
+// ---------------------------------------------------------------------------
+
+describe("dashboard HTTP /api/orchestration-defaults — task-b43bd578", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+
+  function seedConfig(): void {
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\n");
+  }
+
+  test("valid POST writes YAML and returns echo JSON", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "codex", reviewer: "claude-code" }),
+    }));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("application/json");
+    const body = await resp.json() as { coder: string; reviewer: string };
+    expect(body).toEqual({ coder: "codex", reviewer: "claude-code" });
+    const raw = readFileSync(process.env.LUDICS_CONFIG!, "utf-8");
+    expect(raw).toMatch(/default_coder:\s*codex/);
+    expect(raw).toMatch(/default_reviewer:\s*claude-code/);
+  });
+
+  test("missing 'coder' key → 400 + JSON error", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ reviewer: "codex" }),
+    }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toMatch(/coder/);
+  });
+
+  test("invalid provider 'cursor' → 400", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "cursor", reviewer: "codex" }),
+    }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toMatch(/coder/);
+  });
+
+  test("coder===reviewer (both non-null) → 400", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "codex", reviewer: "codex" }),
+    }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toMatch(/differ/);
+  });
+
+  test("both null accepted → 200; persisted YAML has both keys as null (AC 10)", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: null, reviewer: null }),
+    }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { coder: null; reviewer: null };
+    expect(body).toEqual({ coder: null, reviewer: null });
+    const raw = readFileSync(process.env.LUDICS_CONFIG!, "utf-8");
+    expect(raw).toMatch(/default_coder:\s*null/);
+    expect(raw).toMatch(/default_reviewer:\s*null/);
+  });
+
+  test("one null + one provider → 200; dashboard regenerates with null preserved", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: null, reviewer: "codex" }),
+    }));
+    expect(resp.status).toBe(200);
+
+    // After POST, the generator must emit `coder: null` (AC 10/11 reload contract).
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    dashboardGenerate();
+    const out = JSON.parse(readFileSync(join(harnessDir(), "dashboard", "data", "orchestration-defaults.json"), "utf-8"));
+    expect(out).toEqual({ coder: null, reviewer: "codex" });
+  });
+
+  test("GET to /api/orchestration-defaults → 405", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", { method: "GET" }));
+    expect(resp.status).toBe(405);
+  });
+
+  test("invalid JSON body → 400", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not-json",
+    }));
+    expect(resp.status).toBe(400);
+  });
+
+  test("after POST, lastGenerated cache-bust regenerates orchestration-defaults.json on next data read", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+
+    // Seed an initial data file so the static-serve path has something
+    // to serve cached.
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    dashboardGenerate();
+
+    // POST flips defaults.
+    const post = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "codex", reviewer: "claude-code" }),
+    }));
+    expect(post.status).toBe(200);
+
+    // Next data fetch through the handler must trigger regeneration —
+    // the handler regenerates lazily when lastGenerated < now - ttl OR
+    // when lastGenerated was reset to 0. We verify the second.
+    const dataReq = new Request("http://x/data/orchestration-defaults.json");
+    const dataResp = await handler(dataReq);
+    expect(dataResp.status).toBe(200);
+    const dataBody = await dataResp.json() as { coder: string; reviewer: string };
+    expect(dataBody).toEqual({ coder: "codex", reviewer: "claude-code" });
+  });
+});

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1239,3 +1239,91 @@ describe("dashboard HTTP /api/ttyd-reset", () => {
     expect(round!.ttydRestartCounts).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// task-b43bd578 — generateOrchestrationDefaults + dashboardGenerate
+// data-file write coverage.
+// ---------------------------------------------------------------------------
+
+describe("generateOrchestrationDefaults — task-b43bd578", () => {
+  function writeConfigWithMag(magYaml: string): void {
+    const configPath = process.env.LUDICS_CONFIG!;
+    const text = `state_repo: owner/ludics-state\nstate_path: harness\n${magYaml}`;
+    writeFileSync(configPath, text);
+  }
+
+  test("missing mag.orchestration keys → effective fallbacks", async () => {
+    writeConfigWithMag("");
+    const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+    expect(generateOrchestrationDefaults()).toEqual({
+      coder: "claude-code",
+      reviewer: "codex",
+    });
+  });
+
+  test("configured opposite values pass through literally (mutation-test guard)", async () => {
+    writeConfigWithMag("mag:\n  orchestration:\n    default_coder: codex\n    default_reviewer: claude-code\n");
+    const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+    expect(generateOrchestrationDefaults()).toEqual({
+      coder: "codex",
+      reviewer: "claude-code",
+    });
+  });
+
+  test("present-null keys emit `null` in the JSON (AC 10/11 reload contract)", async () => {
+    writeConfigWithMag("mag:\n  orchestration:\n    default_coder: null\n    default_reviewer: codex\n");
+    const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+    expect(generateOrchestrationDefaults()).toEqual({
+      coder: null,
+      reviewer: "codex",
+    });
+  });
+
+  test("present-unknown 'cursor' → effective fallback + console.error warning", async () => {
+    writeConfigWithMag("mag:\n  orchestration:\n    default_coder: cursor\n    default_reviewer: codex\n");
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    let calls: unknown[][] = [];
+    try {
+      const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+      const result = generateOrchestrationDefaults();
+      calls = spy.mock.calls;
+      expect(result).toEqual({ coder: "claude-code", reviewer: "codex" });
+    } finally {
+      spy.mockRestore();
+    }
+    const matched = calls.some((c) => String(c[0]).includes("cursor"));
+    expect(matched).toBe(true);
+  });
+});
+
+describe("dashboardGenerate writes orchestration-defaults.json — task-b43bd578", () => {
+  test("file exists in data dir after dashboardGenerate; content matches generator output", async () => {
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(
+      configPath,
+      "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_coder: codex\n    default_reviewer: claude-code\n",
+    );
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    dashboardGenerate();
+    const outFile = join(harnessDir(), "dashboard", "data", "orchestration-defaults.json");
+    expect(existsSync(outFile)).toBe(true);
+    const parsed = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
+    expect(parsed).toEqual({ coder: "codex", reviewer: "claude-code" });
+  });
+
+  test("regenerates after writeOrchestrationDefaults (POST-then-regenerate path)", async () => {
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\n");
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    dashboardGenerate();
+    const outFile = join(harnessDir(), "dashboard", "data", "orchestration-defaults.json");
+    const before = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
+    expect(before).toEqual({ coder: "claude-code", reviewer: "codex" });
+
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    writeOrchestrationDefaults({ coder: "codex", reviewer: "claude-code" });
+    dashboardGenerate();
+    const after = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
+    expect(after).toEqual({ coder: "codex", reviewer: "claude-code" });
+  });
+});

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -845,7 +845,7 @@ function generateAdapter(): Record<string, unknown> {
 //   - key present and null → null (preserves explicit user "none")
 //   - key present + valid  → the configured value
 
-export function generateOrchestrationDefaults(): Record<string, unknown> {
+export function generateOrchestrationDefaults(): { coder: string | null; reviewer: string | null } {
   try {
     const config = loadConfigSync();
     const mag = config.mag as Record<string, unknown> | undefined;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -21,6 +21,7 @@ import { ludicsSelfCommand } from "./orchestration/util.ts";
 import { startDashboardServer } from "./dashboard-server.ts";
 import { clusterIsController, heartbeatIsFresh, clusterCurrentMachineName } from "./cluster.ts";
 import { getIntentForDashboard } from "./cluster-http.ts";
+import { effectiveDefaultsFromConfig } from "./orchestration-defaults.ts";
 
 function readSlotIntentForDashboard(slotNum: number): { action: string } | null {
   return getIntentForDashboard(slotNum);
@@ -835,6 +836,26 @@ function generateAdapter(): Record<string, unknown> {
   return { adapter: "t3code", t3codeAvailable, t3codeWebUrl: webUrl };
 }
 
+// --- Generate orchestration-defaults.json (task-b43bd578) ---
+//
+// Exposes the persisted mag.orchestration.default_coder / default_reviewer
+// to the dashboard role-switcher (AC 8, AC 11, AC 16).
+// Key-presence semantics live in effectiveDefaultsFromConfig:
+//   - key absent           → effective fallback (claude-code / codex)
+//   - key present and null → null (preserves explicit user "none")
+//   - key present + valid  → the configured value
+
+export function generateOrchestrationDefaults(): Record<string, unknown> {
+  try {
+    const config = loadConfigSync();
+    const mag = config.mag as Record<string, unknown> | undefined;
+    const orch = mag?.orchestration as Record<string, unknown> | undefined;
+    return effectiveDefaultsFromConfig(orch);
+  } catch {
+    return effectiveDefaultsFromConfig(undefined);
+  }
+}
+
 // --- Generate terminals.json ---
 
 function generateTerminals(): Record<string, unknown> {
@@ -1110,6 +1131,9 @@ export function dashboardGenerate(): void {
 
   writeFileSync(join(dataDir, "adapter.json"), JSON.stringify(generateAdapter(), null, 2));
   console.error("  adapter.json");
+
+  writeFileSync(join(dataDir, "orchestration-defaults.json"), JSON.stringify(generateOrchestrationDefaults(), null, 2));
+  console.error("  orchestration-defaults.json");
 
   writeFileSync(join(dataDir, "terminals.json"), JSON.stringify(generateTerminals(), null, 2));
   console.error("  terminals.json");

--- a/src/orchestration-defaults.test.ts
+++ b/src/orchestration-defaults.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  EFFECTIVE_DEFAULTS,
+  PROVIDERS,
+  effectiveDefaultsFromConfig,
+  isProvider,
+  validatePayload,
+} from "./orchestration-defaults.ts";
+
+describe("PROVIDERS constant", () => {
+  test("lists exactly claude-code and codex", () => {
+    expect([...PROVIDERS]).toEqual(["claude-code", "codex"]);
+  });
+
+  test("stays in lockstep with the browser-side role-switcher copy", async () => {
+    const browser = await import("../templates/dashboard/role-switcher.js");
+    expect([...browser.PROVIDERS]).toEqual([...PROVIDERS]);
+  });
+});
+
+describe("isProvider", () => {
+  test("accepts each PROVIDERS member", () => {
+    for (const p of PROVIDERS) expect(isProvider(p)).toBe(true);
+  });
+
+  test("rejects unknown strings, empty string, undefined, null, and non-strings", () => {
+    expect(isProvider("cursor")).toBe(false);
+    expect(isProvider("")).toBe(false);
+    expect(isProvider(undefined)).toBe(false);
+    expect(isProvider(null)).toBe(false);
+    expect(isProvider(42)).toBe(false);
+    expect(isProvider({})).toBe(false);
+  });
+});
+
+describe("validatePayload", () => {
+  test("accepts both providers (distinct)", () => {
+    const r = validatePayload({ coder: "claude-code", reviewer: "codex" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.coder).toBe("claude-code");
+      expect(r.reviewer).toBe("codex");
+    }
+  });
+
+  test("accepts both null", () => {
+    const r = validatePayload({ coder: null, reviewer: null });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.coder).toBeNull();
+      expect(r.reviewer).toBeNull();
+    }
+  });
+
+  test("accepts one null + one provider", () => {
+    const r = validatePayload({ coder: null, reviewer: "codex" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.coder).toBeNull();
+      expect(r.reviewer).toBe("codex");
+    }
+  });
+
+  test("rejects missing coder key", () => {
+    const r = validatePayload({ reviewer: "codex" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/missing 'coder'/);
+  });
+
+  test("rejects missing reviewer key", () => {
+    const r = validatePayload({ coder: "codex" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/missing 'reviewer'/);
+  });
+
+  test("rejects unknown provider name 'cursor'", () => {
+    const r = validatePayload({ coder: "cursor", reviewer: "codex" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/invalid 'coder'/);
+  });
+
+  test("rejects duplicate non-null coder/reviewer", () => {
+    const r = validatePayload({ coder: "codex", reviewer: "codex" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/must differ/);
+  });
+
+  test("rejects non-object bodies", () => {
+    expect(validatePayload(null).ok).toBe(false);
+    expect(validatePayload([]).ok).toBe(false);
+    expect(validatePayload("string").ok).toBe(false);
+  });
+});
+
+describe("effectiveDefaultsFromConfig", () => {
+  test("undefined orch → hard-coded fallbacks", () => {
+    expect(effectiveDefaultsFromConfig(undefined)).toEqual({
+      coder: EFFECTIVE_DEFAULTS.coder,
+      reviewer: EFFECTIVE_DEFAULTS.reviewer,
+    });
+  });
+
+  test("empty orch → hard-coded fallbacks (both absent)", () => {
+    expect(effectiveDefaultsFromConfig({})).toEqual({
+      coder: "claude-code",
+      reviewer: "codex",
+    });
+  });
+
+  test("configured opposite values pass through literally", () => {
+    expect(effectiveDefaultsFromConfig({
+      default_coder: "codex",
+      default_reviewer: "claude-code",
+    })).toEqual({ coder: "codex", reviewer: "claude-code" });
+  });
+
+  test("present-null preserves null for that role (AC 10/11 reload contract)", () => {
+    expect(effectiveDefaultsFromConfig({
+      default_coder: null,
+      default_reviewer: "codex",
+    })).toEqual({ coder: null, reviewer: "codex" });
+  });
+
+  test("both present-null → both null", () => {
+    expect(effectiveDefaultsFromConfig({
+      default_coder: null,
+      default_reviewer: null,
+    })).toEqual({ coder: null, reviewer: null });
+  });
+
+  test("present-unknown 'cursor' falls back + console.error warning", () => {
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const out = effectiveDefaultsFromConfig({
+        default_coder: "cursor",
+        default_reviewer: "codex",
+      });
+      const calls = spy.mock.calls;
+      expect(out).toEqual({ coder: "claude-code", reviewer: "codex" });
+      expect(calls.length).toBeGreaterThan(0);
+      expect(String(calls[0]?.[0])).toMatch(/orchestration-defaults.*cursor/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("mutation-test: absent-key fixture matches default; mutating fixture to non-default propagates", () => {
+    // Guard against `?? EFFECTIVE_DEFAULTS.coder` short-circuit bugs:
+    // if the implementation accidentally collapses all paths to defaults,
+    // the configured opposite-values case wouldn't echo literally.
+    const unset = effectiveDefaultsFromConfig({});
+    const configured = effectiveDefaultsFromConfig({
+      default_coder: "codex",
+      default_reviewer: "claude-code",
+    });
+    expect(unset.coder).toBe("claude-code");
+    expect(configured.coder).toBe("codex");
+    expect(unset.coder).not.toBe(configured.coder);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC 13a — asymmetry pin: dashboard preserves explicit `null` selections,
+// but the auto-fill read sites coerce explicit YAML null to the literal
+// fallback. Pinning here so a future "make null real at auto-fill" change
+// touches these tests deliberately.
+// ---------------------------------------------------------------------------
+
+describe("AC 13a asymmetry pin — selectOrchestrationFlags coerces explicit null", () => {
+  test("default_coder: null in fake config → --coder claude-code", async () => {
+    const { selectOrchestrationFlags } = await import("./adapters/t3code.ts");
+    const fakeConfig = {
+      mag: { orchestration: { default_coder: null, default_reviewer: null } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    const { args } = selectOrchestrationFlags("tiny", fakeConfig);
+    // Asymmetry: null at the YAML layer collapses to the hard-coded literal.
+    expect(args).toContain("--coder claude-code");
+    expect(args).not.toContain("--coder null");
+  });
+
+  test("default_reviewer: null in fake config → --reviewer codex on non-tiny effort", async () => {
+    const { selectOrchestrationFlags } = await import("./adapters/t3code.ts");
+    const fakeConfig = {
+      mag: { orchestration: { default_coder: null, default_reviewer: null, default_mode: "pair" } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    const { args } = selectOrchestrationFlags("medium", fakeConfig);
+    expect(args).toContain("--reviewer codex");
+    expect(args).not.toContain("--reviewer null");
+  });
+});
+
+describe("AC 13a asymmetry pin — expandDuoSlots coerces explicit null", () => {
+  let TMP = "";
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-asym-"));
+    process.env.HOME = TMP;
+    const configDir = join(TMP, ".config", "ludics");
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, "config.yaml");
+    writeFileSync(
+      configPath,
+      "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_coder: null\n    default_reviewer: null\n",
+    );
+    process.env.LUDICS_CONFIG = configPath;
+    process.env.LUDICS_HARNESS_DIR = join(TMP, "harness");
+    mkdirSync(process.env.LUDICS_HARNESS_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+    else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("expandDuoSlots with default_coder: null + default_reviewer: null → literal claude-code + codex", async () => {
+    const { expandDuoSlots } = await import("./slots/duo-expand.ts");
+    const result = expandDuoSlots(1, 2, "");
+    // Asymmetry pin: truthy-guard in duo-expand falls back to literal
+    // defaults when default_coder/default_reviewer are present-null.
+    expect(result.slotA.args).toContain("--coder claude-code");
+    expect(result.slotA.args).toContain("--reviewer codex");
+    expect(result.slotB.args).toContain("--coder codex");
+    expect(result.slotB.args).toContain("--reviewer claude-code");
+  });
+});

--- a/src/orchestration-defaults.ts
+++ b/src/orchestration-defaults.ts
@@ -1,0 +1,102 @@
+// Shared server-side constants + validators for the dashboard's
+// provider-role toggle (task-b43bd578).
+//
+// `PROVIDERS` must stay in lockstep with
+// `templates/dashboard/role-switcher.js`'s browser-local copy; a
+// constant-sync test in `src/orchestration-defaults.test.ts` pins both.
+//
+// Asymmetry (AC 13a): with `PROVIDERS = {claude-code, codex}`, the
+// dashboard persists an explicit `coder: null` / `reviewer: null` choice
+// across reloads, but the auto-fill read sites
+// (`selectOrchestrationFlags`, `expandDuoSlots`) coerce explicit null to
+// the literal fallback. Honouring null at auto-fill is deferred to the
+// N≥3 provider-extension task.
+
+export const PROVIDERS = ["claude-code", "codex"] as const;
+export type Provider = (typeof PROVIDERS)[number];
+
+export const ROLES = ["coder", "reviewer", "none"] as const;
+export type Role = (typeof ROLES)[number];
+
+export const EFFECTIVE_DEFAULTS = {
+  coder: "claude-code" as Provider,
+  reviewer: "codex" as Provider,
+} as const;
+
+export interface OrchestrationDefaultsState {
+  coder: Provider | null;
+  reviewer: Provider | null;
+}
+
+export function isProvider(x: unknown): x is Provider {
+  return typeof x === "string" && (PROVIDERS as readonly string[]).includes(x);
+}
+
+/**
+ * Compute the dashboard's effective defaults from a parsed
+ * `mag.orchestration` config block.
+ *
+ * Key-presence semantics (load-bearing for AC 7 + AC 10 + AC 11):
+ *   - key absent           → effective fallback (claude-code / codex)
+ *   - key present and null → null (preserves explicit user "none")
+ *   - key present + valid  → the configured value
+ *   - key present + invalid (e.g. "cursor") → effective fallback +
+ *     console.error warning (so dashboard generation never crashes)
+ */
+export function effectiveDefaultsFromConfig(
+  orch: Record<string, unknown> | undefined | null,
+): OrchestrationDefaultsState {
+  return {
+    coder: resolveRole(orch, "default_coder", EFFECTIVE_DEFAULTS.coder),
+    reviewer: resolveRole(orch, "default_reviewer", EFFECTIVE_DEFAULTS.reviewer),
+  };
+}
+
+function resolveRole(
+  orch: Record<string, unknown> | undefined | null,
+  key: string,
+  fallback: Provider,
+): Provider | null {
+  if (!orch || !(key in orch)) return fallback;
+  const v = orch[key];
+  if (v === null) return null;
+  if (isProvider(v)) return v;
+  console.error(
+    `ludics: orchestration-defaults: ignoring unknown mag.orchestration.${key}=${JSON.stringify(v)}; falling back to ${fallback}`,
+  );
+  return fallback;
+}
+
+export type ValidatePayloadResult =
+  | { ok: true; coder: Provider | null; reviewer: Provider | null }
+  | { ok: false; error: string };
+
+/**
+ * Validate a POST /api/orchestration-defaults body. Server-side
+ * enforcement of AC 4's ≤1-coder / ≤1-reviewer invariant and AC 10's
+ * shape constraints.
+ */
+export function validatePayload(body: unknown): ValidatePayloadResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "body must be a JSON object" };
+  }
+  const obj = body as Record<string, unknown>;
+  if (!("coder" in obj)) return { ok: false, error: "missing 'coder' key" };
+  if (!("reviewer" in obj)) return { ok: false, error: "missing 'reviewer' key" };
+  const coder = obj.coder;
+  const reviewer = obj.reviewer;
+  if (coder !== null && !isProvider(coder)) {
+    return { ok: false, error: `invalid 'coder' value: ${JSON.stringify(coder)}` };
+  }
+  if (reviewer !== null && !isProvider(reviewer)) {
+    return { ok: false, error: `invalid 'reviewer' value: ${JSON.stringify(reviewer)}` };
+  }
+  if (coder !== null && reviewer !== null && coder === reviewer) {
+    return { ok: false, error: "'coder' and 'reviewer' must differ when both non-null" };
+  }
+  return {
+    ok: true,
+    coder: coder as Provider | null,
+    reviewer: reviewer as Provider | null,
+  };
+}

--- a/templates/dashboard/nav.js
+++ b/templates/dashboard/nav.js
@@ -71,6 +71,38 @@
         statusBar.insertBefore(switcher, statusBar.firstChild);
     }
 
+    // ── Role Switcher (task-b43bd578) ────────────────────────
+    // Inject the provider-role toggle to the LEFT of the theme switcher.
+    // Source of truth is server-rendered data/orchestration-defaults.json,
+    // NOT localStorage — the auto-fill code reads the same config keys, so
+    // localStorage would diverge from the path the slot-start code uses.
+    if (statusBar && switcher) {
+        import('./role-switcher.js').then(function (mod) {
+            return fetch('data/orchestration-defaults.json').then(function (r) {
+                return r.ok ? r.json() : null;
+            }).then(function (data) {
+                if (!data) return;
+                var initialState = mod.fromWireBody(data);
+                var roleSwitcher = mod.createRoleSwitcherElement(initialState, function (newState) {
+                    return fetch('/api/orchestration-defaults', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(newState),
+                    }).then(function (resp) {
+                        if (!resp.ok) {
+                            return resp.json().catch(function () { return { error: 'HTTP ' + resp.status }; })
+                                .then(function (e) { throw new Error(e.error || ('HTTP ' + resp.status)); });
+                        }
+                        return resp.json();
+                    });
+                });
+                statusBar.insertBefore(roleSwitcher, switcher);
+            });
+        }).catch(function (e) {
+            console.warn('ludics: role-switcher injection skipped:', e);
+        });
+    }
+
     // ── t3code Link Status ───────────────────────────────────
     var dataPath = 'data/';
     fetch(dataPath + 't3code.json')

--- a/templates/dashboard/nav.test.ts
+++ b/templates/dashboard/nav.test.ts
@@ -1,0 +1,85 @@
+// task-b43bd578 — source-level pins for nav.js role-switcher wiring
+// and the .role-switcher CSS rules in style.css.
+//
+// nav.js runs in the browser; we can't unit-test the actual DOM
+// injection here (the live HTTP smoke probe (AC 19) does that). What we
+// CAN pin is that the nav.js source contains the required wiring (the
+// dynamic import, the insertBefore against the live theme switcher
+// reference, the fetch URLs, the POST shape) and that style.css carries
+// the required selectors. Drift in these literals would break the
+// browser-side behaviour silently.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const navJsPath = join(__dirname, "nav.js");
+const styleCssPath = join(__dirname, "style.css");
+const navJs = readFileSync(navJsPath, "utf-8");
+const styleCss = readFileSync(styleCssPath, "utf-8");
+
+describe("nav.js — role-switcher wiring (task-b43bd578)", () => {
+  test("dynamically imports ./role-switcher.js (avoids HTML edits)", () => {
+    expect(navJs).toMatch(/import\(['"]\.\/role-switcher\.js['"]\)/);
+  });
+
+  test("fetches data/orchestration-defaults.json on page load", () => {
+    expect(navJs).toMatch(/fetch\(['"]data\/orchestration-defaults\.json['"]/);
+  });
+
+  test("POSTs to /api/orchestration-defaults", () => {
+    expect(navJs).toMatch(/['"]\/api\/orchestration-defaults['"]/);
+    expect(navJs).toMatch(/method:\s*['"]POST['"]/);
+  });
+
+  test("inserts role-switcher BEFORE the live theme-switcher reference (AC 1)", () => {
+    // Use the in-scope `switcher` variable that's already assigned the
+    // theme-switcher element; re-querying after insertion would mis-order.
+    expect(navJs).toMatch(/statusBar\.insertBefore\(roleSwitcher,\s*switcher\)/);
+  });
+
+  test("guards on statusBar AND switcher before injecting", () => {
+    // Theme-switcher block can fail or be skipped; role-switcher must
+    // not insert against a null reference.
+    expect(navJs).toMatch(/if\s*\(statusBar\s*&&\s*switcher\)/);
+  });
+
+  test("negative control: nav.js does NOT use localStorage for role state", () => {
+    // Theme uses localStorage (THEME_KEY = 'ludics-theme'). The role
+    // toggle MUST NOT, because the auto-fill code reads config keys —
+    // localStorage would diverge from the actual auto-fill path.
+    const lines = navJs.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      // Skip pure-comment lines (negative-control should pin code, not docs).
+      if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+      if (!/localStorage/.test(line)) continue;
+      // Allow only theme-related localStorage uses.
+      if (/THEME_KEY|ludics-theme|theme/i.test(line)) continue;
+      throw new Error(`unexpected localStorage use in nav.js: ${line.trim()}`);
+    }
+  });
+
+  test("uses .catch / try-style error handling for the dynamic-import block", () => {
+    // Network or import rejection must NOT brick the rest of nav.js.
+    expect(navJs).toMatch(/\.catch\(function/);
+  });
+});
+
+describe("style.css — role-switcher selectors (task-b43bd578)", () => {
+  test(".role-switcher rule is defined", () => {
+    expect(styleCss).toMatch(/\.role-switcher\s*\{/);
+  });
+
+  test(".role-btn rule is defined", () => {
+    expect(styleCss).toMatch(/\.role-btn\s*\{/);
+  });
+
+  test(".role-btn.active rule (active-state visual marking, AC 3) is defined", () => {
+    expect(styleCss).toMatch(/\.role-btn\.active\s*\{/);
+  });
+
+  test(".role-section-label rule (Defaults for new sessions hint) is defined", () => {
+    expect(styleCss).toMatch(/\.role-section-label\s*\{/);
+  });
+});

--- a/templates/dashboard/role-switcher.d.ts
+++ b/templates/dashboard/role-switcher.d.ts
@@ -23,3 +23,10 @@ export function createRoleSwitcherElement(
 ): HTMLElement;
 
 export function fromWireBody(body: RoleSwitcherWireBody): RoleSwitcherState;
+
+export interface InFlightSequencer {
+  begin(): number;
+  isLatest(id: number): boolean;
+}
+
+export function createInFlightSequencer(): InFlightSequencer;

--- a/templates/dashboard/role-switcher.d.ts
+++ b/templates/dashboard/role-switcher.d.ts
@@ -1,0 +1,25 @@
+// Type declarations for the browser-side role-switcher module.
+// Mirrors templates/dashboard/role-switcher.js; PROVIDERS list is pinned
+// in lockstep with src/orchestration-defaults.ts via a constant-sync test.
+
+export const PROVIDERS: ReadonlyArray<"claude-code" | "codex">;
+
+export type RoleSwitcherRole = "coder" | "reviewer" | "none";
+export type RoleSwitcherState = Record<string, RoleSwitcherRole>;
+export interface RoleSwitcherWireBody {
+  coder: string | null;
+  reviewer: string | null;
+}
+
+export function applyRoleChange(
+  state: RoleSwitcherState,
+  provider: string,
+  role: RoleSwitcherRole,
+): RoleSwitcherState;
+
+export function createRoleSwitcherElement(
+  initialState: RoleSwitcherState,
+  onSubmit: (newState: RoleSwitcherWireBody) => Promise<unknown>,
+): HTMLElement;
+
+export function fromWireBody(body: RoleSwitcherWireBody): RoleSwitcherState;

--- a/templates/dashboard/role-switcher.js
+++ b/templates/dashboard/role-switcher.js
@@ -118,19 +118,26 @@ export function createRoleSwitcherElement(initialState, onSubmit) {
     root.appendChild(row);
   }
 
+  const sequencer = createInFlightSequencer();
+
   async function handleClick(provider, role) {
     const prev = state;
     const next = applyRoleChange(prev, provider, role);
     state = next;
     syncActive();
     root.removeAttribute("title");
+    const myId = sequencer.begin();
     try {
       const confirmed = await onSubmit(toWireBody(next));
+      // Drop stale responses: if a newer click started after this one,
+      // its response (or its failure) is authoritative — not ours.
+      if (!sequencer.isLatest(myId)) return;
       if (confirmed && typeof confirmed === "object") {
         state = fromWireBody(confirmed);
         syncActive();
       }
     } catch (err) {
+      if (!sequencer.isLatest(myId)) return;
       // Pessimistic rollback: server rejected or network failed.
       state = prev;
       syncActive();
@@ -140,6 +147,26 @@ export function createRoleSwitcherElement(initialState, onSubmit) {
 
   syncActive();
   return root;
+}
+
+/**
+ * Per-instance in-flight request sequencer. Each click obtains a fresh
+ * monotonic id via `begin()`; after the POST resolves the handler checks
+ * `isLatest(id)` and drops stale responses. Without this, rapid clicks
+ * whose responses resolve out of order would let an older response
+ * overwrite a newer state mutation (Codex P2 review on PR #523).
+ */
+export function createInFlightSequencer() {
+  let latest = 0;
+  return {
+    begin() {
+      latest += 1;
+      return latest;
+    },
+    isLatest(id) {
+      return id === latest;
+    },
+  };
 }
 
 /** Map internal `none` ↔ wire-body `null`. */

--- a/templates/dashboard/role-switcher.js
+++ b/templates/dashboard/role-switcher.js
@@ -1,0 +1,163 @@
+// Browser-side dashboard provider-role toggle (task-b43bd578).
+//
+// Exports:
+//   - PROVIDERS         literal provider universe (kept in lockstep with
+//                       `src/orchestration-defaults.ts` via constant-sync test).
+//   - applyRoleChange   pure cascade per proposal AC 4–6 + AC 14.
+//   - createRoleSwitcherElement
+//                       DOM constructor. Pure: no fetch, no document mutation
+//                       outside the returned subtree. nav.js owns the
+//                       insertion into `.status-bar`.
+
+export const PROVIDERS = ["claude-code", "codex"];
+
+/**
+ * Pure constraint-propagation cascade.
+ *
+ * State: { [provider]: "coder" | "reviewer" | "none" }
+ * Never mutates the input; returns a new state object.
+ *
+ * On setRole(p, "none"):  clear p only; no cascade (AC 6).
+ * On setRole(p, r) where r ∈ {coder, reviewer} (AC 5):
+ *   - find pOld != p with state[pOld] === r;
+ *   - set state[p] = r;
+ *   - if pOld exists: let rOther be the other role; if no provider currently
+ *     holds rOther, set state[pOld] = rOther; else set state[pOld] = "none".
+ */
+export function applyRoleChange(state, provider, role) {
+  const next = { ...state };
+  if (role === "none") {
+    next[provider] = "none";
+    return next;
+  }
+  const rOther = role === "coder" ? "reviewer" : "coder";
+  // pOld is the (at most one) other provider that currently holds `role`.
+  let pOld = null;
+  for (const p of Object.keys(next)) {
+    if (p !== provider && next[p] === role) {
+      pOld = p;
+      break;
+    }
+  }
+  next[provider] = role;
+  if (pOld === null) return next;
+  // Does any provider (other than pOld, after we update it) currently hold rOther?
+  let rOtherHolder = null;
+  for (const p of Object.keys(next)) {
+    if (p !== pOld && next[p] === rOther) {
+      rOtherHolder = p;
+      break;
+    }
+  }
+  next[pOld] = rOtherHolder === null ? rOther : "none";
+  return next;
+}
+
+/**
+ * Construct a `.role-switcher` element with three buttons per provider.
+ *
+ * `initialState` shape: { [provider]: "coder" | "reviewer" | "none" }
+ * `onSubmit(newState)` is called after each click; should return a Promise
+ * that resolves to the server-confirmed state (or throws on failure).
+ * Pessimistic update: on rejection, the local state is restored and a
+ * compact error message is surfaced via the element's `title` attribute.
+ *
+ * Returns the constructed element. Pure DOM construction — no document
+ * mutation outside the returned subtree.
+ */
+export function createRoleSwitcherElement(initialState, onSubmit) {
+  let state = { ...initialState };
+  const root = document.createElement("div");
+  root.className = "role-switcher";
+  root.setAttribute("aria-label", "Defaults for new sessions");
+
+  const label = document.createElement("span");
+  label.className = "role-section-label";
+  label.textContent = "Defaults for new sessions";
+  root.appendChild(label);
+
+  const buttonRefs = {}; // provider -> { coder, reviewer, none }
+
+  function syncActive() {
+    for (const p of PROVIDERS) {
+      const refs = buttonRefs[p];
+      if (!refs) continue;
+      const current = state[p] ?? "none";
+      refs.coder.classList.toggle("active", current === "coder");
+      refs.reviewer.classList.toggle("active", current === "reviewer");
+      refs.none.classList.toggle("active", current === "none");
+    }
+  }
+
+  for (const provider of PROVIDERS) {
+    const row = document.createElement("div");
+    row.className = "role-row";
+    row.dataset.provider = provider;
+
+    const name = document.createElement("span");
+    name.className = "role-provider-name";
+    name.textContent = provider;
+    row.appendChild(name);
+
+    const group = document.createElement("div");
+    group.className = "role-btn-group";
+    const refs = {};
+    for (const r of ["coder", "reviewer", "none"]) {
+      const btn = document.createElement("button");
+      btn.className = "role-btn";
+      btn.dataset.role = r;
+      btn.dataset.provider = provider;
+      btn.textContent = r;
+      btn.title = `Set ${provider} as ${r}`;
+      btn.addEventListener("click", () => handleClick(provider, r));
+      group.appendChild(btn);
+      refs[r] = btn;
+    }
+    buttonRefs[provider] = refs;
+    row.appendChild(group);
+    root.appendChild(row);
+  }
+
+  async function handleClick(provider, role) {
+    const prev = state;
+    const next = applyRoleChange(prev, provider, role);
+    state = next;
+    syncActive();
+    root.removeAttribute("title");
+    try {
+      const confirmed = await onSubmit(toWireBody(next));
+      if (confirmed && typeof confirmed === "object") {
+        state = fromWireBody(confirmed);
+        syncActive();
+      }
+    } catch (err) {
+      // Pessimistic rollback: server rejected or network failed.
+      state = prev;
+      syncActive();
+      root.setAttribute("title", `Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  syncActive();
+  return root;
+}
+
+/** Map internal `none` ↔ wire-body `null`. */
+function toWireBody(state) {
+  const out = { coder: null, reviewer: null };
+  for (const p of PROVIDERS) {
+    if (state[p] === "coder") out.coder = p;
+    else if (state[p] === "reviewer") out.reviewer = p;
+  }
+  return out;
+}
+
+export function fromWireBody(body) {
+  const state = {};
+  for (const p of PROVIDERS) state[p] = "none";
+  if (body && typeof body === "object") {
+    if (body.coder && PROVIDERS.includes(body.coder)) state[body.coder] = "coder";
+    if (body.reviewer && PROVIDERS.includes(body.reviewer)) state[body.reviewer] = "reviewer";
+  }
+  return state;
+}

--- a/templates/dashboard/role-switcher.test.ts
+++ b/templates/dashboard/role-switcher.test.ts
@@ -1,0 +1,199 @@
+// task-b43bd578 — pure-cascade unit tests for role-switcher.js.
+// AC 14 names this transformation and pins its behaviour independently
+// of the DOM.
+
+import { describe, expect, test } from "bun:test";
+
+import { applyRoleChange, fromWireBody, PROVIDERS } from "./role-switcher.js";
+
+describe("PROVIDERS (browser-side copy)", () => {
+  test("lists exactly claude-code and codex (in this order)", () => {
+    expect([...PROVIDERS]).toEqual(["claude-code", "codex"]);
+  });
+});
+
+describe("applyRoleChange — N=2 cascade (AC 14 bullets 1–2)", () => {
+  test("swap: codex coder ← claude-code coder (swap, claude-code → reviewer)", () => {
+    const before = { "claude-code": "coder", "codex": "reviewer" };
+    const after = applyRoleChange(before, "codex", "coder");
+    expect(after).toEqual({ "claude-code": "reviewer", "codex": "coder" });
+  });
+
+  test("promotion to vacant reviewer: codex none → coder; claude-code was coder, reviewer vacant → claude-code becomes reviewer", () => {
+    const before = { "claude-code": "coder", "codex": "none" };
+    const after = applyRoleChange(before, "codex", "coder");
+    expect(after).toEqual({ "claude-code": "reviewer", "codex": "coder" });
+  });
+
+  test("symmetric promotion (reviewer side): claude-code reviewer + codex none → setRole(codex, reviewer) → claude-code becomes coder", () => {
+    const before = { "claude-code": "reviewer", "codex": "none" };
+    const after = applyRoleChange(before, "codex", "reviewer");
+    expect(after).toEqual({ "claude-code": "coder", "codex": "reviewer" });
+  });
+});
+
+describe("applyRoleChange — N=3 demotion-to-none (AC 14 bullet 3)", () => {
+  // The proposal pins the N>2 branch even though the live UI today has N=2.
+  // Hypothetical 3rd provider "cursor" holding reviewer forces the
+  // displaced previous-coder to "none" because rOther is already taken.
+  test("setRole(codex, coder) with claude-code coder + cursor reviewer + codex none → claude-code becomes none, cursor unchanged", () => {
+    const before = { "claude-code": "coder", "codex": "none", "cursor": "reviewer" };
+    const after = applyRoleChange(before, "codex", "coder");
+    expect(after).toEqual({
+      "claude-code": "none",
+      "codex": "coder",
+      "cursor": "reviewer",
+    });
+  });
+
+  test("symmetric N=3 demotion: setRole(codex, reviewer) with claude-code reviewer + cursor coder + codex none → claude-code becomes none, cursor unchanged", () => {
+    const before = { "claude-code": "reviewer", "codex": "none", "cursor": "coder" };
+    const after = applyRoleChange(before, "codex", "reviewer");
+    expect(after).toEqual({
+      "claude-code": "none",
+      "codex": "reviewer",
+      "cursor": "coder",
+    });
+  });
+});
+
+describe("applyRoleChange — release to none (AC 6 / AC 14 bullet 4)", () => {
+  test("setRole(claude-code, 'none') clears only claude-code; other provider unchanged", () => {
+    const before = { "claude-code": "coder", "codex": "reviewer" };
+    const after = applyRoleChange(before, "claude-code", "none");
+    expect(after["claude-code"]).toBe("none");
+    // Negative assertion at the persistent seam: the other provider's
+    // role must not change. This guards against an accidental cascade
+    // that back-fills the vacated coder slot.
+    expect(after["codex"]).toBe("reviewer");
+  });
+
+  test("setRole on a 3-provider state with role=none does not displace anyone", () => {
+    const before = { "claude-code": "coder", "codex": "reviewer", "cursor": "none" };
+    const after = applyRoleChange(before, "claude-code", "none");
+    expect(after).toEqual({
+      "claude-code": "none",
+      "codex": "reviewer",
+      "cursor": "none",
+    });
+  });
+});
+
+describe("applyRoleChange — ≤1-coder / ≤1-reviewer invariant (AC 4 / AC 14 bullet 5)", () => {
+  function countRoles(state: Record<string, string>) {
+    let c = 0, r = 0;
+    for (const v of Object.values(state)) {
+      if (v === "coder") c++;
+      else if (v === "reviewer") r++;
+    }
+    return { c, r };
+  }
+
+  const scenarios = [
+    {
+      name: "N=2 swap",
+      before: { "claude-code": "coder", "codex": "reviewer" },
+      args: ["codex", "coder"] as const,
+    },
+    {
+      name: "N=2 promotion to vacant reviewer",
+      before: { "claude-code": "coder", "codex": "none" },
+      args: ["codex", "coder"] as const,
+    },
+    {
+      name: "N=3 demotion to none",
+      before: { "claude-code": "coder", "codex": "none", "cursor": "reviewer" },
+      args: ["codex", "coder"] as const,
+    },
+    {
+      name: "release to none",
+      before: { "claude-code": "coder", "codex": "reviewer" },
+      args: ["claude-code", "none"] as const,
+    },
+  ];
+
+  for (const sc of scenarios) {
+    test(`invariant holds after ${sc.name}`, () => {
+      const after = applyRoleChange(sc.before, sc.args[0], sc.args[1]);
+      const { c, r } = countRoles(after);
+      expect(c).toBeLessThanOrEqual(1);
+      expect(r).toBeLessThanOrEqual(1);
+    });
+  }
+});
+
+describe("applyRoleChange — purity / non-mutation", () => {
+  test("output is a fresh object (identity differs)", () => {
+    const before = { "claude-code": "coder", "codex": "reviewer" };
+    const after = applyRoleChange(before, "codex", "coder");
+    expect(after).not.toBe(before);
+  });
+
+  test("input state is unchanged after the call (deep-equality)", () => {
+    const before = { "claude-code": "coder", "codex": "reviewer" };
+    const snapshot = JSON.parse(JSON.stringify(before));
+    applyRoleChange(before, "codex", "coder");
+    expect(before).toEqual(snapshot);
+  });
+});
+
+describe("fromWireBody — null ↔ none mapping", () => {
+  test("both providers covered; explicit roles round-trip", () => {
+    expect(fromWireBody({ coder: "codex", reviewer: "claude-code" })).toEqual({
+      "claude-code": "reviewer",
+      "codex": "coder",
+    });
+  });
+
+  test("nulls map to 'none' for unmentioned providers", () => {
+    expect(fromWireBody({ coder: null, reviewer: "codex" })).toEqual({
+      "claude-code": "none",
+      "codex": "reviewer",
+    });
+  });
+
+  test("both null → both none", () => {
+    expect(fromWireBody({ coder: null, reviewer: null })).toEqual({
+      "claude-code": "none",
+      "codex": "none",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createRoleSwitcherElement source-level pins (AC 1, AC 3, AC 12).
+// Bun's test runtime has no DOM and we don't want to add a polyfill dep
+// just for this test. The live HTTP smoke probe (AC 19) exercises the DOM
+// construction end-to-end against a real browser-like fetcher; here we pin
+// the source-level invariants that the DOM constructor must encode.
+// ---------------------------------------------------------------------------
+
+describe("role-switcher.js source-level pins (AC 1, AC 3, AC 12)", () => {
+  let source = "";
+  test("source file readable", async () => {
+    const { readFileSync } = await import("fs");
+    const { join } = await import("path");
+    source = readFileSync(join(__dirname, "role-switcher.js"), "utf-8");
+    expect(source.length).toBeGreaterThan(0);
+  });
+
+  test("AC 12: 'Defaults for new sessions' label appears as rendered text and aria-label", () => {
+    // Two distinct uses — aria-label (for screen readers) AND a visible
+    // <span> textContent — both pinned to catch single-source removal.
+    const occurrences = (source.match(/Defaults for new sessions/g) ?? []).length;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+    expect(source).toContain('setAttribute("aria-label", "Defaults for new sessions")');
+    expect(source).toMatch(/label\.textContent\s*=\s*"Defaults for new sessions"/);
+  });
+
+  test("AC 1: element class is 'role-switcher' and built via document.createElement", () => {
+    expect(source).toMatch(/className\s*=\s*"role-switcher"/);
+    expect(source).toMatch(/document\.createElement\("div"\)/);
+  });
+
+  test("AC 3: three buttons per provider with role values coder/reviewer/none, classed .role-btn with .active toggle", () => {
+    expect(source).toContain('"coder", "reviewer", "none"');
+    expect(source).toMatch(/btn\.className\s*=\s*"role-btn"/);
+    expect(source).toMatch(/classList\.toggle\("active",/);
+  });
+});

--- a/templates/dashboard/role-switcher.test.ts
+++ b/templates/dashboard/role-switcher.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { applyRoleChange, fromWireBody, PROVIDERS } from "./role-switcher.js";
+import { applyRoleChange, createInFlightSequencer, fromWireBody, PROVIDERS } from "./role-switcher.js";
 
 describe("PROVIDERS (browser-side copy)", () => {
   test("lists exactly claude-code and codex (in this order)", () => {
@@ -168,6 +168,60 @@ describe("fromWireBody — null ↔ none mapping", () => {
 // the source-level invariants that the DOM constructor must encode.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// createInFlightSequencer — pins the stale-response guard. Addresses the
+// Codex P2 review on PR #523: without sequencing, an older POST response
+// can resolve after a newer click and overwrite the newer state. The
+// sequencer is per-instance (so multiple role-switcher elements don't
+// share state) and monotonic.
+// ---------------------------------------------------------------------------
+
+describe("createInFlightSequencer — stale-response guard", () => {
+  test("issues monotonically increasing ids", () => {
+    const seq = createInFlightSequencer();
+    expect(seq.begin()).toBe(1);
+    expect(seq.begin()).toBe(2);
+    expect(seq.begin()).toBe(3);
+  });
+
+  test("isLatest is true only for the most recently issued id", () => {
+    const seq = createInFlightSequencer();
+    const a = seq.begin();
+    const b = seq.begin();
+    expect(seq.isLatest(a)).toBe(false);
+    expect(seq.isLatest(b)).toBe(true);
+  });
+
+  test("isLatest of an unissued id is false", () => {
+    const seq = createInFlightSequencer();
+    expect(seq.isLatest(999)).toBe(false);
+    seq.begin();
+    expect(seq.isLatest(999)).toBe(false);
+  });
+
+  test("each instance has its own counter (no shared module-level state)", () => {
+    const a = createInFlightSequencer();
+    const b = createInFlightSequencer();
+    expect(a.begin()).toBe(1);
+    expect(b.begin()).toBe(1);
+    expect(a.begin()).toBe(2);
+    // b's counter unaffected by a's increments.
+    expect(b.begin()).toBe(2);
+  });
+
+  test("out-of-order resolution scenario: older click's response is dropped after newer click started", () => {
+    // Simulates the bug Codex flagged. Two clicks fire in order; their
+    // POST responses resolve out of order (older response arrives last).
+    const seq = createInFlightSequencer();
+    const click1 = seq.begin();        // user clicks button A
+    const click2 = seq.begin();        // user clicks button B before A's POST resolves
+    // POST for click2 resolves first (newer wins).
+    expect(seq.isLatest(click2)).toBe(true);
+    // POST for click1 resolves second — handler must drop it.
+    expect(seq.isLatest(click1)).toBe(false);
+  });
+});
+
 describe("role-switcher.js source-level pins (AC 1, AC 3, AC 12)", () => {
   let source = "";
   test("source file readable", async () => {
@@ -195,5 +249,15 @@ describe("role-switcher.js source-level pins (AC 1, AC 3, AC 12)", () => {
     expect(source).toContain('"coder", "reviewer", "none"');
     expect(source).toMatch(/btn\.className\s*=\s*"role-btn"/);
     expect(source).toMatch(/classList\.toggle\("active",/);
+  });
+
+  test("handleClick guards both success AND failure paths with sequencer.isLatest", () => {
+    // Codex P2 fix: rapid clicks resolve out of order; older responses
+    // (whether success or thrown error) must be dropped. Pin both arms
+    // so a partial revert wouldn't silently regress the failure path.
+    const matches = source.match(/if \(!sequencer\.isLatest\(myId\)\) return;/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    // Must obtain its myId BEFORE awaiting onSubmit.
+    expect(source).toMatch(/const myId\s*=\s*sequencer\.begin\(\);\s*\n\s*try\s*\{/);
   });
 });

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -317,6 +317,74 @@ header h1 {
     font-weight: 600;
 }
 
+/* ── Role Switcher (task-b43bd578) ─────────────────────────── */
+.role-switcher {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    margin-right: 8px;
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    letter-spacing: 0.02em;
+}
+
+.role-section-label {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-right: 4px;
+}
+
+.role-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 2px 4px;
+}
+
+.role-provider-name {
+    font-family: var(--font-mono, var(--font-body));
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    text-transform: lowercase;
+    padding-right: 2px;
+}
+
+.role-btn-group {
+    display: flex;
+    gap: 2px;
+}
+
+.role-btn {
+    font-family: var(--font-body);
+    font-size: 0.55rem;
+    font-weight: 500;
+    padding: 1px 5px;
+    border: none;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1.4;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.role-btn:hover {
+    color: var(--text-primary);
+    background: var(--bg-panel-hover);
+}
+
+.role-btn.active {
+    color: var(--bg-primary);
+    background: var(--accent);
+    font-weight: 600;
+}
+
 /* ── Main Layout ───────────────────────────────────────────── */
 main {
     padding: 1.25rem 1.5rem;


### PR DESCRIPTION
## Summary

- Adds a top-bar control on every dashboard page (left of the theme switcher) for picking the default `coder` / `reviewer` provider, with per-provider `coder` / `reviewer` / `none` states and the proposal's cascade rule.
- Round-trips through `dashboard/data/orchestration-defaults.json` ↔ `POST /api/orchestration-defaults` ↔ `mag.orchestration.default_coder` / `default_reviewer` in `config.yaml` via `YAML.parseDocument` + `setIn` + atomic write.
- New shared module `src/orchestration-defaults.ts` centralises `PROVIDERS` + `validatePayload` + `effectiveDefaultsFromConfig`. Browser-side `templates/dashboard/role-switcher.js` houses the pure cascade `applyRoleChange` (testable, no DOM); nav.js dynamically imports it (no HTML edits needed).
- Proposal **AC 13a** added in the same PR documenting that `null` role state survives reloads at the dashboard layer but is intentionally coerced to the literal fallback by the auto-fill read sites (`selectOrchestrationFlags` / `expandDuoSlots`) in the N=2 universe — deferred to the N≥3 provider-extension task. Pinned by regression tests against both read sites.
- **Round-2 fix (Codex P2):** `handleClick` now obtains a fresh id from a per-instance `createInFlightSequencer()` *before* awaiting `onSubmit`; stale responses (success or failure) are dropped if a newer click has started. Prevents the rapid-click race where an older POST's response overwrites newer state.

## Commits

1. `2da39d2` — foundation: cascade module + validators + proposal AC 13a.
2. `8f1f0a1` — data-file generator (`dashboard/data/orchestration-defaults.json`) + YAML writer with null-as-explicit-null persistence.
3. `425c83b` — POST `/api/orchestration-defaults` endpoint + nav.js dynamic-import injection + `.role-switcher` CSS.
4. `2d6172a` — in-flight sequencer guards rapid-click race (Codex P2 review fix).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — **2477 pass / 0 fail** (baseline 2397 → +80 new tests across `orchestration-defaults.test.ts`, `role-switcher.test.ts`, `nav.test.ts`, additions to `dashboard.test.ts` + `config.test.ts`).
- [x] `bun run build` — compiles `bin/ludics`.
- [x] Live HTTP smoke probe — transcript at `/tmp/task-b43bd578-smoke.transcript`: walks AC 19.i–iv plus a v1 null round-trip and AC 10 duplicate-rejection check; final line `=== ALL SMOKE ASSERTIONS PASSED ===`.

## AC coverage

20 ACs (proposal §Acceptance Criteria 1–13, 13a, 14–19). Per-AC evidence walked in `.peer-sync/workflow-feedback-coder.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)