### PR TITLE
fix(orchestration): assert PR base repo matches project repo (gh-ludics-529)

### DIFF
--- a/src/orchestration/github.test.ts
+++ b/src/orchestration/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { DEFAULT_CODEX_REVIEW_PROMPT, hasCodexSubmittedReview, postCodexReviewComment } from "./github.ts";
+import { DEFAULT_CODEX_REVIEW_PROMPT, hasCodexSubmittedReview, postCodexReviewComment, prUrlBelongsToRepo, repoSlugFromPrUrl } from "./github.ts";
 
 setDefaultTimeout(20_000);
 
@@ -60,5 +60,89 @@ describe("hasCodexSubmittedReview", () => {
       "https://github.com/nonexistent-owner-zzz/nonexistent-repo-zzz/pull/1"
     );
     expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prUrlBelongsToRepo / repoSlugFromPrUrl — base-repo assertion helpers
+// (gh-ludics-529: prevent coder PRs from targeting the upstream fork-parent)
+// ---------------------------------------------------------------------------
+
+describe("repoSlugFromPrUrl", () => {
+  test("extracts owner/repo from a canonical PR URL", () => {
+    expect(repoSlugFromPrUrl("https://github.com/org/repo/pull/42")).toBe("org/repo");
+  });
+
+  test("returns null for malformed input", () => {
+    expect(repoSlugFromPrUrl("")).toBeNull();
+    expect(repoSlugFromPrUrl("not a url")).toBeNull();
+    expect(repoSlugFromPrUrl("https://example.com/foo/bar/pull/1")).toBeNull();
+    expect(repoSlugFromPrUrl("https://github.com/org/repo/issues/1")).toBeNull();
+  });
+});
+
+describe("prUrlBelongsToRepo", () => {
+  test("returns true for an exact slug match", () => {
+    expect(prUrlBelongsToRepo("https://github.com/org/repo/pull/1", "org/repo")).toBe(true);
+  });
+
+  test("returns true for a case-insensitive match", () => {
+    expect(prUrlBelongsToRepo(
+      "https://github.com/Lukstafi/Ocannl-Staging/pull/5",
+      "lukstafi/ocannl-staging",
+    )).toBe(true);
+  });
+
+  test("returns true when expected repo has trailing whitespace", () => {
+    expect(prUrlBelongsToRepo(
+      "https://github.com/org/repo/pull/1",
+      "  org/repo  ",
+    )).toBe(true);
+  });
+
+  test("returns true when URL slug carries a trailing .git", () => {
+    expect(prUrlBelongsToRepo(
+      "https://github.com/org/repo.git/pull/1",
+      "org/repo",
+    )).toBe(true);
+  });
+
+  test("returns true when expected repo carries a trailing .git", () => {
+    expect(prUrlBelongsToRepo(
+      "https://github.com/org/repo/pull/1",
+      "org/repo.git",
+    )).toBe(true);
+  });
+
+  test("returns true for a combined case + .GIT suffix mismatch (the OCANNL incident shape)", () => {
+    // Mirrors the incident: PR URL targets a fork-parent rendering with weird casing.
+    expect(prUrlBelongsToRepo(
+      "https://github.com/Lukstafi/Ocannl-Staging.GIT/pull/5",
+      "lukstafi/ocannl-staging",
+    )).toBe(true);
+  });
+
+  test("returns false for a slug mismatch (the wrong-base-repo case)", () => {
+    // The OCANNL incident: PR landed on the upstream fork-parent instead of the working repo.
+    expect(prUrlBelongsToRepo(
+      "https://github.com/ahrefs/ocannl/pull/457",
+      "lukstafi/ocannl-staging",
+    )).toBe(false);
+  });
+
+  test("returns false for a malformed PR URL", () => {
+    expect(prUrlBelongsToRepo("not a url", "org/repo")).toBe(false);
+    expect(prUrlBelongsToRepo("", "org/repo")).toBe(false);
+    expect(prUrlBelongsToRepo("https://example.com/foo/bar/pull/1", "org/repo")).toBe(false);
+  });
+
+  test("returns false when expected repo is missing or blank", () => {
+    // The helper itself rejects missing/blank repo — defence in depth.
+    // Call sites still gate on `if (projectRepo) ...` so AC5 skip is also
+    // enforced at the call boundary; this is the redundant guard.
+    expect(prUrlBelongsToRepo("https://github.com/org/repo/pull/1", undefined)).toBe(false);
+    expect(prUrlBelongsToRepo("https://github.com/org/repo/pull/1", null)).toBe(false);
+    expect(prUrlBelongsToRepo("https://github.com/org/repo/pull/1", "")).toBe(false);
+    expect(prUrlBelongsToRepo("https://github.com/org/repo/pull/1", "   ")).toBe(false);
   });
 });

--- a/src/orchestration/github.ts
+++ b/src/orchestration/github.ts
@@ -13,6 +13,29 @@ function parsePrUrl(prUrl: string): { repo: string; prNumber: string } | null {
   return { repo: match[1], prNumber: match[2] };
 }
 
+/** Normalize an `owner/repo` slug for comparison: lowercase, trim, strip one trailing `.git`. */
+function normalizeRepoSlug(slug: string): string {
+  return slug.trim().toLowerCase().replace(/\.git$/, "");
+}
+
+/** Returns the `owner/repo` slug from a GitHub PR URL, or null if malformed. */
+export function repoSlugFromPrUrl(prUrl: string): string | null {
+  const parsed = parsePrUrl(prUrl);
+  return parsed ? parsed.repo : null;
+}
+
+/**
+ * Returns true iff `prUrl` is a GitHub PR URL whose `owner/repo` slug matches
+ * `repo` after slug normalization (case-insensitive, trimmed, trailing `.git`
+ * stripped). Returns false for malformed URLs and for missing/blank `repo`.
+ */
+export function prUrlBelongsToRepo(prUrl: string, repo?: string | null): boolean {
+  if (!repo || !repo.trim()) return false;
+  const parsed = parsePrUrl(prUrl);
+  if (!parsed) return false;
+  return normalizeRepoSlug(parsed.repo) === normalizeRepoSlug(repo);
+}
+
 /**
  * Run `gh api --paginate <endpoint> --jq <jqFilter>`, sum the per-page
  * integers from stdout, and return the total.  Returns 0 on any error.

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1780,16 +1780,31 @@ function promoteOrRejectPrUrl(
       message: buildWrongRepoReason(fixedUrl, projectRepo, upstreamRepo),
     });
     // Do not promote to runtime.prUrl, do not notify, do not baseline.
+    // Also evict any stale wrong-repo URL already in runtime.prUrl — it was
+    // copied there by `refreshAgentStatuses` → `resolvePrUrl` before this
+    // assertion ran, and `getFirstPrUrl` would otherwise keep surfacing the
+    // wrong URL even after the coder repairs `.pr` on retry.
+    if (runtime.prUrl && !prUrlBelongsToRepo(runtime.prUrl, projectRepo)) {
+      runtime.prUrl = null;
+    }
     // The gate-level catch-all routes through handleVerifyFailure → redispatch.
     return;
   }
-  if (!runtime.prUrl) {
+  // Promote when the URL changed. The previous `!runtime.prUrl` guard was a
+  // first-time-only gate intended to suppress repeat notifications; under
+  // retry semantics it also prevented overwriting a stale wrong-repo URL
+  // (copied in by `resolvePrUrl`) with the freshly repaired correct-repo
+  // URL. Notification fires only on actual transitions.
+  if (runtime.prUrl !== fixedUrl) {
+    const isFirstAssignment = !runtime.prUrl;
     runtime.prUrl = fixedUrl;
-    notifyAgents(
-      `Slot ${state.slot} [${state.taskId}]: PR created by ${agent.name}: ${fixedUrl}`,
-      3,
-      `Slot ${state.slot}: PR created`,
-    );
+    if (isFirstAssignment) {
+      notifyAgents(
+        `Slot ${state.slot} [${state.taskId}]: PR created by ${agent.name}: ${fixedUrl}`,
+        3,
+        `Slot ${state.slot}: PR created`,
+      );
+    }
   }
   capturePrBodyBaseline(state, agent, runtime);
 }

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -18,7 +18,7 @@ import {
   type AgentConfig, type OrchestrationState,
 } from "./state.ts";
 import { isoNow, makeId, nowEpoch, sleepMs } from "./util.ts";
-import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, postPrDriftComment, validateAndFixPrFile, type PrVerification } from "./github.ts";
+import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, postPrDriftComment, prUrlBelongsToRepo, repoSlugFromPrUrl, validateAndFixPrFile, type PrVerification } from "./github.ts";
 import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
 import { findProjectConfig, globalAdapter, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
 import { taskFilePath } from "./paths.ts";
@@ -336,6 +336,34 @@ const FINAL_MERGE_GATE: VerificationGateConfig = {
  * hold (max retries), skip (not applicable).
  */
 export { PR_CREATE_GATE, FINAL_MERGE_GATE };
+
+/**
+ * Build a wrong-base-repo failure message used by both the gate-level
+ * catch-all and the early catch inside `validateAgentPrFiles`. Names the
+ * wrong slug, the expected project repo, the recreate-with-`--repo`
+ * instruction, the overwrite-`.peer-sync/<agent>.pr` instruction, and when
+ * the wrong slug matches `upstream_repo` calls out the fork-parent default
+ * of an omitted `--repo`.
+ */
+export function buildWrongRepoReason(
+  prUrl: string,
+  expectedRepo: string,
+  upstreamRepo?: string | null,
+): string {
+  const wrongSlug = repoSlugFromPrUrl(prUrl) ?? "unknown";
+  const isUpstream = !!upstreamRepo && prUrlBelongsToRepo(prUrl, upstreamRepo);
+  const upstreamHint = isUpstream
+    ? ` (this is the project's upstream/fork-parent — \`gh pr create\` without \`--repo\` defaults the base repo to the fork parent)`
+    : "";
+  return (
+    `PR base repo mismatch: ${prUrl} targets ${wrongSlug}, ` +
+    `expected ${expectedRepo}${upstreamHint}. ` +
+    `Recreate the PR with \`gh pr create --repo ${expectedRepo}\` ` +
+    `(close the wrong PR on GitHub first), then overwrite ` +
+    `\`.peer-sync/<agent>.pr\` with the corrected URL.`
+  );
+}
+
 export function verifyPhaseOutcome(state: OrchestrationState, config: VerificationGateConfig): VerificationDecision {
   if (state.phase !== config.phase) return "skip";
   if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return "skip";
@@ -347,7 +375,19 @@ export function verifyPhaseOutcome(state: OrchestrationState, config: Verificati
   }
 
   const v = getPrVerification(prUrl);
-  if (config.checkSuccess(v)) {
+
+  // Wrong-base-repo catch-all for the pr-create gate: an existing PR that
+  // belongs to the wrong owner/repo must not be allowed to advance. Gated on
+  // `prCreate` so FINAL_MERGE_GATE is unaffected. AC5: when projectRepo is
+  // unset/blank, prUrlBelongsToRepo returns false; we treat that as "skip the
+  // assertion" via the explicit `projectRepo` check below.
+  const projectEntry = config.gate === "prCreate"
+    ? findProjectConfig(state.projectDir)
+    : null;
+  const projectRepo = projectEntry?.repo;
+  const wrongRepo = !!(projectRepo && !prUrlBelongsToRepo(prUrl, projectRepo));
+
+  if (config.checkSuccess(v) && !wrongRepo) {
     emitEvent({
       event_type: config.successEvent,
       source: "orchestration", scope: "slot",
@@ -357,6 +397,13 @@ export function verifyPhaseOutcome(state: OrchestrationState, config: Verificati
     });
     state.phaseRetryContext = null;
     return "advance";
+  }
+
+  if (wrongRepo) {
+    return handleVerifyFailure(
+      state, config.gate,
+      buildWrongRepoReason(prUrl, projectRepo!, projectEntry?.upstream_repo),
+    );
   }
 
   return handleVerifyFailure(state, config.gate, config.formatFailure(prUrl, v));
@@ -1670,7 +1717,8 @@ export function checkAndAnnotatePrBodyDrift(state: OrchestrationState): void {
  * Settled-mode repair: existing behavior for when .pr doesn't exist yet.
  */
 export function validateAgentPrFiles(state: OrchestrationState): void {
-  const projectRepo = findProjectConfig(state.projectDir)?.repo;
+  const projectEntry = findProjectConfig(state.projectDir);
+  const projectRepo = projectEntry?.repo;
   for (const agent of state.agents) {
     if (!agentParticipatesInPhase(state, agent)) continue;
     const runtime = state.agentStates[agent.name];
@@ -1684,15 +1732,7 @@ export function validateAgentPrFiles(state: OrchestrationState): void {
         const content = readFileSync(prFile, "utf-8").trim();
         if (content && !isPrUrl(content)) {
           const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch, projectRepo);
-          if (fixedUrl && !runtime.prUrl) {
-            runtime.prUrl = fixedUrl;
-            notifyAgents(
-              `Slot ${state.slot} [${state.taskId}]: PR created by ${agent.name}: ${fixedUrl}`,
-              3,
-              `Slot ${state.slot}: PR created`,
-            );
-          }
-          capturePrBodyBaseline(state, agent, runtime);
+          promoteOrRejectPrUrl(state, agent, runtime, fixedUrl, projectRepo, projectEntry?.upstream_repo);
           continue; // Attempted repair — skip settled-mode path for this agent
         }
       } catch {
@@ -1706,16 +1746,52 @@ export function validateAgentPrFiles(state: OrchestrationState): void {
     const statusDone = DONE_STATUSES.has(runtime.status);
     if (!turnSettled && !statusDone && !runtime.interrupted) continue;
     const fixedUrl = validateAndFixPrFile(prFile, agent.worktreePath, agent.branch, projectRepo);
-    if (fixedUrl && !runtime.prUrl) {
-      runtime.prUrl = fixedUrl;
-      notifyAgents(
-        `Slot ${state.slot} [${state.taskId}]: PR created by ${agent.name}: ${fixedUrl}`,
-        3,
-        `Slot ${state.slot}: PR created`,
-      );
-    }
-    capturePrBodyBaseline(state, agent, runtime);
+    promoteOrRejectPrUrl(state, agent, runtime, fixedUrl, projectRepo, projectEntry?.upstream_repo);
   }
+}
+
+/**
+ * Wrap the `runtime.prUrl` promotion step with the wrong-base-repo early
+ * catch. When the URL belongs to the project's `repo` (or `projectRepo` is
+ * unset — AC5), the existing promotion + notify + baseline-capture path
+ * runs unchanged. When it belongs to a different repo, we emit a visible
+ * warning and refuse to promote — the gate-level catch-all in
+ * `verifyPhaseOutcome` then surfaces a verification failure that routes
+ * through `handleVerifyFailure` with retry context.
+ */
+function promoteOrRejectPrUrl(
+  state: OrchestrationState,
+  agent: AgentConfig,
+  runtime: OrchestrationState["agentStates"][string],
+  fixedUrl: string | null,
+  projectRepo: string | undefined,
+  upstreamRepo: string | undefined,
+): void {
+  if (!fixedUrl) {
+    capturePrBodyBaseline(state, agent, runtime);
+    return;
+  }
+  if (projectRepo && !prUrlBelongsToRepo(fixedUrl, projectRepo)) {
+    emitEvent({
+      event_type: "orchestration_warning",
+      source: "orchestration", scope: "slot",
+      slot: state.slot, task: state.taskId,
+      action: "pr-create base repo validation", status: "failed",
+      message: buildWrongRepoReason(fixedUrl, projectRepo, upstreamRepo),
+    });
+    // Do not promote to runtime.prUrl, do not notify, do not baseline.
+    // The gate-level catch-all routes through handleVerifyFailure → redispatch.
+    return;
+  }
+  if (!runtime.prUrl) {
+    runtime.prUrl = fixedUrl;
+    notifyAgents(
+      `Slot ${state.slot} [${state.taskId}]: PR created by ${agent.name}: ${fixedUrl}`,
+      3,
+      `Slot ${state.slot}: PR created`,
+    );
+  }
+  capturePrBodyBaseline(state, agent, runtime);
 }
 
 /**

--- a/src/orchestration/runner.verification.test.ts
+++ b/src/orchestration/runner.verification.test.ts
@@ -846,6 +846,94 @@ describe("verifyPhaseOutcome (PR_CREATE_GATE)", () => {
     expect(verifyPhaseOutcome(state, PR_CREATE_GATE)).toBe("hold");
     expect(state.prCreateVerifyAttempts).toBe(MAX_VERIFY_ATTEMPTS);
   });
+
+  // gh-ludics-529: wrong-base-repo gate-level catch-all.
+  // Harness: findProjectConfig is mocked to return a repo whose slug differs
+  // from the PR URL's slug. Invariant: even with v.exists === true, the gate
+  // returns "redispatch" via handleVerifyFailure, prCreateVerifyAttempts
+  // increments, and phaseRetryContext is populated with the wrong-repo reason.
+  // Mutation evidence: flipping the mocked repo to match (positive control
+  // below) makes the same call return "advance" — confirms the assertion is
+  // what's driving the redispatch, not some unrelated `v.exists` failure.
+  describe("wrong-base-repo assertion (gh-ludics-529)", () => {
+    let configSpy: ReturnType<typeof spyOn>;
+    beforeEach(() => {
+      configSpy = spyOn(config, "findProjectConfig").mockReturnValue(
+        { repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any,
+      );
+    });
+    afterEach(() => { configSpy.mockRestore(); });
+
+    function makeWrongRepoState(overrides: Partial<OrchestrationState> = {}) {
+      const dir = makeTmpDir();
+      const wrongUrl = "https://github.com/ahrefs/ocannl/pull/457";
+      writeFileSync(join(dir, "coder.pr"), wrongUrl);
+      const state = makeState({ phase: "pr-create", ...overrides }, dir);
+      state.agentStates.coder!.status = "done";
+      state.agentStates.coder!.prUrl = wrongUrl;
+      state.agentStates.coder!.turnLifecycle = makeLifecycle({ state: "settled" });
+      return state;
+    }
+
+    test("returns redispatch when verified PR URL points at upstream/fork-parent, populates retry context", () => {
+      const state = makeWrongRepoState({ prCreateVerifyAttempts: 0 });
+      verificationSpy.mockReturnValue({ exists: true, state: "open" });
+
+      expect(verifyPhaseOutcome(state, PR_CREATE_GATE)).toBe("redispatch");
+      expect(state.prCreateVerifyAttempts).toBe(1);
+      expect(state.phaseRetryContext).toBeTruthy();
+      const reason = state.phaseRetryContext!;
+      expect(reason).toContain("ahrefs/ocannl");
+      expect(reason).toContain("lukstafi/ocannl-staging");
+      expect(reason).toContain("gh pr create --repo lukstafi/ocannl-staging");
+      expect(reason).toContain(".peer-sync/<agent>.pr");
+      // Fork-parent explanation present because wrong slug == upstream_repo.
+      expect(reason).toContain("upstream/fork-parent");
+      // pr_verified MUST NOT have been emitted — wrong-repo branch suppresses
+      // success even though v.exists === true.
+      expect(eventSpy.mock.calls.some((c: any[]) => c[0].event_type === "pr_verified")).toBe(false);
+      // pr_missing event emitted via handleVerifyFailure.
+      expect(eventSpy.mock.calls.some((c: any[]) => c[0].event_type === "pr_missing")).toBe(true);
+    });
+
+    test("retry-context omits fork-parent hint when wrong slug does NOT match upstream_repo", () => {
+      configSpy.mockReturnValue({ repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any);
+      const dir = makeTmpDir();
+      // Wrong repo, but NOT the upstream — e.g. coder typo'd a totally
+      // unrelated repo.
+      const wrongUrl = "https://github.com/someone/elsewhere/pull/9";
+      writeFileSync(join(dir, "coder.pr"), wrongUrl);
+      const state = makeState({ phase: "pr-create", prCreateVerifyAttempts: 0 }, dir);
+      state.agentStates.coder!.status = "done";
+      state.agentStates.coder!.prUrl = wrongUrl;
+      state.agentStates.coder!.turnLifecycle = makeLifecycle({ state: "settled" });
+      verificationSpy.mockReturnValue({ exists: true, state: "open" });
+
+      expect(verifyPhaseOutcome(state, PR_CREATE_GATE)).toBe("redispatch");
+      const reason = state.phaseRetryContext!;
+      expect(reason).toContain("someone/elsewhere");
+      expect(reason).toContain("lukstafi/ocannl-staging");
+      // No upstream/fork-parent explanation because wrong slug != upstream_repo.
+      expect(reason).not.toContain("upstream/fork-parent");
+    });
+
+    test("returns advance when the PR URL slug matches projectRepo (positive control)", () => {
+      configSpy.mockReturnValue({ repo: "org/repo", name: "test" } as any);
+      const state = makePrCreateDoneState();
+      verificationSpy.mockReturnValue({ exists: true, state: "open" });
+      expect(verifyPhaseOutcome(state, PR_CREATE_GATE)).toBe("advance");
+      expect(eventSpy.mock.calls.some((c: any[]) => c[0].event_type === "pr_verified")).toBe(true);
+    });
+
+    test("AC5 skip: when findProjectConfig returns no repo, mismatched URL still advances", () => {
+      // No project repo configured — the wrong-repo branch must no-op.
+      configSpy.mockReturnValue({ name: "ad-hoc" } as any);
+      const state = makeWrongRepoState();
+      verificationSpy.mockReturnValue({ exists: true, state: "open" });
+      expect(verifyPhaseOutcome(state, PR_CREATE_GATE)).toBe("advance");
+      expect(eventSpy.mock.calls.some((c: any[]) => c[0].event_type === "pr_verified")).toBe(true);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -912,6 +1000,23 @@ describe("verifyPhaseOutcome (FINAL_MERGE_GATE)", () => {
 
     expect(verifyPhaseOutcome(state, FINAL_MERGE_GATE)).toBe("hold");
     expect(state.finalMergeVerifyAttempts).toBe(MAX_VERIFY_ATTEMPTS);
+  });
+
+  // gh-ludics-529: confirm the wrong-base-repo assertion does NOT leak into
+  // FINAL_MERGE_GATE. Harness: even if findProjectConfig returns a repo that
+  // doesn't match the PR URL, the final-merge gate advances on a merged PR.
+  test("FINAL_MERGE_GATE is unaffected by the prCreate-gated wrong-base-repo assertion", () => {
+    const configSpy = spyOn(config, "findProjectConfig").mockReturnValue(
+      { repo: "would/not/match", name: "test" } as any,
+    );
+    try {
+      const state = makeFinalMergeDoneState();
+      verificationSpy.mockReturnValue({ exists: true, merged: true, state: "closed" });
+      expect(verifyPhaseOutcome(state, FINAL_MERGE_GATE)).toBe("advance");
+      expect(eventSpy.mock.calls.some((c: any[]) => c[0].event_type === "merge_verified")).toBe(true);
+    } finally {
+      configSpy.mockRestore();
+    }
   });
 });
 
@@ -1013,17 +1118,20 @@ describe("validateAgentPrFiles (eager repair)", () => {
   let fixSpy: ReturnType<typeof spyOn>;
   let notifySpy: ReturnType<typeof spyOn>;
   let configSpy: ReturnType<typeof spyOn>;
+  let eventSpy: ReturnType<typeof spyOn>;
   let dir: string;
 
   beforeEach(() => {
     dir = makeTmpDir();
     notifySpy = spyOn(notify, "notifyAgents").mockImplementation(() => {});
-    configSpy = spyOn(config, "findProjectConfig").mockReturnValue({ repo: "org/test-repo", name: "test" } as any);
+    configSpy = spyOn(config, "findProjectConfig").mockReturnValue({ repo: "org/repo", name: "test" } as any);
+    eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
   });
   afterEach(() => {
     fixSpy?.mockRestore();
     notifySpy.mockRestore();
     configSpy.mockRestore();
+    eventSpy.mockRestore();
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -1037,7 +1145,7 @@ describe("validateAgentPrFiles (eager repair)", () => {
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
     expect(fixSpy).toHaveBeenCalledWith(
-      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+      expect.any(String), expect.any(String), expect.any(String), "org/repo"
     );
     expect(state.agentStates.coder.prUrl).toBe("https://github.com/org/repo/pull/1");
   });
@@ -1071,7 +1179,7 @@ describe("validateAgentPrFiles (eager repair)", () => {
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
     expect(fixSpy).toHaveBeenCalledWith(
-      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+      expect.any(String), expect.any(String), expect.any(String), "org/repo"
     );
   });
 
@@ -1095,10 +1203,95 @@ describe("validateAgentPrFiles (eager repair)", () => {
     validateAgentPrFiles(state);
     expect(fixSpy).toHaveBeenCalled();
     expect(fixSpy).toHaveBeenCalledWith(
-      expect.any(String), expect.any(String), expect.any(String), "org/test-repo"
+      expect.any(String), expect.any(String), expect.any(String), "org/repo"
     );
     expect(state.agentStates.coder.prUrl).toBeFalsy();
     expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  // gh-ludics-529: wrong-base-repo early catch.
+  // Harness: validateAndFixPrFile returns a URL whose slug differs from the
+  // mocked findProjectConfig().repo. Invariant: runtime.prUrl stays unset,
+  // notifyAgents is never called, and an orchestration_warning event with the
+  // pr-create base repo validation action is emitted.
+
+  test("rejects a wrong-repo URL returned from eager repair (does not promote, does not notify, emits warning)", () => {
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/ahrefs/ocannl/pull/457");
+    configSpy.mockReturnValue({ repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any);
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    state.agentStates.coder.turnLifecycle = null;
+    state.agentStates.coder.status = "pr-create-active";
+    writeFileSync(join(dir, "coder.pr"), "# My PR\nbody\n");
+    validateAgentPrFiles(state);
+    expect(fixSpy).toHaveBeenCalled();
+    expect(state.agentStates.coder.prUrl).toBeFalsy();
+    expect(notifySpy).not.toHaveBeenCalled();
+    const warning = eventSpy.mock.calls.find(
+      (c: any[]) => c[0]?.event_type === "orchestration_warning"
+        && c[0]?.action === "pr-create base repo validation",
+    );
+    expect(warning).toBeDefined();
+    // Message must name the wrong repo, the expected repo, recreate-with-
+    // `--repo` instruction, the overwrite-`.peer-sync/<agent>.pr` instruction,
+    // and the fork-parent explanation (wrong slug == upstream_repo here).
+    const msg = (warning![0] as { message: string }).message;
+    expect(msg).toContain("ahrefs/ocannl");
+    expect(msg).toContain("lukstafi/ocannl-staging");
+    expect(msg).toContain("gh pr create --repo lukstafi/ocannl-staging");
+    expect(msg).toContain(".peer-sync/<agent>.pr");
+    expect(msg).toContain("upstream/fork-parent");
+  });
+
+  test("rejects a wrong-repo URL discovered via the settled-mode branch (already-a-URL .pr)", () => {
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/ahrefs/ocannl/pull/457");
+    configSpy.mockReturnValue({ repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any);
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    // Settled lifecycle so the settled-mode branch is the one that fires.
+    state.agentStates.coder.turnLifecycle = makeLifecycle({ state: "settled" });
+    state.agentStates.coder.status = "pr-create-done";
+    // .pr already contains a wrong-repo URL — eager-repair branch skips
+    // (`!isPrUrl(content)` is false), settled-mode calls validateAndFixPrFile
+    // which returns the URL untouched (mocked here as the wrong-repo URL).
+    writeFileSync(join(dir, "coder.pr"), "https://github.com/ahrefs/ocannl/pull/457\n");
+    validateAgentPrFiles(state);
+    expect(state.agentStates.coder.prUrl).toBeFalsy();
+    expect(notifySpy).not.toHaveBeenCalled();
+    expect(eventSpy.mock.calls.some(
+      (c: any[]) => c[0]?.event_type === "orchestration_warning"
+        && c[0]?.action === "pr-create base repo validation",
+    )).toBe(true);
+  });
+
+  test("positive control: a matching-repo URL still promotes + notifies (no behaviour change for the happy path)", () => {
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/org/repo/pull/7");
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    state.agentStates.coder.turnLifecycle = null;
+    state.agentStates.coder.status = "pr-create-active";
+    writeFileSync(join(dir, "coder.pr"), "# My PR\nbody\n");
+    validateAgentPrFiles(state);
+    expect(state.agentStates.coder.prUrl).toBe("https://github.com/org/repo/pull/7");
+    expect(notifySpy).toHaveBeenCalled();
+    expect(eventSpy.mock.calls.some(
+      (c: any[]) => c[0]?.event_type === "orchestration_warning"
+        && c[0]?.action === "pr-create base repo validation",
+    )).toBe(false);
+  });
+
+  test("AC5 skip: when project config has no repo, a non-matching URL still promotes (existing behaviour preserved)", () => {
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/some/other/pull/1");
+    // No repo on the project config → assertion no-ops.
+    configSpy.mockReturnValue({ name: "ad-hoc" } as any);
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    state.agentStates.coder.turnLifecycle = null;
+    state.agentStates.coder.status = "pr-create-active";
+    writeFileSync(join(dir, "coder.pr"), "# My PR\nbody\n");
+    validateAgentPrFiles(state);
+    expect(state.agentStates.coder.prUrl).toBe("https://github.com/some/other/pull/1");
+    expect(notifySpy).toHaveBeenCalled();
+    expect(eventSpy.mock.calls.some(
+      (c: any[]) => c[0]?.event_type === "orchestration_warning"
+        && c[0]?.action === "pr-create base repo validation",
+    )).toBe(false);
   });
 });
 

--- a/src/orchestration/runner.verification.test.ts
+++ b/src/orchestration/runner.verification.test.ts
@@ -1277,6 +1277,55 @@ describe("validateAgentPrFiles (eager repair)", () => {
     )).toBe(false);
   });
 
+  // Codex review (PR #543): when refreshAgentStatuses already copied a
+  // wrong-repo URL into runtime.prUrl, two follow-on hazards bite:
+  //   (a) the wrong URL keeps surfacing via getFirstPrUrl even after `.pr`
+  //       is repaired by the coder on retry;
+  //   (b) the first-time-only `!runtime.prUrl` promotion guard refuses to
+  //       overwrite the stale wrong URL when validateAndFixPrFile creates
+  //       the corrected PR.
+  // Two tests below cover both arms.
+
+  test("clears a stale wrong-repo runtime.prUrl when rejecting a wrong-repo eager-repair URL", () => {
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/ahrefs/ocannl/pull/457");
+    configSpy.mockReturnValue({ repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any);
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    // Simulate `refreshAgentStatuses → resolvePrUrl` having already copied
+    // the wrong-repo URL from `.pr` into runtime.prUrl on a prior tick.
+    state.agentStates.coder.prUrl = "https://github.com/ahrefs/ocannl/pull/457";
+    state.agentStates.coder.turnLifecycle = null;
+    state.agentStates.coder.status = "pr-create-active";
+    writeFileSync(join(dir, "coder.pr"), "# Bad PR\nbody\n");
+    validateAgentPrFiles(state);
+    // Wrong-repo branch must evict the stale runtime URL so getFirstPrUrl
+    // falls back to the (now-being-repaired) `.pr` file on the next tick.
+    expect(state.agentStates.coder.prUrl).toBeNull();
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  test("overwrites a stale wrong-repo runtime.prUrl when the repaired URL belongs to the project repo (no spurious notify)", () => {
+    const goodUrl = "https://github.com/lukstafi/ocannl-staging/pull/25";
+    fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue(goodUrl);
+    configSpy.mockReturnValue({ repo: "lukstafi/ocannl-staging", upstream_repo: "ahrefs/ocannl", name: "ocannl" } as any);
+    const state = makeState({ phase: "pr-create", round: 1 }, dir);
+    // Stale wrong-repo URL from a prior tick's resolvePrUrl fast-path.
+    state.agentStates.coder.prUrl = "https://github.com/ahrefs/ocannl/pull/457";
+    state.agentStates.coder.turnLifecycle = null;
+    state.agentStates.coder.status = "pr-create-active";
+    // Coder has overwritten `.pr` with a fresh markdown body on retry;
+    // eager-repair fires and validateAndFixPrFile (mocked) creates the
+    // corrected staging PR.
+    writeFileSync(join(dir, "coder.pr"), "# Corrected PR\nbody\n");
+    validateAgentPrFiles(state);
+    // Promotion must overwrite the stale URL — getFirstPrUrl would otherwise
+    // keep redispatching against the wrong PR.
+    expect(state.agentStates.coder.prUrl).toBe(goodUrl);
+    // Renotification suppressed: the first-time-only `notifyAgents` was
+    // already fired when the (wrong) URL was first surfaced; a second
+    // "PR created" ping for the corrected URL would be noise.
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
   test("AC5 skip: when project config has no repo, a non-matching URL still promotes (existing behaviour preserved)", () => {
     fixSpy = spyOn(github, "validateAndFixPrFile").mockReturnValue("https://github.com/some/other/pull/1");
     // No repo on the project config → assertion no-ops.


### PR DESCRIPTION
## Summary

Closes #529. Runner-side slug-normalized base-repo assertion at two insertion
points so an orchestrated coder cannot open a PR against the upstream
fork-parent when `gh pr create` is run without `--repo`. Routes through the
existing `handleVerifyFailure` → redispatch path; no new state fields.
`FINAL_MERGE_GATE` unaffected.

- `src/orchestration/github.ts` — export `prUrlBelongsToRepo(prUrl, repo?)`
  and `repoSlugFromPrUrl(prUrl)`; both reuse the private `parsePrUrl`.
  Comparison is lowercase + trimmed + trailing-`.git` stripped.
- `src/orchestration/runner.ts` — early catch in `validateAgentPrFiles`
  via a new `promoteOrRejectPrUrl` helper; gate-level catch-all in
  `verifyPhaseOutcome` gated on `config.gate === "prCreate"`; shared
  `buildWrongRepoReason` produces the retry-context string with all four
  AC4 pieces and the fork-parent hint when wrong slug == `upstream_repo`.
- Stale-URL eviction (Codex review on this PR): when
  `refreshAgentStatuses` has already copied a wrong-repo URL into
  `runtime.prUrl` on a prior tick, the wrong-repo branch nulls it so
  `getFirstPrUrl` falls back to the (being-repaired) `.pr` file; the
  match branch overwrites `runtime.prUrl` on a *change* (not just on
  first assignment) so a freshly-repaired correct-repo URL replaces a
  stale wrong one. `notifyAgents` still fires only on the initial
  transition.
- Fixture realignment in `runner.verification.test.ts` — `validateAgentPrFiles (eager repair)`
  previously mocked project repo as `org/test-repo` while `validateAndFixPrFile`
  mocks returned `org/repo` URLs; latent drift made visible by the new
  assertion. Realigned + dedicated wrong-repo + stale-URL eviction tests
  alongside.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/orchestration/github.test.ts src/orchestration/runner.verification.test.ts` — **96 pass / 0 fail / 216 expects**
- [x] `bun test` — 2570 pass / 0 fail across 115 files
- [x] `bun run build` — binary compiles
- [x] `bun run lint:no-nul-bytes` / `lint:cli-readme` / `lint:no-mock-module` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)