### PR TITLE
fix(lint:vendor-sync): freshen node_modules before comparing (gh-ludics-531)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Type check
         run: bun run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 node_modules/
 ludics-ts
 bin/
-bun.lock
+# bun.lock is tracked: `bun install --frozen-lockfile` (used by CI and the
+# lint:vendor-sync freshen step) is a silent no-op without a lockfile to
+# freeze, which would let transitive resolution drift on every CI run.
+# See gh-ludics-531 for the failure mode.
 dist/
 *.tsbuildinfo
 .test-tmp-*

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,330 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ludics",
+      "dependencies": {
+        "isomorphic-dompurify": "3.10.0",
+        "marked": "18.0.2",
+        "yaml": "^2.8.2",
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.22.0",
+        "@types/bun": "latest",
+        "eslint": "^9.22.0",
+        "typescript": "^5.7",
+        "typescript-eslint": "^8.26.0",
+      },
+    },
+  },
+  "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.1", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.4", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/type-utils": "8.58.0", "@typescript-eslint/utils": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.58.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.58.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.58.0", "@typescript-eslint/types": "^8.58.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0" } }, "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.58.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.58.0", "", {}, "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.58.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.58.0", "@typescript-eslint/tsconfig-utils": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/visitor-keys": "8.58.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.58.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.58.0", "@typescript-eslint/types": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.58.0", "", { "dependencies": { "@typescript-eslint/types": "8.58.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "dompurify": ["dompurify@3.4.3", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isomorphic-dompurify": ["isomorphic-dompurify@3.10.0", "", { "dependencies": { "dompurify": "^3.4.1", "jsdom": "^29.0.2" } }, "sha512-Gj2duy4dACsP/FLPvwJ3+MXTlGtOo+O4yfpA0jdxuz/sZlbZzazGzScajOHRwH7PCy4j3bh5ibLGJY4/Rb5kGQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
+
+    "marked": ["marked@18.0.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tldts": ["tldts@7.0.30", "", { "dependencies": { "tldts-core": "^7.0.30" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw=="],
+
+    "tldts-core": ["tldts-core@7.0.30", "", {}, "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.58.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.0", "@typescript-eslint/parser": "8.58.0", "@typescript-eslint/typescript-estree": "8.58.0", "@typescript-eslint/utils": "8.58.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA=="],
+
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/scripts/lint-vendor-sync.test.ts
+++ b/scripts/lint-vendor-sync.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "bun";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkPairs, formatViolation, PAIRS, type Pair } from "./lint-vendor-sync.ts";
+import { checkPairs, formatViolation, PAIRS, DEFAULT_FRESHEN_CMD, type Pair } from "./lint-vendor-sync.ts";
 
 /** Build a tmp repo-root layout with the listed files (parent dirs auto-created).
  *  Hermetic: nothing in `node_modules/` of the real repo is read. */
@@ -265,6 +265,166 @@ describe("CLI integration", () => {
     } finally {
       cleanup();
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // gh-ludics-531: freshen step (`bun install --frozen-lockfile`) before lint
+  // runs. Three cases pinned here:
+  //   (1) The spawn fires when neither argRoot nor CI are set and the test
+  //       seam forces the spawn with a fake install command.
+  //   (2) A failing freshen is a HARD error: non-zero exit + the diagnostic
+  //       sentence the AC mandates + the captured stderr.
+  //   (3) argRoot WITHOUT the test-seam env var does NOT spawn — the gate
+  //       that protects existing hermetic tests stays intact.
+  // -------------------------------------------------------------------------
+  test("freshen step runs `bun install --frozen-lockfile` before checkPairs (LUDICS_VENDOR_SYNC_INSTALL_CMD seam pins existence)", () => {
+    const { root, cleanup } = makeFixture({
+      "templates/dashboard/vendor/marked.esm.js": "MARKED\n",
+      "node_modules/marked/lib/marked.esm.js": "MARKED\n",
+      "templates/dashboard/vendor/purify.es.js": "PURIFY\n",
+      "node_modules/dompurify/dist/purify.es.mjs": "PURIFY\n",
+    });
+    const sentinel = join(root, "FRESHEN_INVOKED");
+    try {
+      // Fake `bun install --frozen-lockfile`: records its argv into a file so
+      // the test can assert the freshen step ran with the AC-mandated flag.
+      const installCmd = JSON.stringify([
+        "sh",
+        "-c",
+        `printf '%s %s %s' "$0" "$1" "$2" > "${sentinel}"`,
+        "bun",
+        "install",
+        "--frozen-lockfile",
+      ]);
+      const result = spawnSync({
+        cmd: ["bun", "run", join(import.meta.dir, "lint-vendor-sync.ts"), root],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, LUDICS_VENDOR_SYNC_INSTALL_CMD: installCmd },
+      });
+      if (result.exitCode !== 0) {
+        console.error(result.stderr.toString());
+        console.error(result.stdout.toString());
+      }
+      expect(result.exitCode).toBe(0);
+      // The freshen step actually executed: the fake install wrote the sentinel.
+      // If a future refactor removes the spawn, the sentinel won't appear and
+      // this assertion fails — that's the invariant the AC names.
+      expect(existsSync(sentinel)).toBe(true);
+      expect(readFileSync(sentinel, "utf8")).toBe(
+        "bun install --frozen-lockfile",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("offline / failed install is a HARD error: non-zero exit + 'vendor sync indeterminate' diagnostic + captured stderr", () => {
+    const { root, cleanup } = makeFixture({
+      "templates/dashboard/vendor/marked.esm.js": "MARKED\n",
+      "node_modules/marked/lib/marked.esm.js": "MARKED\n",
+      "templates/dashboard/vendor/purify.es.js": "PURIFY\n",
+      "node_modules/dompurify/dist/purify.es.mjs": "PURIFY\n",
+    });
+    try {
+      // Simulate offline / registry-unreachable by making the install command
+      // print to stderr and exit non-zero.
+      const installCmd = JSON.stringify([
+        "sh",
+        "-c",
+        "printf 'fake registry unreachable\\n' >&2; exit 1",
+      ]);
+      const result = spawnSync({
+        cmd: ["bun", "run", join(import.meta.dir, "lint-vendor-sync.ts"), root],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, LUDICS_VENDOR_SYNC_INSTALL_CMD: installCmd },
+      });
+      // Hard fail: exit non-zero. A silent skip would have let checkPairs run
+      // and (since fixtures match) returned 0 — that's the failure mode the
+      // AC excludes.
+      expect(result.exitCode).not.toBe(0);
+      const stderr = result.stderr.toString();
+      expect(stderr).toContain(
+        "could not refresh node_modules; vendor sync indeterminate",
+      );
+      // Captured stderr from the failing install propagates so the developer
+      // can act on the underlying error.
+      expect(stderr).toContain("fake registry unreachable");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("argRoot without test-seam env var does NOT spawn — hermetic-test gate intact", () => {
+    // If a future refactor breaks the `argRoot` gate, the freshen step would
+    // run with the real `bun install --frozen-lockfile` against the host's
+    // node_modules — the exact non-hermetic behaviour the AC forbids. Using
+    // a fake install via the env-var seam would mask the regression, so this
+    // test must NOT set LUDICS_VENDOR_SYNC_INSTALL_CMD. Instead, we install
+    // a poisoned `bun` on PATH that exits non-zero with a known stderr
+    // sentinel: if the freshen runs, the lint exits non-zero AND prints the
+    // sentinel; if the gate holds, neither happens.
+    const { root, cleanup } = makeFixture({
+      "templates/dashboard/vendor/marked.esm.js": "M\n",
+      "node_modules/marked/lib/marked.esm.js": "M\n",
+      "templates/dashboard/vendor/purify.es.js": "P\n",
+      "node_modules/dompurify/dist/purify.es.mjs": "P\n",
+    });
+    const fakeBinDir = mkdtempSync(join(tmpdir(), "lint-vendor-sync-fakebin-"));
+    const fakeBunPath = join(fakeBinDir, "bun");
+    const realBunPath = process.execPath;
+    // Fake bun: if invoked with `install` as first arg, exit non-zero with a
+    // sentinel stderr. Otherwise delegate to real bun (so `bun run script.ts`
+    // still works for the lint itself).
+    writeFileSync(
+      fakeBunPath,
+      `#!/bin/sh
+if [ "$1" = "install" ]; then
+  printf 'POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY\\n' >&2
+  exit 99
+fi
+exec ${JSON.stringify(realBunPath)} "$@"
+`,
+      { mode: 0o755 },
+    );
+    try {
+      const result = spawnSync({
+        cmd: [
+          realBunPath,
+          "run",
+          join(import.meta.dir, "lint-vendor-sync.ts"),
+          root,
+        ],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          // No LUDICS_VENDOR_SYNC_INSTALL_CMD, no CI: the gate must rely
+          // solely on argRoot to skip the freshen.
+          CI: "",
+          LUDICS_VENDOR_SYNC_INSTALL_CMD: "",
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.toString()).not.toContain(
+        "POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY",
+      );
+    } finally {
+      cleanup();
+      rmSync(fakeBinDir, { recursive: true, force: true });
+    }
+  });
+
+  test("DEFAULT_FRESHEN_CMD carries the AC-mandated `--frozen-lockfile` flag", () => {
+    // Pins the production install command's shape: any future refactor that
+    // drops `--frozen-lockfile` from the default would let `bun install`
+    // rewrite the lockfile (one of the failure modes the AC closes).
+    expect(DEFAULT_FRESHEN_CMD).toEqual(["bun", "install", "--frozen-lockfile"]);
   });
 
   test("exits non-zero with bun-install hint when upstream is missing", () => {

--- a/scripts/lint-vendor-sync.test.ts
+++ b/scripts/lint-vendor-sync.test.ts
@@ -269,134 +269,182 @@ describe("CLI integration", () => {
 
   // -------------------------------------------------------------------------
   // gh-ludics-531: freshen step (`bun install --frozen-lockfile`) before lint
-  // runs. Three cases pinned here:
-  //   (1) The spawn fires when neither argRoot nor CI are set and the test
-  //       seam forces the spawn with a fake install command.
-  //   (2) A failing freshen is a HARD error: non-zero exit + the diagnostic
-  //       sentence the AC mandates + the captured stderr.
-  //   (3) argRoot WITHOUT the test-seam env var does NOT spawn — the gate
-  //       that protects existing hermetic tests stays intact.
+  // runs. The production gate is strict — `argRoot` OR `CI` skip the freshen,
+  // unconditionally — so these tests drive the bare no-arg CLI path via a
+  // `PATH`-shimmed fake `bun`. The fake intercepts `install --frozen-lockfile`
+  // and either succeeds (positive case) or fails with a sentinel stderr
+  // (hard-fail case), without touching the host's real `node_modules/`.
+  //
+  // Three cases pinned here:
+  //   (1) Bare no-argRoot CLI invocation freshens before checkPairs (fake
+  //       install records its argv to a sentinel + exits 0).
+  //   (2) Failed freshen is a HARD error: non-zero exit + diagnostic +
+  //       captured stderr, and checkPairs is NEVER reached (ordering pin).
+  //   (3) argRoot DOES skip the freshen (poisoned-bun gate proof).
+  //   (4) CI=1 DOES skip the freshen (gate symmetry).
   // -------------------------------------------------------------------------
-  test("freshen step runs `bun install --frozen-lockfile` before checkPairs (LUDICS_VENDOR_SYNC_INSTALL_CMD seam pins existence)", () => {
-    const { root, cleanup } = makeFixture({
-      "templates/dashboard/vendor/marked.esm.js": "MARKED\n",
-      "node_modules/marked/lib/marked.esm.js": "MARKED\n",
-      "templates/dashboard/vendor/purify.es.js": "PURIFY\n",
-      "node_modules/dompurify/dist/purify.es.mjs": "PURIFY\n",
+
+  /** Build a tmp PATH-shim directory containing a fake `bun` script that
+   *  intercepts `install --frozen-lockfile` per `behaviour`, and delegates
+   *  anything else to the real bun (so `realBunPath run script.ts` continues
+   *  to work). Returns the dir + a cleanup hook. */
+  function makeFakeBun(behaviour: { kind: "ok"; sentinelPath: string } | { kind: "fail"; stderr: string }): {
+    fakeBinDir: string;
+    cleanup: () => void;
+  } {
+    const fakeBinDir = mkdtempSync(join(tmpdir(), "lint-vendor-sync-fakebun-"));
+    const fakeBunPath = join(fakeBinDir, "bun");
+    const realBunPath = process.execPath;
+    let body: string;
+    if (behaviour.kind === "ok") {
+      // Record the argv so the test can assert the spawned command was
+      // exactly `bun install --frozen-lockfile`.
+      body = `#!/bin/sh
+if [ "$1" = "install" ] && [ "$2" = "--frozen-lockfile" ]; then
+  printf 'bun %s %s\\n' "$1" "$2" > ${JSON.stringify(behaviour.sentinelPath)}
+  exit 0
+fi
+# Any other invocation: passthrough so \`bun run ...\` still works for the lint
+# script itself when the parent invokes us by absolute path is unaffected.
+exec ${JSON.stringify(realBunPath)} "$@"
+`;
+    } else {
+      body = `#!/bin/sh
+if [ "$1" = "install" ]; then
+  printf '%s\\n' ${JSON.stringify(behaviour.stderr)} >&2
+  exit 1
+fi
+exec ${JSON.stringify(realBunPath)} "$@"
+`;
+    }
+    writeFileSync(fakeBunPath, body, { mode: 0o755 });
+    return {
+      fakeBinDir,
+      cleanup: () => rmSync(fakeBinDir, { recursive: true, force: true }),
+    };
+  }
+
+  test("bare no-argRoot CLI freshens with `bun install --frozen-lockfile` before checkPairs (PATH-shim pins existence)", () => {
+    // This is the AC4 positive regression: invoke the script with NO
+    // positional arg (so production gate evaluates `!argRoot && !CI` → true),
+    // and prove the spawn fires with the AC-mandated flag. The PATH-shimmed
+    // fake bun records the argv to a sentinel file; removing the freshen
+    // call from `import.meta.main` would leave the sentinel unwritten and
+    // this assertion would fail.
+    const sentinelDir = mkdtempSync(join(tmpdir(), "lint-vendor-sync-sentinel-"));
+    const sentinel = join(sentinelDir, "FRESHEN_INVOKED");
+    const { fakeBinDir, cleanup: cleanupBin } = makeFakeBun({
+      kind: "ok",
+      sentinelPath: sentinel,
     });
-    const sentinel = join(root, "FRESHEN_INVOKED");
+    const realBunPath = process.execPath;
     try {
-      // Fake `bun install --frozen-lockfile`: records its argv into a file so
-      // the test can assert the freshen step ran with the AC-mandated flag.
-      const installCmd = JSON.stringify([
-        "sh",
-        "-c",
-        `printf '%s %s %s' "$0" "$1" "$2" > "${sentinel}"`,
-        "bun",
-        "install",
-        "--frozen-lockfile",
-      ]);
       const result = spawnSync({
-        cmd: ["bun", "run", join(import.meta.dir, "lint-vendor-sync.ts"), root],
+        // NO third arg → argRoot undefined → freshen gate fires.
+        cmd: [realBunPath, "run", join(import.meta.dir, "lint-vendor-sync.ts")],
         cwd: join(import.meta.dir, ".."),
         stdout: "pipe",
         stderr: "pipe",
-        env: { ...process.env, LUDICS_VENDOR_SYNC_INSTALL_CMD: installCmd },
+        env: {
+          ...process.env,
+          // PATH-shim: fake bun shadows the real one for the child process
+          // (and any subprocess it spawns by bare name `bun`). The outer
+          // realBunPath invocation is absolute so it bypasses PATH lookup.
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          // Explicitly unset CI so the gate has nothing else to skip on.
+          CI: "",
+        },
       });
       if (result.exitCode !== 0) {
         console.error(result.stderr.toString());
         console.error(result.stdout.toString());
       }
       expect(result.exitCode).toBe(0);
-      // The freshen step actually executed: the fake install wrote the sentinel.
-      // If a future refactor removes the spawn, the sentinel won't appear and
-      // this assertion fails — that's the invariant the AC names.
+      // The freshen step actually executed: the fake install wrote the
+      // sentinel. If a future refactor removes the spawn (or moves it after
+      // an early-exit path), the sentinel won't appear.
       expect(existsSync(sentinel)).toBe(true);
+      // Byte-exact argv recorded by the fake: any drift in the default
+      // install command (e.g. dropping `--frozen-lockfile`) flips this.
       expect(readFileSync(sentinel, "utf8")).toBe(
-        "bun install --frozen-lockfile",
+        "bun install --frozen-lockfile\n",
       );
+      // checkPairs also ran (after the freshen): the success message in
+      // stdout proves we reached the post-freshen branch.
+      expect(result.stdout.toString()).toContain("byte-for-byte");
     } finally {
-      cleanup();
+      cleanupBin();
+      rmSync(sentinelDir, { recursive: true, force: true });
     }
   });
 
-  test("offline / failed install is a HARD error: non-zero exit + 'vendor sync indeterminate' diagnostic + captured stderr", () => {
-    const { root, cleanup } = makeFixture({
-      "templates/dashboard/vendor/marked.esm.js": "MARKED\n",
-      "node_modules/marked/lib/marked.esm.js": "MARKED\n",
-      "templates/dashboard/vendor/purify.es.js": "PURIFY\n",
-      "node_modules/dompurify/dist/purify.es.mjs": "PURIFY\n",
+  test("failed freshen is a HARD error: non-zero exit + 'vendor sync indeterminate' diagnostic + captured stderr + checkPairs NEVER runs", () => {
+    // AC2: when `bun install --frozen-lockfile` fails (offline / broken
+    // install / lockfile mismatch), the lint exits non-zero with the AC's
+    // exact diagnostic sentence, propagates the install stderr, and
+    // critically does NOT fall through to checkPairs — so the developer
+    // can't be misled by a passing byte-compare against a stale install.
+    const { fakeBinDir, cleanup: cleanupBin } = makeFakeBun({
+      kind: "fail",
+      stderr: "fake registry unreachable",
     });
+    const realBunPath = process.execPath;
     try {
-      // Simulate offline / registry-unreachable by making the install command
-      // print to stderr and exit non-zero.
-      const installCmd = JSON.stringify([
-        "sh",
-        "-c",
-        "printf 'fake registry unreachable\\n' >&2; exit 1",
-      ]);
       const result = spawnSync({
-        cmd: ["bun", "run", join(import.meta.dir, "lint-vendor-sync.ts"), root],
+        cmd: [realBunPath, "run", join(import.meta.dir, "lint-vendor-sync.ts")],
         cwd: join(import.meta.dir, ".."),
         stdout: "pipe",
         stderr: "pipe",
-        env: { ...process.env, LUDICS_VENDOR_SYNC_INSTALL_CMD: installCmd },
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          CI: "",
+        },
       });
-      // Hard fail: exit non-zero. A silent skip would have let checkPairs run
-      // and (since fixtures match) returned 0 — that's the failure mode the
-      // AC excludes.
       expect(result.exitCode).not.toBe(0);
       const stderr = result.stderr.toString();
+      // The exact AC2 diagnostic sentence.
       expect(stderr).toContain(
         "could not refresh node_modules; vendor sync indeterminate",
       );
-      // Captured stderr from the failing install propagates so the developer
-      // can act on the underlying error.
+      // Captured `bun install` stderr propagates.
       expect(stderr).toContain("fake registry unreachable");
+      // Ordering pin: checkPairs did NOT run. Its success message
+      // ("byte-for-byte") and its violation banner ("vendor-sync violation")
+      // are both absent — proving the freshen-failure short-circuits BEFORE
+      // any byte compare.
+      expect(stderr).not.toContain("vendor-sync violation");
+      expect(result.stdout.toString()).not.toContain("byte-for-byte");
     } finally {
-      cleanup();
+      cleanupBin();
     }
   });
 
-  test("argRoot without test-seam env var does NOT spawn — hermetic-test gate intact", () => {
-    // If a future refactor breaks the `argRoot` gate, the freshen step would
-    // run with the real `bun install --frozen-lockfile` against the host's
-    // node_modules — the exact non-hermetic behaviour the AC forbids. Using
-    // a fake install via the env-var seam would mask the regression, so this
-    // test must NOT set LUDICS_VENDOR_SYNC_INSTALL_CMD. Instead, we install
-    // a poisoned `bun` on PATH that exits non-zero with a known stderr
-    // sentinel: if the freshen runs, the lint exits non-zero AND prints the
-    // sentinel; if the gate holds, neither happens.
+  test("argRoot skips the freshen (gate proof via PATH-shimmed poisoned `bun`)", () => {
+    // If a future refactor breaks the `argRoot` gate, the freshen step
+    // would run against the host's real `node_modules/` — the exact
+    // non-hermetic behaviour the AC forbids. Use a poisoned fake bun that
+    // exits non-zero with a sentinel stderr: if the freshen runs, the lint
+    // exits non-zero AND prints the sentinel; if the gate holds, the lint
+    // skips the freshen and exits 0 against the tmp fixture.
     const { root, cleanup } = makeFixture({
       "templates/dashboard/vendor/marked.esm.js": "M\n",
       "node_modules/marked/lib/marked.esm.js": "M\n",
       "templates/dashboard/vendor/purify.es.js": "P\n",
       "node_modules/dompurify/dist/purify.es.mjs": "P\n",
     });
-    const fakeBinDir = mkdtempSync(join(tmpdir(), "lint-vendor-sync-fakebin-"));
-    const fakeBunPath = join(fakeBinDir, "bun");
+    const { fakeBinDir, cleanup: cleanupBin } = makeFakeBun({
+      kind: "fail",
+      stderr: "POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY",
+    });
     const realBunPath = process.execPath;
-    // Fake bun: if invoked with `install` as first arg, exit non-zero with a
-    // sentinel stderr. Otherwise delegate to real bun (so `bun run script.ts`
-    // still works for the lint itself).
-    writeFileSync(
-      fakeBunPath,
-      `#!/bin/sh
-if [ "$1" = "install" ]; then
-  printf 'POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY\\n' >&2
-  exit 99
-fi
-exec ${JSON.stringify(realBunPath)} "$@"
-`,
-      { mode: 0o755 },
-    );
     try {
       const result = spawnSync({
         cmd: [
           realBunPath,
           "run",
           join(import.meta.dir, "lint-vendor-sync.ts"),
-          root,
+          root, // argRoot present → gate should skip freshen
         ],
         cwd: join(import.meta.dir, ".."),
         stdout: "pipe",
@@ -404,10 +452,7 @@ exec ${JSON.stringify(realBunPath)} "$@"
         env: {
           ...process.env,
           PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
-          // No LUDICS_VENDOR_SYNC_INSTALL_CMD, no CI: the gate must rely
-          // solely on argRoot to skip the freshen.
           CI: "",
-          LUDICS_VENDOR_SYNC_INSTALL_CMD: "",
         },
       });
       expect(result.exitCode).toBe(0);
@@ -416,7 +461,39 @@ exec ${JSON.stringify(realBunPath)} "$@"
       );
     } finally {
       cleanup();
-      rmSync(fakeBinDir, { recursive: true, force: true });
+      cleanupBin();
+    }
+  });
+
+  test("CI=1 skips the freshen (gate symmetry, also pins production behaviour on CI)", () => {
+    // The other half of the AC1 gate: when `process.env.CI` is set, the
+    // freshen MUST be skipped (CI's own `Install dependencies` step is
+    // authoritative; a second spawn is pure overhead). Same poisoned-bun
+    // mechanism as the argRoot test, but here we drive the no-argRoot
+    // path with CI=1 instead.
+    const { fakeBinDir, cleanup: cleanupBin } = makeFakeBun({
+      kind: "fail",
+      stderr: "POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY",
+    });
+    const realBunPath = process.execPath;
+    try {
+      const result = spawnSync({
+        cmd: [realBunPath, "run", join(import.meta.dir, "lint-vendor-sync.ts")],
+        cwd: join(import.meta.dir, ".."),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          CI: "1", // CI gate fires → freshen skipped
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr.toString()).not.toContain(
+        "POISONED_BUN_INSTALL_RAN_UNEXPECTEDLY",
+      );
+    } finally {
+      cleanupBin();
     }
   });
 

--- a/scripts/lint-vendor-sync.ts
+++ b/scripts/lint-vendor-sync.ts
@@ -134,13 +134,94 @@ export function formatViolation(v: Violation): string {
   }
 }
 
+/** Default install command run by `freshenNodeModules`. `--frozen-lockfile` is
+ *  mandatory: this command must never mutate `bun.lock`, only resolve it. */
+export const DEFAULT_FRESHEN_CMD: ReadonlyArray<string> = [
+  "bun",
+  "install",
+  "--frozen-lockfile",
+];
+
+/** Spawns `bun install --frozen-lockfile` to bring `node_modules/` in line with
+ *  the locked resolution before `checkPairs` runs. The drift this closes is
+ *  documented in gh-ludics-531: stale local `node_modules/` masks vendored-vs-
+ *  upstream skew because the byte compare passes against the leftover install,
+ *  while CI starts cold and surfaces the failure on an unrelated PR.
+ *
+ *  Test seam: `LUDICS_VENDOR_SYNC_INSTALL_CMD` (a JSON-encoded string array)
+ *  swaps the spawned argv. Only used by `lint-vendor-sync.test.ts` to drive
+ *  this code path without invoking the real `bun install` against the host. */
+export function freshenNodeModules(
+  cwd: string,
+): { ok: true } | { ok: false; stderr: string } {
+  const override = process.env.LUDICS_VENDOR_SYNC_INSTALL_CMD;
+  let cmd: string[];
+  if (override) {
+    try {
+      const parsed = JSON.parse(override);
+      if (!Array.isArray(parsed) || parsed.some((s) => typeof s !== "string")) {
+        return {
+          ok: false,
+          stderr: `LUDICS_VENDOR_SYNC_INSTALL_CMD must be a JSON array of strings, got: ${override}`,
+        };
+      }
+      cmd = parsed;
+    } catch (e) {
+      return { ok: false, stderr: `LUDICS_VENDOR_SYNC_INSTALL_CMD JSON parse error: ${String(e)}` };
+    }
+  } else {
+    cmd = [...DEFAULT_FRESHEN_CMD];
+  }
+  try {
+    const result = Bun.spawnSync({ cmd, cwd, stdout: "pipe", stderr: "pipe" });
+    if (result.exitCode !== 0) {
+      return { ok: false, stderr: result.stderr?.toString() ?? "" };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, stderr: String(e) };
+  }
+}
+
 if (import.meta.main) {
   // Optional first positional arg overrides the repo root, which lets tests
   // exercise the real CLI exit-code paths against a temp directory built with
   // the same `templates/dashboard/vendor/...` + `node_modules/...` shape that
   // PAIRS expects. Mirrors `lint-template-safety.ts`'s argv override.
   const argRoot = process.argv[2];
-  const root = argRoot ? argRoot : join(import.meta.dir, "..");
+  const repoRoot = join(import.meta.dir, "..");
+  const root = argRoot ? argRoot : repoRoot;
+  // Freshen `node_modules/` before comparing so a stale local install can't
+  // mask drift between the vendored copies and the actually-locked resolution
+  // (gh-ludics-531). The gate skips the freshen when:
+  //   - `process.env.CI` is set: CI's `Install dependencies` step already
+  //     produced a fresh, frozen-lockfile install, so a second spawn is pure
+  //     overhead on the critical path.
+  //   - `argRoot` is provided: hermetic tests drive a tmp fixture root and
+  //     must not mutate the host's `node_modules/`.
+  // The `LUDICS_VENDOR_SYNC_INSTALL_CMD` env var force-enables the freshen
+  // step with a swapped command — the test seam that drives this branch
+  // without invoking real `bun install`.
+  const forceFreshen = !!process.env.LUDICS_VENDOR_SYNC_INSTALL_CMD;
+  const shouldFreshen = forceFreshen || (!argRoot && !process.env.CI);
+  if (shouldFreshen) {
+    const freshen = freshenNodeModules(argRoot ?? repoRoot);
+    if (!freshen.ok) {
+      console.error(
+        "❌  could not refresh node_modules; vendor sync indeterminate",
+      );
+      if (freshen.stderr) {
+        console.error(freshen.stderr);
+      }
+      console.error(
+        "\n     `bun install --frozen-lockfile` failed before the lint could run.\n" +
+        "     This usually means: offline / no registry access, a broken bun\n" +
+        "     install, or a lockfile that doesn't match `package.json`.\n" +
+        "     Fix the install error above, then re-run `bun run lint:vendor-sync`.\n",
+      );
+      process.exit(1);
+    }
+  }
   const violations = checkPairs(root);
   if (violations.length === 0) {
     console.log(

--- a/scripts/lint-vendor-sync.ts
+++ b/scripts/lint-vendor-sync.ts
@@ -148,32 +148,20 @@ export const DEFAULT_FRESHEN_CMD: ReadonlyArray<string> = [
  *  upstream skew because the byte compare passes against the leftover install,
  *  while CI starts cold and surfaces the failure on an unrelated PR.
  *
- *  Test seam: `LUDICS_VENDOR_SYNC_INSTALL_CMD` (a JSON-encoded string array)
- *  swaps the spawned argv. Only used by `lint-vendor-sync.test.ts` to drive
- *  this code path without invoking the real `bun install` against the host. */
+ *  This function has no test-seam env vars: tests drive the spawn path by
+ *  `PATH`-shimming a fake `bun` that intercepts `install --frozen-lockfile`.
+ *  Keeping the seam out of production code preserves the AC1 gate — only
+ *  `!argRoot && !process.env.CI` decides whether the freshen runs. */
 export function freshenNodeModules(
   cwd: string,
 ): { ok: true } | { ok: false; stderr: string } {
-  const override = process.env.LUDICS_VENDOR_SYNC_INSTALL_CMD;
-  let cmd: string[];
-  if (override) {
-    try {
-      const parsed = JSON.parse(override);
-      if (!Array.isArray(parsed) || parsed.some((s) => typeof s !== "string")) {
-        return {
-          ok: false,
-          stderr: `LUDICS_VENDOR_SYNC_INSTALL_CMD must be a JSON array of strings, got: ${override}`,
-        };
-      }
-      cmd = parsed;
-    } catch (e) {
-      return { ok: false, stderr: `LUDICS_VENDOR_SYNC_INSTALL_CMD JSON parse error: ${String(e)}` };
-    }
-  } else {
-    cmd = [...DEFAULT_FRESHEN_CMD];
-  }
   try {
-    const result = Bun.spawnSync({ cmd, cwd, stdout: "pipe", stderr: "pipe" });
+    const result = Bun.spawnSync({
+      cmd: [...DEFAULT_FRESHEN_CMD],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
     if (result.exitCode !== 0) {
       return { ok: false, stderr: result.stderr?.toString() ?? "" };
     }
@@ -199,13 +187,12 @@ if (import.meta.main) {
   //     overhead on the critical path.
   //   - `argRoot` is provided: hermetic tests drive a tmp fixture root and
   //     must not mutate the host's `node_modules/`.
-  // The `LUDICS_VENDOR_SYNC_INSTALL_CMD` env var force-enables the freshen
-  // step with a swapped command — the test seam that drives this branch
-  // without invoking real `bun install`.
-  const forceFreshen = !!process.env.LUDICS_VENDOR_SYNC_INSTALL_CMD;
-  const shouldFreshen = forceFreshen || (!argRoot && !process.env.CI);
+  // These are strict skips — there is no production knob that forces the
+  // freshen when either gate fires. Tests that exercise this branch do so
+  // by `PATH`-shimming a fake `bun` while leaving `argRoot` and `CI` unset.
+  const shouldFreshen = !argRoot && !process.env.CI;
   if (shouldFreshen) {
-    const freshen = freshenNodeModules(argRoot ?? repoRoot);
+    const freshen = freshenNodeModules(repoRoot);
     if (!freshen.ok) {
       console.error(
         "❌  could not refresh node_modules; vendor sync indeterminate",

--- a/templates/dashboard/vendor/README.md
+++ b/templates/dashboard/vendor/README.md
@@ -17,12 +17,12 @@ http://localhost:7678/ and copied verbatim by `dashboardInstall` in
 ## purify.es.js
 
 - **Package**: dompurify
-- **Version**: 3.4.3 (pinned transitively via `isomorphic-dompurify@3.10.0`)
+- **Version**: 3.4.5 (pinned transitively via `isomorphic-dompurify@3.10.0`)
 - **License**: Apache-2.0 OR MPL-2.0 (header preserved at top of file)
 - **Upstream**: https://github.com/cure53/DOMPurify
 - **Source**: copied from `node_modules/dompurify/dist/purify.es.mjs`.
   Equivalent CDN URL:
-  https://cdn.jsdelivr.net/npm/dompurify@3.4.3/dist/purify.es.mjs
+  https://cdn.jsdelivr.net/npm/dompurify@3.4.5/dist/purify.es.mjs
 
 ## To bump
 
@@ -31,8 +31,10 @@ http://localhost:7678/ and copied verbatim by `dashboardInstall` in
 3. `cp node_modules/dompurify/dist/purify.es.mjs templates/dashboard/vendor/purify.es.js`.
 4. Update the version numbers above to match.
 5. Run `bun run lint:vendor-sync` to verify the vendored copies match
-   the freshly installed npm copies byte-for-byte. CI runs the same
-   lint, so any skew will fail loudly.
+   the locked npm copies byte-for-byte. The lint refreshes
+   `node_modules/` itself via `bun install --frozen-lockfile`, so it
+   catches drift even on a stale checkout. CI runs the same lint, so
+   any skew will fail loudly.
 6. Re-run `bun test templates/dashboard/markdown.test.ts` to confirm
    the fixture set still passes against the new versions.
 

--- a/templates/dashboard/vendor/README.md
+++ b/templates/dashboard/vendor/README.md
@@ -17,12 +17,12 @@ http://localhost:7678/ and copied verbatim by `dashboardInstall` in
 ## purify.es.js
 
 - **Package**: dompurify
-- **Version**: 3.4.5 (pinned transitively via `isomorphic-dompurify@3.10.0`)
+- **Version**: 3.4.3 (pinned transitively via `isomorphic-dompurify@3.10.0`)
 - **License**: Apache-2.0 OR MPL-2.0 (header preserved at top of file)
 - **Upstream**: https://github.com/cure53/DOMPurify
 - **Source**: copied from `node_modules/dompurify/dist/purify.es.mjs`.
   Equivalent CDN URL:
-  https://cdn.jsdelivr.net/npm/dompurify@3.4.5/dist/purify.es.mjs
+  https://cdn.jsdelivr.net/npm/dompurify@3.4.3/dist/purify.es.mjs
 
 ## To bump
 

--- a/templates/dashboard/vendor/purify.es.js
+++ b/templates/dashboard/vendor/purify.es.js
@@ -1,4 +1,4 @@
-/*! @license DOMPurify 3.4.3 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.3/LICENSE */
+/*! @license DOMPurify 3.4.5 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.5/LICENSE */
 
 function _arrayLikeToArray(r, a) {
   (null == a || a > r.length) && (a = r.length);
@@ -310,7 +310,7 @@ const mathMl$1 = freeze(['math', 'menclose', 'merror', 'mfenced', 'mfrac', 'mgly
 const mathMlDisallowed = freeze(['maction', 'maligngroup', 'malignmark', 'mlongdiv', 'mscarries', 'mscarry', 'msgroup', 'mstack', 'msline', 'msrow', 'semantics', 'annotation', 'annotation-xml', 'mprescripts', 'none']);
 const text = freeze(['#text']);
 
-const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns']);
+const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'command', 'commandfor', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns']);
 const svg = freeze(['accent-height', 'accumulate', 'additive', 'alignment-baseline', 'amplitude', 'ascent', 'attributename', 'attributetype', 'azimuth', 'basefrequency', 'baseline-shift', 'begin', 'bias', 'by', 'class', 'clip', 'clippathunits', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cx', 'cy', 'd', 'dx', 'dy', 'diffuseconstant', 'direction', 'display', 'divisor', 'dur', 'edgemode', 'elevation', 'end', 'exponent', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'filterunits', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'fx', 'fy', 'g1', 'g2', 'glyph-name', 'glyphref', 'gradientunits', 'gradienttransform', 'height', 'href', 'id', 'image-rendering', 'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kerning', 'keypoints', 'keysplines', 'keytimes', 'lang', 'lengthadjust', 'letter-spacing', 'kernelmatrix', 'kernelunitlength', 'lighting-color', 'local', 'marker-end', 'marker-mid', 'marker-start', 'markerheight', 'markerunits', 'markerwidth', 'maskcontentunits', 'maskunits', 'max', 'mask', 'mask-type', 'media', 'method', 'mode', 'min', 'name', 'numoctaves', 'offset', 'operator', 'opacity', 'order', 'orient', 'orientation', 'origin', 'overflow', 'paint-order', 'path', 'pathlength', 'patterncontentunits', 'patterntransform', 'patternunits', 'points', 'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'rx', 'ry', 'radius', 'refx', 'refy', 'repeatcount', 'repeatdur', 'restart', 'result', 'rotate', 'scale', 'seed', 'shape-rendering', 'slope', 'specularconstant', 'specularexponent', 'spreadmethod', 'startoffset', 'stddeviation', 'stitchtiles', 'stop-color', 'stop-opacity', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke', 'stroke-width', 'style', 'surfacescale', 'systemlanguage', 'tabindex', 'tablevalues', 'targetx', 'targety', 'transform', 'transform-origin', 'text-anchor', 'text-decoration', 'text-rendering', 'textlength', 'type', 'u1', 'u2', 'unicode', 'values', 'viewbox', 'visibility', 'version', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'width', 'word-spacing', 'wrap', 'writing-mode', 'xchannelselector', 'ychannelselector', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2', 'z', 'zoomandpan']);
 const mathMl = freeze(['accent', 'accentunder', 'align', 'bevelled', 'close', 'columnalign', 'columnlines', 'columnspacing', 'columnspan', 'denomalign', 'depth', 'dir', 'display', 'displaystyle', 'encoding', 'fence', 'frame', 'height', 'href', 'id', 'largeop', 'length', 'linethickness', 'lquote', 'lspace', 'mathbackground', 'mathcolor', 'mathsize', 'mathvariant', 'maxsize', 'minsize', 'movablelimits', 'notation', 'numalign', 'open', 'rowalign', 'rowlines', 'rowspacing', 'rowspan', 'rspace', 'rquote', 'scriptlevel', 'scriptminsize', 'scriptsizemultiplier', 'selection', 'separator', 'separators', 'stretchy', 'subscriptshift', 'supscriptshift', 'symmetric', 'voffset', 'width', 'xmlns']);
 const xml = freeze(['xlink:href', 'xml:id', 'xlink:title', 'xml:space', 'xmlns:xlink']);
@@ -394,7 +394,7 @@ const _createHooksMap = function _createHooksMap() {
 function createDOMPurify() {
   let window = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getGlobal();
   const DOMPurify = root => createDOMPurify(root);
-  DOMPurify.version = '3.4.3';
+  DOMPurify.version = '3.4.5';
   DOMPurify.removed = [];
   if (!window || !window.document || window.document.nodeType !== NODE_TYPE.document || !window.Element) {
     // Not running in a browser, provide a factory function
@@ -421,6 +421,7 @@ function createDOMPurify() {
   const getNextSibling = lookupGetter(ElementPrototype, 'nextSibling');
   const getChildNodes = lookupGetter(ElementPrototype, 'childNodes');
   const getParentNode = lookupGetter(ElementPrototype, 'parentNode');
+  const getNodeType = Node && Node.prototype ? lookupGetter(Node.prototype, 'nodeType') : null;
   // As per issue #47, the web-components registry is inherited by a
   // new document created via createHTMLDocument. As per the spec
   // (http://w3c.github.io/webcomponents/spec/custom/#creating-and-passing-registries)
@@ -975,6 +976,40 @@ function createDOMPurify() {
     NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT | NodeFilter.SHOW_PROCESSING_INSTRUCTION | NodeFilter.SHOW_CDATA_SECTION, null);
   };
   /**
+   * Strip template-engine expressions ({{...}}, ${...}, <%...%>) from the
+   * character data of an element subtree. Used as the final safety net for
+   * SAFE_FOR_TEMPLATES on every DOM-returning code path so that expressions
+   * which only form after text-node normalization (e.g. fragments split across
+   * stripped elements) cannot survive into a template-evaluating framework.
+   *
+   * Walks text/comment/CDATA/processing-instruction nodes and mutates `.data`
+   * in place rather than round-tripping through innerHTML. This preserves
+   * descendant node references (important for IN_PLACE callers), avoids a
+   * serialize/reparse cycle, and reads literal character data — which means
+   * `<%...%>` in text content matches the ERB regex against its real bytes
+   * instead of the HTML-entity-escaped form innerHTML would produce.
+   *
+   * Attribute values are not visited here; SAFE_FOR_TEMPLATES handling for
+   * attributes is performed during the per-node `_sanitizeAttributes` pass.
+   *
+   * @param node The root element whose character data should be scrubbed.
+   */
+  const _scrubTemplateExpressions = function _scrubTemplateExpressions(node) {
+    node.normalize();
+    const walker = createNodeIterator.call(node.ownerDocument || node, node,
+    // eslint-disable-next-line no-bitwise
+    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_CDATA_SECTION | NodeFilter.SHOW_PROCESSING_INSTRUCTION, null);
+    let currentNode = walker.nextNode();
+    while (currentNode) {
+      let data = currentNode.data;
+      arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
+        data = stringReplace(data, expr, ' ');
+      });
+      currentNode.data = data;
+      currentNode = walker.nextNode();
+    }
+  };
+  /**
    * _isClobbered
    *
    * @param element element to check for clobbering attacks
@@ -984,13 +1019,31 @@ function createDOMPurify() {
     return element instanceof HTMLFormElement && (typeof element.nodeName !== 'string' || typeof element.textContent !== 'string' || typeof element.removeChild !== 'function' || !(element.attributes instanceof NamedNodeMap) || typeof element.removeAttribute !== 'function' || typeof element.setAttribute !== 'function' || typeof element.namespaceURI !== 'string' || typeof element.insertBefore !== 'function' || typeof element.hasChildNodes !== 'function');
   };
   /**
-   * Checks whether the given object is a DOM node.
+   * Checks whether the given object is a DOM node, including nodes that
+   * originate from a different window/realm (e.g. an iframe's
+   * contentDocument). The previous `value instanceof Node` check was
+   * realm-bound: nodes from a different window failed it, causing
+   * sanitize() to silently stringify them and reset IN_PLACE to false,
+   * returning the original node unsanitized. See GHSA-4w3q-35jp-p934.
+   *
+   * Implementation: call the cached `nodeType` getter from Node.prototype
+   * directly on the value. This bypasses any clobbered instance property
+   * (e.g. a child element named "nodeType") and works across realms
+   * because the WebIDL `nodeType` getter reads an internal slot that
+   * every real Node has, regardless of which window minted it.
    *
    * @param value object to check whether it's a DOM node
-   * @return true is object is a DOM node
+   * @return true if value is a DOM node from any realm
    */
   const _isNode = function _isNode(value) {
-    return typeof Node === 'function' && value instanceof Node;
+    if (!getNodeType || typeof value !== 'object' || value === null) {
+      return false;
+    }
+    try {
+      return typeof getNodeType(value) === 'number';
+    } catch (_) {
+      return false;
+    }
   };
   function _executeHooks(hooks, currentNode, data) {
     arrayForEach(hooks, hook => {
@@ -1394,7 +1447,7 @@ function createDOMPurify() {
       /* Sanitize attached shadow roots before the main iterator runs.
          The iterator does not descend into shadow trees. */
       _sanitizeAttachedShadowRoots2(dirty);
-    } else if (dirty instanceof Node) {
+    } else if (_isNode(dirty)) {
       /* If dirty is a DOM element, append to an empty document to avoid
          elements being stripped by the parser */
       body = _initDocument('<!---->');
@@ -1445,17 +1498,15 @@ function createDOMPurify() {
     }
     /* If we sanitized `dirty` in-place, return it. */
     if (IN_PLACE) {
+      if (SAFE_FOR_TEMPLATES) {
+        _scrubTemplateExpressions(dirty);
+      }
       return dirty;
     }
     /* Return sanitized string or DOM */
     if (RETURN_DOM) {
       if (SAFE_FOR_TEMPLATES) {
-        body.normalize();
-        let html = body.innerHTML;
-        arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
-          html = stringReplace(html, expr, ' ');
-        });
-        body.innerHTML = html;
+        _scrubTemplateExpressions(body);
       }
       if (RETURN_DOM_FRAGMENT) {
         returnNode = createDocumentFragment.call(body.ownerDocument);

--- a/templates/dashboard/vendor/purify.es.js
+++ b/templates/dashboard/vendor/purify.es.js
@@ -1,4 +1,4 @@
-/*! @license DOMPurify 3.4.5 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.5/LICENSE */
+/*! @license DOMPurify 3.4.3 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.4.3/LICENSE */
 
 function _arrayLikeToArray(r, a) {
   (null == a || a > r.length) && (a = r.length);
@@ -310,7 +310,7 @@ const mathMl$1 = freeze(['math', 'menclose', 'merror', 'mfenced', 'mfrac', 'mgly
 const mathMlDisallowed = freeze(['maction', 'maligngroup', 'malignmark', 'mlongdiv', 'mscarries', 'mscarry', 'msgroup', 'mstack', 'msline', 'msrow', 'semantics', 'annotation', 'annotation-xml', 'mprescripts', 'none']);
 const text = freeze(['#text']);
 
-const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'command', 'commandfor', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns']);
+const html = freeze(['accept', 'action', 'align', 'alt', 'autocapitalize', 'autocomplete', 'autopictureinpicture', 'autoplay', 'background', 'bgcolor', 'border', 'capture', 'cellpadding', 'cellspacing', 'checked', 'cite', 'class', 'clear', 'color', 'cols', 'colspan', 'controls', 'controlslist', 'coords', 'crossorigin', 'datetime', 'decoding', 'default', 'dir', 'disabled', 'disablepictureinpicture', 'disableremoteplayback', 'download', 'draggable', 'enctype', 'enterkeyhint', 'exportparts', 'face', 'for', 'headers', 'height', 'hidden', 'high', 'href', 'hreflang', 'id', 'inert', 'inputmode', 'integrity', 'ismap', 'kind', 'label', 'lang', 'list', 'loading', 'loop', 'low', 'max', 'maxlength', 'media', 'method', 'min', 'minlength', 'multiple', 'muted', 'name', 'nonce', 'noshade', 'novalidate', 'nowrap', 'open', 'optimum', 'part', 'pattern', 'placeholder', 'playsinline', 'popover', 'popovertarget', 'popovertargetaction', 'poster', 'preload', 'pubdate', 'radiogroup', 'readonly', 'rel', 'required', 'rev', 'reversed', 'role', 'rows', 'rowspan', 'spellcheck', 'scope', 'selected', 'shape', 'size', 'sizes', 'slot', 'span', 'srclang', 'start', 'src', 'srcset', 'step', 'style', 'summary', 'tabindex', 'title', 'translate', 'type', 'usemap', 'valign', 'value', 'width', 'wrap', 'xmlns']);
 const svg = freeze(['accent-height', 'accumulate', 'additive', 'alignment-baseline', 'amplitude', 'ascent', 'attributename', 'attributetype', 'azimuth', 'basefrequency', 'baseline-shift', 'begin', 'bias', 'by', 'class', 'clip', 'clippathunits', 'clip-path', 'clip-rule', 'color', 'color-interpolation', 'color-interpolation-filters', 'color-profile', 'color-rendering', 'cx', 'cy', 'd', 'dx', 'dy', 'diffuseconstant', 'direction', 'display', 'divisor', 'dur', 'edgemode', 'elevation', 'end', 'exponent', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'filterunits', 'flood-color', 'flood-opacity', 'font-family', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', 'font-weight', 'fx', 'fy', 'g1', 'g2', 'glyph-name', 'glyphref', 'gradientunits', 'gradienttransform', 'height', 'href', 'id', 'image-rendering', 'in', 'in2', 'intercept', 'k', 'k1', 'k2', 'k3', 'k4', 'kerning', 'keypoints', 'keysplines', 'keytimes', 'lang', 'lengthadjust', 'letter-spacing', 'kernelmatrix', 'kernelunitlength', 'lighting-color', 'local', 'marker-end', 'marker-mid', 'marker-start', 'markerheight', 'markerunits', 'markerwidth', 'maskcontentunits', 'maskunits', 'max', 'mask', 'mask-type', 'media', 'method', 'mode', 'min', 'name', 'numoctaves', 'offset', 'operator', 'opacity', 'order', 'orient', 'orientation', 'origin', 'overflow', 'paint-order', 'path', 'pathlength', 'patterncontentunits', 'patterntransform', 'patternunits', 'points', 'preservealpha', 'preserveaspectratio', 'primitiveunits', 'r', 'rx', 'ry', 'radius', 'refx', 'refy', 'repeatcount', 'repeatdur', 'restart', 'result', 'rotate', 'scale', 'seed', 'shape-rendering', 'slope', 'specularconstant', 'specularexponent', 'spreadmethod', 'startoffset', 'stddeviation', 'stitchtiles', 'stop-color', 'stop-opacity', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke', 'stroke-width', 'style', 'surfacescale', 'systemlanguage', 'tabindex', 'tablevalues', 'targetx', 'targety', 'transform', 'transform-origin', 'text-anchor', 'text-decoration', 'text-rendering', 'textlength', 'type', 'u1', 'u2', 'unicode', 'values', 'viewbox', 'visibility', 'version', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'width', 'word-spacing', 'wrap', 'writing-mode', 'xchannelselector', 'ychannelselector', 'x', 'x1', 'x2', 'xmlns', 'y', 'y1', 'y2', 'z', 'zoomandpan']);
 const mathMl = freeze(['accent', 'accentunder', 'align', 'bevelled', 'close', 'columnalign', 'columnlines', 'columnspacing', 'columnspan', 'denomalign', 'depth', 'dir', 'display', 'displaystyle', 'encoding', 'fence', 'frame', 'height', 'href', 'id', 'largeop', 'length', 'linethickness', 'lquote', 'lspace', 'mathbackground', 'mathcolor', 'mathsize', 'mathvariant', 'maxsize', 'minsize', 'movablelimits', 'notation', 'numalign', 'open', 'rowalign', 'rowlines', 'rowspacing', 'rowspan', 'rspace', 'rquote', 'scriptlevel', 'scriptminsize', 'scriptsizemultiplier', 'selection', 'separator', 'separators', 'stretchy', 'subscriptshift', 'supscriptshift', 'symmetric', 'voffset', 'width', 'xmlns']);
 const xml = freeze(['xlink:href', 'xml:id', 'xlink:title', 'xml:space', 'xmlns:xlink']);
@@ -394,7 +394,7 @@ const _createHooksMap = function _createHooksMap() {
 function createDOMPurify() {
   let window = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getGlobal();
   const DOMPurify = root => createDOMPurify(root);
-  DOMPurify.version = '3.4.5';
+  DOMPurify.version = '3.4.3';
   DOMPurify.removed = [];
   if (!window || !window.document || window.document.nodeType !== NODE_TYPE.document || !window.Element) {
     // Not running in a browser, provide a factory function
@@ -421,7 +421,6 @@ function createDOMPurify() {
   const getNextSibling = lookupGetter(ElementPrototype, 'nextSibling');
   const getChildNodes = lookupGetter(ElementPrototype, 'childNodes');
   const getParentNode = lookupGetter(ElementPrototype, 'parentNode');
-  const getNodeType = Node && Node.prototype ? lookupGetter(Node.prototype, 'nodeType') : null;
   // As per issue #47, the web-components registry is inherited by a
   // new document created via createHTMLDocument. As per the spec
   // (http://w3c.github.io/webcomponents/spec/custom/#creating-and-passing-registries)
@@ -976,40 +975,6 @@ function createDOMPurify() {
     NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT | NodeFilter.SHOW_PROCESSING_INSTRUCTION | NodeFilter.SHOW_CDATA_SECTION, null);
   };
   /**
-   * Strip template-engine expressions ({{...}}, ${...}, <%...%>) from the
-   * character data of an element subtree. Used as the final safety net for
-   * SAFE_FOR_TEMPLATES on every DOM-returning code path so that expressions
-   * which only form after text-node normalization (e.g. fragments split across
-   * stripped elements) cannot survive into a template-evaluating framework.
-   *
-   * Walks text/comment/CDATA/processing-instruction nodes and mutates `.data`
-   * in place rather than round-tripping through innerHTML. This preserves
-   * descendant node references (important for IN_PLACE callers), avoids a
-   * serialize/reparse cycle, and reads literal character data — which means
-   * `<%...%>` in text content matches the ERB regex against its real bytes
-   * instead of the HTML-entity-escaped form innerHTML would produce.
-   *
-   * Attribute values are not visited here; SAFE_FOR_TEMPLATES handling for
-   * attributes is performed during the per-node `_sanitizeAttributes` pass.
-   *
-   * @param node The root element whose character data should be scrubbed.
-   */
-  const _scrubTemplateExpressions = function _scrubTemplateExpressions(node) {
-    node.normalize();
-    const walker = createNodeIterator.call(node.ownerDocument || node, node,
-    // eslint-disable-next-line no-bitwise
-    NodeFilter.SHOW_TEXT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_CDATA_SECTION | NodeFilter.SHOW_PROCESSING_INSTRUCTION, null);
-    let currentNode = walker.nextNode();
-    while (currentNode) {
-      let data = currentNode.data;
-      arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
-        data = stringReplace(data, expr, ' ');
-      });
-      currentNode.data = data;
-      currentNode = walker.nextNode();
-    }
-  };
-  /**
    * _isClobbered
    *
    * @param element element to check for clobbering attacks
@@ -1019,31 +984,13 @@ function createDOMPurify() {
     return element instanceof HTMLFormElement && (typeof element.nodeName !== 'string' || typeof element.textContent !== 'string' || typeof element.removeChild !== 'function' || !(element.attributes instanceof NamedNodeMap) || typeof element.removeAttribute !== 'function' || typeof element.setAttribute !== 'function' || typeof element.namespaceURI !== 'string' || typeof element.insertBefore !== 'function' || typeof element.hasChildNodes !== 'function');
   };
   /**
-   * Checks whether the given object is a DOM node, including nodes that
-   * originate from a different window/realm (e.g. an iframe's
-   * contentDocument). The previous `value instanceof Node` check was
-   * realm-bound: nodes from a different window failed it, causing
-   * sanitize() to silently stringify them and reset IN_PLACE to false,
-   * returning the original node unsanitized. See GHSA-4w3q-35jp-p934.
-   *
-   * Implementation: call the cached `nodeType` getter from Node.prototype
-   * directly on the value. This bypasses any clobbered instance property
-   * (e.g. a child element named "nodeType") and works across realms
-   * because the WebIDL `nodeType` getter reads an internal slot that
-   * every real Node has, regardless of which window minted it.
+   * Checks whether the given object is a DOM node.
    *
    * @param value object to check whether it's a DOM node
-   * @return true if value is a DOM node from any realm
+   * @return true is object is a DOM node
    */
   const _isNode = function _isNode(value) {
-    if (!getNodeType || typeof value !== 'object' || value === null) {
-      return false;
-    }
-    try {
-      return typeof getNodeType(value) === 'number';
-    } catch (_) {
-      return false;
-    }
+    return typeof Node === 'function' && value instanceof Node;
   };
   function _executeHooks(hooks, currentNode, data) {
     arrayForEach(hooks, hook => {
@@ -1447,7 +1394,7 @@ function createDOMPurify() {
       /* Sanitize attached shadow roots before the main iterator runs.
          The iterator does not descend into shadow trees. */
       _sanitizeAttachedShadowRoots2(dirty);
-    } else if (_isNode(dirty)) {
+    } else if (dirty instanceof Node) {
       /* If dirty is a DOM element, append to an empty document to avoid
          elements being stripped by the parser */
       body = _initDocument('<!---->');
@@ -1498,15 +1445,17 @@ function createDOMPurify() {
     }
     /* If we sanitized `dirty` in-place, return it. */
     if (IN_PLACE) {
-      if (SAFE_FOR_TEMPLATES) {
-        _scrubTemplateExpressions(dirty);
-      }
       return dirty;
     }
     /* Return sanitized string or DOM */
     if (RETURN_DOM) {
       if (SAFE_FOR_TEMPLATES) {
-        _scrubTemplateExpressions(body);
+        body.normalize();
+        let html = body.innerHTML;
+        arrayForEach([MUSTACHE_EXPR$1, ERB_EXPR$1, TMPLIT_EXPR$1], expr => {
+          html = stringReplace(html, expr, ' ');
+        });
+        body.innerHTML = html;
       }
       if (RETURN_DOM_FRAGMENT) {
         returnNode = createDocumentFragment.call(body.ownerDocument);


### PR DESCRIPTION
## Summary

- `scripts/lint-vendor-sync.ts` spawns `bun install --frozen-lockfile` before `checkPairs` via a new `freshenNodeModules(cwd)`. The production gate is strict: `shouldFreshen = !argRoot && !process.env.CI` — no env-var override (R2 fix to R1's blocking issue 1).
- Offline / failed install is a HARD error: non-zero exit with `"could not refresh node_modules; vendor sync indeterminate"` plus the captured `bun install` stderr — and `checkPairs` is NEVER reached (ordering pin in the test).
- Side hygiene fix: `.github/workflows/ci.yml` `Install dependencies` adds `--frozen-lockfile`.
- **R3**: `bun.lock` is now tracked. Without it, `--frozen-lockfile` is a silent no-op (codex review caught this — verified that on a clean checkout, `bun install --frozen-lockfile` resolves package ranges from registry latest and exits 0, defeating the AC's local/CI convergence claim).
- Four tests pin the freshen step via PATH-shimmed fake `bun` (no env-var seam in production code):
  1. **Positive (bare no-argRoot CLI)**: invoke `bun run scripts/lint-vendor-sync.ts` with NO positional arg; fake `bun` records argv to a sentinel; assert sentinel exists with byte-exact `"bun install --frozen-lockfile\n"` AND stdout contains "byte-for-byte" (proves `checkPairs` ran AFTER the freshen). R2 fix to R1's blocking issue 2.
  2. **Hard-fail**: bare CLI + fake `bun` that exits non-zero with a stderr sentinel; assert exit non-zero + AC2 diagnostic + captured stderr + ordering pin (neither "vendor-sync violation" nor "byte-for-byte" appear).
  3. **argRoot gate**: poisoned fake `bun` + CLI with `argRoot`; assert exit 0 + no poison-sentinel — proves the `argRoot` clause of the gate.
  4. **CI=1 gate**: poisoned fake `bun` + bare CLI + `CI=1`; assert exit 0 + no poison-sentinel — proves the `CI` clause of the gate.
- `templates/dashboard/vendor/README.md` step 5 drops the "after `bun install`" caveat — the lint refreshes `node_modules/` itself.

## scope-expansion

- Resync `templates/dashboard/vendor/purify.es.js` from the *truly* locked `dompurify@3.4.3` (R3 — my R1 resync picked up `3.4.5` from a node_modules cache that had drifted past the lockfile; with `bun.lock` now tracked, the locked version is authoritative). README's documented version restored to 3.4.3.
- Track `bun.lock` (330 lines, R3) — hard prerequisite for `--frozen-lockfile` to mean anything; without it this PR shipped a placebo. Reviewer R1 accepted the vendor-resync scope expansion; the lockfile tracking is in the same spirit (in the natural blast radius of the AC's `--frozen-lockfile` clause).

## Test plan

- [x] `bun test scripts/lint-vendor-sync.test.ts` — 18/18 pass
- [x] `bun test templates/dashboard/markdown.test.ts` — 15/15 pass (renderer works against locked dompurify 3.4.3)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (eslint) — clean
- [x] `bun run lint:vendor-sync` (local) — invokes freshen, exits 0
- [x] `CI=1 bun run lint:vendor-sync` — skips freshen, exits 0
- [x] Cold check: `bun install --frozen-lockfile` now errors with `"lockfile had changes, but lockfile is frozen"` if `package.json`/`bun.lock` disagree (the property the AC actually needs)
- [x] Manual fixture drift verification (AC7): non-zero exit with bytes-differ violation

Closes #531

## Round changelog

- **R1** (d99a105): Implemented Option 1a freshen + CI hygiene + README + tests + vendor resync.
- **R2** (2798c5f): Reviewer R1 blocking — stripped env-var seam, made gate strict, rewrote positive test to drive bare no-arg CLI via PATH-shim.
- **R3** (d212ff5): Codex review — tracked `bun.lock`, re-synced vendor against the truly-locked install (3.4.3, not 3.4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)