### PR TITLE
fix: delivery-confirmation sentinel for Mag queue (gh-ludics-526)

### DIFF
--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -15,7 +15,7 @@ import { emitEvent } from "./events.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { readTmuxSlotState, writeTmuxSlotState } from "./adapters/tmux-adapter.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
-import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce } from "./mag.ts";
+import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce, readInFlightDelivery } from "./mag.ts";
 import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
 import { resolveSkillCommand } from "./skill-queue-registry.ts";
 import { handleClusterRequest } from "./cluster-http.ts";
@@ -666,7 +666,11 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
           delete d.output; // strip large blobs — UI only needs id/status/timestamp
           return d;
         });
-        return new Response(JSON.stringify({ pending, results }), {
+        // gh-ludics-526: a popped-but-not-completed request is in neither
+        // `pending` nor `results`. Surface the in-flight delivery sentinel
+        // (null when there is none, or once its result JSON exists).
+        const inFlight = readInFlightDelivery();
+        return new Response(JSON.stringify({ pending, results, inFlight }), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (e) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -749,6 +749,62 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
   });
 });
 
+// gh-ludics-526: a popped-but-not-completed skill request is in neither the
+// `pending` queue nor the `results` tile. GET /api/queue surfaces it via the
+// `inFlight` field, read from mag/last-delivered.json.
+describe("dashboard HTTP GET /api/queue — inFlight sentinel (AC 8)", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+  function magDir(): string {
+    const dir = join(harnessDir(), "mag");
+    mkdirSync(join(dir, "results"), { recursive: true });
+    return dir;
+  }
+
+  test("includes inFlight when last-delivered.json exists with no matching result", async () => {
+    // Harness condition: an unresolved sentinel — present, no result JSON.
+    writeFileSync(join(magDir(), "last-delivered.json"), JSON.stringify({
+      requestId: "req-IF", command: "/ludics-briefing", line: "{}",
+      deliveredAt: "2026-05-14T08:06:28Z",
+    }));
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: { requestId: string; command: string; deliveredAt: string } | null };
+    // The invariant: a delivered-but-unconfirmed request is visible. If the
+    // handler ignored the sentinel, inFlight would be null here.
+    expect(body.inFlight).not.toBeNull();
+    expect(body.inFlight!.requestId).toBe("req-IF");
+    expect(body.inFlight!.command).toBe("/ludics-briefing");
+    expect(body.inFlight!.deliveredAt).toBe("2026-05-14T08:06:28Z");
+  });
+
+  test("inFlight is null once a matching result JSON exists", async () => {
+    // Harness condition: sentinel present AND its result file written — the
+    // request is no longer in flight.
+    writeFileSync(join(magDir(), "last-delivered.json"), JSON.stringify({
+      requestId: "req-IF", command: "/ludics-briefing", line: "{}",
+      deliveredAt: "2026-05-14T08:06:28Z",
+    }));
+    writeFileSync(join(magDir(), "results", "req-IF.json"), JSON.stringify({ id: "req-IF", status: "ok" }));
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: unknown };
+    expect(body.inFlight).toBeNull();
+  });
+
+  test("inFlight is null when no sentinel exists", async () => {
+    magDir(); // ensure mag/ dir exists, but no sentinel
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: unknown };
+    expect(body.inFlight).toBeNull();
+  });
+});
+
 // task-2db5eca6: priority-bump and queue-promote should clear the
 // auto-proposal debounce so the next keepalive cycle re-evaluates the task.
 // Decreases (slot-postpone) keep the sentinel intact (asymmetric by design).

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -208,6 +208,65 @@ describe("reconcileLastDelivered (AC 2, AC 3)", () => {
   });
 });
 
