### PR TITLE
Replace sentinel+retry delivery confirmation with passive in-flight panel

### DIFF
--- a/docs/proposals/queue-delivery-confirmation-sentinel.md
+++ b/docs/proposals/queue-delivery-confirmation-sentinel.md
@@ -1,5 +1,15 @@
 # Queue delivery-confirmation sentinel — stop silently dropping skill items delivered right before auto-compaction
 
+> **Superseded by [`in-flight-deliveries-panel.md`](in-flight-deliveries-panel.md) (gh-ludics-535).**
+> The sentinel + 10-minute timeout + retry-cap loop proposed here was
+> replaced by a passive `mag/in-flight/` directory and an "Unresolved
+> deliveries" dashboard panel. Three live failure modes showed the
+> auto-retry mechanism multiplied non-transient errors rather than
+> recovering from them; see the new proposal for context.
+
+---
+
+
 ## Goal
 
 Queue items delivered into the Mag pane immediately before an auto-compaction

--- a/scripts/lint-state-migration.test.ts
+++ b/scripts/lint-state-migration.test.ts
@@ -919,6 +919,8 @@ describe("CLI integration", () => {
         "import { test } from 'bun:test';\ntest('placeholder', () => {});\n",
       "src/orchestration/deferred-cleanup.ts":
         "export function loadDeferredCleanups() { return []; }\nexport interface CleanupEntry { slot: number; }\n",
+      "src/mag.ts":
+        "export function migrateLastDeliveredFile() {}\nexport interface InFlightDelivery { requestId: string; }\n",
       "src/slots/preempt.ts":
         "export function readStash() { return null; }\nexport interface PreemptStash { slotNum: number; }\n",
       "src/sessions/sweep-state.ts":
@@ -931,6 +933,7 @@ describe("CLI integration", () => {
         OrchestrationState: ["slot"],
         OrchestrationConfig: ["timeouts"],
         CleanupEntry: ["slot"],
+        InFlightDelivery: ["requestId"],
         PreemptStash: ["slotNum"],
         SessionSweepState: ["sessions", "version"],
         SlotData: ["slot"],
@@ -963,6 +966,9 @@ describe("CLI integration", () => {
         cwd: repoRoot, stdout: "pipe", stderr: "pipe",
         env: { ...process.env, GIT_BASE: baseSha },
       });
+      if (result.exitCode !== 0) {
+        console.error("STDERR:", result.stderr.toString());
+      }
       expect(result.exitCode).toBe(0);
     } finally { cleanup(); }
   });
@@ -1077,6 +1083,7 @@ describe("CLI integration", () => {
       OrchestrationState: ["slot"],
       OrchestrationConfig: ["timeouts"],
       CleanupEntry: ["slot"],
+      InFlightDelivery: ["requestId"],
       PreemptStash: ["slotNum"],
       SessionSweepState: ["sessions", "version"],
       SlotData: ["slot"],
@@ -1088,6 +1095,8 @@ describe("CLI integration", () => {
         "import { test } from 'bun:test';\ntest('placeholder', () => {});\n",
       "src/orchestration/deferred-cleanup.ts":
         "export function loadDeferredCleanups() { return []; }\nexport interface CleanupEntry {\n  slot: number;\n}\n",
+      "src/mag.ts":
+        "export function migrateLastDeliveredFile() {}\nexport interface InFlightDelivery {\n  requestId: string;\n}\n",
       "src/slots/preempt.ts":
         "export function readStash() { return null; }\nexport interface PreemptStash {\n  slotNum: number;\n}\n",
       "src/sessions/sweep-state.ts":
@@ -1127,6 +1136,7 @@ describe("CLI integration", () => {
         OrchestrationState: ["newField", "slot"],
         OrchestrationConfig: ["timeouts"],
         CleanupEntry: ["slot"],
+        InFlightDelivery: ["requestId"],
         PreemptStash: ["slotNum"],
         SessionSweepState: ["sessions", "version"],
         SlotData: ["slot"],

--- a/scripts/lint-state-migration.ts
+++ b/scripts/lint-state-migration.ts
@@ -69,6 +69,7 @@ export const PERSISTED_TYPES: ReadonlyArray<PersistedType> = [
   { typeName: "OrchestrationConfig", sourcePath: "src/orchestration/state.ts" },
   // Remaining entries alphabetised by typeName.
   { typeName: "CleanupEntry", sourcePath: "src/orchestration/deferred-cleanup.ts" },
+  { typeName: "InFlightDelivery", sourcePath: "src/mag.ts" },
   { typeName: "PreemptStash", sourcePath: "src/slots/preempt.ts" },
   { typeName: "SessionSweepState", sourcePath: "src/sessions/sweep-state.ts" },
   { typeName: "SlotData", sourcePath: "src/slots/types.ts" },
@@ -98,6 +99,7 @@ export const MIGRATOR_SITES: Readonly<Record<string, MigratorSite>> = {
   OrchestrationState: { path: "src/orchestration/state.ts", fnName: "migrateState" },
   OrchestrationConfig: { path: "src/orchestration/state.ts", fnName: "migrateState" },
   CleanupEntry: { path: "src/orchestration/deferred-cleanup.ts", fnName: "loadDeferredCleanups" },
+  InFlightDelivery: { path: "src/mag.ts", fnName: "migrateLastDeliveredFile" },
   PreemptStash: { path: "src/slots/preempt.ts", fnName: "readStash" },
   SessionSweepState: { path: "src/sessions/sweep-state.ts", fnName: "loadSessionSweepState" },
   SlotData: { path: "src/slots/json.ts", fnName: "normalizeTaskId" },

--- a/scripts/snapshots/state.shape.snapshot.json
+++ b/scripts/snapshots/state.shape.snapshot.json
@@ -12,6 +12,12 @@
     "tmuxSessionNames",
     "worktreePaths"
   ],
+  "InFlightDelivery": [
+    "command",
+    "deliveredAt",
+    "line",
+    "requestId"
+  ],
   "OrchestrationConfig": [
     "autoFinish",
     "autoFinishTimeout",

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -15,8 +15,8 @@ import { emitEvent } from "./events.ts";
 import { ADAPTER_NAMES } from "./adapters/index.ts";
 import { readTmuxSlotState, writeTmuxSlotState } from "./adapters/tmux-adapter.ts";
 import { tasksAbandon, tasksCreate } from "./tasks/index.ts";
-import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce, readInFlightDelivery } from "./mag.ts";
-import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel } from "./queue.ts";
+import { setQueueHold, maybeFeedMagQueue, clearAutoProposalDebounce, listInFlightDeliveries, readInFlight, clearInFlight, magResultFile, type InFlightDelivery } from "./mag.ts";
+import { queueList, queueRequest, recentResults, queuePromoteToTop, queueCancel, queueReinsertHeadWithFreshId } from "./queue.ts";
 import { resolveSkillCommand } from "./skill-queue-registry.ts";
 import { handleClusterRequest } from "./cluster-http.ts";
 import { validatePayload } from "./orchestration-defaults.ts";
@@ -666,11 +666,85 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
           delete d.output; // strip large blobs — UI only needs id/status/timestamp
           return d;
         });
-        // gh-ludics-526: a popped-but-not-completed request is in neither
-        // `pending` nor `results`. Surface the in-flight delivery sentinel
-        // (null when there is none, or once its result JSON exists).
-        const inFlight = readInFlightDelivery();
+        // gh-ludics-535: a popped-but-not-completed request is in neither
+        // `pending` nor `results`. Surface every unresolved in-flight record
+        // (one file per delivery under mag/in-flight/, sorted by deliveredAt
+        // ascending). Always an array — `[]` when there are none.
+        const inFlight: InFlightDelivery[] = listInFlightDeliveries();
         return new Response(JSON.stringify({ pending, results, inFlight }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: re-fire an in-flight delivery (gh-ludics-535 A8). Mints a fresh
+    // queue id, sets `re-fired-from: <original>` provenance, reinserts at
+    // queue head, and clears the original in-flight record. Short-circuits
+    // to `already-completed` when the original result file has appeared
+    // since the dashboard last fetched.
+    if (pathname === "/api/in-flight-refire" && req.method === "POST") {
+      const idParam = url.searchParams.get("id");
+      if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+        return new Response("Bad Request: invalid queue id", { status: 400 });
+      }
+      try {
+        const record = readInFlight(idParam);
+        if (!record) {
+          return new Response(JSON.stringify({ status: "not-found" }), {
+            status: 404, headers: { "Content-Type": "application/json" },
+          });
+        }
+        // Race: result landed in the dashboard-read → click window. Clear
+        // the in-flight record and tell the client; do not re-queue.
+        if (existsSync(magResultFile(idParam))) {
+          clearInFlight(idParam);
+          return new Response(JSON.stringify({ status: "already-completed" }), {
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        // Parse the original line tolerantly. A malformed line still gets
+        // wrapped into `{ raw }` so provenance is preserved.
+        let parsed: Record<string, unknown>;
+        try {
+          const maybeObj: unknown = JSON.parse(record.line);
+          parsed = (maybeObj && typeof maybeObj === "object" && !Array.isArray(maybeObj))
+            ? (maybeObj as Record<string, unknown>) : { raw: record.line };
+        } catch {
+          parsed = { raw: record.line };
+        }
+        const newId = queueReinsertHeadWithFreshId(parsed, idParam);
+        clearInFlight(idParam);
+        emitEvent({
+          event_type: "mag_in_flight_refired", source: "dashboard", scope: "mag",
+          message: `re-fired ${idParam} as ${newId}`,
+        });
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "refired", newId }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // API: discard an in-flight delivery (gh-ludics-535 A8). Idempotent —
+    // ENOENT is a no-op. No archive directory; the briefing-prep step
+    // absorbs orphans (A9) as the audit trail.
+    if (pathname === "/api/in-flight-discard" && req.method === "POST") {
+      const idParam = url.searchParams.get("id");
+      if (!idParam || !QUEUE_ID_RE.test(idParam)) {
+        return new Response("Bad Request: invalid queue id", { status: 400 });
+      }
+      try {
+        clearInFlight(idParam);
+        emitEvent({
+          event_type: "mag_in_flight_discarded", source: "dashboard", scope: "mag",
+          message: `discarded ${idParam}`,
+        });
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "discarded" }), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (e) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -749,10 +749,11 @@ describe("dashboard HTTP /api/queue-promote and /api/queue-cancel", () => {
   });
 });
 
-// gh-ludics-526: a popped-but-not-completed skill request is in neither the
-// `pending` queue nor the `results` tile. GET /api/queue surfaces it via the
-// `inFlight` field, read from mag/last-delivered.json.
-describe("dashboard HTTP GET /api/queue — inFlight sentinel (AC 8)", () => {
+// gh-ludics-535: a popped-but-not-completed skill request is in neither the
+// `pending` queue nor the `results` tile. GET /api/queue surfaces every
+// unresolved record via the `inFlight` field — always an InFlightDelivery[],
+// sorted by deliveredAt ascending.
+describe("dashboard HTTP GET /api/queue — inFlight array (AC 8)", () => {
   async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
     const { buildHandlers } = await import("./dashboard-server.ts");
     const dashboardDir = join(harnessDir(), "dashboard");
@@ -762,46 +763,207 @@ describe("dashboard HTTP GET /api/queue — inFlight sentinel (AC 8)", () => {
   function magDir(): string {
     const dir = join(harnessDir(), "mag");
     mkdirSync(join(dir, "results"), { recursive: true });
+    mkdirSync(join(dir, "in-flight"), { recursive: true });
     return dir;
   }
-
-  test("includes inFlight when last-delivered.json exists with no matching result", async () => {
-    // Harness condition: an unresolved sentinel — present, no result JSON.
-    writeFileSync(join(magDir(), "last-delivered.json"), JSON.stringify({
-      requestId: "req-IF", command: "/ludics-briefing", line: "{}",
-      deliveredAt: "2026-05-14T08:06:28Z",
+  function seedInFlight(dir: string, id: string, deliveredAt: string, command = "/ludics-briefing"): void {
+    writeFileSync(join(dir, "in-flight", `${id}.json`), JSON.stringify({
+      requestId: id, command, line: JSON.stringify({ id, action: "briefing" }),
+      deliveredAt,
     }));
+  }
+  type InFlight = { requestId: string; command: string; deliveredAt: string };
+
+  test("includes a record when its in-flight file exists with no matching result", async () => {
+    const dir = magDir();
+    seedInFlight(dir, "req-IF", "2026-05-14T08:06:28Z");
     const handler = await makeHandler();
     const resp = await handler(new Request("http://x/api/queue"));
-    const body = await resp.json() as { inFlight: { requestId: string; command: string; deliveredAt: string } | null };
+    const body = await resp.json() as { inFlight: InFlight[] };
     // The invariant: a delivered-but-unconfirmed request is visible. If the
-    // handler ignored the sentinel, inFlight would be null here.
-    expect(body.inFlight).not.toBeNull();
-    expect(body.inFlight!.requestId).toBe("req-IF");
-    expect(body.inFlight!.command).toBe("/ludics-briefing");
-    expect(body.inFlight!.deliveredAt).toBe("2026-05-14T08:06:28Z");
+    // handler returned [] here, the dashboard would never surface the row.
+    expect(body.inFlight).toHaveLength(1);
+    expect(body.inFlight[0]!.requestId).toBe("req-IF");
+    expect(body.inFlight[0]!.command).toBe("/ludics-briefing");
+    expect(body.inFlight[0]!.deliveredAt).toBe("2026-05-14T08:06:28Z");
   });
 
-  test("inFlight is null once a matching result JSON exists", async () => {
-    // Harness condition: sentinel present AND its result file written — the
-    // request is no longer in flight.
-    writeFileSync(join(magDir(), "last-delivered.json"), JSON.stringify({
-      requestId: "req-IF", command: "/ludics-briefing", line: "{}",
-      deliveredAt: "2026-05-14T08:06:28Z",
+  test("filters out records whose matching result JSON exists", async () => {
+    const dir = magDir();
+    seedInFlight(dir, "req-IF", "2026-05-14T08:06:28Z");
+    writeFileSync(join(dir, "results", "req-IF.json"), JSON.stringify({ id: "req-IF", status: "ok" }));
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: InFlight[] };
+    expect(body.inFlight).toEqual([]);
+  });
+
+  test("returns an empty array when no in-flight records exist", async () => {
+    magDir();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: InFlight[] };
+    // Array, never null — this is the wire-shape contract change vs
+    // gh-ludics-526.
+    expect(Array.isArray(body.inFlight)).toBe(true);
+    expect(body.inFlight).toEqual([]);
+  });
+
+  test("multiple records are sorted by deliveredAt ascending (oldest first)", async () => {
+    const dir = magDir();
+    seedInFlight(dir, "req-NEW", "2026-05-15T12:00:00Z", "/ludics-learn");
+    seedInFlight(dir, "req-OLD", "2026-05-14T08:00:00Z", "/ludics-briefing");
+    seedInFlight(dir, "req-MID", "2026-05-15T08:00:00Z", "/ludics-feedback-digest");
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/queue"));
+    const body = await resp.json() as { inFlight: InFlight[] };
+    // Predictable order matters for the dashboard's Re-fire / Discard
+    // per-row choice — the user picks the oldest unresolved item first.
+    expect(body.inFlight.map(r => r.requestId)).toEqual(["req-OLD", "req-MID", "req-NEW"]);
+  });
+});
+
+// gh-ludics-535 A8: /api/in-flight-refire mints a fresh queue id, stamps
+// `re-fired-from: <original>` provenance, reinserts at queue head, and
+// clears the original record. Short-circuits to `already-completed` when
+// the original result file appeared in the dashboard-read → click window.
+describe("dashboard HTTP POST /api/in-flight-refire", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+  function magDir(): string {
+    const dir = join(harnessDir(), "mag");
+    mkdirSync(join(dir, "results"), { recursive: true });
+    mkdirSync(join(dir, "in-flight"), { recursive: true });
+    return dir;
+  }
+  function seedInFlight(dir: string, id: string, payload?: Record<string, unknown>): void {
+    const line = JSON.stringify(payload ?? { id, action: "learn" });
+    writeFileSync(join(dir, "in-flight", `${id}.json`), JSON.stringify({
+      requestId: id, command: "/ludics-learn", line,
+      deliveredAt: "2026-05-15T10:00:00Z",
     }));
-    writeFileSync(join(magDir(), "results", "req-IF.json"), JSON.stringify({ id: "req-IF", status: "ok" }));
+  }
+  function readEvents(): Record<string, unknown>[] {
+    const file = join(harnessDir(), "journal", "events.jsonl");
+    if (!existsSync(file)) return [];
+    const content = readFileSync(file, "utf-8").trim();
+    if (!content) return [];
+    return content.split("\n").map(l => JSON.parse(l) as Record<string, unknown>);
+  }
+
+  test("happy path: mints fresh id, stamps re-fired-from, clears original record, emits mag_in_flight_refired", async () => {
+    const dir = magDir();
+    seedInFlight(dir, "req-1778832000-1");
     const handler = await makeHandler();
-    const resp = await handler(new Request("http://x/api/queue"));
-    const body = await resp.json() as { inFlight: unknown };
-    expect(body.inFlight).toBeNull();
+
+    const resp = await handler(new Request("http://x/api/in-flight-refire?id=req-1778832000-1", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string; newId?: string };
+    expect(body.status).toBe("refired");
+    expect(body.newId).toBeDefined();
+    expect(body.newId).toMatch(/^req-\d+-\d+$/);
+
+    // Original in-flight file is unlinked.
+    expect(existsSync(join(dir, "in-flight", "req-1778832000-1.json"))).toBe(false);
+    // Queue head carries the new id and the re-fired-from provenance.
+    const queueContent = readFileSync(join(dir, "queue.jsonl"), "utf-8").trim();
+    const head = JSON.parse(queueContent.split("\n")[0]!);
+    expect(head.id).toBe(body.newId);
+    expect(head["re-fired-from"]).toBe("req-1778832000-1");
+    expect(head.action).toBe("learn");
+    // Event emitted.
+    expect(readEvents().some(e => e.event_type === "mag_in_flight_refired")).toBe(true);
   });
 
-  test("inFlight is null when no sentinel exists", async () => {
-    magDir(); // ensure mag/ dir exists, but no sentinel
+  test("already-completed: result file present → clears record, returns 'already-completed', does NOT enqueue", async () => {
+    const dir = magDir();
+    seedInFlight(dir, "req-1778832000-2");
+    writeFileSync(join(dir, "results", "req-1778832000-2.json"), JSON.stringify({ id: "req-1778832000-2", status: "ok" }));
     const handler = await makeHandler();
-    const resp = await handler(new Request("http://x/api/queue"));
-    const body = await resp.json() as { inFlight: unknown };
-    expect(body.inFlight).toBeNull();
+
+    const resp = await handler(new Request("http://x/api/in-flight-refire?id=req-1778832000-2", { method: "POST" }));
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("already-completed");
+    // In-flight file is unlinked.
+    expect(existsSync(join(dir, "in-flight", "req-1778832000-2.json"))).toBe(false);
+    // Queue is empty — the race must NOT cause a duplicate enqueue.
+    expect(existsSync(join(dir, "queue.jsonl")) ? readFileSync(join(dir, "queue.jsonl"), "utf-8").trim() : "").toBe("");
+    // The refired event must NOT have been emitted on the already-completed branch.
+    expect(readEvents().some(e => e.event_type === "mag_in_flight_refired")).toBe(false);
+  });
+
+  test("missing record → 404", async () => {
+    magDir();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/in-flight-refire?id=req-9999999999-1", { method: "POST" }));
+    expect(resp.status).toBe(404);
+  });
+
+  test("malformed id → 400 (does not pass QUEUE_ID_RE)", async () => {
+    magDir();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/in-flight-refire?id=not-a-queue-id", { method: "POST" }));
+    expect(resp.status).toBe(400);
+  });
+});
+
+// gh-ludics-535 A8: /api/in-flight-discard unlinks the record idempotently.
+describe("dashboard HTTP POST /api/in-flight-discard", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+  function magDir(): string {
+    const dir = join(harnessDir(), "mag");
+    mkdirSync(join(dir, "results"), { recursive: true });
+    mkdirSync(join(dir, "in-flight"), { recursive: true });
+    return dir;
+  }
+  function readEvents(): Record<string, unknown>[] {
+    const file = join(harnessDir(), "journal", "events.jsonl");
+    if (!existsSync(file)) return [];
+    const content = readFileSync(file, "utf-8").trim();
+    if (!content) return [];
+    return content.split("\n").map(l => JSON.parse(l) as Record<string, unknown>);
+  }
+
+  test("happy path: unlinks the in-flight file, returns 'discarded', emits mag_in_flight_discarded", async () => {
+    const dir = magDir();
+    writeFileSync(join(dir, "in-flight", "req-1778832000-3.json"), JSON.stringify({
+      requestId: "req-1778832000-3", command: "/ludics-learn", line: "{}",
+      deliveredAt: "2026-05-15T10:00:00Z",
+    }));
+    const handler = await makeHandler();
+
+    const resp = await handler(new Request("http://x/api/in-flight-discard?id=req-1778832000-3", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("discarded");
+    expect(existsSync(join(dir, "in-flight", "req-1778832000-3.json"))).toBe(false);
+    expect(readEvents().some(e => e.event_type === "mag_in_flight_discarded")).toBe(true);
+  });
+
+  test("idempotent: discard against a non-existent id is still 'discarded' (ENOENT swallowed)", async () => {
+    magDir();
+    const handler = await makeHandler();
+    // Well-formed id, but no file on disk.
+    const resp = await handler(new Request("http://x/api/in-flight-discard?id=req-9999999999-9", { method: "POST" }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string };
+    expect(body.status).toBe("discarded");
+  });
+
+  test("malformed id → 400", async () => {
+    magDir();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/in-flight-discard?id=not-a-queue-id", { method: "POST" }));
+    expect(resp.status).toBe(400);
   });
 });
 

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -1,10 +1,12 @@
-// Regression tests for the delivery-confirmation sentinel (gh-ludics-526).
+// Regression tests for the in-flight delivery directory (gh-ludics-535;
+// supersedes the gh-ludics-526 sentinel + timeout + retry-cap suite).
 //
-// maybeFeedMagQueue() used to be fire-and-forget: a skill delivered into the
-// Mag pane right before an auto-compaction (or crash, or dropped input) was
-// silently lost — no result JSON, no retry. These tests pin the sentinel
-// write, the reconciliation pass, the delivery gate, and the shared retry-cap
-// helper that together close that gap.
+// Each test pins one of the proposal's acceptance criteria from
+// docs/proposals/in-flight-deliveries-panel.md. The shared invariant is
+// that the gate stays serializing (≤ 1 unresolved delivery at a time)
+// but recovery is passive: a delivery resolves naturally when its result
+// JSON appears, or by user action via the dashboard panel. Nothing
+// auto-times-out, auto-requeues, or auto-drops.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
@@ -25,7 +27,13 @@ function magDir(): string {
 function queueFile(): string {
   return join(magDir(), "queue.jsonl");
 }
-function lastDeliveredFile(): string {
+function inFlightDirPath(): string {
+  return join(magDir(), "in-flight");
+}
+function inFlightFilePath(id: string): string {
+  return join(inFlightDirPath(), `${id}.json`);
+}
+function legacyLastDeliveredPath(): string {
   return join(magDir(), "last-delivered.json");
 }
 function resultFile(id: string): string {
@@ -35,7 +43,7 @@ function currentRequestIdFile(): string {
   return join(magDir(), "current-request-id");
 }
 
-function writeConfig(homeDir: string, magSection = ""): string {
+function writeConfig(homeDir: string): string {
   const configDir = join(homeDir, ".config", "ludics");
   mkdirSync(configDir, { recursive: true });
   const configPath = join(configDir, "config.yaml");
@@ -43,7 +51,7 @@ function writeConfig(homeDir: string, magSection = ""): string {
 state_path: harness
 slots:
   count: 2
-${magSection}`);
+`);
   return configPath;
 }
 
@@ -81,10 +89,10 @@ afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
 });
 
-// --- AC 1: sentinel written on the success path, none on send failure ---
+// --- A1: deliverPoppedSkill writes mag/in-flight/<id>.json on Tier-2 send ---
 
-describe("deliverPoppedSkill — sentinel write (AC 1)", () => {
-  test("successful send writes mag/last-delivered.json and emits mag_queue_feed", async () => {
+describe("deliverPoppedSkill — in-flight write (A1)", () => {
+  test("successful Tier-2 send writes mag/in-flight/<id>.json with all fields and emits mag_queue_feed", async () => {
     const { deliverPoppedSkill } = await import("./mag.ts");
     const line = JSON.stringify({ id: "req-A", action: "learn" });
 
@@ -94,16 +102,21 @@ describe("deliverPoppedSkill — sentinel write (AC 1)", () => {
     );
 
     expect(sent).toBe(true);
-    expect(existsSync(lastDeliveredFile())).toBe(true);
-    const sentinel = JSON.parse(readFileSync(lastDeliveredFile(), "utf-8"));
-    expect(sentinel.requestId).toBe("req-A");
-    expect(sentinel.command).toBe("/ludics-learn");
-    expect(sentinel.line).toBe(line);
-    expect(sentinel.deliveredAt).toBe("2026-05-14T08:06:28Z");
+    expect(existsSync(inFlightFilePath("req-A"))).toBe(true);
+    const record = JSON.parse(readFileSync(inFlightFilePath("req-A"), "utf-8"));
+    expect(record.requestId).toBe("req-A");
+    expect(record.command).toBe("/ludics-learn");
+    expect(record.line).toBe(line);
+    // ISO-with-no-ms format is contract — the dashboard renders it raw.
+    expect(record.deliveredAt).toBe("2026-05-14T08:06:28Z");
     expect(readEvents().some((e) => e.event_type === "mag_queue_feed")).toBe(true);
   });
+});
 
-  test("failed send writes NO sentinel and re-queues via the retry-cap path", async () => {
+// --- A5: send-failure rollback — verbatim line, no retry-count, no events ---
+
+describe("deliverPoppedSkill — send-failure rollback (A5)", () => {
+  test("failed send writes NO in-flight record and reinserts the verbatim line at queue head", async () => {
     const { deliverPoppedSkill } = await import("./mag.ts");
     const line = JSON.stringify({ id: "req-A", action: "learn" });
 
@@ -113,23 +126,23 @@ describe("deliverPoppedSkill — sentinel write (AC 1)", () => {
     );
 
     expect(sent).toBe(false);
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-    // re-queued at head with an incremented _retry_count
+    expect(existsSync(inFlightFilePath("req-A"))).toBe(false);
     const content = readFileSync(queueFile(), "utf-8").trim();
-    expect(JSON.parse(content)._retry_count).toBe(1);
-    expect(JSON.parse(content).id).toBe("req-A");
+    const reinserted = JSON.parse(content);
+    expect(reinserted.id).toBe("req-A");
+    // Verbatim: no `_retry_count` key added — the entire retry-cap machinery
+    // (gh-ludics-526) is gone with gh-ludics-535.
+    expect("_retry_count" in reinserted).toBe(false);
+    // No `mag_queue_requeued` / `mag_queue_dropped` events on this path.
+    expect(readEvents().some((e) => e.event_type === "mag_queue_requeued")).toBe(false);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_dropped")).toBe(false);
   });
 });
 
-// --- Tier-3 fire-and-forget: programmatic items skip the sentinel ---
-//
-// Tier-3 items (action: message, /compact) never write a result JSON, so
-// recording a delivery sentinel for them wedges deliveryGateBlocked for the
-// full timeout and then re-queues a spurious duplicate. queuePopSkill marks
-// them expectsResult=false and deliverPoppedSkill must not write the sentinel.
+// --- A1 (Tier-3 control): expectsResult:false skips the in-flight write ---
 
-describe("deliverPoppedSkill — Tier-3 items skip the sentinel", () => {
-  test("expectsResult:false → successful send writes NO sentinel but still emits mag_queue_feed", async () => {
+describe("deliverPoppedSkill — Tier-3 items skip the in-flight write", () => {
+  test("expectsResult:false → successful send writes NO in-flight record but still emits mag_queue_feed", async () => {
     const { deliverPoppedSkill } = await import("./mag.ts");
     const line = JSON.stringify({ id: "req-MSG", action: "message", content: "hello" });
 
@@ -139,11 +152,11 @@ describe("deliverPoppedSkill — Tier-3 items skip the sentinel", () => {
     );
 
     expect(sent).toBe(true);
-    expect(existsSync(lastDeliveredFile())).toBe(false);
+    expect(existsSync(inFlightFilePath("req-MSG"))).toBe(false);
     expect(readEvents().some((e) => e.event_type === "mag_queue_feed")).toBe(true);
   });
 
-  test("expectsResult:true → sentinel still written (Tier-2 unchanged)", async () => {
+  test("expectsResult:true → in-flight record still written (Tier-2 unchanged)", async () => {
     const { deliverPoppedSkill } = await import("./mag.ts");
     const line = JSON.stringify({ id: "req-SKILL", action: "learn" });
 
@@ -153,7 +166,7 @@ describe("deliverPoppedSkill — Tier-3 items skip the sentinel", () => {
     );
 
     expect(sent).toBe(true);
-    expect(existsSync(lastDeliveredFile())).toBe(true);
+    expect(existsSync(inFlightFilePath("req-SKILL"))).toBe(true);
   });
 });
 
@@ -187,280 +200,336 @@ describe("queuePopSkill — requestId exposure (AC 7)", () => {
   });
 });
 
-// --- AC 2 / AC 3: reconciliation confirms, re-queues, or drops ---
+// --- A2: reconcileInFlight is passive — delete on result-exists, nothing else ---
 
-describe("reconcileLastDelivered (AC 2, AC 3)", () => {
-  test("result JSON present → sentinel cleared, queue untouched (result checked before timeout)", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    // Harness condition: an OLD deliveredAt (well past the timeout) AND a
-    // present result file — the confirmed branch must win over the timeout
-    // branch, so the line is never re-queued.
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-DONE", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-DONE", action: "learn" }),
+describe("reconcileInFlight (A2)", () => {
+  function seedInFlight(id: string): void {
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(inFlightFilePath(id), JSON.stringify({
+      requestId: id,
+      command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
       deliveredAt: "2020-01-01T00:00:00Z",
     }));
+  }
+
+  test("result JSON present → record deleted, queue untouched (no re-queue)", async () => {
+    const { reconcileInFlight } = await import("./mag.ts");
+    seedInFlight("req-DONE");
     writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
 
-    reconcileLastDelivered();
+    reconcileInFlight();
 
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-    expect(readQueueIds()).toEqual([]); // not double-queued
+    // The invariant: a resolved record is cleared, never re-queued — A2
+    // (passive deletion). If reconcileInFlight had carried forward the
+    // gh-ludics-526 timeout branch this would also append to queue.jsonl.
+    expect(existsSync(inFlightFilePath("req-DONE"))).toBe(false);
+    expect(readQueueIds()).toEqual([]);
   });
 
-  test("past threshold, no result → line re-queued at head with _retry_count++, sentinel cleared, mag_queue_requeued emitted", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    const line = JSON.stringify({ id: "req-LOST", action: "learn" });
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-LOST", command: "/ludics-learn", line,
-      deliveredAt: "2020-01-01T00:00:00Z",
-    }));
+  test("no result, old deliveredAt → record left alone (no auto-requeue, no auto-drop)", async () => {
+    const { reconcileInFlight } = await import("./mag.ts");
+    seedInFlight("req-OLD");
 
-    reconcileLastDelivered();
+    reconcileInFlight();
 
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-    const content = readFileSync(queueFile(), "utf-8").trim();
-    expect(JSON.parse(content).id).toBe("req-LOST");
-    expect(JSON.parse(content)._retry_count).toBe(1);
-    expect(readEvents().some((e) => e.event_type === "mag_queue_requeued")).toBe(true);
+    // The A2 invariant: age does NOT trigger requeue/drop. Under
+    // gh-ludics-526 this would have re-queued at the 10-min timeout — A4
+    // removes that branch.
+    expect(existsSync(inFlightFilePath("req-OLD"))).toBe(true);
+    expect(readQueueIds()).toEqual([]);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_requeued")).toBe(false);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_dropped")).toBe(false);
   });
 
-  test("past threshold, _retry_count at the cap → item dropped, not reinserted, sentinel cleared, mag_queue_dropped emitted", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    // Harness condition: _retry_count already at DEFAULT_MAX_REQUEUE_RETRIES (3).
-    const line = JSON.stringify({ id: "req-POISON", action: "learn", _retry_count: 3 });
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-POISON", command: "/ludics-learn", line,
-      deliveredAt: "2020-01-01T00:00:00Z",
-    }));
+  test("idempotent — second reconcile is a no-op after the first cleared the record", async () => {
+    const { reconcileInFlight } = await import("./mag.ts");
+    seedInFlight("req-DONE");
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
 
-    reconcileLastDelivered();
+    reconcileInFlight();
+    reconcileInFlight(); // double-clear path — unlinkSync ENOENT swallow
 
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-    expect(readQueueIds()).toEqual([]); // dropped, not reinserted
-    expect(readEvents().some((e) => e.event_type === "mag_queue_dropped")).toBe(true);
-  });
-
-  test("under threshold, no result → sentinel left untouched for the next tick", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-FRESH", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-FRESH", action: "learn" }),
-      deliveredAt: new Date().toISOString(),
-    }));
-
-    reconcileLastDelivered();
-
-    expect(existsSync(lastDeliveredFile())).toBe(true);
+    expect(existsSync(inFlightFilePath("req-DONE"))).toBe(false);
     expect(readQueueIds()).toEqual([]);
   });
 });
 
-// --- Concurrency: the re-queue path atomically claims the sentinel so two
-// concurrent callers (keepalive loop + dashboard server) cannot both
-// re-queue the same line (codex review, PR #528). ---
+// --- A3: deliveryGateBlocked is true iff any record lacks a matching result ---
 
-describe("reconcileLastDelivered — atomic claim guards against double-requeue", () => {
-  const reconcilingFile = () => lastDeliveredFile() + ".reconciling";
-
-  test("a lost delivery is re-queued exactly once and leaves no .reconciling claim file", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-LOST", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-LOST", action: "learn" }),
-      deliveredAt: "2020-01-01T00:00:00Z",
-    }));
-
-    reconcileLastDelivered();
-
-    // Re-queued exactly once; the claim file is consumed, not left to wedge
-    // or be re-processed.
-    expect(readQueueIds()).toEqual(["req-LOST"]);
-    expect(existsSync(reconcilingFile())).toBe(false);
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-  });
-
-  test("a second reconcile after the sentinel is claimed+cleared is a no-op — no duplicate enqueue", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-LOST", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-LOST", action: "learn" }),
-      deliveredAt: "2020-01-01T00:00:00Z",
-    }));
-
-    // First caller claims, re-queues, clears. Second caller (the concurrent
-    // loser, modelled by a sequential second call) finds nothing to do.
-    reconcileLastDelivered();
-    reconcileLastDelivered();
-
-    // Still exactly one copy — the claim+clear prevents the second pass from
-    // re-queuing the same line.
-    expect(readQueueIds()).toEqual(["req-LOST"]);
-  });
-
-  test("a sentinel already claimed by a concurrent winner (.reconciling staged, last-delivered.json gone) is not re-queued", async () => {
-    const { reconcileLastDelivered } = await import("./mag.ts");
-    // Models the state right after another caller won the renameSync claim:
-    // last-delivered.json no longer exists, the content lives in the claim
-    // file. The losing caller must observe nothing and re-queue nothing.
-    writeFileSync(reconcilingFile(), JSON.stringify({
-      requestId: "req-CLAIMED", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-CLAIMED", action: "learn" }),
-      deliveredAt: "2020-01-01T00:00:00Z",
-    }));
-
-    reconcileLastDelivered();
-
-    expect(readQueueIds()).toEqual([]); // the winner owns it, not us
-  });
-});
-
-// --- AC 4: delivery gated on the sentinel ---
-
-describe("deliveryGateBlocked (AC 4)", () => {
-  function writeSentinel(deliveredAt: string): void {
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-INFLIGHT", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-INFLIGHT", action: "learn" }),
+describe("deliveryGateBlocked (A3)", () => {
+  function writeRecord(id: string, deliveredAt: string = new Date().toISOString()): void {
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(inFlightFilePath(id), JSON.stringify({
+      requestId: id, command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
       deliveredAt,
     }));
   }
 
-  test("unresolved sentinel under threshold → blocked", async () => {
+  test("unresolved record present → blocked", async () => {
     const { deliveryGateBlocked } = await import("./mag.ts");
-    writeSentinel(new Date().toISOString());
+    writeRecord("req-INFLIGHT");
     expect(deliveryGateBlocked()).toBe(true);
   });
 
-  test("matching result JSON exists → not blocked", async () => {
+  test("record present AND matching result JSON exists → not blocked", async () => {
     const { deliveryGateBlocked } = await import("./mag.ts");
-    writeSentinel(new Date().toISOString());
+    writeRecord("req-INFLIGHT");
     writeFileSync(resultFile("req-INFLIGHT"), JSON.stringify({ id: "req-INFLIGHT", status: "ok" }));
     expect(deliveryGateBlocked()).toBe(false);
   });
 
-  test("sentinel past threshold → not blocked", async () => {
+  test("no records → not blocked", async () => {
     const { deliveryGateBlocked } = await import("./mag.ts");
-    writeSentinel("2020-01-01T00:00:00Z");
     expect(deliveryGateBlocked()).toBe(false);
   });
 
-  test("no sentinel → not blocked", async () => {
+  test("record with an ancient deliveredAt is STILL blocking — no age cutoff (A4)", async () => {
     const { deliveryGateBlocked } = await import("./mag.ts");
-    expect(deliveryGateBlocked()).toBe(false);
+    // Mutation-test the gate against the removed age branch: under
+    // gh-ludics-526 this returned false at age > 10 min; under A3 the gate
+    // is purely "record exists without result".
+    writeRecord("req-OLD", "2020-01-01T00:00:00Z");
+    expect(deliveryGateBlocked()).toBe(true);
   });
 });
 
 // --- AC 4: direct (non-keepalive) callers also reconcile before popping ---
 
 describe("maybeFeedMagQueue — reconcile-as-invariant for direct callers (AC 4)", () => {
-  test("a direct call with an expired sentinel for A re-queues A and clears the sentinel before B can be delivered", async () => {
+  test("a resolved in-flight record is cleared before any pop", async () => {
     const { maybeFeedMagQueue } = await import("./mag.ts");
     const { touchSentinel } = await import("./sentinel.ts");
 
-    // A was delivered long ago and never confirmed (compaction lost it).
+    // A was delivered and its result has landed but reconcile hasn't run yet.
+    mkdirSync(inFlightDirPath(), { recursive: true });
     const lineA = JSON.stringify({ id: "req-A", action: "learn" });
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
+    writeFileSync(inFlightFilePath("req-A"), JSON.stringify({
       requestId: "req-A", command: "/ludics-learn", line: lineA,
       deliveredAt: "2020-01-01T00:00:00Z",
     }));
+    writeFileSync(resultFile("req-A"), JSON.stringify({ id: "req-A", status: "ok" }));
     // B is queued behind it.
     writeFileSync(queueFile(), JSON.stringify({ id: "req-B", action: "learn" }) + "\n");
     // Mag is settled so maybeFeedMagQueue proceeds past the readiness guard.
     touchSentinel(join(magDir(), "settled"));
 
-    // Inject a failing send so the test never touches a real tmux pane; the
-    // reconcile/gate logic under test runs identically regardless of send.
+    // Inject a failing send so the test never touches a real tmux pane.
     await maybeFeedMagQueue({ send: () => false });
 
-    // The in-function reconcileLastDelivered() must have run BEFORE any pop:
-    // A's sentinel is cleared (not overwritten by a B sentinel) and A's line
-    // is back in the durable queue — never silently lost.
-    expect(existsSync(lastDeliveredFile())).toBe(false);
-    const ids = readQueueIds();
-    expect(ids).toContain("req-A");
-    expect(ids).toContain("req-B");
+    // The in-function reconcileInFlight() must have run BEFORE any pop —
+    // A's record is gone (result landed) and B's verbatim line is back in
+    // the durable queue (the failed-send rollback never overwrote anything).
+    expect(existsSync(inFlightFilePath("req-A"))).toBe(false);
+    expect(readQueueIds()).toContain("req-B");
   });
 });
 
-// --- AC 6: shared retry-cap helper ---
+// --- A6: pre-send result-file dedup (Tier-2 only) ---
 
-describe("requeueWithRetryCap — shared retry-cap logic (AC 6)", () => {
-  test("under the cap → reinserts at head with _retry_count++ and returns 'requeued'", async () => {
-    const { requeueWithRetryCap } = await import("./mag.ts");
-    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 1 });
+describe("deliverPoppedSkill — pre-send dedup (A6)", () => {
+  test("Tier-2 + pre-existing result file → no send, no in-flight write, mag_queue_already_resolved emitted, pop consumed", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-X", action: "learn" });
+    // Pre-write the result before the pop is delivered (the manual-bypass
+    // pattern Mag uses, A10).
+    writeFileSync(resultFile("req-X"), JSON.stringify({ id: "req-X", status: "ok" }));
+    let called = 0;
+    const sendSpy = (_s: string, _cmd: string): boolean => { called++; return true; };
 
-    const outcome = requeueWithRetryCap(line, "/ludics-learn", "send-failed");
+    const sent = deliverPoppedSkill(
+      { requestId: "req-X", command: "/ludics-learn", line },
+      { send: sendSpy },
+    );
 
-    expect(outcome).toBe("requeued");
-    const content = readFileSync(queueFile(), "utf-8").trim();
-    expect(JSON.parse(content)._retry_count).toBe(2);
+    // The A6 invariant — send must not run, pop is consumed (return true so
+    // the caller knows not to reinsert), no in-flight record written.
+    expect(called).toBe(0);
+    expect(sent).toBe(true);
+    expect(existsSync(inFlightFilePath("req-X"))).toBe(false);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_already_resolved")).toBe(true);
   });
 
-  test("at the cap → drops the item, returns 'dropped', does not reinsert", async () => {
-    const { requeueWithRetryCap } = await import("./mag.ts");
-    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 3 });
+  test("Tier-2 + no result file → normal delivery path (send called, in-flight written)", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-X", action: "learn" });
+    let called = 0;
+    const sendSpy = (_s: string, _cmd: string): boolean => { called++; return true; };
 
-    const outcome = requeueWithRetryCap(line, "/ludics-learn", "delivery-unconfirmed");
+    const sent = deliverPoppedSkill(
+      { requestId: "req-X", command: "/ludics-learn", line },
+      { send: sendSpy },
+    );
 
-    expect(outcome).toBe("dropped");
-    expect(readQueueIds()).toEqual([]);
+    expect(called).toBe(1);
+    expect(sent).toBe(true);
+    expect(existsSync(inFlightFilePath("req-X"))).toBe(true);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_already_resolved")).toBe(false);
   });
 
-  test("honors a configured mag.max_requeue_retries", async () => {
-    process.env.LUDICS_CONFIG = writeConfig(TMP, "mag:\n  max_requeue_retries: 5\n");
-    const { requeueWithRetryCap } = await import("./mag.ts");
-    // _retry_count 3 is under a configured cap of 5 → still requeued.
-    const line = JSON.stringify({ id: "req-1", action: "learn", _retry_count: 3 });
+  test("Tier-3 + pre-existing result file → send STILL runs (dedup gated off, no in-flight write)", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    const line = JSON.stringify({ id: "req-MSG", action: "message", content: "hi" });
+    // Tier-3 items never expect a result file — even if one happens to
+    // exist with a matching id, dedup must skip the check.
+    writeFileSync(resultFile("req-MSG"), JSON.stringify({ id: "req-MSG", status: "ok" }));
+    let called = 0;
+    const sendSpy = (_s: string, _cmd: string): boolean => { called++; return true; };
 
-    const outcome = requeueWithRetryCap(line, "/ludics-learn", "send-failed");
+    const sent = deliverPoppedSkill(
+      { requestId: "req-MSG", command: "hi", line, expectsResult: false },
+      { send: sendSpy },
+    );
 
-    expect(outcome).toBe("requeued");
-    expect(JSON.parse(readFileSync(queueFile(), "utf-8").trim())._retry_count).toBe(4);
+    expect(called).toBe(1);
+    expect(sent).toBe(true);
+    expect(existsSync(inFlightFilePath("req-MSG"))).toBe(false);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_already_resolved")).toBe(false);
   });
+
+  // A10: manual bypass — Mag pre-writes a result with a skip-marker status
+  // and the A6 dedup check honours it by construction. Three documented
+  // status conventions exercised separately.
+  for (const status of ["skipped-duplicate", "skipped-superseded", "preempted"] as const) {
+    test(`A10 manual bypass: pre-written result status "${status}" suppresses delivery`, async () => {
+      const { deliverPoppedSkill } = await import("./mag.ts");
+      const line = JSON.stringify({ id: "req-SKIP", action: "learn" });
+      // Synthetic result with the skip-marker status — same result-file
+      // machinery the worker uses, distinguished only by `status` string.
+      writeFileSync(resultFile("req-SKIP"), JSON.stringify({
+        id: "req-SKIP", status, timestamp: "2026-05-15T10:00:00Z",
+      }));
+      let called = 0;
+      const sendSpy = (_s: string, _cmd: string): boolean => { called++; return true; };
+
+      const sent = deliverPoppedSkill(
+        { requestId: "req-SKIP", command: "/ludics-learn", line },
+        { send: sendSpy },
+      );
+
+      expect(called).toBe(0);
+      expect(sent).toBe(true);
+      expect(existsSync(inFlightFilePath("req-SKIP"))).toBe(false);
+    });
+  }
 });
 
-// --- AC 8: dashboard in-flight sentinel exposure (server contract) ---
+// --- A8: listInFlightDeliveries returns sorted array, filters resolved ---
 
-describe("readInFlightDelivery (AC 8)", () => {
-  test("returns the sentinel payload when unresolved", async () => {
-    const { readInFlightDelivery } = await import("./mag.ts");
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-IF", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-IF", action: "learn" }),
-      deliveredAt: "2026-05-14T08:06:28Z",
+describe("listInFlightDeliveries (A8)", () => {
+  function seed(id: string, deliveredAt: string): void {
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(inFlightFilePath(id), JSON.stringify({
+      requestId: id, command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
+      deliveredAt,
     }));
+  }
 
-    const inFlight = readInFlightDelivery();
-    expect(inFlight).not.toBeNull();
-    expect(inFlight!.requestId).toBe("req-IF");
-    expect(inFlight!.command).toBe("/ludics-learn");
-    expect(inFlight!.deliveredAt).toBe("2026-05-14T08:06:28Z");
+  test("returns records sorted by deliveredAt ascending (oldest first)", async () => {
+    const { listInFlightDeliveries } = await import("./mag.ts");
+    seed("req-NEW", "2026-05-15T12:00:00Z");
+    seed("req-OLD", "2026-05-14T08:00:00Z");
+    seed("req-MID", "2026-05-15T08:00:00Z");
+
+    const got = listInFlightDeliveries();
+    expect(got.map(r => r.requestId)).toEqual(["req-OLD", "req-MID", "req-NEW"]);
   });
 
-  test("returns null once a matching result JSON exists", async () => {
-    const { readInFlightDelivery } = await import("./mag.ts");
-    writeFileSync(lastDeliveredFile(), JSON.stringify({
-      requestId: "req-IF", command: "/ludics-learn",
-      line: JSON.stringify({ id: "req-IF", action: "learn" }),
-      deliveredAt: "2026-05-14T08:06:28Z",
-    }));
-    writeFileSync(resultFile("req-IF"), JSON.stringify({ id: "req-IF", status: "ok" }));
+  test("filters out records whose result JSON has appeared", async () => {
+    const { listInFlightDeliveries } = await import("./mag.ts");
+    seed("req-PENDING", "2026-05-15T10:00:00Z");
+    seed("req-DONE", "2026-05-15T11:00:00Z");
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
 
-    expect(readInFlightDelivery()).toBeNull();
+    const got = listInFlightDeliveries();
+    expect(got.map(r => r.requestId)).toEqual(["req-PENDING"]);
   });
 
-  test("returns null when there is no sentinel", async () => {
-    const { readInFlightDelivery } = await import("./mag.ts");
-    expect(readInFlightDelivery()).toBeNull();
+  test("returns [] when directory is absent", async () => {
+    const { listInFlightDeliveries } = await import("./mag.ts");
+    expect(listInFlightDeliveries()).toEqual([]);
   });
 });
 
-// --- Round-trip fidelity: sentinel survives write → read ---
+// --- A11: state-migration triple ---
+// (1) positive backfill from legacy mag/last-delivered.json
+// (2) negative control — no inputs, no directory created
+// (3) JSON round-trip fidelity via writeInFlight/readInFlight
+// Plus: malformed record is skipped without crashing the keepalive.
 
-describe("last-delivered sentinel round-trip fidelity", () => {
-  test("deliverPoppedSkill write → readInFlightDelivery preserves every field", async () => {
-    const { deliverPoppedSkill, readInFlightDelivery } = await import("./mag.ts");
+describe("migrateLastDeliveredFile (A11 positive backfill)", () => {
+  test("legacy mag/last-delivered.json is migrated to mag/in-flight/<id>.json and the old file is unlinked", async () => {
+    const { migrateLastDeliveredFile, readInFlight } = await import("./mag.ts");
+    // Harness condition: a valid legacy sentinel from gh-ludics-526's regime.
+    const legacyRecord = {
+      requestId: "req-LEG",
+      command: "/ludics-briefing",
+      line: JSON.stringify({ id: "req-LEG", action: "briefing" }),
+      deliveredAt: "2026-05-15T07:40:12Z",
+    };
+    writeFileSync(legacyLastDeliveredPath(), JSON.stringify(legacyRecord));
+
+    migrateLastDeliveredFile();
+
+    expect(existsSync(inFlightFilePath("req-LEG"))).toBe(true);
+    expect(existsSync(legacyLastDeliveredPath())).toBe(false);
+    const got = readInFlight("req-LEG");
+    expect(got).toEqual(legacyRecord);
+  });
+
+  test("idempotent — re-running on a worktree with no legacy file is a no-op", async () => {
+    const { migrateLastDeliveredFile } = await import("./mag.ts");
+    const legacyRecord = {
+      requestId: "req-LEG",
+      command: "/ludics-briefing",
+      line: JSON.stringify({ id: "req-LEG", action: "briefing" }),
+      deliveredAt: "2026-05-15T07:40:12Z",
+    };
+    writeFileSync(legacyLastDeliveredPath(), JSON.stringify(legacyRecord));
+
+    migrateLastDeliveredFile();
+    // Second run: legacy file is gone — must not throw, must not unwrite.
+    migrateLastDeliveredFile();
+
+    expect(existsSync(inFlightFilePath("req-LEG"))).toBe(true);
+  });
+});
+
+describe("migrateLastDeliveredFile (A11 negative control)", () => {
+  test("no legacy file and no in-flight dir → migrator creates no directory and writes no record", async () => {
+    const { migrateLastDeliveredFile, listInFlight } = await import("./mag.ts");
+
+    migrateLastDeliveredFile();
+
+    // The A11 negative-control invariant: idempotent means no side effects,
+    // not "equivalent output after a terminate-and-restart". Asserting
+    // `existsSync(inFlightDirPath())` is false catches a migrator that
+    // unconditionally mkdirs.
+    expect(existsSync(inFlightDirPath())).toBe(false);
+    expect(listInFlight()).toEqual([]);
+  });
+});
+
+describe("in-flight record round-trip fidelity (A11 JSON round-trip leg)", () => {
+  test("writeInFlight → readInFlight preserves every field byte-equal", async () => {
+    const { writeInFlight, readInFlight } = await import("./mag.ts");
+    const record = {
+      requestId: "req-RT",
+      command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-RT", action: "learn", _retry_count: 2 }),
+      deliveredAt: "2026-05-14T09:00:00Z",
+    };
+
+    writeInFlight(record);
+    const got = readInFlight("req-RT");
+
+    expect(got).toEqual(record);
+  });
+
+  test("deliverPoppedSkill write → readInFlight preserves every field", async () => {
+    const { deliverPoppedSkill, readInFlight } = await import("./mag.ts");
     const line = JSON.stringify({ id: "req-RT", action: "learn", _retry_count: 2 });
 
     deliverPoppedSkill(
@@ -468,12 +537,42 @@ describe("last-delivered sentinel round-trip fidelity", () => {
       { send: () => true, nowMs: Date.parse("2026-05-14T09:00:00Z") },
     );
 
-    const got = readInFlightDelivery();
-    expect(got).toEqual({
+    expect(readInFlight("req-RT")).toEqual({
       requestId: "req-RT",
       command: "/ludics-learn",
       line,
       deliveredAt: "2026-05-14T09:00:00Z",
     });
+  });
+});
+
+describe("listInFlight — skips malformed records (A11 robustness)", () => {
+  test("malformed JSON in the directory is skipped; valid records still surface", async () => {
+    const { listInFlight, reconcileInFlight } = await import("./mag.ts");
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(join(inFlightDirPath(), "req-BAD.json"), "{not valid json");
+    writeFileSync(inFlightFilePath("req-OK"), JSON.stringify({
+      requestId: "req-OK", command: "/ludics-learn",
+      line: JSON.stringify({ id: "req-OK", action: "learn" }),
+      deliveredAt: "2026-05-15T10:00:00Z",
+    }));
+
+    // The list helper must filter the malformed entry, not throw.
+    const got = listInFlight();
+    expect(got.map(r => r.requestId)).toEqual(["req-OK"]);
+    // reconcileInFlight iterates listInFlight — also must not throw.
+    reconcileInFlight();
+    expect(existsSync(inFlightFilePath("req-OK"))).toBe(true);
+  });
+
+  test("record missing requestId / line is rejected as malformed", async () => {
+    const { readInFlight } = await import("./mag.ts");
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    // Missing `line` — required field.
+    writeFileSync(inFlightFilePath("req-MISSING"), JSON.stringify({
+      requestId: "req-MISSING", command: "/ludics-learn", deliveredAt: "2026-05-15T10:00:00Z",
+    }));
+
+    expect(readInFlight("req-MISSING")).toBeNull();
   });
 });

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -651,6 +651,152 @@ describe("briefingPrecomputeContext — Upstream vs Staging Lag section", () => 
   });
 });
 
+// gh-ludics-535 A9: briefing-prep absorbs orphan in-flight records (records
+// whose request id is no longer in queue.jsonl and whose result JSON is
+// absent — the post-boot-race shape from the issue body). The orphan stanza
+// is the audit trail; non-orphan records are left untouched. A resolved
+// record (result file exists) is cleared by the leading reconcileInFlight()
+// call, not by the orphan loop.
+describe("briefingPrecomputeContext — orphan absorption (A9)", () => {
+  let tmpHome: string;
+  let tmpConfig: string;
+  let tmpHarness: string;
+  let magDirPath: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function snapshotEnv(keys: string[]) {
+    for (const k of keys) savedEnv[k] = process.env[k];
+  }
+  function restoreEnv() {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "mag-orphan-home-"));
+    tmpHarness = mkdtempSync(join(tmpdir(), "mag-orphan-harness-"));
+    tmpConfig = join(tmpHome, "config.yaml");
+    snapshotEnv(["LUDICS_CONFIG", "LUDICS_HARNESS_DIR"]);
+    process.env.LUDICS_CONFIG = tmpConfig;
+    process.env.LUDICS_HARNESS_DIR = tmpHarness;
+    magDirPath = join(tmpHarness, "mag");
+    mkdirSync(join(magDirPath, "in-flight"), { recursive: true });
+    mkdirSync(join(magDirPath, "results"), { recursive: true });
+    writeFileSync(tmpConfig, [
+      "state_repo: test/testrepo",
+      "state_path: harness",
+      "mag:",
+      "  ensure_t3code: false",
+      "projects: []",
+    ].join("\n"));
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHarness, { recursive: true, force: true });
+  });
+
+  function inFlightFile(id: string): string {
+    return join(magDirPath, "in-flight", `${id}.json`);
+  }
+  function resultFile(id: string): string {
+    return join(magDirPath, "results", `${id}.json`);
+  }
+  function queueFile(): string {
+    return join(magDirPath, "queue.jsonl");
+  }
+  function contextFile(): string {
+    return join(magDirPath, "briefing-context.md");
+  }
+  function seedInFlight(id: string, deliveredAt = "2026-05-15T10:00:00Z"): void {
+    writeFileSync(inFlightFile(id), JSON.stringify({
+      requestId: id, command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
+      deliveredAt,
+    }));
+  }
+
+  const noopRunGit: RunGit = () => ({ stdout: "", exitCode: 0 });
+
+  test("orphan record (id absent from queue, no result) is appended to briefing context and unlinked", async () => {
+    seedInFlight("req-ORPHAN");
+    // Queue does not contain req-ORPHAN.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-OTHER", action: "learn" }) + "\n");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    const content = readFileSync(contextFile(), "utf-8");
+    expect(content).toContain("## Unresolved Deliveries (orphans)");
+    expect(content).toContain("req-ORPHAN");
+    expect(content).toContain("/ludics-learn");
+    expect(content).toContain("2026-05-15T10:00:00Z");
+    // Orphan record is unlinked so the next briefing doesn't re-list it.
+    expect(existsSync(inFlightFile("req-ORPHAN"))).toBe(false);
+  });
+
+  test("non-orphan (id still in queue) is NOT listed and NOT unlinked", async () => {
+    seedInFlight("req-PENDING");
+    // Queue still has the id — record is still genuinely in flight.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-PENDING", action: "learn" }) + "\n");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    const content = readFileSync(contextFile(), "utf-8");
+    // The orphans section reads "(none)" because req-PENDING isn't an orphan.
+    expect(content).toContain("## Unresolved Deliveries (orphans)\n\n(none)");
+    // Non-orphan record is preserved.
+    expect(existsSync(inFlightFile("req-PENDING"))).toBe(true);
+  });
+
+  test("resolved record (result file exists) is cleared by the leading reconcileInFlight call and NOT listed as orphan", async () => {
+    // This is the load-bearing assertion for the explicit reconcileInFlight()
+    // call at the top of the A9 step. If that call were removed, the orphan
+    // filter would still skip req-DONE (it has a result), so the section
+    // would still read "(none)" — but req-DONE's in-flight file would stay
+    // on disk. The unlink assertion is the mutation-test signal.
+    seedInFlight("req-DONE");
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
+    writeFileSync(queueFile(), "");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    const content = readFileSync(contextFile(), "utf-8");
+    expect(content).toContain("## Unresolved Deliveries (orphans)\n\n(none)");
+    // Removing the leading reconcileInFlight() makes this fail.
+    expect(existsSync(inFlightFile("req-DONE"))).toBe(false);
+  });
+
+  test("no in-flight records → section reads '(none)' and no directory side effects", async () => {
+    writeFileSync(queueFile(), "");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    const content = readFileSync(contextFile(), "utf-8");
+    expect(content).toContain("## Unresolved Deliveries (orphans)\n\n(none)");
+  });
+
+  test("mix: one orphan + one pending + one resolved — only the orphan is listed; non-orphan survives; resolved is cleared", async () => {
+    seedInFlight("req-ORPHAN", "2026-05-15T09:00:00Z");
+    seedInFlight("req-PENDING", "2026-05-15T10:00:00Z");
+    seedInFlight("req-DONE", "2026-05-15T11:00:00Z");
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-PENDING", action: "learn" }) + "\n");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    const content = readFileSync(contextFile(), "utf-8");
+    expect(content).toContain("req-ORPHAN");
+    expect(content).not.toContain("req-PENDING");
+    expect(content).not.toContain("req-DONE");
+    expect(existsSync(inFlightFile("req-ORPHAN"))).toBe(false);
+    expect(existsSync(inFlightFile("req-PENDING"))).toBe(true);
+    expect(existsSync(inFlightFile("req-DONE"))).toBe(false);
+  });
+});
+
 describe("stale settled sentinel detection", () => {
   // Migrated to call the production clearStaleSettled() directly (task-1b44d17b).
   // Tests drive the function via injected { nowMs, graceMs, currentHash } and

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -795,6 +795,34 @@ describe("briefingPrecomputeContext — orphan absorption (A9)", () => {
     expect(existsSync(inFlightFile("req-PENDING"))).toBe(true);
     expect(existsSync(inFlightFile("req-DONE"))).toBe(false);
   });
+
+  // Codex review on PR #536: queuePopSkill removes the entry from queue.jsonl
+  // BEFORE deliverPoppedSkill writes the in-flight record. So the
+  // currently-active delivery's requestId is absent from queue.jsonl AND its
+  // result file does not yet exist — the literal orphan filter would
+  // (incorrectly) absorb it. The active id sits in mag/current-request-id;
+  // briefingPrecomputeContext must exclude it from the orphan set.
+  test("ACTIVE delivery (id in mag/current-request-id, absent from queue.jsonl, no result) is NOT absorbed", async () => {
+    // Harness condition reconstructed from queuePopSkill's pop→deliver
+    // sequence: the active id sits in mag/current-request-id, the in-flight
+    // record is on disk, the entry is no longer in queue.jsonl, the result
+    // file is still absent. This is the exact state that
+    // briefingPrecomputeContext sees when invoked from inside a Tier-2
+    // briefing skill (e.g., action: "briefing").
+    seedInFlight("req-ACTIVE", "2026-05-15T10:00:00Z");
+    writeFileSync(join(magDirPath, "current-request-id"), "req-ACTIVE");
+    writeFileSync(queueFile(), "");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+
+    // The gate invariant: an active delivery must remain on disk so
+    // deliveryGateBlocked() stays true. Without the exclusion, this
+    // assertion fails — the briefing would unlink its own record and
+    // unblock the gate, letting the next pop dispatch prematurely.
+    expect(existsSync(inFlightFile("req-ACTIVE"))).toBe(true);
+    const content = readFileSync(contextFile(), "utf-8");
+    expect(content).toContain("## Unresolved Deliveries (orphans)\n\n(none)");
+  });
 });
 
 describe("stale settled sentinel detection", () => {

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -101,12 +101,6 @@ function triggerSkill(session: string, cmd: string): boolean {
 const DEFAULT_STALL_THRESHOLD_MS = 120_000; // 2 minutes
 const DEFAULT_STALL_NUDGE_COOLDOWN_MS = 120_000; // 2 minutes between stall nudges
 const DEFAULT_READY_THRESHOLD_MS = 5_000; // pane must be stable this long to count as ready
-const DEFAULT_MAX_REQUEUE_RETRIES = 3;
-// gh-ludics-526: a skill delivery with no result JSON after this long is
-// treated as lost (compaction/crash/dropped input). Hard-coded, not a config
-// key — comfortably past a compaction and well past any current skill's
-// runtime (briefing/feedback-digest finish in well under a minute).
-const DELIVERY_CONFIRM_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 const DEFAULT_STARTUP_WATCHDOG_SECONDS = 60;
 const DEFAULT_STARTUP_HELPER_STUCK_SECONDS = 45;
 const STARTUP_ALERT_TITLE = "Mag alert";
@@ -314,42 +308,108 @@ export function applyQueueFeedPrefix(rawLine: string, command: string): string {
   return `Ludics: ${command}`;
 }
 
-// --- Delivery-confirmation sentinel (gh-ludics-526) ---
+// --- In-flight delivery directory (gh-ludics-535; supersedes gh-ludics-526
+// single-file sentinel + timeout + retry-cap loop) ---
+//
+// Each outstanding Tier-2 delivery is recorded as one file under
+// `mag/in-flight/<requestId>.json`. Reconciliation is passive: a record is
+// deleted iff its matching `mag/results/<requestId>.json` exists. There is
+// no timeout, no auto-retry, no claim file — the gate just stays blocked
+// until the user resolves the record via the dashboard's "Unresolved
+// deliveries" panel (Re-fire / Discard) or the briefing-prep step absorbs
+// it as an orphan.
 
-/** Shape of the mag/last-delivered.json sentinel. */
-interface LastDeliveredSentinel {
+/** Shape of one `mag/in-flight/<requestId>.json` record. */
+export interface InFlightDelivery {
   requestId: string;
   command: string;
   line: string;
   deliveredAt: string;
 }
 
-function lastDeliveredFile(): string {
+export function inFlightDir(): string {
+  return join(magStateDir(), "in-flight");
+}
+
+function inFlightFile(requestId: string): string {
+  return join(inFlightDir(), `${requestId}.json`);
+}
+
+/** Legacy single-file sentinel path (gh-ludics-526). Used only by the
+ *  one-shot migrator below; not read by any production path. */
+function legacyLastDeliveredFile(): string {
   return join(magStateDir(), "last-delivered.json");
 }
 
-/** Path of the result JSON a completed skill writes (matches queue.ts writeResult). */
-function magResultFile(requestId: string): string {
+/** Path of the result JSON a completed skill writes (matches queue.ts
+ *  writeResult). Exported for the dashboard Re-fire handler's
+ *  "already-completed" short-circuit. */
+export function magResultFile(requestId: string): string {
   return join(harnessDir(), "mag", "results", `${requestId}.json`);
 }
 
-function writeLastDelivered(sentinel: LastDeliveredSentinel): void {
-  writeJsonFile(lastDeliveredFile(), sentinel);
+/** One-shot, idempotent migrator (gh-ludics-535 A11). If a legacy
+ *  `mag/last-delivered.json` exists, parse it and write the record under
+ *  `mag/in-flight/<requestId>.json`, then unlink the old path. ENOENT /
+ *  malformed → no-op (no directory created — A11 negative control).
+ *
+ *  Migrator-site target for `lint:state-migration` (A12). */
+export function migrateLastDeliveredFile(): void {
+  const legacy = legacyLastDeliveredFile();
+  if (!existsSync(legacy)) return;
+  let parsed: InFlightDelivery | null = null;
+  try {
+    const raw: unknown = JSON.parse(readFileSync(legacy, "utf-8"));
+    if (isPlainObject(raw)) {
+      const requestId = String(raw.requestId ?? "");
+      const command = String(raw.command ?? "");
+      const line = String(raw.line ?? "");
+      const deliveredAt = String(raw.deliveredAt ?? "");
+      if (requestId && line) parsed = { requestId, command, line, deliveredAt };
+    }
+  } catch { /* fall through to unlink-only */ }
+  if (parsed) {
+    writeInFlight(parsed);
+  }
+  try { unlinkSync(legacy); } catch { /* already gone */ }
 }
 
-/**
- * Parse a delivery-sentinel JSON file; tolerate a missing or malformed file
- * by returning null. Shared by readLastDelivered() and the post-claim read in
- * reconcileLastDelivered().
- */
-function parseSentinelFile(path: string): LastDeliveredSentinel | null {
+/** Write one in-flight record (gh-ludics-535 A1). Refuses to overwrite
+ *  an existing `<requestId>.json` — the gate guarantees this is
+ *  unreachable, but a programming bug that violates the gate should
+ *  surface loud (`mag_in_flight_duplicate_write` event) rather than
+ *  silently trample the prior record. */
+export function writeInFlight(record: InFlightDelivery): void {
+  mkdirSync(inFlightDir(), { recursive: true });
+  const path = inFlightFile(record.requestId);
+  if (existsSync(path)) {
+    emitEvent({
+      event_type: "mag_in_flight_duplicate_write",
+      source: "keepalive",
+      scope: "mag",
+      status: "warning",
+      message: `refused overwrite for ${record.requestId} (${record.command})`,
+    });
+    return;
+  }
+  writeJsonFile(path, record);
+}
+
+/** Parse one `mag/in-flight/<id>.json` file. Returns null on missing /
+ *  malformed / required-field-absent. */
+export function readInFlight(requestId: string): InFlightDelivery | null {
+  return parseInFlightFile(inFlightFile(requestId));
+}
+
+function parseInFlightFile(path: string): InFlightDelivery | null {
+  if (!existsSync(path)) return null;
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
-    if (!isPlainObject(parsed)) return null;
-    const requestId = String(parsed.requestId ?? "");
-    const command = String(parsed.command ?? "");
-    const line = String(parsed.line ?? "");
-    const deliveredAt = String(parsed.deliveredAt ?? "");
+    const raw: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    if (!isPlainObject(raw)) return null;
+    const requestId = String(raw.requestId ?? "");
+    const command = String(raw.command ?? "");
+    const line = String(raw.line ?? "");
+    const deliveredAt = String(raw.deliveredAt ?? "");
     if (!requestId || !line) return null;
     return { requestId, command, line, deliveredAt };
   } catch {
@@ -357,167 +417,89 @@ function parseSentinelFile(path: string): LastDeliveredSentinel | null {
   }
 }
 
-/**
- * Read the delivery sentinel; tolerate a missing or malformed file by
- * returning null (this runs in the keepalive path and in /api/queue).
- */
-function readLastDelivered(): LastDeliveredSentinel | null {
-  return parseSentinelFile(lastDeliveredFile());
-}
-
-function clearLastDelivered(): void {
-  try { unlinkSync(lastDeliveredFile()); } catch { /* already gone */ }
-}
-
-/**
- * Age of a sentinel in ms. A deliveredAt that fails Date.parse is treated as
- * infinitely old, so a corrupt timestamp re-queues + clears rather than
- * wedging the delivery gate forever.
- */
-function deliveredAtAgeMs(sentinel: LastDeliveredSentinel, nowMs: number): number {
-  const delivered = Date.parse(sentinel.deliveredAt);
-  if (Number.isNaN(delivered)) return Number.POSITIVE_INFINITY;
-  return nowMs - delivered;
-}
-
-/**
- * Shared retry-cap requeue path (gh-ludics-526). Used by both the
- * triggerSkill send-failure branch and the delivery-confirmation
- * reconciliation pass. Parses `_retry_count` from `line`, honors
- * `mag.max_requeue_retries` / `DEFAULT_MAX_REQUEUE_RETRIES`, and either
- * reinserts the line at the queue head with an incremented `_retry_count`
- * (`mag_queue_requeued`) or drops it once the cap is reached
- * (`mag_queue_dropped`). `reason` is folded into the event message only.
+/** Enumerate every valid in-flight record on disk, sorted by `deliveredAt`
+ *  ascending (oldest first — predictable order for the dashboard's per-row
+ *  Re-fire / Discard choice). Returns `[]` when the directory is absent.
  *
- * Exported for tests.
- */
-export function requeueWithRetryCap(line: string, command: string, reason: string): "requeued" | "dropped" {
-  let retryCount = 0;
+ *  Runs `migrateLastDeliveredFile()` first so any legacy
+ *  `mag/last-delivered.json` left over from gh-ludics-526 is absorbed on
+ *  the first read from any caller (keepalive, dashboard, briefing). */
+export function listInFlight(): InFlightDelivery[] {
+  migrateLastDeliveredFile();
+  const dir = inFlightDir();
+  let entries: string[];
   try {
-    const parsed: unknown = JSON.parse(line);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      retryCount = Number((parsed as Record<string, unknown>)._retry_count) || 0;
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: InFlightDelivery[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const rec = parseInFlightFile(join(dir, name));
+    if (rec) out.push(rec);
+  }
+  out.sort((a, b) => a.deliveredAt.localeCompare(b.deliveredAt));
+  return out;
+}
+
+/** Dashboard helper (gh-ludics-535 A8): every in-flight record whose result
+ *  JSON has not yet appeared, sorted by `deliveredAt` ascending. */
+export function listInFlightDeliveries(): InFlightDelivery[] {
+  return listInFlight().filter(r => !existsSync(magResultFile(r.requestId)));
+}
+
+/** Unlink a single in-flight record. ENOENT is a no-op (idempotent —
+ *  concurrent callers can safely double-clear). */
+export function clearInFlight(requestId: string): void {
+  try { unlinkSync(inFlightFile(requestId)); } catch { /* already gone */ }
+}
+
+/** Passive reconciliation (gh-ludics-535 A2): for each in-flight record,
+ *  delete it iff `mag/results/<requestId>.json` exists. Never re-queues,
+ *  never times out, no `.reconciling` claim file — passive deletion is
+ *  idempotent across concurrent callers (the keepalive loop AND the
+ *  dashboard server can both run this without coordination). */
+export function reconcileInFlight(): void {
+  for (const record of listInFlight()) {
+    if (existsSync(magResultFile(record.requestId))) {
+      clearInFlight(record.requestId);
     }
-  } catch { /* use 0 */ }
+  }
+}
 
-  const config = loadConfigSync();
-  const magCfg = config.mag as Record<string, unknown> | undefined;
-  const configuredRetries = Number(magCfg?.max_requeue_retries);
-  const maxRetries = (Number.isFinite(configuredRetries) && configuredRetries > 0)
-    ? configuredRetries : DEFAULT_MAX_REQUEUE_RETRIES;
-  if (retryCount >= maxRetries) {
-    console.error(`ludics: queue item dropped after ${maxRetries} failed retries`);
-    emitEvent({ event_type: "mag_queue_dropped", source: "keepalive", scope: "mag", status: "dropped", message: `dropped after ${maxRetries} retries (${reason}): ${command}` });
-    return "dropped";
-  }
-  // Increment retry count and reinsert at front of queue
-  let updated: Record<string, unknown>;
-  try {
-    updated = JSON.parse(line) as Record<string, unknown>;
-  } catch {
-    updated = { raw: line };
-  }
-  updated._retry_count = retryCount + 1;
-  queueReinsertHead(JSON.stringify(updated));
-  console.error(`ludics: requeued failed delivery (retry ${retryCount + 1}/${maxRetries})`);
-  emitEvent({ event_type: "mag_queue_requeued", source: "keepalive", scope: "mag", message: `retry ${retryCount + 1}/${maxRetries} (${reason}): ${command}` });
-  return "requeued";
+/** True when at least one in-flight record exists with no matching result
+ *  JSON — i.e. a Tier-2 delivery is still genuinely in flight. While this
+ *  holds, `maybeFeedMagQueue` must not deliver the next skill (gh-ludics-535
+ *  A3 — same serialization invariant as gh-ludics-526's gate, minus the
+ *  age check that fed the now-removed auto-retry loop). */
+export function deliveryGateBlocked(): boolean {
+  return listInFlight().some(r => !existsSync(magResultFile(r.requestId)));
 }
 
 /**
- * Delivery-confirmation reconciliation (gh-ludics-526). Runs each keepalive
- * tick AND inside maybeFeedMagQueue before any pop, so every delivery path
- * resolves a stale sentinel before it can deliver the next item.
+ * Deliver one popped skill item into the Mag pane (gh-ludics-535).
  *
- * - sentinel + matching result JSON → confirmed; clear the sentinel.
- * - sentinel older than the timeout, no result → delivery lost; re-queue the
- *   line through the shared retry-cap path and clear the sentinel.
- * - sentinel present, no result, under the timeout → leave for the next tick.
+ * Path:
+ *   1. Compute `delivered = applyQueueFeedPrefix(line, command)`.
+ *   2. **Pre-send result-file dedup (A6)** — when `popped.expectsResult !==
+ *      false` and `mag/results/<requestId>.json` already exists, emit
+ *      `mag_queue_already_resolved` and return `true` (the pop is consumed;
+ *      no send, no in-flight record). This formalises the manual-bypass
+ *      pattern (A10): Mag can pre-write a result with a skip-marker status
+ *      (`skipped-duplicate`, `skipped-superseded`, `preempted`) to
+ *      suppress a queued request.
+ *   3. Call `send`. On success and `expectsResult !== false`, write
+ *      `mag/in-flight/<requestId>.json` (A1) and emit `mag_queue_feed`.
+ *      Tier-3 items (`expectsResult: false`) skip both the dedup check
+ *      and the in-flight write — they have no result-file contract.
+ *   4. On send failure, call `queueReinsertHead(popped.line)` verbatim
+ *      (A5). No `_retry_count`, no cap, no `mag_queue_requeued` /
+ *      `mag_queue_dropped` events. The retry-cap machinery is gone with
+ *      gh-ludics-526; the dashboard's pending queue count is the user-
+ *      facing signal that the queue isn't draining.
  *
- * Result-existence is checked first: a skill that completed late (within the
- * timeout window) is cleared as confirmed and never double-queued.
- *
- * Concurrency: `maybeFeedMagQueue` runs this from multiple processes (the
- * keepalive loop and the dashboard server). The re-queue path atomically
- * claims the sentinel via `renameSync` before re-queuing, so two concurrent
- * callers that both observe the same expired sentinel cannot both call
- * `queueReinsertHead` — only the caller that wins the rename re-queues; the
- * loser's `renameSync` throws (source gone) and it bails.
- *
- * Exported for tests; `nowMs` drives the timeout deterministically.
- */
-export function reconcileLastDelivered(nowMs: number = Date.now()): void {
-  // Cheap peek without claiming — avoids a rename on every quiet tick.
-  const peek = readLastDelivered();
-  if (!peek) return;
-  if (existsSync(magResultFile(peek.requestId))) {
-    // Confirmed. clearLastDelivered() swallows ENOENT, so a concurrent
-    // double-clear is harmless — no claim needed on this branch.
-    clearLastDelivered();
-    return;
-  }
-  if (deliveredAtAgeMs(peek, nowMs) < DELIVERY_CONFIRM_TIMEOUT_MS) return;
-
-  // Past the timeout with no result → delivery lost. Atomically claim the
-  // sentinel before re-queuing so concurrent callers cannot double-enqueue.
-  const claimPath = lastDeliveredFile() + ".reconciling";
-  try {
-    renameSync(lastDeliveredFile(), claimPath);
-  } catch {
-    return; // another caller already claimed (or cleared) it
-  }
-  // Read from the claimed copy — the file content may have been replaced
-  // between the peek and the claim, so trust only what we atomically own.
-  const claimed = parseSentinelFile(claimPath);
-  // Re-check result existence after the claim: a result that landed in the
-  // peek→claim window means the delivery completed late — don't re-queue.
-  if (claimed && !existsSync(magResultFile(claimed.requestId))) {
-    requeueWithRetryCap(claimed.line, claimed.command, "delivery-unconfirmed");
-  }
-  try { unlinkSync(claimPath); } catch { /* ignore */ }
-}
-
-/**
- * True when a skill delivery is still in flight: the sentinel exists, no
- * result JSON has appeared, and it is younger than the timeout. While this
- * holds, maybeFeedMagQueue must not deliver the next skill item (gh-ludics-526
- * fix part 1b). Exported for tests.
- */
-export function deliveryGateBlocked(nowMs: number = Date.now()): boolean {
-  const sentinel = readLastDelivered();
-  if (!sentinel) return false;
-  if (existsSync(magResultFile(sentinel.requestId))) return false;
-  return deliveredAtAgeMs(sentinel, nowMs) < DELIVERY_CONFIRM_TIMEOUT_MS;
-}
-
-/**
- * Dashboard helper (gh-ludics-526 fix part 2): the in-flight delivery
- * sentinel, or null when there is none or its result JSON already exists.
- * Age is not considered — an expired-but-not-yet-reconciled sentinel still
- * reads as in flight until the next keepalive tick clears it.
- */
-export function readInFlightDelivery(): LastDeliveredSentinel | null {
-  const sentinel = readLastDelivered();
-  if (!sentinel) return null;
-  if (existsSync(magResultFile(sentinel.requestId))) return null;
-  return sentinel;
-}
-
-/**
- * Deliver one popped skill item into the Mag pane. On a successful send,
- * record the mag/last-delivered.json sentinel (gh-ludics-526) and emit
- * `mag_queue_feed`; on a failed send, re-queue through the shared retry-cap
- * path without writing a sentinel. Returns whether the send succeeded.
- *
- * Only Tier-2 skill items (`expectsResult`) write the sentinel: they are the
- * ones that produce a result JSON the reconciliation pass can confirm against.
- * Tier-3 programmatic items (`action: message`, `/compact`) never write a
- * result file — recording a sentinel for them wedges `deliveryGateBlocked`
- * for DELIVERY_CONFIRM_TIMEOUT_MS and then re-queues a spurious duplicate.
- * `expectsResult` defaults to true when absent so existing callers/tests keep
- * the confirmed-delivery behavior.
- *
- * Exported for tests; `send` is injectable to exercise both paths without
+ * Exported for tests; `send` is injectable to exercise each path without
  * tmux, and `nowMs` pins the `deliveredAt` timestamp deterministically.
  */
 export function deliverPoppedSkill(
@@ -526,10 +508,22 @@ export function deliverPoppedSkill(
 ): boolean {
   const send = opts.send ?? triggerSkill;
   const delivered = applyQueueFeedPrefix(popped.line, popped.command);
+  // A6 pre-send dedup: a Tier-2 request whose result file already exists is
+  // either a real already-completed item (race) or a manual-bypass skip-marker
+  // (A10). Either way, consume the pop without sending.
+  if (popped.expectsResult !== false && existsSync(magResultFile(popped.requestId))) {
+    emitEvent({
+      event_type: "mag_queue_already_resolved",
+      source: "keepalive",
+      scope: "mag",
+      message: `skipped: ${delivered}`,
+    });
+    return true;
+  }
   const sent = send(MAG_SESSION_NAME, delivered);
   if (sent) {
     if (popped.expectsResult !== false) {
-      writeLastDelivered({
+      writeInFlight({
         requestId: popped.requestId,
         command: popped.command,
         line: popped.line,
@@ -538,7 +532,10 @@ export function deliverPoppedSkill(
     }
     emitEvent({ event_type: "mag_queue_feed", source: "keepalive", scope: "mag", message: `delivered: ${delivered}` });
   } else {
-    requeueWithRetryCap(popped.line, popped.command, "send-failed");
+    // A5: roll back the pop — reinsert the verbatim line at queue head.
+    // No retry-count, no cap, no drop. tmux unreachable is itself a serial
+    // bottleneck the user will notice via the dashboard's pending count.
+    queueReinsertHead(popped.line);
   }
   return sent;
 }
@@ -562,18 +559,19 @@ export async function maybeFeedMagQueue(
   await drainProgrammaticQueueHead();
   if (!queuePending()) return false;
 
-  // Delivery-confirmation invariant (gh-ludics-526): reconcile a stale
-  // sentinel before any pop, so every caller of maybeFeedMagQueue — the
-  // keepalive tick AND the direct callers (fresh-start ready path, on-stop
-  // hook, dashboard /api/queue-deliver and /api/queue) — clears or re-queues
-  // a resolved/expired sentinel before it can deliver the next item. Without
-  // this, a direct caller could pop B and let deliverPoppedSkill overwrite
-  // the single-valued sentinel for A before A is re-queued.
-  reconcileLastDelivered();
+  // Delivery-gate invariant (gh-ludics-526 + gh-ludics-535): passively
+  // reconcile every in-flight record before any pop, so every caller of
+  // maybeFeedMagQueue — the keepalive tick AND the direct callers
+  // (fresh-start ready path, on-stop hook, dashboard /api/queue-deliver
+  // and /api/queue) — clears records whose result JSON has appeared before
+  // it can deliver the next item. Passive only: nothing auto-times-out,
+  // nothing auto-requeues. The dashboard's "Unresolved deliveries" panel
+  // is the user's recovery path for records that never resolve.
+  reconcileInFlight();
   // Gate: do not deliver the next skill while a delivery is still in flight
-  // (sentinel present, no result, under the timeout). reconcileLastDelivered
-  // above has already cleared confirmed/expired sentinels, so a block here
-  // means a genuinely in-flight delivery.
+  // (any record present without a matching result JSON). reconcileInFlight
+  // above has already cleared resolved records, so a block here means a
+  // genuinely unresolved delivery.
   if (deliveryGateBlocked()) return false;
 
   // Atomic claim: if settled, consume the sentinel so concurrent ticks
@@ -3134,11 +3132,12 @@ export async function magStart(args: string[]): Promise<void> {
     // If Mag resumed running (e.g. manual turn) since settling, clear stale sentinel
     clearStaleSettled();
 
-    // Delivery-confirmation reconciliation (gh-ludics-526): confirm or re-queue
-    // a stale delivery sentinel. Kept here in addition to the in-function call
-    // in maybeFeedMagQueue, because maybeFeedMagQueue returns early on an empty
+    // Passive in-flight reconciliation (gh-ludics-535; supersedes the
+    // gh-ludics-526 retry-cap pass). Confirm and clear records whose result
+    // JSON has appeared. Kept here in addition to the in-function call in
+    // maybeFeedMagQueue, because maybeFeedMagQueue returns early on an empty
     // queue and would otherwise never reconcile while the queue is drained.
-    reconcileLastDelivered();
+    reconcileInFlight();
 
     // Settled-aware queue feed: deliver one Mag-turn item if settled
     const fed = await maybeFeedMagQueue();

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1930,12 +1930,29 @@ export async function briefingPrecomputeContext(opts?: { runGit?: RunGit }): Pro
   // whose result file is still absent — that's the post-boot-race / lost-
   // delivery shape. Briefing context absorbs the orphan (paper trail) and
   // unlinks the record so the panel signal stays high.
+  //
+  // Exclude the currently-active delivery (the request whose id sits in
+  // `mag/current-request-id`) from the orphan set. queuePopSkill removes
+  // the entry from queue.jsonl BEFORE deliverPoppedSkill writes the
+  // in-flight record, so during a Mag-turn delivery (including this
+  // briefing's own delivery when it was popped as action: "briefing") the
+  // record's id is absent from queue.jsonl but the delivery is still
+  // genuinely active. Without this exclusion, briefing-prep would
+  // unlink its own in-flight record and unblock deliveryGateBlocked(),
+  // letting the next pop dispatch before the current delivery completes —
+  // a load-bearing violation of the A3 gate invariant.
   reconcileInFlight();
   const queueIds = new Set(
     queueList().map(r => String(r.id ?? "")).filter(Boolean),
   );
+  let activeRequestId = "";
+  try {
+    activeRequestId = readFileSync(join(harnessDir(), "mag", "current-request-id"), "utf-8").trim();
+  } catch { /* file absent on fresh boot — no active delivery to exclude */ }
   const orphans = listInFlight().filter(
-    r => !queueIds.has(r.requestId) && !existsSync(magResultFile(r.requestId)),
+    r => r.requestId !== activeRequestId
+      && !queueIds.has(r.requestId)
+      && !existsSync(magResultFile(r.requestId)),
   );
   const orphanLines = orphans.length === 0
     ? "(none)"

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -11,7 +11,7 @@ import { atomicWriteFileSync, isPlainObject, writeJsonFile, writeJsonFileCompact
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, recentResults } from "./queue.ts";
+import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -1921,6 +1921,29 @@ export async function briefingPrecomputeContext(opts?: { runGit?: RunGit }): Pro
     ? `## Upstream vs Staging Lag\n\n${upstreamLag.trimEnd()}\n\n`
     : "";
 
+  // gh-ludics-535 A9: orphan absorption. First passively reconcile so any
+  // record whose result file has appeared is cleared (without this step, a
+  // record that resolved between the last keepalive tick and the briefing
+  // would still be on disk and the orphan filter would correctly skip it,
+  // but the in-flight directory wouldn't be cleaned up). Then surface every
+  // remaining in-flight record whose id is no longer in queue.jsonl AND
+  // whose result file is still absent — that's the post-boot-race / lost-
+  // delivery shape. Briefing context absorbs the orphan (paper trail) and
+  // unlinks the record so the panel signal stays high.
+  reconcileInFlight();
+  const queueIds = new Set(
+    queueList().map(r => String(r.id ?? "")).filter(Boolean),
+  );
+  const orphans = listInFlight().filter(
+    r => !queueIds.has(r.requestId) && !existsSync(magResultFile(r.requestId)),
+  );
+  const orphanLines = orphans.length === 0
+    ? "(none)"
+    : orphans.map(o =>
+        `- ${o.requestId} (${o.command}) — delivered ${o.deliveredAt}\n  line: ${o.line}`
+      ).join("\n");
+  const orphanSection = `## Unresolved Deliveries (orphans)\n\n${orphanLines}\n\n`;
+
   const contextContent = `# Briefing Context
 
 Generated: ${timestamp}
@@ -1959,10 +1982,16 @@ ${needsElabOutput}
 ## Recent Journal
 
 ${journalOutput}
-`;
+
+${orphanSection}`;
 
   writeFileSync(contextFile + ".tmp", contextContent);
   renameSync(contextFile + ".tmp", contextFile);
+  // After the section is written, unlink each orphan so the next briefing
+  // doesn't re-surface a stanza for the same id. (Idempotent — ENOENT swallow.)
+  for (const o of orphans) {
+    clearInFlight(o.requestId);
+  }
   console.error(`ludics: briefing context written to ${contextFile}`);
 }
 

--- a/src/queue-reinsert.test.ts
+++ b/src/queue-reinsert.test.ts
@@ -46,18 +46,6 @@ afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
 });
 
-function writeConfigWithMag(homeDir: string, magSection: string): string {
-  const configDir = join(homeDir, ".config", "ludics");
-  mkdirSync(configDir, { recursive: true });
-  const configPath = join(configDir, "config.yaml");
-  writeFileSync(configPath, `state_repo: owner/ludics-state
-state_path: harness
-slots:
-  count: 2
-${magSection}`);
-  return configPath;
-}
-
 describe("queueReinsertHead", () => {
   test("prepends line to empty queue", async () => {
     const { queueReinsertHead } = await import("./queue.ts");
@@ -98,75 +86,62 @@ describe("queueReinsertHead", () => {
   });
 });
 
-describe("requeue retry-count simulation", () => {
-  test("retry count increments on each reinsert and item is droppable after max", async () => {
-    const { queueReinsertHead } = await import("./queue.ts");
-    const DEFAULT_MAX = 3;
+// gh-ludics-535: helper used by the dashboard's /api/in-flight-refire to
+// mint a fresh queue id, stamp `re-fired-from` provenance, and reinsert at
+// queue head. Keeps id minting owned by queue.ts (the request-id generator
+// stays file-private).
+describe("queueReinsertHeadWithFreshId", () => {
+  test("mints a fresh req-<epoch>-<counter> id and stamps re-fired-from provenance", async () => {
+    const { queueReinsertHeadWithFreshId } = await import("./queue.ts");
+    // Empty queue → head must be the newly inserted line.
+    writeFileSync(queueFile(), "");
+    const originalId = "req-1778830000-1";
+    const record = { id: originalId, action: "learn" };
 
-    // Simulate the requeue logic from maybeFeedMagQueue
-    const original = { id: "req-99", action: "briefing", timestamp: "2026-04-15T00:00:00Z" };
-    let line = JSON.stringify(original);
+    const newId = queueReinsertHeadWithFreshId(record, originalId);
 
-    for (let attempt = 0; attempt < DEFAULT_MAX; attempt++) {
-      // Parse, increment retry count, reinsert
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      const retryCount = Number(parsed._retry_count) || 0;
-      expect(retryCount).toBe(attempt);
-
-      parsed._retry_count = retryCount + 1;
-      const updatedLine = JSON.stringify(parsed);
-
-      // Clear queue and reinsert
-      writeFileSync(queueFile(), "");
-      queueReinsertHead(updatedLine);
-
-      // Read it back
-      const content = readFileSync(queueFile(), "utf-8").trim();
-      const readBack = JSON.parse(content);
-      expect(readBack._retry_count).toBe(attempt + 1);
-      expect(readBack.id).toBe("req-99");
-      line = content;
-    }
-
-    // After max retries, should be dropped (retry count >= max)
-    const final = JSON.parse(line) as Record<string, unknown>;
-    expect(Number(final._retry_count)).toBe(DEFAULT_MAX);
-    expect(Number(final._retry_count) >= DEFAULT_MAX).toBe(true);
-  });
-});
-
-describe("configurable max_requeue_retries", () => {
-  test("config value is read when set to a positive number", async () => {
-    process.env.LUDICS_CONFIG = writeConfigWithMag(TMP, `mag:
-  max_requeue_retries: 5
-`);
-    const { loadConfigSync } = await import("./config.ts");
-    const config = loadConfigSync();
-    const mag = config.mag as Record<string, unknown> | undefined;
-    const configured = Number(mag?.max_requeue_retries);
-    expect(configured).toBe(5);
-    expect(Number.isFinite(configured) && configured > 0).toBe(true);
+    // The invariant: a fresh id is minted (not the original), matching the
+    // req-<epoch>-<counter> shape — reusing the original would re-trip the
+    // A6 pre-send result-file dedup check on the next pop.
+    expect(newId).toMatch(/^req-\d+-\d+$/);
+    expect(newId).not.toBe(originalId);
+    const head = JSON.parse(readFileSync(queueFile(), "utf-8").trim());
+    expect(head.id).toBe(newId);
+    expect(head["re-fired-from"]).toBe(originalId);
+    expect(head.action).toBe("learn");
   });
 
-  test("falls back to default when not configured", async () => {
-    // Default config has no mag section
-    const { loadConfigSync } = await import("./config.ts");
-    const config = loadConfigSync();
-    const mag = config.mag as Record<string, unknown> | undefined;
-    const configured = Number(mag?.max_requeue_retries);
-    const maxRetries = (Number.isFinite(configured) && configured > 0) ? configured : 3;
-    expect(maxRetries).toBe(3);
+  test("preserves the original record's other fields through the round-trip", async () => {
+    const { queueReinsertHeadWithFreshId } = await import("./queue.ts");
+    writeFileSync(queueFile(), "");
+    const record = {
+      id: "req-old",
+      action: "elaborate",
+      task: "task-abc",
+      content: "do the thing",
+      timestamp: "2026-05-15T10:00:00Z",
+    };
+
+    queueReinsertHeadWithFreshId(record, "req-old");
+
+    const head = JSON.parse(readFileSync(queueFile(), "utf-8").trim());
+    expect(head.action).toBe("elaborate");
+    expect(head.task).toBe("task-abc");
+    expect(head.content).toBe("do the thing");
+    expect(head.timestamp).toBe("2026-05-15T10:00:00Z");
   });
 
-  test("falls back to default when value is invalid", async () => {
-    process.env.LUDICS_CONFIG = writeConfigWithMag(TMP, `mag:
-  max_requeue_retries: -1
-`);
-    const { loadConfigSync } = await import("./config.ts");
-    const config = loadConfigSync();
-    const mag = config.mag as Record<string, unknown> | undefined;
-    const configured = Number(mag?.max_requeue_retries);
-    const maxRetries = (Number.isFinite(configured) && configured > 0) ? configured : 3;
-    expect(maxRetries).toBe(3);
+  test("inserts at queue head: existing entries remain behind the re-fired line", async () => {
+    const { queueReinsertHeadWithFreshId } = await import("./queue.ts");
+    const existing = JSON.stringify({ id: "req-existing", action: "suggest" });
+    writeFileSync(queueFile(), existing + "\n");
+
+    queueReinsertHeadWithFreshId({ id: "req-old", action: "learn" }, "req-old");
+
+    const lines = readFileSync(queueFile(), "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const head = JSON.parse(lines[0]!);
+    expect(head["re-fired-from"]).toBe("req-old");
+    expect(JSON.parse(lines[1]!).id).toBe("req-existing");
   });
 });

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -176,6 +176,24 @@ export function queueReinsertHead(line: string): void {
   });
 }
 
+/**
+ * Re-fire helper (gh-ludics-535): mint a fresh request id (same shape as
+ * queueRequest's `req-<epoch>-<counter>`), stamp the original id as
+ * `re-fired-from` provenance, and reinsert at the queue head. Returns the
+ * new id. Used by the dashboard's `/api/in-flight-refire` endpoint to
+ * avoid duplicate-fire when the pre-send dedup check sees the original
+ * result file.
+ */
+export function queueReinsertHeadWithFreshId(
+  record: Record<string, unknown>,
+  originalId: string,
+): string {
+  const newId = nextRequestId();
+  const updated = { ...record, id: newId, "re-fired-from": originalId };
+  queueReinsertHead(JSON.stringify(updated));
+  return newId;
+}
+
 export function queuePopOne(): string | null {
   const result = withQueueLock(() => {
     const lines = readQueueLines();

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -91,7 +91,6 @@ mag:
                                      # touches slot worktrees, aborts on dirty tree or divergence. Disable with `false`.
   stall_threshold_seconds: 120    # How long pane output must be unchanged before a stall nudge (default: 120)
   stall_nudge_cooldown_seconds: 120  # Minimum gap between stall nudges (default: 120)
-  max_requeue_retries: 3          # Max times a failed queue delivery is retried before dropping (default: 3)
   test_health_night_hours: [0, 6]  # Local-time hour window [start, end) during which test suites
                                    # are eligible to run. Uses local time to match launchd semantics.
                                    # Tests also run if last run was 24+ hours ago (stale fallback).

--- a/templates/dashboard/dashboard.test.ts
+++ b/templates/dashboard/dashboard.test.ts
@@ -92,11 +92,12 @@ describe("style.css contains pending-action-badge class", () => {
   });
 });
 
-// gh-ludics-526: the Mag queue renderer must surface a popped-but-not-completed
-// skill request as an "In flight" section between Pending and Recent. These
-// tests extract the real renderQueue / escapeHtml from mag.html and drive them
-// against a minimal document stub (the readFileSync + new Function pattern).
-describe("mag.html renderQueue — In flight section (gh-ludics-526)", () => {
+// gh-ludics-535: the Mag queue renderer must surface unresolved deliveries
+// as an "Unresolved deliveries" panel between Pending and Recent. `inFlight`
+// is always an array (possibly empty). These tests extract the real
+// renderQueue / escapeHtml from mag.html and drive them against a minimal
+// document stub.
+describe("mag.html renderQueue — Unresolved deliveries section (gh-ludics-535)", () => {
   const magSrc = readFileSync(join(import.meta.dir, "mag.html"), "utf-8");
   const renderQueueSrc = magSrc.slice(
     magSrc.indexOf("function renderQueue("),
@@ -107,9 +108,11 @@ describe("mag.html renderQueue — In flight section (gh-ludics-526)", () => {
     magSrc.indexOf("function setConnectionStatus"),
   );
 
+  type InFlightRow = { requestId: string; command: string; deliveredAt: string };
+
   // Minimal document stub: getElementById returns the live list element;
   // createElement('div') backs escapeHtml's textContent → innerHTML escaping.
-  function makeRenderQueue(listEl: { innerHTML: string }): (p: unknown[], r: unknown[], i: unknown) => void {
+  function makeRenderQueue(listEl: { innerHTML: string }): (p: unknown[], r: unknown[], i: InFlightRow[]) => void {
     const documentStub = {
       getElementById: () => listEl,
       createElement: () => {
@@ -125,53 +128,94 @@ describe("mag.html renderQueue — In flight section (gh-ludics-526)", () => {
     return new Function(
       "document",
       `${escapeHtmlSrc}\n${renderQueueSrc}\nreturn renderQueue;`,
-    )(documentStub) as (p: unknown[], r: unknown[], i: unknown) => void;
+    )(documentStub) as (p: unknown[], r: unknown[], i: InFlightRow[]) => void;
   }
 
-  test("renders 'In flight' between 'Pending' and 'Recent'", () => {
+  test("renders 'Unresolved deliveries' between 'Pending' and 'Recent'", () => {
     const listEl = { innerHTML: "" };
     const renderQueue = makeRenderQueue(listEl);
     renderQueue(
       [{ id: "req-p", action: "elaborate" }],
       [{ id: "req-r", status: "ok" }],
-      { requestId: "req-if", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" },
+      [{ requestId: "req-if", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" }],
     );
     const html = listEl.innerHTML;
     const pendingIdx = html.indexOf("Pending");
-    const inFlightIdx = html.indexOf("In flight");
+    const unresolvedIdx = html.indexOf("Unresolved deliveries");
     const recentIdx = html.indexOf("Recent");
-    // The invariant: an in-flight request is visible and ordered between the
-    // durable queue and completed results. If the section were missing or
-    // misplaced, this ordering chain would break.
+    // The invariant: an unresolved delivery is visible and ordered between
+    // the durable queue and completed results. If the section were missing
+    // or misplaced, this ordering chain would break.
     expect(pendingIdx).toBeGreaterThanOrEqual(0);
-    expect(inFlightIdx).toBeGreaterThan(pendingIdx);
-    expect(recentIdx).toBeGreaterThan(inFlightIdx);
+    expect(unresolvedIdx).toBeGreaterThan(pendingIdx);
+    expect(recentIdx).toBeGreaterThan(unresolvedIdx);
     expect(html).toContain("/ludics-briefing");
     expect(html).toContain("2026-05-14T08:06:28Z");
   });
 
-  test("escapes the in-flight command", () => {
+  test("escapes the unresolved-delivery command (XSS guard)", () => {
     const listEl = { innerHTML: "" };
     const renderQueue = makeRenderQueue(listEl);
-    renderQueue([], [], { requestId: "x", command: "<script>evil</script>", deliveredAt: "" });
+    renderQueue([], [], [{ requestId: "req-x", command: "<script>evil</script>", deliveredAt: "" }]);
     expect(listEl.innerHTML).toContain("&lt;script&gt;evil&lt;/script&gt;");
     expect(listEl.innerHTML).not.toContain("<script>evil");
   });
 
-  test("suppresses 'No activity' while in-flight data exists", () => {
+  test("suppresses 'No activity' while at least one unresolved delivery exists", () => {
     const listEl = { innerHTML: "" };
     const renderQueue = makeRenderQueue(listEl);
-    // Harness condition: pending AND results empty — only the sentinel is set.
-    // Without inFlight in the empty-state guard, this would render "No activity".
-    renderQueue([], [], { requestId: "x", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" });
+    // Harness condition: pending AND results empty — only the unresolved set
+    // is non-empty. Without inFlight.length === 0 in the empty-state guard,
+    // this would render "No activity".
+    renderQueue([], [], [{ requestId: "req-x", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:06:28Z" }]);
     expect(listEl.innerHTML).not.toContain("No activity");
-    expect(listEl.innerHTML).toContain("In flight");
+    expect(listEl.innerHTML).toContain("Unresolved deliveries");
   });
 
   test("still shows 'No activity' when pending, results, and inFlight are all empty", () => {
     const listEl = { innerHTML: "" };
     const renderQueue = makeRenderQueue(listEl);
-    renderQueue([], [], null);
+    renderQueue([], [], []);
     expect(listEl.innerHTML).toContain("No activity");
+  });
+
+  test("renders multiple unresolved deliveries in server-provided order", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    // Server sorts ascending by deliveredAt; the renderer preserves order.
+    renderQueue([], [], [
+      { requestId: "req-A", command: "/ludics-briefing", deliveredAt: "2026-05-14T08:00:00Z" },
+      { requestId: "req-B", command: "/ludics-learn", deliveredAt: "2026-05-14T09:00:00Z" },
+    ]);
+    const html = listEl.innerHTML;
+    expect(html.indexOf("/ludics-briefing")).toBeLessThan(html.indexOf("/ludics-learn"));
+  });
+
+  test("renders Re-fire and Discard buttons per row", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [], [
+      { requestId: "req-A", command: "/ludics-briefing", deliveredAt: "" },
+      { requestId: "req-B", command: "/ludics-learn", deliveredAt: "" },
+    ]);
+    const html = listEl.innerHTML;
+    // Two of each — one per row. The presence of these onclick handlers is
+    // load-bearing: they are the only path to /api/in-flight-{refire,discard}
+    // from the dashboard UI.
+    const refireMatches = html.match(/onclick="refireInFlight\(/g) ?? [];
+    const discardMatches = html.match(/onclick="discardInFlight\(/g) ?? [];
+    expect(refireMatches).toHaveLength(2);
+    expect(discardMatches).toHaveLength(2);
+  });
+
+  test("renders a count badge with the array length", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [], [
+      { requestId: "req-A", command: "/x", deliveredAt: "" },
+      { requestId: "req-B", command: "/y", deliveredAt: "" },
+      { requestId: "req-C", command: "/z", deliveredAt: "" },
+    ]);
+    expect(listEl.innerHTML).toContain('<span class="mag-queue-badge">3</span>');
   });
 });

--- a/templates/dashboard/mag.html
+++ b/templates/dashboard/mag.html
@@ -100,7 +100,7 @@
                 const response = await fetch('/api/queue');
                 if (!response.ok) return;
                 const data = await response.json();
-                renderQueue(data.pending || [], data.results || [], data.inFlight || null);
+                renderQueue(data.pending || [], data.results || [], data.inFlight || []);
             } catch {
                 // Silently skip — don't break the terminal
             }
@@ -110,7 +110,7 @@
             const list = document.getElementById('queue-list');
             if (!list) return;
 
-            if (pending.length === 0 && results.length === 0 && !inFlight) {
+            if (pending.length === 0 && results.length === 0 && inFlight.length === 0) {
                 list.innerHTML = '<div class="mag-queue-empty">No activity</div>';
                 return;
             }
@@ -137,12 +137,20 @@
                 }
             }
 
-            if (inFlight) {
-                html += '<div class="mag-queue-section-title">In flight</div>';
-                const command = escapeHtml(String(inFlight.command || 'unknown'));
-                const ts = inFlight.deliveredAt
-                    ? `<div class="timestamp">${escapeHtml(String(inFlight.deliveredAt))}</div>` : '';
-                html += `<div class="mag-queue-item"><span class="action">[delivered]</span> ${command}${ts}</div>`;
+            if (inFlight.length > 0) {
+                const badge = `<span class="mag-queue-badge">${inFlight.length}</span>`;
+                html += `<div class="mag-queue-section-title">Unresolved deliveries ${badge}</div>`;
+                for (const item of inFlight) {
+                    const command = escapeHtml(String(item.command || 'unknown'));
+                    const id = item.requestId ? escapeHtml(String(item.requestId)) : '';
+                    const ts = item.deliveredAt
+                        ? `<div class="timestamp">${escapeHtml(String(item.deliveredAt))}</div>` : '';
+                    const actions = id ? `<div class="mag-queue-actions">` +
+                        `<button type="button" class="mag-queue-action refire" title="Re-fire" data-queue-id="${id}" onclick="refireInFlight('${id}')">⟲</button>` +
+                        `<button type="button" class="mag-queue-action discard" title="Discard" data-queue-id="${id}" onclick="discardInFlight('${id}')">✖</button>` +
+                        `</div>` : '';
+                    html += `<div class="mag-queue-item"><span class="action">[delivered]</span> ${command}${ts}${actions}</div>`;
+                }
             }
 
             if (results.length > 0) {
@@ -187,6 +195,24 @@
         async function promoteQueueItem(id) {
             try {
                 await fetch('/api/queue-promote?id=' + encodeURIComponent(id), { method: 'POST' });
+            } catch {
+                // Silently skip — next poll will reconverge
+            }
+            fetchQueue();
+        }
+
+        async function refireInFlight(id) {
+            try {
+                await fetch('/api/in-flight-refire?id=' + encodeURIComponent(id), { method: 'POST' });
+            } catch {
+                // Silently skip — next poll will reconverge
+            }
+            fetchQueue();
+        }
+
+        async function discardInFlight(id) {
+            try {
+                await fetch('/api/in-flight-discard?id=' + encodeURIComponent(id), { method: 'POST' });
             } catch {
                 // Silently skip — next poll will reconverge
             }


### PR DESCRIPTION
## Summary

Implements gh-ludics-535: replaces the gh-ludics-526 single-file
`mag/last-delivered.json` sentinel + 10-min timeout + retry-cap loop
with a passive `mag/in-flight/<requestId>.json` directory and an
"Unresolved deliveries" dashboard panel.

- **Gate stays serializing** — `deliveryGateBlocked()` returns true
  while any record lacks a matching result JSON, but nothing
  auto-times-out, auto-requeues, or auto-drops. Recovery is the user's
  job via the dashboard's Re-fire / Discard buttons.
- **Pre-send dedup (A6)** — `deliverPoppedSkill` short-circuits when a
  result file already exists, formalising the manual-bypass pattern
  (Mag pre-writes a `skipped-duplicate` / `skipped-superseded` /
  `preempted` result to suppress a queued request).
- **Send-failure rollback (A5)** — verbatim `queueReinsertHead`, no
  `_retry_count`, no events. The dashboard's pending count is the
  user-facing signal that the queue isn't draining.
- **Briefing-prep orphan absorption (A9)** — `briefingPrecomputeContext`
  passively reconciles, then appends every still-orphaned record (id
  absent from `queue.jsonl` AND `mag/current-request-id` AND no result)
  to `briefing-context.md` and unlinks the in-flight file. The
  `mag/current-request-id` exclusion was added in f5a91c1 (Codex
  review): `queuePopSkill` removes the queue entry *before*
  `deliverPoppedSkill` writes the in-flight record, so the active
  delivery's id satisfies the literal "not in queue AND no result"
  filter and would have been unlinked, breaking the A3 gate.
- **One-shot migrator (A11)** — legacy `mag/last-delivered.json` files
  from gh-ludics-526's regime are absorbed on first read.
- **State-shape lock (A12)** — `InFlightDelivery` joins the
  `lint:state-migration` allowlist with `migrateLastDeliveredFile` as
  its migrator site.

Supersedes the gh-ludics-526 stack: removes `DELIVERY_CONFIRM_TIMEOUT_MS`,
`DEFAULT_MAX_REQUEUE_RETRIES`, `requeueWithRetryCap`, the `.reconciling`
claim-file machinery, `mag.max_requeue_retries` config + reference-yaml
sample, and the `mag_queue_requeued` / `mag_queue_dropped` events.

## Commits

1. `13b46b6` — core in-flight directory primitives + A1/A2/A3/A4/A5/A6/A8/A10/A11 tests.
2. `a2ca736` — A9 briefing-prep orphan absorption + A12 state-shape lock + obsolete config/test cleanup.
3. `f5a91c1` — A9 fix: exclude `mag/current-request-id` from orphan filter so the briefing's own active delivery isn't unlinked (Codex review).

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 2548 pass, 0 fail (was 2527 baseline; +21 new tests across A1, A2, A3, A5, A6, A8, A9, A10, A11 plus the active-delivery-exclusion regression).
- [x] `bun run lint:state-migration` — passes.
- [x] `bun run lint:cli-readme` — passes (no CLI surface change).
- [x] `bun run build` — compiles to `bin/ludics`.
- [x] Occurrence sweep `rg 'last-delivered|requeueWithRetryCap|DELIVERY_CONFIRM_TIMEOUT_MS|mag_queue_requeued|mag_queue_dropped|max_requeue_retries' templates/ src/` — remaining hits are only in the migrator, the migrator's test, and doc-comments naming the removed symbols (intentional).
- [ ] Manual dashboard smoke — seed two `mag/in-flight/*.json` files,
      open dashboard, confirm sorted rows, Re-fire mints a fresh id with
      `re-fired-from` provenance, Discard unlinks, badge tracks count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)