### PR TITLE
fix(mag): couple auto-/compact to health-check gate

### DIFF
--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -128,22 +128,54 @@ describe("runMag health-check auto-compact follow-up", () => {
     expect(items[0]!.action).toBe("health-check");
   });
 
-  test("non-skipped delivery appends /compact to the queue", async () => {
+  test("non-skipped delivery enqueues /compact at the queue head", async () => {
     const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    const { queuePopExpected } = await import("./queue.ts");
     await runMag(["health-check"]);
 
-    // Resolve with executeProgrammatic: true so the gate-check branch runs.
+    // Model the production flow: pop health-check first, then resolve.
     // With no prior snapshot the gate fails open (first-run reason), so the
     // health-check resolves to its skill command and the auto-compact
-    // follow-up is appended.
-    const command = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    // follow-up is enqueued.
+    const popped = queuePopExpected();
+    expect(popped.status).toBe("popped");
+    const command = await resolveQueueRequestCommand(popped.request!, true);
     expect(command).toBe("/ludics-health-check");
 
     const items = readQueue();
+    expect(items).toHaveLength(1);
+    expect(items[0]!.action).toBe("message");
+    expect(items[0]!.content).toBe("/compact");
+  });
+
+  test("intervening enqueues don't slip in front of /compact (Codex P2 regression)", async () => {
+    // Models the race: another request lands on the queue tail between
+    // `mag health-check` enqueue and the moment health-check is popped for
+    // dispatch. The /compact follow-up must still run *immediately after*
+    // the triggering health-check, not after the intervening tail item —
+    // otherwise the "trim context before next heavy action" guarantee from
+    // task-a00fc0d9 breaks.
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    const { queuePopExpected } = await import("./queue.ts");
+
+    await runMag(["health-check"]);            // queue: [health-check]
+    await runMag(["elaborate", "task-x"]);     // queue: [health-check, elaborate]
+
+    // Pop the head (health-check) as production does, then resolve.
+    const popped = queuePopExpected();
+    expect(popped.status).toBe("popped");
+    expect((popped.request as { action: string }).action).toBe("health-check");
+
+    const command = await resolveQueueRequestCommand(popped.request!, true);
+    expect(command).toBe("/ludics-health-check");
+
+    // /compact must be at queue head (the position the popped health-check
+    // vacated), ahead of the intervening elaborate.
+    const items = readQueue();
     expect(items).toHaveLength(2);
-    expect(items[0]!.action).toBe("health-check");
-    expect(items[1]!.action).toBe("message");
-    expect(items[1]!.content).toBe("/compact");
+    expect(items[0]!.action).toBe("message");
+    expect(items[0]!.content).toBe("/compact");
+    expect(items[1]!.action).toBe("elaborate");
   });
 
   test("gate-skipped delivery does not append /compact", async () => {

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -116,15 +116,57 @@ describe("magBriefing auto-compact follow-up", () => {
 });
 
 describe("runMag health-check auto-compact follow-up", () => {
-  test("enqueues /compact directly behind the health-check entry", async () => {
+  test("CLI enqueues only health-check; /compact is appended later by the gate-check path on a non-skipped delivery", async () => {
     const { runMag } = await import("./mag.ts");
     await runMag(["health-check"]);
+
+    // /compact is no longer enqueued at CLI time — it's coupled to the gate
+    // and appended by resolveQueueRequestCommand only when the gate does not
+    // skip the delivery. This avoids spurious /compact on idle ticks.
+    const items = readQueue();
+    expect(items).toHaveLength(1);
+    expect(items[0]!.action).toBe("health-check");
+  });
+
+  test("non-skipped delivery appends /compact to the queue", async () => {
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    await runMag(["health-check"]);
+
+    // Resolve with executeProgrammatic: true so the gate-check branch runs.
+    // With no prior snapshot the gate fails open (first-run reason), so the
+    // health-check resolves to its skill command and the auto-compact
+    // follow-up is appended.
+    const command = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    expect(command).toBe("/ludics-health-check");
 
     const items = readQueue();
     expect(items).toHaveLength(2);
     expect(items[0]!.action).toBe("health-check");
     expect(items[1]!.action).toBe("message");
     expect(items[1]!.content).toBe("/compact");
+  });
+
+  test("gate-skipped delivery does not append /compact", async () => {
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+
+    // Seed a prior snapshot so the gate has an anchor to compare against.
+    // With currentLines == priorLines (delta 0), the gate skips.
+    const eventsFile = join(getTmpDir(), "journal", "events.jsonl");
+    mkdirSync(join(getTmpDir(), "journal"), { recursive: true });
+    writeFileSync(eventsFile, '{"event_type":"placeholder"}\n');
+    const snapPath = join(getTmpDir(), "mag", "health-last.json");
+    writeFileSync(snapPath, JSON.stringify({ eventsJsonlLines: 1 }));
+
+    await runMag(["health-check"]);
+    const before = readQueue();
+    expect(before).toHaveLength(1);
+
+    const command = await resolveQueueRequestCommand({ action: "health-check" }, true);
+    expect(command).toBeNull();
+
+    const after = readQueue();
+    expect(after).toHaveLength(1);
+    expect(after[0]!.action).toBe("health-check");
   });
 });
 

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -138,7 +138,7 @@ describe("runMag health-check auto-compact follow-up", () => {
     // health-check resolves to its skill command and the auto-compact
     // follow-up is enqueued.
     const popped = queuePopExpected();
-    expect(popped.status).toBe("popped");
+    if (popped.status !== "popped") throw new Error(`expected popped, got ${popped.status}`);
     const command = await resolveQueueRequestCommand(popped.request!, true);
     expect(command).toBe("/ludics-health-check");
 
@@ -163,7 +163,7 @@ describe("runMag health-check auto-compact follow-up", () => {
 
     // Pop the head (health-check) as production does, then resolve.
     const popped = queuePopExpected();
-    expect(popped.status).toBe("popped");
+    if (popped.status !== "popped") throw new Error(`expected popped, got ${popped.status}`);
     expect((popped.request as { action: string }).action).toBe("health-check");
 
     const command = await resolveQueueRequestCommand(popped.request!, true);

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1524,6 +1524,11 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
       } catch (err) {
         console.error("ludics: test health check failed:", err);
       }
+      // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
+      // docs/proposals/auto-compact-after-checkpoints.md). Coupled to the gate
+      // here so idle ticks that skip the health-check do not also fire a
+      // no-op /compact.
+      queueRequest({ action: "message", content: "/compact" });
     }
   }
 
@@ -3890,10 +3895,9 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
       return;
     }
     queueRequest({ action: "health-check" });
-    // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
-    // docs/proposals/auto-compact-after-checkpoints.md). Enqueued unconditionally;
-    // a no-op /compact on a small context is acceptable.
-    queueRequest({ action: "message", content: "/compact" });
+    // /compact is enqueued by the gate-check path in resolveQueueRequestCommand
+    // only when the health-check actually runs (gate did not skip). Coupling
+    // /compact to a real checkpoint avoids spurious compactions on idle ticks.
     console.log("Queued health-check request");
   }],
   ["message", (args) => {

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -11,7 +11,7 @@ import { atomicWriteFileSync, isPlainObject, writeJsonFile, writeJsonFileCompact
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults } from "./queue.ts";
+import { queueRequest, queueRequestAtHead, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -1527,8 +1527,10 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
       // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
       // docs/proposals/auto-compact-after-checkpoints.md). Coupled to the gate
       // here so idle ticks that skip the health-check do not also fire a
-      // no-op /compact.
-      queueRequest({ action: "message", content: "/compact" });
+      // no-op /compact. Head-insert (not tail-append) preserves the
+      // health-check → /compact → next ordering even when other requests
+      // landed on the queue tail between health-check enqueue and dispatch.
+      queueRequestAtHead({ action: "message", content: "/compact" });
     }
   }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -177,6 +177,22 @@ export function queueReinsertHead(line: string): void {
 }
 
 /**
+ * Like queueRequest, but prepends to the queue head instead of appending to
+ * the tail. Used to enforce ordering when one dispatched request must enqueue
+ * a follow-up that runs *before* anything that landed in the tail meanwhile
+ * (e.g., health-check coupling /compact directly behind itself — see
+ * docs/proposals/auto-compact-after-checkpoints.md).
+ */
+export function queueRequestAtHead(req: QueueAction): string {
+  const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const requestId = nextRequestId();
+  const record = { id: requestId, ...req, timestamp };
+  queueReinsertHead(JSON.stringify(record));
+  emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action: req.action, message: requestId });
+  return requestId;
+}
+
+/**
  * Re-fire helper (gh-ludics-535): mint a fresh request id (same shape as
  * queueRequest's `req-<epoch>-<counter>`), stamp the original id as
  * `re-fired-from` provenance, and reinsert at the queue head. Returns the


### PR DESCRIPTION
## Summary
- `mag health-check` CLI used to enqueue both `health-check` and a follow-up `message: /compact` unconditionally; when the activity-volume gate skipped the health-check at delivery time, the sibling `/compact` was already queued and still fired, producing spurious compactions on idle ticks.
- Move the `/compact` enqueue from the CLI command into the gate-check path in `resolveQueueRequestCommand`, after the skip decision. `/compact` now follows only when the health-check actually runs.
- Briefing's auto-`/compact` is unchanged — briefing has no gate, so coupling there would have no effect.

## Behaviour change vs. task-a00fc0d9
The original auto-compact-after-checkpoints proposal said the follow-up was "enqueued unconditionally; a no-op `/compact` on a small context is acceptable." That was true when every checkpoint actually ran. Once the health-check gate (gh-ludics-???) started skipping idle ticks, the unconditional enqueue meant `/compact` ran *more* often than its checkpoint did. This PR restores the original 1:1 intent: one checkpoint, one compaction.

## Test plan
- [x] `bun test src/mag-auto-compact.test.ts src/mag-health-gate.test.ts` — 14 pass
- [x] `bun test src/mag` — 147 pass (full mag suite)
- [x] `bun test` — 2550 pass / 0 fail (full suite)
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)