+// --- Concurrency: the re-queue path atomically claims the sentinel so two
+// concurrent callers (keepalive loop + dashboard server) cannot both
+// re-queue the same line (codex review, PR #528). ---
+
+describe("reconcileLastDelivered — atomic claim guards against double-requeue", () => {
+  const reconcilingFile = () => lastDeliveredFile() + ".reconciling";
+
+  test("a lost delivery is re-queued exactly once and leaves no .reconciling claim file", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-LOST", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-LOST", action: "learn" }),
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+
+    reconcileLastDelivered();
+
+    // Re-queued exactly once; the claim file is consumed, not left to wedge
+    // or be re-processed.
+    expect(readQueueIds()).toEqual(["req-LOST"]);
+    expect(existsSync(reconcilingFile())).toBe(false);
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+  });
+
+  test("a second reconcile after the sentinel is claimed+cleared is a no-op — no duplicate enqueue", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-LOST", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-LOST", action: "learn" }),
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+
+    // First caller claims, re-queues, clears. Second caller (the concurrent
+    // loser, modelled by a sequential second call) finds nothing to do.
+    reconcileLastDelivered();
+    reconcileLastDelivered();
+
+    // Still exactly one copy — the claim+clear prevents the second pass from
+    // re-queuing the same line.
+    expect(readQueueIds()).toEqual(["req-LOST"]);
+  });
+
+  test("a sentinel already claimed by a concurrent winner (.reconciling staged, last-delivered.json gone) is not re-queued", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    // Models the state right after another caller won the renameSync claim:
+    // last-delivered.json no longer exists, the content lives in the claim
+    // file. The losing caller must observe nothing and re-queue nothing.
+    writeFileSync(reconcilingFile(), JSON.stringify({
+      requestId: "req-CLAIMED", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-CLAIMED", action: "learn" }),
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+
+    reconcileLastDelivered();
+
+    expect(readQueueIds()).toEqual([]); // the winner owns it, not us
+  });
+});
+
 // --- AC 4: delivery gated on the sentinel ---
 
 describe("deliveryGateBlocked (AC 4)", () => {

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -1,0 +1,372 @@
+// Regression tests for the delivery-confirmation sentinel (gh-ludics-526).
+//
+// maybeFeedMagQueue() used to be fire-and-forget: a skill delivered into the
+// Mag pane right before an auto-compaction (or crash, or dropped input) was
+// silently lost — no result JSON, no retry. These tests pin the sentinel
+// write, the reconciliation pass, the delivery gate, and the shared retry-cap
+// helper that together close that gap.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+function harnessDir(): string {
+  return join(TMP, "harness");
+}
+function magDir(): string {
+  return join(harnessDir(), "mag");
+}
+function queueFile(): string {
+  return join(magDir(), "queue.jsonl");
+}
+function lastDeliveredFile(): string {
+  return join(magDir(), "last-delivered.json");
+}
+function resultFile(id: string): string {
+  return join(magDir(), "results", `${id}.json`);
+}
+function currentRequestIdFile(): string {
+  return join(magDir(), "current-request-id");
+}
+
+function writeConfig(homeDir: string, magSection = ""): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+${magSection}`);
+  return configPath;
+}
+
+function readQueueIds(): string[] {
+  if (!existsSync(queueFile())) return [];
+  const content = readFileSync(queueFile(), "utf-8").trim();
+  if (!content) return [];
+  return content.split("\n").map((l) => JSON.parse(l).id as string);
+}
+
+function readEvents(): Record<string, unknown>[] {
+  const file = join(harnessDir(), "journal", "events.jsonl");
+  if (!existsSync(file)) return [];
+  const content = readFileSync(file, "utf-8").trim();
+  if (!content) return [];
+  return content.split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-delivery-confirm-"));
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = harnessDir();
+  mkdirSync(join(magDir(), "results"), { recursive: true });
+  mkdirSync(join(harnessDir(), "journal"), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+// --- AC 1: sentinel written on the success path, none on send failure ---
+
+describe("deliverPoppedSkill — sentinel write (AC 1)", () => {
+  test("successful send writes mag/last-delivered.json and emits mag_queue_feed", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-A", action: "learn" });
+
+    const sent = deliverPoppedSkill(
+      { requestId: "req-A", command: "/ludics-learn", line },
+      { send: () => true, nowMs: Date.parse("2026-05-14T08:06:28Z") },
+    );
+
+    expect(sent).toBe(true);
+    expect(existsSync(lastDeliveredFile())).toBe(true);
+    const sentinel = JSON.parse(readFileSync(lastDeliveredFile(), "utf-8"));
+    expect(sentinel.requestId).toBe("req-A");
+    expect(sentinel.command).toBe("/ludics-learn");
+    expect(sentinel.line).toBe(line);
+    expect(sentinel.deliveredAt).toBe("2026-05-14T08:06:28Z");
+    expect(readEvents().some((e) => e.event_type === "mag_queue_feed")).toBe(true);
+  });
+
+  test("failed send writes NO sentinel and re-queues via the retry-cap path", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-A", action: "learn" });
+
+    const sent = deliverPoppedSkill(
+      { requestId: "req-A", command: "/ludics-learn", line },
+      { send: () => false },
+    );
+
+    expect(sent).toBe(false);
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+    // re-queued at head with an incremented _retry_count
+    const content = readFileSync(queueFile(), "utf-8").trim();
+    expect(JSON.parse(content)._retry_count).toBe(1);
+    expect(JSON.parse(content).id).toBe("req-A");
+  });
+});
+
+// --- AC 7: queuePopSkill exposes the requestId captured at pop time ---
+
+describe("queuePopSkill — requestId exposure (AC 7)", () => {
+  test("return value includes requestId matching the request id and current-request-id file", async () => {
+    const { queuePopSkill } = await import("./mag.ts");
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-POP-1", action: "learn" }) + "\n");
+
+    const popped = await queuePopSkill();
+
+    expect(popped).not.toBeNull();
+    expect(popped!.requestId).toBe("req-POP-1");
+    expect(popped!.command).toBe("/ludics-learn");
+    // The id must be captured at pop time, not re-read later — it is also the
+    // value written to mag/current-request-id.
+    expect(readFileSync(currentRequestIdFile(), "utf-8")).toBe("req-POP-1");
+  });
+});
+
+// --- AC 2 / AC 3: reconciliation confirms, re-queues, or drops ---
+
+describe("reconcileLastDelivered (AC 2, AC 3)", () => {
+  test("result JSON present → sentinel cleared, queue untouched (result checked before timeout)", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    // Harness condition: an OLD deliveredAt (well past the timeout) AND a
+    // present result file — the confirmed branch must win over the timeout
+    // branch, so the line is never re-queued.
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-DONE", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-DONE", action: "learn" }),
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
+
+    reconcileLastDelivered();
+
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+    expect(readQueueIds()).toEqual([]); // not double-queued
+  });
+
+  test("past threshold, no result → line re-queued at head with _retry_count++, sentinel cleared, mag_queue_requeued emitted", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-LOST", action: "learn" });
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-LOST", command: "/ludics-learn", line,
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+
+    reconcileLastDelivered();
+
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+    const content = readFileSync(queueFile(), "utf-8").trim();
+    expect(JSON.parse(content).id).toBe("req-LOST");
+    expect(JSON.parse(content)._retry_count).toBe(1);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_requeued")).toBe(true);
+  });
+
+  test("past threshold, _retry_count at the cap → item dropped, not reinserted, sentinel cleared, mag_queue_dropped emitted", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    // Harness condition: _retry_count already at DEFAULT_MAX_REQUEUE_RETRIES (3).
+    const line = JSON.stringify({ id: "req-POISON", action: "learn", _retry_count: 3 });
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-POISON", command: "/ludics-learn", line,
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+
+    reconcileLastDelivered();
+
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+    expect(readQueueIds()).toEqual([]); // dropped, not reinserted
+    expect(readEvents().some((e) => e.event_type === "mag_queue_dropped")).toBe(true);
+  });
+
+  test("under threshold, no result → sentinel left untouched for the next tick", async () => {
+    const { reconcileLastDelivered } = await import("./mag.ts");
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-FRESH", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-FRESH", action: "learn" }),
+      deliveredAt: new Date().toISOString(),
+    }));
+
+    reconcileLastDelivered();
+
+    expect(existsSync(lastDeliveredFile())).toBe(true);
+    expect(readQueueIds()).toEqual([]);
+  });
+});
+
+// --- AC 4: delivery gated on the sentinel ---
+
+describe("deliveryGateBlocked (AC 4)", () => {
+  function writeSentinel(deliveredAt: string): void {
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-INFLIGHT", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-INFLIGHT", action: "learn" }),
+      deliveredAt,
+    }));
+  }
+
+  test("unresolved sentinel under threshold → blocked", async () => {
+    const { deliveryGateBlocked } = await import("./mag.ts");
+    writeSentinel(new Date().toISOString());
+    expect(deliveryGateBlocked()).toBe(true);
+  });
+
+  test("matching result JSON exists → not blocked", async () => {
+    const { deliveryGateBlocked } = await import("./mag.ts");
+    writeSentinel(new Date().toISOString());
+    writeFileSync(resultFile("req-INFLIGHT"), JSON.stringify({ id: "req-INFLIGHT", status: "ok" }));
+    expect(deliveryGateBlocked()).toBe(false);
+  });
+
+  test("sentinel past threshold → not blocked", async () => {
+    const { deliveryGateBlocked } = await import("./mag.ts");
+    writeSentinel("2020-01-01T00:00:00Z");
+    expect(deliveryGateBlocked()).toBe(false);
+  });
+
+  test("no sentinel → not blocked", async () => {
+    const { deliveryGateBlocked } = await import("./mag.ts");
+    expect(deliveryGateBlocked()).toBe(false);
+  });
+});
+
+// --- AC 4: direct (non-keepalive) callers also reconcile before popping ---
+
+describe("maybeFeedMagQueue — reconcile-as-invariant for direct callers (AC 4)", () => {
+  test("a direct call with an expired sentinel for A re-queues A and clears the sentinel before B can be delivered", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    // A was delivered long ago and never confirmed (compaction lost it).
+    const lineA = JSON.stringify({ id: "req-A", action: "learn" });
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-A", command: "/ludics-learn", line: lineA,
+      deliveredAt: "2020-01-01T00:00:00Z",
+    }));
+    // B is queued behind it.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-B", action: "learn" }) + "\n");
+    // Mag is settled so maybeFeedMagQueue proceeds past the readiness guard.
+    touchSentinel(join(magDir(), "settled"));
+
+    // Inject a failing send so the test never touches a real tmux pane; the
+    // reconcile/gate logic under test runs identically regardless of send.
+    await maybeFeedMagQueue({ send: () => false });
+
+    // The in-function reconcileLastDelivered() must have run BEFORE any pop:
+    // A's sentinel is cleared (not overwritten by a B sentinel) and A's line
+    // is back in the durable queue — never silently lost.
+    expect(existsSync(lastDeliveredFile())).toBe(false);
+    const ids = readQueueIds();
+    expect(ids).toContain("req-A");
+    expect(ids).toContain("req-B");
+  });
+});
+
+// --- AC 6: shared retry-cap helper ---
+
+describe("requeueWithRetryCap — shared retry-cap logic (AC 6)", () => {
+  test("under the cap → reinserts at head with _retry_count++ and returns 'requeued'", async () => {
+    const { requeueWithRetryCap } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 1 });
+
+    const outcome = requeueWithRetryCap(line, "/ludics-learn", "send-failed");
+
+    expect(outcome).toBe("requeued");
+    const content = readFileSync(queueFile(), "utf-8").trim();
+    expect(JSON.parse(content)._retry_count).toBe(2);
+  });
+
+  test("at the cap → drops the item, returns 'dropped', does not reinsert", async () => {
+    const { requeueWithRetryCap } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 3 });
+
+    const outcome = requeueWithRetryCap(line, "/ludics-learn", "delivery-unconfirmed");
+
+    expect(outcome).toBe("dropped");
+    expect(readQueueIds()).toEqual([]);
+  });
+
+  test("honors a configured mag.max_requeue_retries", async () => {
+    process.env.LUDICS_CONFIG = writeConfig(TMP, "mag:\n  max_requeue_retries: 5\n");
+    const { requeueWithRetryCap } = await import("./mag.ts");
+    // _retry_count 3 is under a configured cap of 5 → still requeued.
+    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 3 });
+
+    const outcome = requeueWithRetryCap(line, "/ludics-learn", "send-failed");
+
+    expect(outcome).toBe("requeued");
+    expect(JSON.parse(readFileSync(queueFile(), "utf-8").trim())._retry_count).toBe(4);
+  });
+});
+
+// --- AC 8: dashboard in-flight sentinel exposure (server contract) ---
+
+describe("readInFlightDelivery (AC 8)", () => {
+  test("returns the sentinel payload when unresolved", async () => {
+    const { readInFlightDelivery } = await import("./mag.ts");
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-IF", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-IF", action: "learn" }),
+      deliveredAt: "2026-05-14T08:06:28Z",
+    }));
+
+    const inFlight = readInFlightDelivery();
+    expect(inFlight).not.toBeNull();
+    expect(inFlight!.requestId).toBe("req-IF");
+    expect(inFlight!.command).toBe("/ludics-learn");
+    expect(inFlight!.deliveredAt).toBe("2026-05-14T08:06:28Z");
+  });
+
+  test("returns null once a matching result JSON exists", async () => {
+    const { readInFlightDelivery } = await import("./mag.ts");
+    writeFileSync(lastDeliveredFile(), JSON.stringify({
+      requestId: "req-IF", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-IF", action: "learn" }),
+      deliveredAt: "2026-05-14T08:06:28Z",
+    }));
+    writeFileSync(resultFile("req-IF"), JSON.stringify({ id: "req-IF", status: "ok" }));
+
+    expect(readInFlightDelivery()).toBeNull();
+  });
+
+  test("returns null when there is no sentinel", async () => {
+    const { readInFlightDelivery } = await import("./mag.ts");
+    expect(readInFlightDelivery()).toBeNull();
+  });
+});
+
+// --- Round-trip fidelity: sentinel survives write → read ---
+
+describe("last-delivered sentinel round-trip fidelity", () => {
+  test("deliverPoppedSkill write → readInFlightDelivery preserves every field", async () => {
+    const { deliverPoppedSkill, readInFlightDelivery } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-RT", action: "learn", _retry_count: 2 });
+
+    deliverPoppedSkill(
+      { requestId: "req-RT", command: "/ludics-learn", line },
+      { send: () => true, nowMs: Date.parse("2026-05-14T09:00:00Z") },
+    );
+
+    const got = readInFlightDelivery();
+    expect(got).toEqual({
+      requestId: "req-RT",
+      command: "/ludics-learn",
+      line,
+      deliveredAt: "2026-05-14T09:00:00Z",
+    });
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -338,12 +338,13 @@ function writeLastDelivered(sentinel: LastDeliveredSentinel): void {
 }
 
 /**
- * Read the delivery sentinel; tolerate a missing or malformed file by
- * returning null (this runs in the keepalive path and in /api/queue).
+ * Parse a delivery-sentinel JSON file; tolerate a missing or malformed file
+ * by returning null. Shared by readLastDelivered() and the post-claim read in
+ * reconcileLastDelivered().
  */
-function readLastDelivered(): LastDeliveredSentinel | null {
+function parseSentinelFile(path: string): LastDeliveredSentinel | null {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(lastDeliveredFile(), "utf-8"));
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
     if (!isPlainObject(parsed)) return null;
     const requestId = String(parsed.requestId ?? "");
     const command = String(parsed.command ?? "");
@@ -354,6 +355,14 @@ function readLastDelivered(): LastDeliveredSentinel | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Read the delivery sentinel; tolerate a missing or malformed file by
+ * returning null (this runs in the keepalive path and in /api/queue).
+ */
+function readLastDelivered(): LastDeliveredSentinel | null {
+  return parseSentinelFile(lastDeliveredFile());
 }
 
 function clearLastDelivered(): void {
@@ -428,19 +437,44 @@ export function requeueWithRetryCap(line: string, command: string, reason: strin
  * Result-existence is checked first: a skill that completed late (within the
  * timeout window) is cleared as confirmed and never double-queued.
  *
+ * Concurrency: `maybeFeedMagQueue` runs this from multiple processes (the
+ * keepalive loop and the dashboard server). The re-queue path atomically
+ * claims the sentinel via `renameSync` before re-queuing, so two concurrent
+ * callers that both observe the same expired sentinel cannot both call
+ * `queueReinsertHead` — only the caller that wins the rename re-queues; the
+ * loser's `renameSync` throws (source gone) and it bails.
+ *
  * Exported for tests; `nowMs` drives the timeout deterministically.
  */
 export function reconcileLastDelivered(nowMs: number = Date.now()): void {
-  const sentinel = readLastDelivered();
-  if (!sentinel) return;
-  if (existsSync(magResultFile(sentinel.requestId))) {
+  // Cheap peek without claiming — avoids a rename on every quiet tick.
+  const peek = readLastDelivered();
+  if (!peek) return;
+  if (existsSync(magResultFile(peek.requestId))) {
+    // Confirmed. clearLastDelivered() swallows ENOENT, so a concurrent
+    // double-clear is harmless — no claim needed on this branch.
     clearLastDelivered();
     return;
   }
-  if (deliveredAtAgeMs(sentinel, nowMs) >= DELIVERY_CONFIRM_TIMEOUT_MS) {
-    requeueWithRetryCap(sentinel.line, sentinel.command, "delivery-unconfirmed");
-    clearLastDelivered();
+  if (deliveredAtAgeMs(peek, nowMs) < DELIVERY_CONFIRM_TIMEOUT_MS) return;
+
+  // Past the timeout with no result → delivery lost. Atomically claim the
+  // sentinel before re-queuing so concurrent callers cannot double-enqueue.
+  const claimPath = lastDeliveredFile() + ".reconciling";
+  try {
+    renameSync(lastDeliveredFile(), claimPath);
+  } catch {
+    return; // another caller already claimed (or cleared) it
   }
+  // Read from the claimed copy — the file content may have been replaced
+  // between the peek and the claim, so trust only what we atomically own.
+  const claimed = parseSentinelFile(claimPath);
+  // Re-check result existence after the claim: a result that landed in the
+  // peek→claim window means the delivery completed late — don't re-queue.
+  if (claimed && !existsSync(magResultFile(claimed.requestId))) {
+    requeueWithRetryCap(claimed.line, claimed.command, "delivery-unconfirmed");
+  }
+  try { unlinkSync(claimPath); } catch { /* ignore */ }
 }
 
 /**

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -102,6 +102,11 @@ const DEFAULT_STALL_THRESHOLD_MS = 120_000; // 2 minutes
 const DEFAULT_STALL_NUDGE_COOLDOWN_MS = 120_000; // 2 minutes between stall nudges
 const DEFAULT_READY_THRESHOLD_MS = 5_000; // pane must be stable this long to count as ready
 const DEFAULT_MAX_REQUEUE_RETRIES = 3;
+// gh-ludics-526: a skill delivery with no result JSON after this long is
+// treated as lost (compaction/crash/dropped input). Hard-coded, not a config
+// key — comfortably past a compaction and well past any current skill's
+// runtime (briefing/feedback-digest finish in well under a minute).
+const DELIVERY_CONFIRM_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 const DEFAULT_STARTUP_WATCHDOG_SECONDS = 60;
 const DEFAULT_STARTUP_HELPER_STUCK_SECONDS = 45;
 const STARTUP_ALERT_TITLE = "Mag alert";
@@ -309,6 +314,191 @@ export function applyQueueFeedPrefix(rawLine: string, command: string): string {
   return `Ludics: ${command}`;
 }
 
+// --- Delivery-confirmation sentinel (gh-ludics-526) ---
+
+/** Shape of the mag/last-delivered.json sentinel. */
+interface LastDeliveredSentinel {
+  requestId: string;
+  command: string;
+  line: string;
+  deliveredAt: string;
+}
+
+function lastDeliveredFile(): string {
+  return join(magStateDir(), "last-delivered.json");
+}
+
+/** Path of the result JSON a completed skill writes (matches queue.ts writeResult). */
+function magResultFile(requestId: string): string {
+  return join(harnessDir(), "mag", "results", `${requestId}.json`);
+}
+
+function writeLastDelivered(sentinel: LastDeliveredSentinel): void {
+  writeJsonFile(lastDeliveredFile(), sentinel);
+}
+
+/**
+ * Read the delivery sentinel; tolerate a missing or malformed file by
+ * returning null (this runs in the keepalive path and in /api/queue).
+ */
+function readLastDelivered(): LastDeliveredSentinel | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(lastDeliveredFile(), "utf-8"));
+    if (!isPlainObject(parsed)) return null;
+    const requestId = String(parsed.requestId ?? "");
+    const command = String(parsed.command ?? "");
+    const line = String(parsed.line ?? "");
+    const deliveredAt = String(parsed.deliveredAt ?? "");
+    if (!requestId || !line) return null;
+    return { requestId, command, line, deliveredAt };
+  } catch {
+    return null;
+  }
+}
+
+function clearLastDelivered(): void {
+  try { unlinkSync(lastDeliveredFile()); } catch { /* already gone */ }
+}
+
+/**
+ * Age of a sentinel in ms. A deliveredAt that fails Date.parse is treated as
+ * infinitely old, so a corrupt timestamp re-queues + clears rather than
+ * wedging the delivery gate forever.
+ */
+function deliveredAtAgeMs(sentinel: LastDeliveredSentinel, nowMs: number): number {
+  const delivered = Date.parse(sentinel.deliveredAt);
+  if (Number.isNaN(delivered)) return Number.POSITIVE_INFINITY;
+  return nowMs - delivered;
+}
+
+/**
+ * Shared retry-cap requeue path (gh-ludics-526). Used by both the
+ * triggerSkill send-failure branch and the delivery-confirmation
+ * reconciliation pass. Parses `_retry_count` from `line`, honors
+ * `mag.max_requeue_retries` / `DEFAULT_MAX_REQUEUE_RETRIES`, and either
+ * reinserts the line at the queue head with an incremented `_retry_count`
+ * (`mag_queue_requeued`) or drops it once the cap is reached
+ * (`mag_queue_dropped`). `reason` is folded into the event message only.
+ *
+ * Exported for tests.
+ */
+export function requeueWithRetryCap(line: string, command: string, reason: string): "requeued" | "dropped" {
+  let retryCount = 0;
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      retryCount = Number((parsed as Record<string, unknown>)._retry_count) || 0;
+    }
+  } catch { /* use 0 */ }
+
+  const config = loadConfigSync();
+  const magCfg = config.mag as Record<string, unknown> | undefined;
+  const configuredRetries = Number(magCfg?.max_requeue_retries);
+  const maxRetries = (Number.isFinite(configuredRetries) && configuredRetries > 0)
+    ? configuredRetries : DEFAULT_MAX_REQUEUE_RETRIES;
+  if (retryCount >= maxRetries) {
+    console.error(`ludics: queue item dropped after ${maxRetries} failed retries`);
+    emitEvent({ event_type: "mag_queue_dropped", source: "keepalive", scope: "mag", status: "dropped", message: `dropped after ${maxRetries} retries (${reason}): ${command}` });
+    return "dropped";
+  }
+  // Increment retry count and reinsert at front of queue
+  let updated: Record<string, unknown>;
+  try {
+    updated = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    updated = { raw: line };
+  }
+  updated._retry_count = retryCount + 1;
+  queueReinsertHead(JSON.stringify(updated));
+  console.error(`ludics: requeued failed delivery (retry ${retryCount + 1}/${maxRetries})`);
+  emitEvent({ event_type: "mag_queue_requeued", source: "keepalive", scope: "mag", message: `retry ${retryCount + 1}/${maxRetries} (${reason}): ${command}` });
+  return "requeued";
+}
+
+/**
+ * Delivery-confirmation reconciliation (gh-ludics-526). Runs each keepalive
+ * tick AND inside maybeFeedMagQueue before any pop, so every delivery path
+ * resolves a stale sentinel before it can deliver the next item.
+ *
+ * - sentinel + matching result JSON → confirmed; clear the sentinel.
+ * - sentinel older than the timeout, no result → delivery lost; re-queue the
+ *   line through the shared retry-cap path and clear the sentinel.
+ * - sentinel present, no result, under the timeout → leave for the next tick.
+ *
+ * Result-existence is checked first: a skill that completed late (within the
+ * timeout window) is cleared as confirmed and never double-queued.
+ *
+ * Exported for tests; `nowMs` drives the timeout deterministically.
+ */
+export function reconcileLastDelivered(nowMs: number = Date.now()): void {
+  const sentinel = readLastDelivered();
+  if (!sentinel) return;
+  if (existsSync(magResultFile(sentinel.requestId))) {
+    clearLastDelivered();
+    return;
+  }
+  if (deliveredAtAgeMs(sentinel, nowMs) >= DELIVERY_CONFIRM_TIMEOUT_MS) {
+    requeueWithRetryCap(sentinel.line, sentinel.command, "delivery-unconfirmed");
+    clearLastDelivered();
+  }
+}
+
+/**
+ * True when a skill delivery is still in flight: the sentinel exists, no
+ * result JSON has appeared, and it is younger than the timeout. While this
+ * holds, maybeFeedMagQueue must not deliver the next skill item (gh-ludics-526
+ * fix part 1b). Exported for tests.
+ */
+export function deliveryGateBlocked(nowMs: number = Date.now()): boolean {
+  const sentinel = readLastDelivered();
+  if (!sentinel) return false;
+  if (existsSync(magResultFile(sentinel.requestId))) return false;
+  return deliveredAtAgeMs(sentinel, nowMs) < DELIVERY_CONFIRM_TIMEOUT_MS;
+}
+
+/**
+ * Dashboard helper (gh-ludics-526 fix part 2): the in-flight delivery
+ * sentinel, or null when there is none or its result JSON already exists.
+ * Age is not considered — an expired-but-not-yet-reconciled sentinel still
+ * reads as in flight until the next keepalive tick clears it.
+ */
+export function readInFlightDelivery(): LastDeliveredSentinel | null {
+  const sentinel = readLastDelivered();
+  if (!sentinel) return null;
+  if (existsSync(magResultFile(sentinel.requestId))) return null;
+  return sentinel;
+}
+
+/**
+ * Deliver one popped skill item into the Mag pane. On a successful send,
+ * record the mag/last-delivered.json sentinel (gh-ludics-526) and emit
+ * `mag_queue_feed`; on a failed send, re-queue through the shared retry-cap
+ * path without writing a sentinel. Returns whether the send succeeded.
+ *
+ * Exported for tests; `send` is injectable to exercise both paths without
+ * tmux, and `nowMs` pins the `deliveredAt` timestamp deterministically.
+ */
+export function deliverPoppedSkill(
+  popped: { requestId: string; command: string; line: string },
+  opts: { send?: (session: string, cmd: string) => boolean; nowMs?: number } = {},
+): boolean {
+  const send = opts.send ?? triggerSkill;
+  const delivered = applyQueueFeedPrefix(popped.line, popped.command);
+  const sent = send(MAG_SESSION_NAME, delivered);
+  if (sent) {
+    writeLastDelivered({
+      requestId: popped.requestId,
+      command: popped.command,
+      line: popped.line,
+      deliveredAt: new Date(opts.nowMs ?? Date.now()).toISOString().replace(/\.\d{3}Z$/, "Z"),
+    });
+    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${delivered}` });
+  } else {
+    requeueWithRetryCap(popped.line, popped.command, "send-failed");
+  }
+  return sent;
+}
+
 /**
  * When Mag is ready for input and queue has Mag-turn work, pop one item
  * and deliver. "Ready" means either the settled sentinel is set (stop
@@ -318,13 +508,29 @@ export function applyQueueFeedPrefix(rawLine: string, command: string): string {
  * where clearStaleSettled has cleared the sentinel). Returns true if a
  * command was dispatched.
  */
-export async function maybeFeedMagQueue(): Promise<boolean> {
+export async function maybeFeedMagQueue(
+  opts: { send?: (session: string, cmd: string) => boolean } = {},
+): Promise<boolean> {
   if (!isMagSettled() && !isMagReady()) return false;
   if (!queuePending()) return false;
 
   // Drain programmatic entries first (they don't need a Mag turn)
   await drainProgrammaticQueueHead();
   if (!queuePending()) return false;
+
+  // Delivery-confirmation invariant (gh-ludics-526): reconcile a stale
+  // sentinel before any pop, so every caller of maybeFeedMagQueue — the
+  // keepalive tick AND the direct callers (fresh-start ready path, on-stop
+  // hook, dashboard /api/queue-deliver and /api/queue) — clears or re-queues
+  // a resolved/expired sentinel before it can deliver the next item. Without
+  // this, a direct caller could pop B and let deliverPoppedSkill overwrite
+  // the single-valued sentinel for A before A is re-queued.
+  reconcileLastDelivered();
+  // Gate: do not deliver the next skill while a delivery is still in flight
+  // (sentinel present, no result, under the timeout). reconcileLastDelivered
+  // above has already cleared confirmed/expired sentinels, so a block here
+  // means a genuinely in-flight delivery.
+  if (deliveryGateBlocked()) return false;
 
   // Atomic claim: if settled, consume the sentinel so concurrent ticks
   // see !settled. In the ready-only path there's no sentinel to consume;
@@ -343,43 +549,7 @@ export async function maybeFeedMagQueue(): Promise<boolean> {
   const popped = await queuePopSkill();
   if (!popped) return false;
 
-  const delivered = applyQueueFeedPrefix(popped.line, popped.command);
-  const sent = triggerSkill(MAG_SESSION_NAME, delivered);
-  if (sent) {
-    emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${delivered}` });
-  } else {
-    // Requeue the failed item for retry on next keepalive cycle.
-    let retryCount = 0;
-    try {
-      const parsed: unknown = JSON.parse(popped.line);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        retryCount = Number((parsed as Record<string, unknown>)._retry_count) || 0;
-      }
-    } catch { /* use 0 */ }
-
-    const config = loadConfigSync();
-    const magCfg = config.mag as Record<string, unknown> | undefined;
-    const configuredRetries = Number(magCfg?.max_requeue_retries);
-    const maxRetries = (Number.isFinite(configuredRetries) && configuredRetries > 0)
-      ? configuredRetries : DEFAULT_MAX_REQUEUE_RETRIES;
-    if (retryCount >= maxRetries) {
-      console.error(`ludics: queue item dropped after ${maxRetries} failed retries`);
-      emitEvent({ event_type: "mag_queue_dropped", source: "keepalive", scope: "mag", status: "dropped", message: `dropped after ${maxRetries} retries: ${popped.command}` });
-    } else {
-      // Increment retry count and reinsert at front of queue
-      let updated: Record<string, unknown>;
-      try {
-        updated = JSON.parse(popped.line) as Record<string, unknown>;
-      } catch {
-        updated = { raw: popped.line };
-      }
-      updated._retry_count = retryCount + 1;
-      queueReinsertHead(JSON.stringify(updated));
-      console.error(`ludics: requeued failed delivery (retry ${retryCount + 1}/${maxRetries})`);
-      emitEvent({ event_type: "mag_queue_requeued", source: "keepalive", scope: "mag", message: `retry ${retryCount + 1}/${maxRetries}: ${popped.command}` });
-    }
-  }
-  return sent;
+  return deliverPoppedSkill(popped, { send: opts.send });
 }
 
 /**
@@ -1241,7 +1411,9 @@ async function launchSessionFromNotification(taskId: string, adapterArgs: string
   console.error(`ludics: launched t3code for ${taskId} in slot ${slotNum} (${actionLabel})`);
 }
 
-async function queuePopSkill(): Promise<{ command: string; line: string } | null> {
+/** @internal Exported for tests — pops the queue head, resolves it to a skill
+ *  command, and exposes the request id captured at pop time (gh-ludics-526). */
+export async function queuePopSkill(): Promise<{ requestId: string; command: string; line: string } | null> {
   const popped = queuePopExpected();
   if (popped.status !== "popped") return null;
 
@@ -1260,7 +1432,10 @@ async function queuePopSkill(): Promise<{ command: string; line: string } | null
 
   const command = await resolveQueueRequestCommand(request, true);
   if (!command) return null;
-  return { command, line: popped.line };
+  // requestId is captured here at delivery time — never re-read from
+  // mag/current-request-id later, since the next queuePopSkill overwrites it
+  // (gh-ludics-526).
+  return { requestId, command, line: popped.line };
 }
 
 /** Resolve a queue request to a skill command or execute it programmatically.
@@ -2910,6 +3085,12 @@ export async function magStart(args: string[]): Promise<void> {
 
     // If Mag resumed running (e.g. manual turn) since settling, clear stale sentinel
     clearStaleSettled();
+
+    // Delivery-confirmation reconciliation (gh-ludics-526): confirm or re-queue
+    // a stale delivery sentinel. Kept here in addition to the in-function call
+    // in maybeFeedMagQueue, because maybeFeedMagQueue returns early on an empty
+    // queue and would otherwise never reconcile while the queue is drained.
+    reconcileLastDelivered();
 
     // Settled-aware queue feed: deliver one Mag-turn item if settled
     const fed = await maybeFeedMagQueue();

--- a/templates/dashboard/dashboard.test.ts
+++ b/templates/dashboard/dashboard.test.ts
@@ -91,3 +91,87 @@ describe("style.css contains pending-action-badge class", () => {
     expect(rule).toContain("var(--warning");
   });
 });
+
+// gh-ludics-526: the Mag queue renderer must surface a popped-but-not-completed
+// skill request as an "In flight" section between Pending and Recent. These
+// tests extract the real renderQueue / escapeHtml from mag.html and drive them
+// against a minimal document stub (the readFileSync + new Function pattern).
+describe("mag.html renderQueue — In flight section (gh-ludics-526)", () => {
+  const magSrc = readFileSync(join(import.meta.dir, "mag.html"), "utf-8");
+  const renderQueueSrc = magSrc.slice(
+    magSrc.indexOf("function renderQueue("),
+    magSrc.indexOf("async function promoteQueueItem"),
+  );
+  const escapeHtmlSrc = magSrc.slice(
+    magSrc.indexOf("function escapeHtml("),
+    magSrc.indexOf("function setConnectionStatus"),
+  );
+
+  // Minimal document stub: getElementById returns the live list element;
+  // createElement('div') backs escapeHtml's textContent → innerHTML escaping.
+  function makeRenderQueue(listEl: { innerHTML: string }): (p: unknown[], r: unknown[], i: unknown) => void {
+    const documentStub = {
+      getElementById: () => listEl,
+      createElement: () => {
+        let text = "";
+        return {
+          set textContent(v: string) { text = String(v); },
+          get innerHTML() {
+            return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+          },
+        };
+      },
+    };
+    return new Function(
+      "document",
+      `${escapeHtmlSrc}\n${renderQueueSrc}\nreturn renderQueue;`,
+    )(documentStub) as (p: unknown[], r: unknown[], i: unknown) => void;
+  }
+
+  test("renders 'In flight' between 'Pending' and 'Recent'", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue(
+      [{ id: "req-p", action: "elaborate" }],
+      [{ id: "req-r", status: "ok" }],
+      { requestId: "req-if", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" },
+    );
+    const html = listEl.innerHTML;
+    const pendingIdx = html.indexOf("Pending");
+    const inFlightIdx = html.indexOf("In flight");
+    const recentIdx = html.indexOf("Recent");
+    // The invariant: an in-flight request is visible and ordered between the
+    // durable queue and completed results. If the section were missing or
+    // misplaced, this ordering chain would break.
+    expect(pendingIdx).toBeGreaterThanOrEqual(0);
+    expect(inFlightIdx).toBeGreaterThan(pendingIdx);
+    expect(recentIdx).toBeGreaterThan(inFlightIdx);
+    expect(html).toContain("/ludics-briefing");
+    expect(html).toContain("2026-05-14T08:06:28Z");
+  });
+
+  test("escapes the in-flight command", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [], { requestId: "x", command: "<script>evil</script>", deliveredAt: "" });
+    expect(listEl.innerHTML).toContain("&lt;script&gt;evil&lt;/script&gt;");
+    expect(listEl.innerHTML).not.toContain("<script>evil");
+  });
+
+  test("suppresses 'No activity' while in-flight data exists", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    // Harness condition: pending AND results empty — only the sentinel is set.
+    // Without inFlight in the empty-state guard, this would render "No activity".
+    renderQueue([], [], { requestId: "x", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" });
+    expect(listEl.innerHTML).not.toContain("No activity");
+    expect(listEl.innerHTML).toContain("In flight");
+  });
+
+  test("still shows 'No activity' when pending, results, and inFlight are all empty", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [], null);
+    expect(listEl.innerHTML).toContain("No activity");
+  });
+});

--- a/templates/dashboard/mag.html
+++ b/templates/dashboard/mag.html
@@ -100,17 +100,17 @@
                 const response = await fetch('/api/queue');
                 if (!response.ok) return;
                 const data = await response.json();
-                renderQueue(data.pending || [], data.results || []);
+                renderQueue(data.pending || [], data.results || [], data.inFlight || null);
             } catch {
                 // Silently skip — don't break the terminal
             }
         }
 
-        function renderQueue(pending, results) {
+        function renderQueue(pending, results, inFlight) {
             const list = document.getElementById('queue-list');
             if (!list) return;
 
-            if (pending.length === 0 && results.length === 0) {
+            if (pending.length === 0 && results.length === 0 && !inFlight) {
                 list.innerHTML = '<div class="mag-queue-empty">No activity</div>';
                 return;
             }
@@ -135,6 +135,14 @@
                         `</div>` : '';
                     html += `<div class="mag-queue-item"><span class="action">[${action}]</span>${task}${content}${ts}${actions}</div>`;
                 }
+            }
+
+            if (inFlight) {
+                html += '<div class="mag-queue-section-title">In flight</div>';
+                const command = escapeHtml(String(inFlight.command || 'unknown'));
+                const ts = inFlight.deliveredAt
+                    ? `<div class="timestamp">${escapeHtml(String(inFlight.deliveredAt))}</div>` : '';
+                html += `<div class="mag-queue-item"><span class="action">[delivered]</span> ${command}${ts}</div>`;
             }
 
             if (results.length > 0) {


### PR DESCRIPTION
## Summary

Queue items delivered into the Mag pane immediately before an auto-compaction (or a crash mid-turn, or a dropped tmux input) were silently lost: `triggerSkill` returns truthy when keystrokes *land in the pane*, not when Mag *processes the skill and writes a result*. `maybeFeedMagQueue` treated the item as done — no result JSON, no retry. On 2026-05-14 the morning daily briefing was lost this way.

One mechanism — a single-valued `mag/last-delivered.json` sentinel — closes both the retry gap and the dashboard-visibility gap.

## Changes

- **`deliverPoppedSkill`** writes the sentinel on a successful send and emits `mag_queue_feed`; on a failed send it re-queues without a sentinel.
- **`reconcileLastDelivered`** runs each keepalive tick **and inside `maybeFeedMagQueue` before any pop** — so every delivery path (keepalive + the direct callers: fresh-start, on-stop hook, dashboard `/api/queue-deliver` and `/api/queue`) confirms (result JSON exists) or re-queues (past `DELIVERY_CONFIRM_TIMEOUT_MS`) a stale sentinel before it can deliver the next item. Result-existence is checked **before** the timeout branch, so a late-completing skill is never double-queued.
- **`deliveryGateBlocked`** keeps the next skill in the durable `queue.jsonl` while a delivery is genuinely in flight. The in-function reconcile makes the single-valued sentinel correct by construction (never overwritten before reconciliation).
- **`DELIVERY_CONFIRM_TIMEOUT_MS`** — hard-coded 10 min constant alongside `DEFAULT_MAX_REQUEUE_RETRIES`, not a config key (user decision 2026-05-14).
- **`requeueWithRetryCap`** — the existing send-failure retry-cap logic, factored out and shared with the reconciliation pass (byte-identical event types `mag_queue_requeued` / `mag_queue_dropped`).
- **`queuePopSkill`** now returns `requestId`, captured at pop time (not re-read from the overwritable `mag/current-request-id`).
- **`/api/queue`** exposes an `inFlight` field; **`mag.html` `renderQueue`** renders an "In flight" section between Pending and Recent.

## Follow-up commit (`3ee6dd0`) — codex review

`reconcileLastDelivered`'s re-queue path now **atomically claims** `mag/last-delivered.json` via `renameSync(…, ".reconciling")` before re-queuing — the same atomic-claim idiom `maybeFeedMagQueue` already uses for the settled sentinel. Two concurrent callers (keepalive loop + dashboard server) can no longer both observe the same expired sentinel and both `queueReinsertHead`: only the rename winner re-queues, the loser's `renameSync` throws (source gone) and bails. The sentinel is re-read from the claimed copy and result-existence is re-checked post-claim.

## Worst-case bound

A skill that truly hangs (never writes a result, never crashes) blocks the next item for one threshold interval, gets re-queued, and after `mag.max_requeue_retries` is dropped with `mag_queue_dropped`.

## Out of scope / notes

The deprecated `queue-pop` Stop hook (`mag.ts`) consumes only `popped.command` and does not write a sentinel — left untouched (additive `requestId` field is harmless).

## Tests

- `src/mag-delivery-confirmation.test.ts` (new) — sentinel write / no-write, `queuePopSkill` requestId exposure, reconciliation confirm / requeue / drop / leave, the atomic-claim concurrency guard, gate states, the direct-call reconcile-as-invariant, shared retry-cap, `readInFlightDelivery`, round-trip fidelity.
- `src/dashboard.test.ts` — `GET /api/queue` `inFlight` contract.
- `templates/dashboard/dashboard.test.ts` — `renderQueue` "In flight" section, escaping, `No activity` suppression.

`bun test` 2524 pass / 0 fail · `bun run typecheck` · `bun run lint` · `bun run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)