### PR TITLE
Activity gate for periodic skills (gh-ludics-538)

### DIFF
--- a/docs/proposals/activity-gate-periodic-skills.md
+++ b/docs/proposals/activity-gate-periodic-skills.md
@@ -93,9 +93,11 @@ Issue: https://github.com/lukstafi/ludics/issues/538
 
 6. The `lastUserActionEpoch` signal is the maximum of:
    - `notify_incoming` event timestamps from `journal/events.jsonl`.
-   - Non-Mag-authored commits touching task frontmatter (i.e., commits to
-     `tasks/*.md` whose author is not the Mag identity — file mtime + git
-     blame on the modified frontmatter line range), with a bounded look-back
+   - Non-Mag-authored commits touching task frontmatter — commits to
+     `tasks/*.md` whose author is not the Mag identity (recognized by a
+     `Co-Authored-By: Claude` trailer) AND at least one of whose diff hunks
+     overlaps the file's YAML frontmatter line range at that commit. A
+     body-only edit does not advance the signal. Bounded by a look-back
      window appropriate to the 18h threshold.
    - Queue request entries whose `action` is NOT in `MAG_AUTO_ACTIONS`.
 

--- a/docs/proposals/activity-gate-periodic-skills.md
+++ b/docs/proposals/activity-gate-periodic-skills.md
@@ -52,8 +52,13 @@ Issue: https://github.com/lukstafi/ludics/issues/538
 3. In `src/mag.ts` `resolveQueueRequestCommand` (the `executeProgrammatic`
    branch), each of the three new gated actions has an arm parallel to the
    existing `health-check` arm:
-   - `briefing` — gate signal `lastUserActionEpoch`, threshold = 18h
-     (skip when `(now - lastUserActionEpoch) < 18h`).
+   - `briefing` — gate signal `lastUserActionEpoch`, threshold = 18h.
+     Skip when no qualifying user action has advanced since the prior
+     briefing snapshot AND the latest qualifying user action is older
+     than `(now - 18h)`. The "no progress since prior snapshot" arm is
+     the proposal's core skip case; the 18h staleness arm is the
+     slow-decay safeguard so we never permanently suppress a briefing
+     on a repo whose user-action clock barely moves.
    - `adopt-sessions` — gate signal `unclassifiedFingerprint`, skip when
      unchanged since the last run.
    - On skip, emit `<gate>_skipped` (`briefing_skipped`,
@@ -226,12 +231,12 @@ Issue: https://github.com/lukstafi/ludics/issues/538
 
 ### Event-type stability
 
-17. The four gate-skip event types — `health_check_skipped`,
-    `briefing_skipped`, `feedback_digest_skipped`, `adopt_sessions_skipped` —
-    are committed names. Existing readers of `health_check_skipped`
-    continue to work unchanged. (The unified `meta.gateSkip: true` marker
-    is additive — it sits alongside the per-event-type name, not in place
-    of it.)
+17. The five gate-skip event types — `health_check_skipped`,
+    `briefing_skipped`, `feedback_digest_skipped`, `adopt_sessions_skipped`,
+    and `verify_completion_skipped` — are committed names. Existing
+    readers of `health_check_skipped` continue to work unchanged. (The
+    unified `meta.gateSkip: true` marker is additive — it sits alongside
+    the per-event-type name, not in place of it.)
 
 ## Context
 

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -6,7 +6,7 @@
 import { existsSync, readFileSync, statSync, writeFileSync } from "fs";
 import { resolve, extname, join } from "path";
 import YAML from "yaml";
-import { dashboardGenerate } from "./dashboard.ts";
+import { dashboardGenerate, generateGateSkips } from "./dashboard.ts";
 import { harnessDir, loadConfigSync } from "./config.ts";
 import { readSlotJson, normalizeTaskId } from "./slots/json.ts";
 import { slotClear, slotSetMode, slotStart, slotResume, findSlotForTask, VALID_CLEAR_STATUSES, CLEAR_STATUS_READY, CLEAR_STATUS_DONE } from "./slots/index.ts";
@@ -758,6 +758,18 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         const config = loadConfigSync();
         const projects = (config.projects ?? []).map((p: { name?: string }) => String(p.name ?? "")).filter(Boolean);
         return new Response(JSON.stringify({ projects }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
+    // gh-ludics-538 AC 12: read-only "Skipped because X" surface. Reads
+    // journal/events.jsonl directly — no new persistent state.
+    if (pathname === "/api/gate-skips") {
+      try {
+        return new Response(JSON.stringify(generateGateSkips()), {
           headers: { "Content-Type": "application/json" },
         });
       } catch (e) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -271,6 +271,54 @@ describe("generateGateSkips read-side aggregator", () => {
     const out = generateGateSkips();
     expect(out.feedback_digest_skipped?.reason).toBe("no feedback files");
   });
+});
+
+// gh-ludics-538 AC 16: assert the route handler itself — not just the
+// underlying aggregator — returns 200 + application/json + the grouped
+// payload. Catches misspelled routes, missing handlers, wrong content
+// types, and serialization failures that the data-layer tests miss.
+describe("dashboard HTTP /api/gate-skips", () => {
+  async function makeHandler(): Promise<(req: Request) => Promise<Response>> {
+    const { buildHandlers } = await import("./dashboard-server.ts");
+    const dashboardDir = join(harnessDir(), "dashboard");
+    mkdirSync(dashboardDir, { recursive: true });
+    mkdirSync(join(dashboardDir, "data"), { recursive: true });
+    return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
+  }
+
+  test("GET /api/gate-skips returns 200, application/json, and the grouped aggregator payload", async () => {
+    const journal = join(harnessDir(), "journal");
+    mkdirSync(journal, { recursive: true });
+    const lines = [
+      JSON.stringify({ ts: "2026-05-02T00:00:00Z", epoch: 1700100000, event_type: "health_check_skipped", source: "k", scope: "m", message: "old health skip", meta: { gateSkip: true }, currentLines: 10, priorLines: 5 }),
+      JSON.stringify({ ts: "2026-05-02T00:01:00Z", epoch: 1700100060, event_type: "briefing_skipped", source: "m", scope: "m", message: "briefing idle", meta: { gateSkip: true }, current: 1700000000, prior: 1700000000 }),
+      // Non-marker event — must not pollute the response.
+      JSON.stringify({ ts: "2026-05-02T00:02:00Z", epoch: 1700100120, event_type: "queue_request", source: "cli", scope: "queue", action: "elaborate", message: "req-x" }),
+    ];
+    writeFileSync(join(journal, "events.jsonl"), lines.join("\n") + "\n");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/gate-skips"));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("application/json");
+    const body = await resp.json() as Record<string, { gate: string; reason: string; timestamp: string }>;
+    expect(body.health_check_skipped?.reason).toBe("old health skip");
+    expect(body.briefing_skipped?.reason).toBe("briefing idle");
+    expect(body.queue_request).toBeUndefined();
+  });
+
+  test("GET /api/gate-skips returns 200 + empty JSON object when no skip events exist", async () => {
+    const journal = join(harnessDir(), "journal");
+    mkdirSync(journal, { recursive: true });
+    writeFileSync(join(journal, "events.jsonl"), "");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/gate-skips"));
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("content-type")).toContain("application/json");
+    const body = await resp.json() as Record<string, unknown>;
+    expect(body).toEqual({});
+  });
 
   test("doctor cache TTL eviction replaces the returned doctor.timestamp across the boundary", async () => {
     const {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -221,6 +221,57 @@ describe("generateHealthData", () => {
     expect(second.doctor.timestamp).toBe(first.doctor.timestamp);
   });
 
+  // gh-ludics-538 AC 13: gateSkips aggregate is attached to health.json.
+  test("gateSkips is a present object on the health surface (default empty)", async () => {
+    const data = await getHealthData() as any;
+    expect(typeof data.gateSkips).toBe("object");
+    expect(data.gateSkips).not.toBeNull();
+  });
+
+  test("gateSkips surfaces latest skip per gate from events.jsonl", async () => {
+    const journal = join(harnessDir(), "journal");
+    mkdirSync(journal, { recursive: true });
+    const lines = [
+      JSON.stringify({ ts: "2026-05-01T00:00:00Z", epoch: 1700000000, event_type: "health_check_skipped", source: "k", scope: "m", message: "old health skip", meta: { gateSkip: true }, currentLines: 10, priorLines: 5 }),
+      JSON.stringify({ ts: "2026-05-02T00:00:00Z", epoch: 1700100000, event_type: "health_check_skipped", source: "k", scope: "m", message: "newer health skip", meta: { gateSkip: true }, currentLines: 20, priorLines: 15 }),
+      JSON.stringify({ ts: "2026-05-02T00:01:00Z", epoch: 1700100060, event_type: "briefing_skipped", source: "m", scope: "m", message: "briefing idle", meta: { gateSkip: true }, current: 1700000000, prior: 1700000000 }),
+      // Non-marker line (real event) — must NOT appear in the aggregate.
+      JSON.stringify({ ts: "2026-05-02T00:02:00Z", epoch: 1700100120, event_type: "queue_request", source: "cli", scope: "queue", action: "elaborate", message: "req-x" }),
+      // Malformed line — must be ignored.
+      "not json",
+    ];
+    writeFileSync(join(journal, "events.jsonl"), lines.join("\n") + "\n");
+
+    const data = await getHealthData() as any;
+    expect(data.gateSkips.health_check_skipped.reason).toBe("newer health skip");
+    expect(data.gateSkips.briefing_skipped.reason).toBe("briefing idle");
+    expect(data.gateSkips.queue_request).toBeUndefined();
+  });
+});
+
+// gh-ludics-538 AC 16: GET /api/gate-skips serves the aggregation.
+describe("generateGateSkips read-side aggregator", () => {
+  test("empty events.jsonl → empty object", async () => {
+    const journal = join(harnessDir(), "journal");
+    mkdirSync(journal, { recursive: true });
+    writeFileSync(join(journal, "events.jsonl"), "");
+    const { generateGateSkips } = await import("./dashboard.ts");
+    expect(generateGateSkips()).toEqual({});
+  });
+
+  test("only meta.gateSkip records pass through", async () => {
+    const journal = join(harnessDir(), "journal");
+    mkdirSync(journal, { recursive: true });
+    const lines = [
+      JSON.stringify({ ts: "2026-05-02T00:00:00Z", epoch: 1700100000, event_type: "feedback_digest_skipped", source: "m", scope: "m", message: "no feedback files", meta: { gateSkip: true } }),
+      JSON.stringify({ ts: "2026-05-02T00:00:01Z", epoch: 1700100001, event_type: "feedback_digest_skipped", source: "m", scope: "m", message: "still no files" }), // no marker
+    ];
+    writeFileSync(join(journal, "events.jsonl"), lines.join("\n") + "\n");
+    const { generateGateSkips } = await import("./dashboard.ts");
+    const out = generateGateSkips();
+    expect(out.feedback_digest_skipped?.reason).toBe("no feedback files");
+  });
+
   test("doctor cache TTL eviction replaces the returned doctor.timestamp across the boundary", async () => {
     const {
       generateHealthData,

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -286,14 +286,19 @@ describe("dashboard HTTP /api/gate-skips", () => {
     return buildHandlers({ dashboardDir, ttlSeconds: 3600 });
   }
 
-  test("GET /api/gate-skips returns 200, application/json, and the grouped aggregator payload", async () => {
+  test("GET /api/gate-skips covers all 5 committed gate names + asserts current/prior signal pair (AC 12/16/17)", async () => {
     const journal = join(harnessDir(), "journal");
     mkdirSync(journal, { recursive: true });
+    // One skip event per AC-17 committed gate name + a non-marker control.
+    // Each carries `current`/`prior` per AC 3/12 minimum diagnostic shape.
     const lines = [
-      JSON.stringify({ ts: "2026-05-02T00:00:00Z", epoch: 1700100000, event_type: "health_check_skipped", source: "k", scope: "m", message: "old health skip", meta: { gateSkip: true }, currentLines: 10, priorLines: 5 }),
+      JSON.stringify({ ts: "2026-05-02T00:00:00Z", epoch: 1700100000, event_type: "health_check_skipped", source: "k", scope: "m", message: "old health skip", meta: { gateSkip: true }, current: 10, prior: 5, currentLines: 10, priorLines: 5 }),
       JSON.stringify({ ts: "2026-05-02T00:01:00Z", epoch: 1700100060, event_type: "briefing_skipped", source: "m", scope: "m", message: "briefing idle", meta: { gateSkip: true }, current: 1700000000, prior: 1700000000 }),
+      JSON.stringify({ ts: "2026-05-02T00:02:00Z", epoch: 1700100120, event_type: "feedback_digest_skipped", source: "m", scope: "m", message: "no feedback files", meta: { gateSkip: true }, current: 0, prior: 0 }),
+      JSON.stringify({ ts: "2026-05-02T00:03:00Z", epoch: 1700100180, event_type: "adopt_sessions_skipped", source: "m", scope: "m", message: "fingerprint unchanged", meta: { gateSkip: true }, current: "hashA", prior: "hashA" }),
+      JSON.stringify({ ts: "2026-05-02T00:04:00Z", epoch: 1700100240, event_type: "verify_completion_skipped", source: "m", scope: "m", message: "epoch unchanged", meta: { gateSkip: true }, current: 1700050000, prior: 1700050000, task: "task-zzz" }),
       // Non-marker event — must not pollute the response.
-      JSON.stringify({ ts: "2026-05-02T00:02:00Z", epoch: 1700100120, event_type: "queue_request", source: "cli", scope: "queue", action: "elaborate", message: "req-x" }),
+      JSON.stringify({ ts: "2026-05-02T00:05:00Z", epoch: 1700100300, event_type: "queue_request", source: "cli", scope: "queue", action: "elaborate", message: "req-x" }),
     ];
     writeFileSync(join(journal, "events.jsonl"), lines.join("\n") + "\n");
 
@@ -301,9 +306,22 @@ describe("dashboard HTTP /api/gate-skips", () => {
     const resp = await handler(new Request("http://x/api/gate-skips"));
     expect(resp.status).toBe(200);
     expect(resp.headers.get("content-type")).toContain("application/json");
-    const body = await resp.json() as Record<string, { gate: string; reason: string; timestamp: string }>;
+    const body = await resp.json() as Record<string, { gate?: string; reason?: string; timestamp?: string; current?: unknown; prior?: unknown }>;
+
+    // All 5 committed gate names present.
     expect(body.health_check_skipped?.reason).toBe("old health skip");
     expect(body.briefing_skipped?.reason).toBe("briefing idle");
+    expect(body.feedback_digest_skipped?.reason).toBe("no feedback files");
+    expect(body.adopt_sessions_skipped?.reason).toBe("fingerprint unchanged");
+    expect(body.verify_completion_skipped?.reason).toBe("epoch unchanged");
+    // Signal pair surfaces at the HTTP boundary (AC 12 minimum diagnostic shape).
+    expect(body.health_check_skipped?.current).toBe(10);
+    expect(body.health_check_skipped?.prior).toBe(5);
+    expect(body.briefing_skipped?.current).toBe(1700000000);
+    expect(body.adopt_sessions_skipped?.current).toBe("hashA");
+    expect(body.adopt_sessions_skipped?.prior).toBe("hashA");
+    expect(body.verify_completion_skipped?.current).toBe(1700050000);
+    // Non-marker event excluded.
     expect(body.queue_request).toBeUndefined();
   });
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1077,7 +1077,61 @@ export function generateHealthData(): Record<string, unknown> {
   return {
     healthReport,
     doctor: { output: doctorCache.output, timestamp: doctorCache.timestamp },
+    gateSkips: generateGateSkips(),
   };
+}
+
+/** Gate-skip surface for the dashboard health card (gh-ludics-538 AC 12 / 13).
+ *
+ *  Reads journal/events.jsonl directly — no new persistent state file. The
+ *  aggregator filters TO records bearing meta.gateSkip === true, groups by
+ *  event_type, and retains the latest record per group. Each summary
+ *  includes the gate name, ISO timestamp, the gate's reason string, and the
+ *  current/prior signal pair when present. */
+export interface GateSkipSummary {
+  gate: string;
+  timestamp: string;
+  reason: string;
+  current: unknown;
+  prior: unknown;
+}
+
+export function generateGateSkips(eventsFile?: string): Record<string, GateSkipSummary> {
+  const path = eventsFile ?? join(harnessDir(), "journal", "events.jsonl");
+  if (!existsSync(path)) return {};
+  let buf: string;
+  try { buf = readFileSync(path, "utf-8"); } catch { return {}; }
+  if (!buf) return {};
+  const out: Record<string, GateSkipSummary> = {};
+  for (const line of buf.split("\n")) {
+    if (!line) continue;
+    let parsed: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(line) as unknown;
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+      parsed = raw as Record<string, unknown>;
+    } catch { continue; }
+    const meta = parsed.meta;
+    if (!meta || typeof meta !== "object" || (meta as Record<string, unknown>).gateSkip !== true) continue;
+    const eventType = typeof parsed.event_type === "string" ? parsed.event_type : "";
+    if (!eventType) continue;
+    const ts = typeof parsed.ts === "string" ? parsed.ts : "";
+    const reason = typeof parsed.message === "string" ? parsed.message : "";
+    const summary: GateSkipSummary = {
+      gate: eventType,
+      timestamp: ts,
+      reason,
+      current: parsed.current ?? parsed.currentLines ?? null,
+      prior: parsed.prior ?? parsed.priorLines ?? null,
+    };
+    const existing = out[eventType];
+    if (!existing || (existing.timestamp && summary.timestamp && summary.timestamp >= existing.timestamp)) {
+      out[eventType] = summary;
+    } else if (!existing.timestamp) {
+      out[eventType] = summary;
+    }
+  }
+  return out;
 }
 
 // --- Generate all ---

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -9,6 +9,7 @@ import {
   HEALTH_GATE_THRESHOLD,
   MAG_AUTO_ACTIONS,
   isMagAutoAction,
+  isMagAuthoredCommit,
   latestUserActionEpoch,
   writeGateSnapshot,
   countGateEligibleLines,
@@ -470,6 +471,82 @@ describe("latestUserActionEpoch", () => {
     expect(got).toBeGreaterThan(0);
     rmSync(dir, { recursive: true });
   });
+
+  test("Mag-authored task commit does NOT advance signal (AC 6 author predicate)", () => {
+    const dir = makeTmpDir();
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    writeFileSync(join(dir, "tasks", "test.md"), "---\nstatus: ready\n---\nhi\n");
+    r(["add", "tasks/test.md"]);
+    // Commit with a Co-Authored-By: Claude trailer. Same git author as the
+    // user-task test above — the predicate must NOT depend on `%an` alone.
+    r(["commit", "-q", "-m", "mag-touched task\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"]);
+    const now = new Date();
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    // Clean scan, all candidate commits filtered by the Mag-author trailer.
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("mixed authorship: only non-Mag commits advance the signal", () => {
+    const dir = makeTmpDir();
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    // First commit: Mag-authored (older).
+    writeFileSync(join(dir, "tasks", "a.md"), "a\n");
+    r(["add", "tasks/a.md"]);
+    r(["commit", "-q", "--date=2026-04-01T12:00:00Z", "-m", "mag commit\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"]);
+    const magEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
+    // Second commit: user-authored (newer in repo order but older epoch).
+    writeFileSync(join(dir, "tasks", "b.md"), "b\n");
+    r(["add", "tasks/b.md"]);
+    r(["commit", "-q", "--date=2026-04-02T12:00:00Z", "-m", "user commit"]);
+    const userEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
+
+    const now = new Date((userEpoch + 3600) * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 24 * 365 });
+    // Must be the user epoch, not max(magEpoch, userEpoch). magEpoch is
+    // older here but the predicate must reject it regardless of relative age.
+    expect(got).toBe(userEpoch);
+    expect(got).not.toBe(magEpoch);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("isMagAuthoredCommit", () => {
+  test("recognizes Co-Authored-By: Claude trailer", () => {
+    expect(isMagAuthoredCommit("foo\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>")).toBe(true);
+  });
+
+  test("recognizes lowercase + spacing variants", () => {
+    expect(isMagAuthoredCommit("foo\n\nco-authored-by:   claude  <x@y>")).toBe(true);
+  });
+
+  test("does not match Co-Authored-By trailer with a non-Claude collaborator", () => {
+    expect(isMagAuthoredCommit("foo\n\nCo-Authored-By: Alice Smith <alice@example.com>")).toBe(false);
+  });
+
+  test("does not match a body that merely mentions Claude in prose", () => {
+    expect(isMagAuthoredCommit("ran the claude API once\n\nCo-Authored-By: Alice <a@b>")).toBe(false);
+  });
+
+  test("empty body → false", () => {
+    expect(isMagAuthoredCommit("")).toBe(false);
+  });
+});
+
+describe("latestUserActionEpoch look-back window", () => {
+  function ev(epoch: number, extra: Record<string, unknown>): string {
+    return JSON.stringify({ ts: new Date(epoch * 1000).toISOString(), epoch, source: "test", scope: "test", ...extra });
+  }
 
   test("look-back window bounds activity (very old activity excluded)", () => {
     const dir = makeTmpDir();

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -284,6 +284,22 @@ describe("shouldSkipPeriodic — mode dispatch", () => {
     rmSync(dir, { recursive: true });
   });
 
+  test("activity-window: current=0 AND prior in the future → run (clock-skew beats the zero-activity fast path, codex P1)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br.json");
+    const now = new Date(2_000_000_000 * 1000);
+    const futurePrior = Math.floor(now.getTime() / 1000) + 1_000_000;
+    writeGateSnapshot(snap, futurePrior);
+    // current === 0 (idle look-back) WITH a future prior snapshot. Before the
+    // P1 fix the `current === 0` fast path returned skip:true ahead of the
+    // clock-skew guard, suppressing briefing indefinitely. The guard must win.
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 3600, mode: "activity-window", now });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("clock skew");
+    expect(dec.reason).toContain("fail open");
+    rmSync(dir, { recursive: true });
+  });
+
   test("epoch-unchanged: current <= prior → skip", () => {
     const dir = makeTmpDir();
     const snap = join(dir, "mag", "v.json");
@@ -537,6 +553,33 @@ describe("latestUserActionEpoch", () => {
     const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 24 * 365 });
     // Frontmatter edit by non-Mag author → advance.
     expect(got).toBe(userFmEpoch);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("non-Mag commit REMOVING task frontmatter advances signal (codex P2 — pre-image range)", () => {
+    const dir = makeTmpDir();
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    // Mag-authored seed with frontmatter (lines 1-3) + body (line 4).
+    writeFileSync(join(dir, "tasks", "t.md"), "---\nstatus: ready\n---\nbody\n");
+    r(["add", "tasks/t.md"]);
+    r(["commit", "-q", "--date=2026-04-01T12:00:00Z", "-m", "seed\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"]);
+    // Non-Mag commit DELETES the frontmatter delimiters entirely — the
+    // post-image has no parseable frontmatter, so the post-only check would
+    // miss it; the pre-image range (1-3) + the deletion hunk's OLD side catch it.
+    writeFileSync(join(dir, "tasks", "t.md"), "body\n");
+    r(["add", "tasks/t.md"]);
+    r(["commit", "-q", "--date=2026-04-02T12:00:00Z", "-m", "drop frontmatter"]);
+
+    const removalEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
+    const now = new Date((removalEpoch + 3600) * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 24 * 365 });
+    // Removing frontmatter IS a frontmatter modification → advance.
+    expect(got).toBe(removalEpoch);
     rmSync(dir, { recursive: true });
   });
 

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { spawnSync } from "child_process";
@@ -322,6 +322,22 @@ describe("shouldSkipPeriodic — mode dispatch", () => {
     rmSync(dir, { recursive: true });
   });
 
+  test("epoch-unchanged: prior > now (clock skew) → run (fail open, AC 1)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "v.json");
+    // Pin `now` and stamp the prior signal one hour AFTER `now`. Without the
+    // future-prior guard the gate would take the `cur <= prior` branch and
+    // skip — that would let a clock skew permanently suppress verify-completion.
+    const now = new Date(1_700_000_000 * 1000);
+    const futurePrior = 1_700_003_600; // now + 1h
+    writeGateSnapshot(snap, futurePrior);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 1_700_000_000, threshold: 0, mode: "epoch-unchanged", now });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("clock skew");
+    expect(dec.reason).toContain("fail open");
+    rmSync(dir, { recursive: true });
+  });
+
   test("epoch-unchanged: current=0 + first run → run (fail open via first-run arm)", () => {
     const dir = makeTmpDir();
     const snap = join(dir, "mag", "missing.json");
@@ -453,7 +469,7 @@ describe("latestUserActionEpoch", () => {
     rmSync(dir, { recursive: true });
   });
 
-  test("non-Mag task commit advances signal (Gap C — conservative proxy)", () => {
+  test("non-Mag commit creating a task with frontmatter advances signal (AC 6 strict — initial-add hunk covers frontmatter)", () => {
     const dir = makeTmpDir();
     // Init a real git repo so `git log -- tasks/` returns commits.
     const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
@@ -469,6 +485,58 @@ describe("latestUserActionEpoch", () => {
     const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
     expect(typeof got).toBe("number");
     expect(got).toBeGreaterThan(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("non-Mag commit touching only task BODY does NOT advance signal (AC 6 strict — frontmatter-bounded)", () => {
+    const dir = makeTmpDir();
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    // Seed with Mag-authored initial commit so the file exists. Mag-authored
+    // → ignored upstream so it doesn't pollute the signal we're measuring.
+    writeFileSync(join(dir, "tasks", "test.md"), "---\nstatus: ready\n---\nbody-v1\n");
+    r(["add", "tasks/test.md"]);
+    r(["commit", "-q", "--date=2026-04-01T12:00:00Z", "-m", "seed task\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"]);
+    // Non-Mag commit that edits ONLY the body (line 4), frontmatter (lines 1-3) untouched.
+    writeFileSync(join(dir, "tasks", "test.md"), "---\nstatus: ready\n---\nbody-v2\n");
+    r(["add", "tasks/test.md"]);
+    r(["commit", "-q", "--date=2026-04-02T12:00:00Z", "-m", "tweak body"]);
+
+    const userBodyEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
+    const now = new Date((userBodyEpoch + 3600) * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 24 * 365 });
+    // Body-only change → frontmatter predicate rejects this commit. The seed
+    // commit was Mag-authored → also rejected. Clean scan → 0.
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("non-Mag commit touching task FRONTMATTER advances signal (AC 6 strict — frontmatter-only hunk)", () => {
+    const dir = makeTmpDir();
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    // Seed with a Mag-authored commit so file exists.
+    writeFileSync(join(dir, "tasks", "t.md"), "---\nstatus: ready\nproject: ludics\n---\nbody\n");
+    r(["add", "tasks/t.md"]);
+    r(["commit", "-q", "--date=2026-04-01T12:00:00Z", "-m", "seed\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"]);
+    // Non-Mag commit edits ONLY line 2 (frontmatter, `status:`); body untouched.
+    writeFileSync(join(dir, "tasks", "t.md"), "---\nstatus: done\nproject: ludics\n---\nbody\n");
+    r(["add", "tasks/t.md"]);
+    r(["commit", "-q", "--date=2026-04-02T12:00:00Z", "-m", "mark done"]);
+
+    const userFmEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
+    const now = new Date((userFmEpoch + 3600) * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 24 * 365 });
+    // Frontmatter edit by non-Mag author → advance.
+    expect(got).toBe(userFmEpoch);
     rmSync(dir, { recursive: true });
   });
 
@@ -500,13 +568,14 @@ describe("latestUserActionEpoch", () => {
     r(["config", "user.name", "Test User"]);
     r(["config", "commit.gpgsign", "false"]);
     mkdirSync(join(dir, "tasks"));
-    // First commit: Mag-authored (older).
-    writeFileSync(join(dir, "tasks", "a.md"), "a\n");
+    // First commit: Mag-authored (older). Includes frontmatter so the AC 6
+    // strict frontmatter predicate would otherwise count it.
+    writeFileSync(join(dir, "tasks", "a.md"), "---\nstatus: ready\n---\na\n");
     r(["add", "tasks/a.md"]);
     r(["commit", "-q", "--date=2026-04-01T12:00:00Z", "-m", "mag commit\n\nCo-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"]);
     const magEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
-    // Second commit: user-authored (newer in repo order but older epoch).
-    writeFileSync(join(dir, "tasks", "b.md"), "b\n");
+    // Second commit: user-authored, also touches frontmatter on a new task.
+    writeFileSync(join(dir, "tasks", "b.md"), "---\nstatus: ready\n---\nb\n");
     r(["add", "tasks/b.md"]);
     r(["commit", "-q", "--date=2026-04-02T12:00:00Z", "-m", "user commit"]);
     const userEpoch = Number.parseInt(spawnSync("git", ["log", "-1", "--format=%at"], { cwd: dir, encoding: "utf8" }).stdout.trim(), 10);
@@ -577,7 +646,7 @@ describe("writeGateSnapshot round-trip", () => {
     const dir = makeTmpDir();
     const path = join(dir, "mag", "test-last.json");
     writeGateSnapshot(path, 12345);
-    const parsed = JSON.parse(require("fs").readFileSync(path, "utf8"));
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
     expect(parsed.signal).toBe(12345);
     expect(parsed.eventsJsonlLines).toBe(12345);
     expect(typeof parsed.timestamp).toBe("string");
@@ -588,7 +657,7 @@ describe("writeGateSnapshot round-trip", () => {
     const dir = makeTmpDir();
     const path = join(dir, "mag", "fp-last.json");
     writeGateSnapshot(path, "abc123");
-    const parsed = JSON.parse(require("fs").readFileSync(path, "utf8"));
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
     expect(parsed.signal).toBe("abc123");
     expect("eventsJsonlLines" in parsed).toBe(false);
     rmSync(dir, { recursive: true });

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -1,8 +1,18 @@
 import { describe, test, expect } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { shouldSkipHealthCheck, HEALTH_GATE_THRESHOLD } from "./health-gate.ts";
+import { spawnSync } from "child_process";
+import {
+  shouldSkipHealthCheck,
+  shouldSkipPeriodic,
+  HEALTH_GATE_THRESHOLD,
+  MAG_AUTO_ACTIONS,
+  isMagAutoAction,
+  latestUserActionEpoch,
+  writeGateSnapshot,
+  countGateEligibleLines,
+} from "./health-gate.ts";
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `health-gate-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -17,11 +27,11 @@ function writeEvents(dir: string, lines: number): void {
   writeFileSync(join(dir, "journal", "events.jsonl"), body);
 }
 
-function writeSnapshot(dir: string, obj: Record<string, unknown>): void {
+function writeHealthSnapshot(dir: string, obj: Record<string, unknown>): void {
   writeFileSync(join(dir, "mag", "health-last.json"), JSON.stringify(obj));
 }
 
-describe("shouldSkipHealthCheck", () => {
+describe("shouldSkipHealthCheck (compat wrapper)", () => {
   test("first run with no health-last.json → skip: false", () => {
     const dir = makeTmpDir();
     writeEvents(dir, 100);
@@ -35,17 +45,17 @@ describe("shouldSkipHealthCheck", () => {
   test("snapshot present but missing eventsJsonlLines → skip: false", () => {
     const dir = makeTmpDir();
     writeEvents(dir, 100);
-    writeSnapshot(dir, { timestamp: "2026-04-24T00:00:00Z", findings: [] });
+    writeHealthSnapshot(dir, { timestamp: "2026-04-24T00:00:00Z", findings: [] });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
-    expect(res.reason).toContain("eventsJsonlLines");
+    expect(res.reason).toContain("signal");
     rmSync(dir, { recursive: true });
   });
 
   test("delta under threshold → skip: true", () => {
     const dir = makeTmpDir();
     writeEvents(dir, 1030);
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(true);
     expect(res.currentLines).toBe(1030);
@@ -54,10 +64,10 @@ describe("shouldSkipHealthCheck", () => {
     rmSync(dir, { recursive: true });
   });
 
-  test("delta exactly at threshold (50) → skip: false", () => {
+  test("delta exactly at threshold (300) → skip: false", () => {
     const dir = makeTmpDir();
-    writeEvents(dir, 1050);
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeEvents(dir, 1000 + HEALTH_GATE_THRESHOLD);
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
     expect(res.currentLines - res.priorLines).toBe(HEALTH_GATE_THRESHOLD);
@@ -66,18 +76,18 @@ describe("shouldSkipHealthCheck", () => {
 
   test("delta over threshold → skip: false", () => {
     const dir = makeTmpDir();
-    writeEvents(dir, 1200);
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeEvents(dir, 1000 + HEALTH_GATE_THRESHOLD + 100);
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
-    expect(res.currentLines).toBe(1200);
+    expect(res.currentLines).toBe(1000 + HEALTH_GATE_THRESHOLD + 100);
     expect(res.priorLines).toBe(1000);
     rmSync(dir, { recursive: true });
   });
 
   test("events.jsonl missing → skip: false (fail open)", () => {
     const dir = makeTmpDir();
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
     expect(res.reason).toContain("fail open");
@@ -87,7 +97,7 @@ describe("shouldSkipHealthCheck", () => {
   test("events.jsonl empty → skip: false (fail open)", () => {
     const dir = makeTmpDir();
     writeFileSync(join(dir, "journal", "events.jsonl"), "");
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
     expect(res.reason).toContain("fail open");
@@ -97,17 +107,17 @@ describe("shouldSkipHealthCheck", () => {
   test("non-numeric eventsJsonlLines → skip: false", () => {
     const dir = makeTmpDir();
     writeEvents(dir, 100);
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: "1000" });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: "1000" });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
-    expect(res.reason).toContain("eventsJsonlLines");
+    expect(res.reason).toContain("signal");
     rmSync(dir, { recursive: true });
   });
 
   test("line count handles file without trailing newline", () => {
     const dir = makeTmpDir();
     writeFileSync(join(dir, "journal", "events.jsonl"), "a\nb\nc");
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.currentLines).toBe(3);
     rmSync(dir, { recursive: true });
@@ -115,9 +125,8 @@ describe("shouldSkipHealthCheck", () => {
 
   test("negative delta (rotated/compacted log) → skip: false (fail open)", () => {
     const dir = makeTmpDir();
-    // Current file has 200 eligible lines; prior anchor claims 1000.
     writeEvents(dir, 200);
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 1000 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.skip).toBe(false);
     expect(res.reason).toContain("backward");
@@ -127,28 +136,365 @@ describe("shouldSkipHealthCheck", () => {
     rmSync(dir, { recursive: true });
   });
 
-  test("health_check_skipped events are excluded from the gate count", () => {
+  test("health_check_skipped events are excluded from the gate count (legacy substring fallback)", () => {
     const dir = makeTmpDir();
-    // 40 real events + 20 skip-marker events = 60 physical lines, but only
-    // 40 gate-eligible. Prior 0 → delta 40 < 50 → skip.
     const realLines = Array.from({ length: 40 }, (_, i) => JSON.stringify({ event_type: "mag_queue_feed", n: i }));
     const skipLines = Array.from({ length: 20 }, (_, i) => JSON.stringify({ event_type: "health_check_skipped", n: i }));
     writeFileSync(join(dir, "journal", "events.jsonl"), [...realLines, ...skipLines].join("\n") + "\n");
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.currentLines).toBe(40);
     expect(res.skip).toBe(true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("meta.gateSkip: true events are excluded from the gate count (unified marker)", () => {
+    const dir = makeTmpDir();
+    const realLines = Array.from({ length: 40 }, (_, i) => JSON.stringify({ event_type: "mag_queue_feed", n: i }));
+    // Use a non-canonical event_type so legacy substring exclusion can't act.
+    const skipLines = Array.from({ length: 20 }, (_, i) => JSON.stringify({ event_type: "some_other_skip", meta: { gateSkip: true }, n: i }));
+    writeFileSync(join(dir, "journal", "events.jsonl"), [...realLines, ...skipLines].join("\n") + "\n");
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    const res = shouldSkipHealthCheck({ stateDir: dir });
+    // 40 real + 0 marker-excluded = 40 eligible, delta 40 < 300 → skip.
+    expect(res.currentLines).toBe(40);
+    expect(res.skip).toBe(true);
+    rmSync(dir, { recursive: true });
   });
 
   test("many skip-marker events alone cannot push delta over threshold", () => {
     const dir = makeTmpDir();
-    // Simulate 100 accumulated skip events and 0 real activity since last run.
     const skipLines = Array.from({ length: 100 }, (_, i) => JSON.stringify({ event_type: "health_check_skipped", n: i }));
     writeFileSync(join(dir, "journal", "events.jsonl"), skipLines.join("\n") + "\n");
-    writeSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
+    writeHealthSnapshot(dir, { timestamp: "x", eventsJsonlLines: 0 });
     const res = shouldSkipHealthCheck({ stateDir: dir });
     expect(res.currentLines).toBe(0);
     expect(res.skip).toBe(false);
     expect(res.reason).toContain("empty");
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("shouldSkipPeriodic — mode dispatch", () => {
+  test("count mode: same semantics as wrapper, plus fail-open on negative", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "test-last.json");
+    writeGateSnapshot(snap, 1000);
+    const dec = shouldSkipPeriodic({
+      gateName: "test", snapshotPath: snap, signal: 1100, threshold: 300, mode: "count",
+    });
+    expect(dec.skip).toBe(true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fingerprint mode: equal → skip, changed → run", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "fp-last.json");
+    writeGateSnapshot(snap, "abc");
+    const eq = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: "abc", threshold: 0, mode: "fingerprint" });
+    expect(eq.skip).toBe(true);
+    const diff = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: "xyz", threshold: 0, mode: "fingerprint" });
+    expect(diff.skip).toBe(false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("fingerprint mode: first run → run (fail open)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "fp-missing.json");
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: "abc", threshold: 0, mode: "fingerprint" });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("first run");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current=null (read error) → run", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br-last.json");
+    writeGateSnapshot(snap, 100);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: null, threshold: 3600, mode: "activity-window" });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("unreadable");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current=0 + prior snapshot → skip (proposal's core skip case)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br-last.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 3600, mode: "activity-window" });
+    expect(dec.skip).toBe(true);
+    expect(dec.reason).toContain("no qualifying user activity");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current=0 + first run → run", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br-missing.json");
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 3600, mode: "activity-window" });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("first run");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current > prior → run (new activity since prior)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const now = new Date(2_000_000_000 * 1000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 1_999_999_900, threshold: 3600, mode: "activity-window", now });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("new user activity");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current <= prior + recent → run (defensive recent-activity arm)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br.json");
+    const now = new Date(2_000_000_000 * 1000);
+    const recent = Math.floor(now.getTime() / 1000) - 60; // 60s ago
+    writeGateSnapshot(snap, recent);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: recent, threshold: 3600, mode: "activity-window", now });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("recent activity");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: current <= prior + stale → skip", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br.json");
+    const now = new Date(2_000_000_000 * 1000);
+    const stale = Math.floor(now.getTime() / 1000) - 24 * 3600; // 24h ago
+    writeGateSnapshot(snap, stale);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: stale, threshold: 18 * 3600, mode: "activity-window", now });
+    expect(dec.skip).toBe(true);
+    expect(dec.reason).toContain("no progress");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("activity-window: prior in the future → run (clock-skew defense)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "br.json");
+    const now = new Date(2_000_000_000 * 1000);
+    const futurePrior = Math.floor(now.getTime() / 1000) + 1_000_000;
+    writeGateSnapshot(snap, futurePrior);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: futurePrior - 10, threshold: 3600, mode: "activity-window", now });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("clock skew");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("epoch-unchanged: current <= prior → skip", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "v.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 1_000_000_000, threshold: 0, mode: "epoch-unchanged" });
+    expect(dec.skip).toBe(true);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("epoch-unchanged: current > prior → run", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "v.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 1_000_000_100, threshold: 0, mode: "epoch-unchanged" });
+    expect(dec.skip).toBe(false);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("epoch-unchanged: current=0 (unresolvable) → run (fail open)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "v.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 0, mode: "epoch-unchanged" });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("no resolvable activity epoch");
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("isMagAutoAction", () => {
+  test("each MAG_AUTO_ACTIONS entry classifies as auto", () => {
+    for (const action of MAG_AUTO_ACTIONS) {
+      expect(isMagAutoAction({ action })).toBe(true);
+    }
+  });
+
+  test("message + /compact classifies as auto", () => {
+    expect(isMagAutoAction({ action: "message", messageContent: "/compact" })).toBe(true);
+  });
+
+  test("message + user-content does NOT classify as auto", () => {
+    expect(isMagAutoAction({ action: "message", messageContent: "hello world" })).toBe(false);
+  });
+
+  test("message + missing messageContent (pre-upgrade) fails open to user-action", () => {
+    expect(isMagAutoAction({ action: "message" })).toBe(false);
+  });
+
+  test("non-denylisted action (elaborate) classifies as user", () => {
+    expect(isMagAutoAction({ action: "elaborate" })).toBe(false);
+  });
+
+  test("empty record → false", () => {
+    expect(isMagAutoAction({})).toBe(false);
+  });
+});
+
+describe("latestUserActionEpoch", () => {
+  function ev(epoch: number, extra: Record<string, unknown>): string {
+    return JSON.stringify({ ts: new Date(epoch * 1000).toISOString(), epoch, source: "test", scope: "test", ...extra });
+  }
+
+  test("notify_incoming advances the signal", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "notify_incoming", message: "msg" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(target);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("Mag-auto briefing queue_request does NOT advance signal", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "queue_request", action: "briefing", message: "req-x" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("user-initiated elaborate queue_request advances signal", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "queue_request", action: "elaborate", message: "req-x" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(target);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("auto-/compact message queue_request does NOT advance signal", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "queue_request", action: "message", messageContent: "/compact", message: "req-x" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("user message queue_request advances signal (messageContent != /compact)", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "queue_request", action: "message", messageContent: "hello", message: "req-x" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(target);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("meta.gateSkip events are excluded even when their action would otherwise count", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const target = Math.floor(now.getTime() / 1000) - 300;
+    // notify_incoming-shaped event but marked as gate skip — should be excluded.
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(target, { event_type: "notify_incoming", message: "msg", meta: { gateSkip: true } }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("empty events.jsonl + no git repo → returns 0 (clean dead window)", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "journal", "events.jsonl"), "");
+    // No tasks/ subdir at all so the git source is skipped (existsSync false).
+    const now = new Date(2_000_000_000 * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("corrupt events.jsonl read error → returns null (signal unreadable)", () => {
+    const dir = makeTmpDir();
+    // Truly unreadable: a directory at the path where the file should be.
+    rmSync(join(dir, "journal"), { recursive: true });
+    mkdirSync(join(dir, "journal", "events.jsonl"), { recursive: true });
+    const now = new Date(2_000_000_000 * 1000);
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(null);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("non-Mag task commit advances signal (Gap C — conservative proxy)", () => {
+    const dir = makeTmpDir();
+    // Init a real git repo so `git log -- tasks/` returns commits.
+    const r = (args: string[]) => spawnSync("git", args, { cwd: dir, encoding: "utf8" });
+    r(["init", "-q"]);
+    r(["config", "user.email", "test@example.com"]);
+    r(["config", "user.name", "Test User"]);
+    r(["config", "commit.gpgsign", "false"]);
+    mkdirSync(join(dir, "tasks"));
+    writeFileSync(join(dir, "tasks", "test.md"), "---\nstatus: ready\n---\nhi\n");
+    r(["add", "tasks/test.md"]);
+    r(["commit", "-q", "-m", "add task"]);
+    const now = new Date();
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(typeof got).toBe("number");
+    expect(got).toBeGreaterThan(0);
+    rmSync(dir, { recursive: true });
+  });
+
+  test("look-back window bounds activity (very old activity excluded)", () => {
+    const dir = makeTmpDir();
+    const now = new Date(2_000_000_000 * 1000);
+    const ancient = Math.floor(now.getTime() / 1000) - 100 * 24 * 3600; // 100 days ago
+    writeFileSync(join(dir, "journal", "events.jsonl"),
+      ev(ancient, { event_type: "notify_incoming", message: "msg" }) + "\n");
+    const got = latestUserActionEpoch({ stateDir: dir, now, lookbackHours: 48 });
+    expect(got).toBe(0);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("countGateEligibleLines — JSON-aware predicate", () => {
+  test("excludes meta.gateSkip lines from arbitrary event types", () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "journal", "events.jsonl");
+    const real = JSON.stringify({ event_type: "any", n: 1 });
+    const skip = JSON.stringify({ event_type: "made_up_skip", n: 2, meta: { gateSkip: true } });
+    writeFileSync(path, [real, skip, real, real].join("\n") + "\n");
+    expect(countGateEligibleLines(path)).toBe(3);
+    rmSync(dir, { recursive: true });
+  });
+});
+
+describe("writeGateSnapshot round-trip", () => {
+  test("number signal also preserved under legacy eventsJsonlLines alias", () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "mag", "test-last.json");
+    writeGateSnapshot(path, 12345);
+    const parsed = JSON.parse(require("fs").readFileSync(path, "utf8"));
+    expect(parsed.signal).toBe(12345);
+    expect(parsed.eventsJsonlLines).toBe(12345);
+    expect(typeof parsed.timestamp).toBe("string");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("string signal omits the legacy alias", () => {
+    const dir = makeTmpDir();
+    const path = join(dir, "mag", "fp-last.json");
+    writeGateSnapshot(path, "abc123");
+    const parsed = JSON.parse(require("fs").readFileSync(path, "utf8"));
+    expect(parsed.signal).toBe("abc123");
+    expect("eventsJsonlLines" in parsed).toBe(false);
+    rmSync(dir, { recursive: true });
   });
 });

--- a/src/health-gate.test.ts
+++ b/src/health-gate.test.ts
@@ -301,13 +301,32 @@ describe("shouldSkipPeriodic — mode dispatch", () => {
     rmSync(dir, { recursive: true });
   });
 
-  test("epoch-unchanged: current=0 (unresolvable) → run (fail open)", () => {
+  test("epoch-unchanged: current=0 with prior snapshot → skip (no advance)", () => {
     const dir = makeTmpDir();
     const snap = join(dir, "mag", "v.json");
     writeGateSnapshot(snap, 1_000_000_000);
     const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 0, mode: "epoch-unchanged" });
+    expect(dec.skip).toBe(true);
+    expect(dec.reason).toContain("no activity epoch resolvable");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("epoch-unchanged: current=null (read error) → run (fail open)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "v.json");
+    writeGateSnapshot(snap, 1_000_000_000);
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: null, threshold: 0, mode: "epoch-unchanged" });
     expect(dec.skip).toBe(false);
-    expect(dec.reason).toContain("no resolvable activity epoch");
+    expect(dec.reason).toContain("unreadable");
+    rmSync(dir, { recursive: true });
+  });
+
+  test("epoch-unchanged: current=0 + first run → run (fail open via first-run arm)", () => {
+    const dir = makeTmpDir();
+    const snap = join(dir, "mag", "missing.json");
+    const dec = shouldSkipPeriodic({ gateName: "t", snapshotPath: snap, signal: 0, threshold: 0, mode: "epoch-unchanged" });
+    expect(dec.skip).toBe(false);
+    expect(dec.reason).toContain("first run");
     rmSync(dir, { recursive: true });
   });
 });

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -233,13 +233,14 @@ export function shouldSkipPeriodic(opts: PeriodicGateOptions): PeriodicGateDecis
       return { skip: true, reason: `no progress since prior snapshot and latest activity ${age}s ago >= ${opts.threshold}s threshold`, current: cur, prior };
     }
     case "epoch-unchanged": {
-      // current === 0: no activity epoch resolvable for this target — run
-      // (per-target epochs should always reach something on a real task).
-      if (current === 0) {
-        return { skip: false, reason: "no resolvable activity epoch — fail open", current: 0, prior: snap.signal };
-      }
-      const cur = current as number;
+      // current === 0 with prior snapshot present: clean sources returned no
+      // activity for this target since we last checked — that IS "no advance",
+      // so skip. (Read-error returns null, which fails open above.)
+      const cur = (current as number) | 0;
       const prior = snap.signal as number;
+      if (cur === 0) {
+        return { skip: true, reason: "no activity epoch resolvable for this target since prior snapshot", current: 0, prior };
+      }
       if (cur <= prior) {
         return { skip: true, reason: `epoch ${cur} <= prior ${prior} — unchanged`, current: cur, prior };
       }

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -298,6 +298,22 @@ export interface UserActionSignalOptions {
   lookbackHours: number;
 }
 
+/** Predicate that recognizes a Mag-authored commit by its `Co-Authored-By:`
+ *  trailer referencing Claude (case-insensitive). Mag runs Claude in tmux
+ *  and shares the user's local git identity, so the trailer is the only
+ *  durable in-band marker that distinguishes Mag commits from human
+ *  commits in the state repo. Used to exclude Mag's own task-frontmatter
+ *  edits from the briefing user-action signal (AC 6). Exported for tests. */
+export function isMagAuthoredCommit(commitBody: string): boolean {
+  if (!commitBody) return false;
+  for (const rawLine of commitBody.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.toLowerCase().startsWith("co-authored-by:")) continue;
+    if (/claude/i.test(line)) return true;
+  }
+  return false;
+}
+
 /** Compute the max epoch across qualifying user activity sources in the
  *  look-back window. Three-valued return:
  *    number  — Unix epoch of the latest qualifying activity.
@@ -343,26 +359,38 @@ export function latestUserActionEpoch(opts: UserActionSignalOptions): number | n
   }
   // If the events file is absent, treat as "clean empty scan" (not error).
 
-  // Source 3: non-Mag-authored commits to tasks/*.md. Conservative proxy
-  // per docs/proposals/activity-gate-periodic-skills.md Gap C — every
-  // commit touching tasks/ counts (no author filter), since the state-repo's
-  // task frontmatter is user-edited in practice.
+  // Source 3: non-Mag-authored commits to tasks/*.md. Per AC 6, commits
+  // authored by Mag (recognized by a `Co-Authored-By:` trailer referencing
+  // Claude — see isMagAuthoredCommit) MUST NOT advance the signal. The
+  // strict frontmatter-line-range proposal text was relaxed to "any
+  // non-Mag-authored commit touching tasks/*.md" per Gap C in the merged
+  // plan, but the non-Mag-author predicate stands.
   const tasksDir = join(opts.stateDir, "tasks");
   if (existsSync(tasksDir)) {
     try {
+      // %at = author epoch; the body follows; we delimit records with an
+      // ASCII sentinel ("---END-OF-COMMIT---") that cannot collide with a
+      // commit message line (no embedded control bytes — lint:no-nul-bytes
+      // safe). The delimiter is anchored by surrounding newlines on split.
       const res = spawnSync("git", [
         "log",
         `--since=${opts.lookbackHours} hours ago`,
-        "--format=%at",
+        "--format=%at%n%B%n---END-OF-COMMIT---",
         "--",
         "tasks/",
       ], { cwd: opts.stateDir, encoding: "utf8", timeout: 5000 });
       if (res.status === 0 && typeof res.stdout === "string") {
-        for (const line of res.stdout.trim().split("\n")) {
-          const epoch = Number.parseInt(line, 10);
-          if (Number.isFinite(epoch) && epoch >= horizon && epoch > best) {
-            best = epoch;
-          }
+        const records = res.stdout.split("\n---END-OF-COMMIT---\n");
+        for (const rec of records) {
+          if (!rec.trim()) continue;
+          const newlineIdx = rec.indexOf("\n");
+          if (newlineIdx < 0) continue;
+          const epochStr = rec.slice(0, newlineIdx);
+          const body = rec.slice(newlineIdx + 1);
+          const epoch = Number.parseInt(epochStr, 10);
+          if (!Number.isFinite(epoch) || epoch < horizon) continue;
+          if (isMagAuthoredCommit(body)) continue;
+          if (epoch > best) best = epoch;
         }
       } else if (res.status !== null && res.status !== 0) {
         // git ran but returned non-zero (not a repo / bad ref) — count as error.

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -215,16 +215,21 @@ export function shouldSkipPeriodic(opts: PeriodicGateOptions): PeriodicGateDecis
       return { skip: false, reason: "fingerprint changed", current: cur, prior };
     }
     case "activity-window": {
+      const prior = snap.signal as number;
+      // Clock-skew defence FIRST: a future stored epoch fails open (run)
+      // regardless of the current signal — including the zero-activity fast
+      // path below. If this ran after the `current === 0` check, a future
+      // snapshot + an idle look-back would skip indefinitely until fresh
+      // activity appeared, instead of failing open. (codex P1)
+      if (prior > nowEpoch) {
+        return { skip: false, reason: "prior snapshot epoch in future — clock skew, fail open", current, prior };
+      }
       // current === 0: clean scan, no qualifying activity in the look-back.
       // With a prior snapshot present, this is the proposal's core skip case.
       if (current === 0) {
-        return { skip: true, reason: "no qualifying user activity since prior snapshot", current: 0, prior: snap.signal };
+        return { skip: true, reason: "no qualifying user activity since prior snapshot", current: 0, prior };
       }
       const cur = current as number;
-      const prior = snap.signal as number;
-      if (prior > nowEpoch) {
-        return { skip: false, reason: "prior snapshot epoch in future — clock skew, fail open", current: cur, prior };
-      }
       if (cur > prior) {
         return { skip: false, reason: "new user activity since prior snapshot", current: cur, prior };
       }
@@ -430,15 +435,31 @@ export function frontmatterRange(content: string): { start: number; end: number 
   return null;
 }
 
+/** True if one side of a unified=0 hunk (start line + line count) overlaps
+ *  the inclusive [start,end] frontmatter range. A zero-count side is a pure
+ *  insertion/deletion boundary — git reports `start` as the line it sits
+ *  against, so we test that single line for membership. */
+function hunkSideOverlaps(start: number, count: number, range: { start: number; end: number }): boolean {
+  if (!Number.isFinite(start)) return false;
+  if (count === 0) return start >= range.start && start <= range.end;
+  const end = start + count - 1;
+  return start <= range.end && end >= range.start;
+}
+
 /** AC 6 strict predicate: did this commit modify the frontmatter region of
  *  any `tasks/*.md` file? Returns false on read error (treats unreadable
  *  commits as "did not touch frontmatter" — the wider non-Mag predicate
  *  upstream already filtered to commits touching tasks/, so a read failure
  *  here only means we conservatively drop one commit, not the whole signal).
  *
- *  Mechanism: for each task file the commit modified, fetch the file content
- *  AT THAT COMMIT (`git show <sha>:<file>`), locate its frontmatter range,
- *  then walk the commit's unified=0 hunk headers and test for overlap. */
+ *  Mechanism: for each task file the commit modified, locate the YAML
+ *  frontmatter range in BOTH the post-commit content (`git show <sha>:<file>`)
+ *  and the pre-commit content (`git show <sha>^:<file>`), then walk the
+ *  commit's unified=0 hunk headers. A hunk's NEW range is tested against the
+ *  post-image frontmatter, its OLD range against the pre-image frontmatter.
+ *  Checking the pre-image is what catches a commit that *removes* or breaks
+ *  the frontmatter delimiters — the post-image then has no parseable block,
+ *  yet the deletion still modified real frontmatter (codex P2). */
 export function commitTouchedTaskFrontmatter(sha: string, cwd: string): boolean {
   if (!sha) return false;
   // List task files this commit touched. `git show --name-only` with an empty
@@ -455,14 +476,17 @@ export function commitTouchedTaskFrontmatter(sha: string, cwd: string): boolean 
   if (taskFiles.length === 0) return false;
 
   for (const file of taskFiles) {
-    // File content at this commit — gives us the frontmatter range as it
-    // existed at the commit (which may differ from the working tree).
-    const contentRes = spawnSync("git", [
-      "show", `${sha}:${file}`,
-    ], { cwd, encoding: "utf8", timeout: 3000 });
-    if (contentRes.status !== 0 || typeof contentRes.stdout !== "string") continue;
-    const range = frontmatterRange(contentRes.stdout);
-    if (!range) continue;
+    // Post-commit content → post-image frontmatter range.
+    const postRes = spawnSync("git", ["show", `${sha}:${file}`], { cwd, encoding: "utf8", timeout: 3000 });
+    const postRange = (postRes.status === 0 && typeof postRes.stdout === "string")
+      ? frontmatterRange(postRes.stdout) : null;
+    // Parent content → pre-image frontmatter range. Absent for an initial-add
+    // or root commit (`git show <sha>^:<file>` fails) — fine, the post-image
+    // range covers initial-add.
+    const preRes = spawnSync("git", ["show", `${sha}^:${file}`], { cwd, encoding: "utf8", timeout: 3000 });
+    const preRange = (preRes.status === 0 && typeof preRes.stdout === "string")
+      ? frontmatterRange(preRes.stdout) : null;
+    if (!postRange && !preRange) continue;
 
     // Unified=0 diff for this single file at this commit. Hunk headers have
     // the shape `@@ -<old_start>[,<old_count>] +<new_start>[,<new_count>] @@`.
@@ -470,20 +494,15 @@ export function commitTouchedTaskFrontmatter(sha: string, cwd: string): boolean 
       "show", "--unified=0", "--no-color", "--format=", sha, "--", file,
     ], { cwd, encoding: "utf8", timeout: 3000 });
     if (diffRes.status !== 0 || typeof diffRes.stdout !== "string") continue;
-    const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm;
+    const hunkRe = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/gm;
     let match: RegExpExecArray | null;
     while ((match = hunkRe.exec(diffRes.stdout)) !== null) {
-      const newStart = Number.parseInt(match[1], 10);
-      const newCount = match[2] !== undefined ? Number.parseInt(match[2], 10) : 1;
-      if (!Number.isFinite(newStart)) continue;
-      if (newCount === 0) {
-        // Deletion-only hunk: new_start is the line preceding the deletion.
-        // If that line is within frontmatter, the deletion modified frontmatter.
-        if (newStart >= range.start && newStart <= range.end) return true;
-        continue;
-      }
-      const newEnd = newStart + newCount - 1;
-      if (newStart <= range.end && newEnd >= range.start) return true;
+      const oldStart = Number.parseInt(match[1], 10);
+      const oldCount = match[2] !== undefined ? Number.parseInt(match[2], 10) : 1;
+      const newStart = Number.parseInt(match[3], 10);
+      const newCount = match[4] !== undefined ? Number.parseInt(match[4], 10) : 1;
+      if (postRange && hunkSideOverlaps(newStart, newCount, postRange)) return true;
+      if (preRange && hunkSideOverlaps(oldStart, oldCount, preRange)) return true;
     }
   }
   return false;

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -62,8 +62,9 @@ export function isMagAutoAction(eventRecord: Record<string, unknown>): boolean {
   return false;
 }
 
-function lineIsGateSkip(parsed: Record<string, unknown>): boolean {
-  const meta = parsed.meta;
+function lineIsGateSkip(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const meta = (parsed as Record<string, unknown>).meta;
   if (meta && typeof meta === "object" && (meta as Record<string, unknown>).gateSkip === true) {
     return true;
   }
@@ -322,7 +323,9 @@ export function latestUserActionEpoch(opts: UserActionSignalOptions): number | n
         if (!line) continue;
         let parsed: Record<string, unknown>;
         try {
-          parsed = JSON.parse(line) as Record<string, unknown>;
+          const raw = JSON.parse(line) as unknown;
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+          parsed = raw as Record<string, unknown>;
         } catch { continue; }
         if (lineIsGateSkip(parsed)) continue;
         const epoch = readEventEpoch(parsed);

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -1,37 +1,79 @@
-// Activity-volume gate for the periodic health check.
+// Activity-volume gate for periodic Mag skills.
 //
-// Counts lines appended to journal/events.jsonl since the last executed
-// health check (recorded as eventsJsonlLines in mag/health-last.json). Skips
-// the check when fewer than HEALTH_GATE_THRESHOLD new lines have accumulated.
+// Originally a single-purpose gate for the morning health check; now a
+// generalized gate that handles four signal modes:
+//   - "count":            health-check (lines appended to events.jsonl).
+//   - "fingerprint":      adopt-sessions (unclassified-sessions hash).
+//   - "activity-window":  briefing (last-user-action epoch within 18h window).
+//   - "epoch-unchanged":  verify-completion (per-task last-activity epoch).
+//
+// gh-ludics-538 generalized the gate. shouldSkipHealthCheck is preserved as a
+// thin wrapper over shouldSkipPeriodic so existing callers/tests see no diff.
 
-import { existsSync, readFileSync, statSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
 import { harnessDir } from "./config.ts";
 
-export const HEALTH_GATE_THRESHOLD = 50;
+export const HEALTH_GATE_THRESHOLD = 300;
 
-// Event types emitted by the gate itself — excluded from the line-delta
-// signal so self-generated telemetry cannot push future ticks over the
-// threshold on an otherwise-idle system.
-const GATE_INTERNAL_EVENT_MARKERS: readonly string[] = [
-  '"event_type":"health_check_skipped"',
+// Periodic actions Mag self-enqueues. Excluded from the user-action signal so
+// the gate's own follow-ups (briefing → feedback-digest, health-check → /compact,
+// hourly keepalive nags) cannot reset the briefing clock.
+export const MAG_AUTO_ACTIONS: readonly string[] = [
+  "briefing",
+  "feedback-digest",
+  "health-check",
+  "adopt-sessions",
+  "verify-completion",
+  "sync-learnings",
 ];
 
-export interface HealthGateDecision {
-  skip: boolean;
-  reason: string;
-  currentLines: number;
-  priorLines: number;
+// For action="message" enqueues, the content distinguishes Mag-auto (e.g.
+// "/compact" after a checkpoint) from user-initiated messages. Compared
+// against the additive `messageContent` field on `queue_request` events
+// (see src/queue.ts buildQueueRequestEvent).
+export const MAG_AUTO_MESSAGE_CONTENTS: readonly string[] = ["/compact"];
+
+// Legacy substring fallback for excluding gate-self-telemetry from the
+// count signal. Retained alongside the unified `meta.gateSkip` JSON marker
+// so events written before the v2 upgrade continue to be excluded.
+const GATE_INTERNAL_EVENT_MARKERS: readonly string[] = [
+  '"event_type":"health_check_skipped"',
+  '"event_type":"briefing_skipped"',
+  '"event_type":"feedback_digest_skipped"',
+  '"event_type":"adopt_sessions_skipped"',
+  '"event_type":"verify_completion_skipped"',
+];
+
+/** True if the parsed event record is one of Mag's own enqueues. For
+ *  action="message" records, requires a known auto-content match — a missing
+ *  `messageContent` field (pre-upgrade events) fails open to "user action"
+ *  so the gate never false-skips on uncertain provenance. */
+export function isMagAutoAction(eventRecord: Record<string, unknown>): boolean {
+  const action = typeof eventRecord.action === "string" ? eventRecord.action : "";
+  if (!action) return false;
+  if (MAG_AUTO_ACTIONS.includes(action)) return true;
+  if (action === "message") {
+    const content = eventRecord.messageContent;
+    if (typeof content !== "string") return false;
+    return MAG_AUTO_MESSAGE_CONTENTS.includes(content);
+  }
+  return false;
 }
 
-export interface HealthGateOptions {
-  now?: Date;
-  stateDir?: string;
+function lineIsGateSkip(parsed: Record<string, unknown>): boolean {
+  const meta = parsed.meta;
+  if (meta && typeof meta === "object" && (meta as Record<string, unknown>).gateSkip === true) {
+    return true;
+  }
+  return false;
 }
 
 /** Count event lines eligible for the gate signal.
- *  Excludes lines containing any GATE_INTERNAL_EVENT_MARKERS so the gate's
- *  own skip telemetry cannot influence its future decisions. Returns null
+ *  Primary path: parse each line as JSON, exclude records with
+ *  `meta.gateSkip === true`. Falls back to GATE_INTERNAL_EVENT_MARKERS
+ *  substring match for pre-upgrade lines lacking the marker. Returns null
  *  on read error, 0 on empty/missing file. */
 export function countGateEligibleLines(path: string): number | null {
   try {
@@ -48,8 +90,15 @@ export function countGateEligibleLines(path: string): number | null {
         if (i > lineStart) {
           const line = buf.slice(lineStart, i);
           let excluded = false;
-          for (const marker of GATE_INTERNAL_EVENT_MARKERS) {
-            if (line.includes(marker)) { excluded = true; break; }
+          // Primary JSON-aware exclusion via meta.gateSkip.
+          try {
+            const parsed = JSON.parse(line) as Record<string, unknown>;
+            if (lineIsGateSkip(parsed)) excluded = true;
+          } catch { /* not JSON — fall through to substring fallback */ }
+          if (!excluded) {
+            for (const marker of GATE_INTERNAL_EVENT_MARKERS) {
+              if (line.includes(marker)) { excluded = true; break; }
+            }
           }
           if (!excluded) count++;
         }
@@ -62,84 +111,278 @@ export function countGateEligibleLines(path: string): number | null {
   }
 }
 
-function readPriorLines(stateDir: string): { value: number | null; hadFile: boolean; hadField: boolean } {
-  const snapPath = join(stateDir, "mag", "health-last.json");
-  if (!existsSync(snapPath)) return { value: null, hadFile: false, hadField: false };
+// --- Snapshot envelope (shared across modes) -----------------------------
+
+interface GateSnapshot<T = unknown> {
+  hadFile: boolean;
+  hadSignal: boolean;
+  signal: T | null;
+}
+
+function readSnapshot<T>(snapshotPath: string): GateSnapshot<T> {
+  if (!existsSync(snapshotPath)) return { hadFile: false, hadSignal: false, signal: null };
   try {
-    const raw = readFileSync(snapPath, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object") return { value: null, hadFile: true, hadField: false };
-    const v = (parsed as Record<string, unknown>).eventsJsonlLines;
-    if (typeof v !== "number" || !Number.isFinite(v)) return { value: null, hadFile: true, hadField: false };
-    return { value: v, hadFile: true, hadField: true };
+    const parsed = JSON.parse(readFileSync(snapshotPath, "utf8")) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object") return { hadFile: true, hadSignal: false, signal: null };
+    if ("signal" in parsed && parsed.signal !== undefined && parsed.signal !== null) {
+      return { hadFile: true, hadSignal: true, signal: parsed.signal as T };
+    }
+    // Legacy back-compat: mag/health-last.json with `eventsJsonlLines` and
+    // no top-level `signal` field. The wrapper paths it through.
+    if (typeof parsed.eventsJsonlLines === "number" && Number.isFinite(parsed.eventsJsonlLines)) {
+      return { hadFile: true, hadSignal: true, signal: parsed.eventsJsonlLines as unknown as T };
+    }
+    return { hadFile: true, hadSignal: false, signal: null };
   } catch {
-    return { value: null, hadFile: true, hadField: false };
+    return { hadFile: true, hadSignal: false, signal: null };
   }
+}
+
+/** Write the snapshot envelope. Caller is responsible for refreshing the
+ *  snapshot only when the gate has decided to RUN (not skip). */
+export function writeGateSnapshot(snapshotPath: string, signal: unknown, now?: Date): void {
+  mkdirSync(dirname(snapshotPath), { recursive: true });
+  const ts = (now ?? new Date()).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const body: Record<string, unknown> = { timestamp: ts, signal };
+  // Preserve the legacy field for the health-check arm so out-of-process
+  // readers that still expect `eventsJsonlLines` continue to work.
+  if (typeof signal === "number") body.eventsJsonlLines = signal;
+  writeFileSync(snapshotPath, JSON.stringify(body));
+}
+
+// --- Generalized gate ----------------------------------------------------
+
+export type GateMode = "count" | "fingerprint" | "activity-window" | "epoch-unchanged";
+
+export interface PeriodicGateOptions {
+  gateName: string;
+  snapshotPath: string;        // absolute path to JSON snapshot file
+  signal: unknown | (() => unknown);
+  threshold: number;           // count: line delta; window: seconds; others: ignored
+  mode: GateMode;
+  now?: Date;
+}
+
+export interface PeriodicGateDecision {
+  skip: boolean;
+  reason: string;
+  current: unknown;
+  prior: unknown;
+}
+
+/** Generalized gate dispatch. The semantics per mode are documented in
+ *  docs/proposals/activity-gate-periodic-skills.md AC 1 (and gh-ludics-538). */
+export function shouldSkipPeriodic(opts: PeriodicGateOptions): PeriodicGateDecision {
+  const now = opts.now ?? new Date();
+  const nowEpoch = Math.floor(now.getTime() / 1000);
+  const current = typeof opts.signal === "function" ? (opts.signal as () => unknown)() : opts.signal;
+  const snap = readSnapshot<unknown>(opts.snapshotPath);
+
+  // Fail-open: signal unreadable.
+  if (current === null) {
+    return { skip: false, reason: "signal unreadable — fail open", current: null, prior: snap.signal };
+  }
+  // Fail-open: first run (no snapshot file).
+  if (!snap.hadFile) {
+    return { skip: false, reason: "first run — no prior snapshot", current, prior: null };
+  }
+  if (!snap.hadSignal) {
+    return { skip: false, reason: "prior snapshot missing signal field — fail open", current, prior: null };
+  }
+
+  switch (opts.mode) {
+    case "count": {
+      const cur = current as number;
+      const prior = snap.signal as number;
+      const delta = cur - prior;
+      if (delta < 0) {
+        return { skip: false, reason: `events.jsonl line count went backward (delta ${delta}) — anchor stale, fail open`, current: cur, prior };
+      }
+      if (delta < opts.threshold) {
+        return { skip: true, reason: `delta ${delta} < ${opts.threshold} threshold`, current: cur, prior };
+      }
+      return { skip: false, reason: `delta ${delta} >= ${opts.threshold} threshold`, current: cur, prior };
+    }
+    case "fingerprint": {
+      const cur = current as string;
+      const prior = snap.signal as string;
+      if (cur === prior) {
+        return { skip: true, reason: "fingerprint unchanged", current: cur, prior };
+      }
+      return { skip: false, reason: "fingerprint changed", current: cur, prior };
+    }
+    case "activity-window": {
+      // current === 0: clean scan, no qualifying activity in the look-back.
+      // With a prior snapshot present, this is the proposal's core skip case.
+      if (current === 0) {
+        return { skip: true, reason: "no qualifying user activity since prior snapshot", current: 0, prior: snap.signal };
+      }
+      const cur = current as number;
+      const prior = snap.signal as number;
+      if (prior > nowEpoch) {
+        return { skip: false, reason: "prior snapshot epoch in future — clock skew, fail open", current: cur, prior };
+      }
+      if (cur > prior) {
+        return { skip: false, reason: "new user activity since prior snapshot", current: cur, prior };
+      }
+      // cur <= prior — no progress. Skip only if also outside the recent-activity window.
+      const age = nowEpoch - cur;
+      if (age < opts.threshold) {
+        return { skip: false, reason: `recent activity (${age}s ago) within ${opts.threshold}s window`, current: cur, prior };
+      }
+      return { skip: true, reason: `no progress since prior snapshot and latest activity ${age}s ago >= ${opts.threshold}s threshold`, current: cur, prior };
+    }
+    case "epoch-unchanged": {
+      // current === 0: no activity epoch resolvable for this target — run
+      // (per-target epochs should always reach something on a real task).
+      if (current === 0) {
+        return { skip: false, reason: "no resolvable activity epoch — fail open", current: 0, prior: snap.signal };
+      }
+      const cur = current as number;
+      const prior = snap.signal as number;
+      if (cur <= prior) {
+        return { skip: true, reason: `epoch ${cur} <= prior ${prior} — unchanged`, current: cur, prior };
+      }
+      return { skip: false, reason: `epoch ${cur} > prior ${prior} — advanced`, current: cur, prior };
+    }
+  }
+}
+
+// --- Compatibility wrapper: shouldSkipHealthCheck ------------------------
+
+export interface HealthGateDecision {
+  skip: boolean;
+  reason: string;
+  currentLines: number;
+  priorLines: number;
+}
+
+export interface HealthGateOptions {
+  now?: Date;
+  stateDir?: string;
 }
 
 export function shouldSkipHealthCheck(opts: HealthGateOptions = {}): HealthGateDecision {
   const stateDir = opts.stateDir ?? harnessDir();
   const eventsFile = join(stateDir, "journal", "events.jsonl");
+  const snapshotPath = join(stateDir, "mag", "health-last.json");
 
   const count = countGateEligibleLines(eventsFile);
   if (count === null) {
-    return {
-      skip: false,
-      reason: "events.jsonl missing — fail open",
-      currentLines: 0,
-      priorLines: 0,
-    };
+    return { skip: false, reason: "events.jsonl missing — fail open", currentLines: 0, priorLines: 0 };
   }
   if (count === 0) {
-    return {
-      skip: false,
-      reason: "events.jsonl empty — fail open",
-      currentLines: 0,
-      priorLines: 0,
-    };
+    return { skip: false, reason: "events.jsonl empty — fail open", currentLines: 0, priorLines: 0 };
   }
 
-  const prior = readPriorLines(stateDir);
-  if (!prior.hadFile) {
-    return {
-      skip: false,
-      reason: "first run — no prior snapshot",
-      currentLines: count,
-      priorLines: 0,
-    };
+  const decision = shouldSkipPeriodic({
+    gateName: "health-check",
+    snapshotPath,
+    signal: count,
+    threshold: HEALTH_GATE_THRESHOLD,
+    mode: "count",
+    now: opts.now,
+  });
+  const currentLines = typeof decision.current === "number" ? decision.current : count;
+  const priorLines = typeof decision.prior === "number" ? decision.prior : 0;
+  return { skip: decision.skip, reason: decision.reason, currentLines, priorLines };
+}
+
+// --- User-action signal helper (briefing) --------------------------------
+
+export interface UserActionSignalOptions {
+  stateDir: string;
+  now: Date;
+  lookbackHours: number;
+}
+
+/** Compute the max epoch across qualifying user activity sources in the
+ *  look-back window. Three-valued return:
+ *    number  — Unix epoch of the latest qualifying activity.
+ *    0       — clean scan, no qualifying activity found in the window.
+ *    null    — at least one input source threw / was unreadable.
+ *
+ *  Sources: notify_incoming events, queue_request events (excluding
+ *  Mag-auto actions), non-Mag-authored commits touching tasks/*.md.
+ *  Excludes events bearing meta.gateSkip === true. */
+export function latestUserActionEpoch(opts: UserActionSignalOptions): number | null {
+  const nowEpoch = Math.floor(opts.now.getTime() / 1000);
+  const horizon = nowEpoch - opts.lookbackHours * 3600;
+  let best = 0;
+  let sawError = false;
+
+  // Source 1+2: events.jsonl (notify_incoming + non-auto queue_request).
+  const eventsFile = join(opts.stateDir, "journal", "events.jsonl");
+  if (existsSync(eventsFile)) {
+    try {
+      const buf = readFileSync(eventsFile, "utf8");
+      const lines = buf.length > 0 ? buf.split("\n") : [];
+      for (const line of lines) {
+        if (!line) continue;
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line) as Record<string, unknown>;
+        } catch { continue; }
+        if (lineIsGateSkip(parsed)) continue;
+        const epoch = readEventEpoch(parsed);
+        if (epoch === null || epoch < horizon) continue;
+        const eventType = typeof parsed.event_type === "string" ? parsed.event_type : "";
+        if (eventType === "notify_incoming") {
+          if (epoch > best) best = epoch;
+        } else if (eventType === "queue_request") {
+          if (!isMagAutoAction(parsed) && epoch > best) best = epoch;
+        }
+      }
+    } catch {
+      sawError = true;
+    }
   }
-  if (!prior.hadField || prior.value === null) {
-    return {
-      skip: false,
-      reason: "prior snapshot missing eventsJsonlLines field",
-      currentLines: count,
-      priorLines: 0,
-    };
+  // If the events file is absent, treat as "clean empty scan" (not error).
+
+  // Source 3: non-Mag-authored commits to tasks/*.md. Conservative proxy
+  // per docs/proposals/activity-gate-periodic-skills.md Gap C — every
+  // commit touching tasks/ counts (no author filter), since the state-repo's
+  // task frontmatter is user-edited in practice.
+  const tasksDir = join(opts.stateDir, "tasks");
+  if (existsSync(tasksDir)) {
+    try {
+      const res = spawnSync("git", [
+        "log",
+        `--since=${opts.lookbackHours} hours ago`,
+        "--format=%at",
+        "--",
+        "tasks/",
+      ], { cwd: opts.stateDir, encoding: "utf8", timeout: 5000 });
+      if (res.status === 0 && typeof res.stdout === "string") {
+        for (const line of res.stdout.trim().split("\n")) {
+          const epoch = Number.parseInt(line, 10);
+          if (Number.isFinite(epoch) && epoch >= horizon && epoch > best) {
+            best = epoch;
+          }
+        }
+      } else if (res.status !== null && res.status !== 0) {
+        // git ran but returned non-zero (not a repo / bad ref) — count as error.
+        sawError = true;
+      }
+    } catch {
+      sawError = true;
+    }
   }
 
-  const delta = count - prior.value;
-  if (delta < 0) {
-    // events.jsonl shrank vs the stored anchor (rotation, compaction, restore).
-    // The anchor is no longer trustworthy — fail open so a real run resets it.
-    return {
-      skip: false,
-      reason: `events.jsonl line count went backward (delta ${delta}) — anchor stale, fail open`,
-      currentLines: count,
-      priorLines: prior.value,
-    };
+  if (best > 0) return best;
+  if (sawError) return null;
+  return 0;
+}
+
+function readEventEpoch(parsed: Record<string, unknown>): number | null {
+  // Primary canonical field is `epoch: number` (src/events.ts).
+  if (typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch)) {
+    return parsed.epoch;
   }
-  if (delta < HEALTH_GATE_THRESHOLD) {
-    return {
-      skip: true,
-      reason: `delta ${delta} < ${HEALTH_GATE_THRESHOLD} threshold`,
-      currentLines: count,
-      priorLines: prior.value,
-    };
+  // Defensive fallback: parse ISO `ts` if present.
+  if (typeof parsed.ts === "string") {
+    const ms = Date.parse(parsed.ts);
+    if (Number.isFinite(ms)) return Math.floor(ms / 1000);
   }
-  return {
-    skip: false,
-    reason: `delta ${delta} >= ${HEALTH_GATE_THRESHOLD} threshold`,
-    currentLines: count,
-    priorLines: prior.value,
-  };
+  return null;
 }

--- a/src/health-gate.ts
+++ b/src/health-gate.ts
@@ -158,7 +158,9 @@ export type GateMode = "count" | "fingerprint" | "activity-window" | "epoch-unch
 export interface PeriodicGateOptions {
   gateName: string;
   snapshotPath: string;        // absolute path to JSON snapshot file
-  signal: unknown | (() => unknown);
+  // A comparable value or a thunk producing one. `unknown` already subsumes
+  // the function form; the thunk is unwrapped at the top of shouldSkipPeriodic.
+  signal: unknown;
   threshold: number;           // count: line delta; window: seconds; others: ignored
   mode: GateMode;
   now?: Date;
@@ -239,6 +241,12 @@ export function shouldSkipPeriodic(opts: PeriodicGateOptions): PeriodicGateDecis
       // so skip. (Read-error returns null, which fails open above.)
       const cur = (current as number) | 0;
       const prior = snap.signal as number;
+      // AC 1 clock-skew defence: a future stored epoch fails open (run), so a
+      // clock skew can't permanently suppress verify-completion via a snapshot
+      // that's "ahead" of the wall clock. Mirrors the activity-window arm.
+      if (prior > nowEpoch) {
+        return { skip: false, reason: "prior snapshot epoch in future — clock skew, fail open", current: cur, prior };
+      }
       if (cur === 0) {
         return { skip: true, reason: "no activity epoch resolvable for this target since prior snapshot", current: 0, prior };
       }
@@ -359,23 +367,21 @@ export function latestUserActionEpoch(opts: UserActionSignalOptions): number | n
   }
   // If the events file is absent, treat as "clean empty scan" (not error).
 
-  // Source 3: non-Mag-authored commits to tasks/*.md. Per AC 6, commits
-  // authored by Mag (recognized by a `Co-Authored-By:` trailer referencing
-  // Claude — see isMagAuthoredCommit) MUST NOT advance the signal. The
-  // strict frontmatter-line-range proposal text was relaxed to "any
-  // non-Mag-authored commit touching tasks/*.md" per Gap C in the merged
-  // plan, but the non-Mag-author predicate stands.
+  // Source 3: non-Mag-authored commits that modified task frontmatter (per
+  // AC 6 strict reading). Mechanism: enumerate commits in the look-back, drop
+  // Mag-authored ones (Co-Authored-By: Claude trailer — see
+  // isMagAuthoredCommit), then for each remaining commit check whether any of
+  // its hunks fall inside a task file's frontmatter line range AT THAT COMMIT.
+  // Body-only edits to tasks/foo.md do NOT advance the signal.
   const tasksDir = join(opts.stateDir, "tasks");
   if (existsSync(tasksDir)) {
     try {
-      // %at = author epoch; the body follows; we delimit records with an
-      // ASCII sentinel ("---END-OF-COMMIT---") that cannot collide with a
-      // commit message line (no embedded control bytes — lint:no-nul-bytes
-      // safe). The delimiter is anchored by surrounding newlines on split.
+      // %H = sha, %at = author epoch, %B = body; sentinel split. Bare ASCII
+      // tokens — no embedded control bytes (lint:no-nul-bytes safe).
       const res = spawnSync("git", [
         "log",
         `--since=${opts.lookbackHours} hours ago`,
-        "--format=%at%n%B%n---END-OF-COMMIT---",
+        "--format=%H%n%at%n%B%n---END-OF-COMMIT---",
         "--",
         "tasks/",
       ], { cwd: opts.stateDir, encoding: "utf8", timeout: 5000 });
@@ -383,13 +389,17 @@ export function latestUserActionEpoch(opts: UserActionSignalOptions): number | n
         const records = res.stdout.split("\n---END-OF-COMMIT---\n");
         for (const rec of records) {
           if (!rec.trim()) continue;
-          const newlineIdx = rec.indexOf("\n");
-          if (newlineIdx < 0) continue;
-          const epochStr = rec.slice(0, newlineIdx);
-          const body = rec.slice(newlineIdx + 1);
+          const firstNL = rec.indexOf("\n");
+          if (firstNL < 0) continue;
+          const secondNL = rec.indexOf("\n", firstNL + 1);
+          if (secondNL < 0) continue;
+          const sha = rec.slice(0, firstNL).trim();
+          const epochStr = rec.slice(firstNL + 1, secondNL);
+          const body = rec.slice(secondNL + 1);
           const epoch = Number.parseInt(epochStr, 10);
           if (!Number.isFinite(epoch) || epoch < horizon) continue;
           if (isMagAuthoredCommit(body)) continue;
+          if (!commitTouchedTaskFrontmatter(sha, opts.stateDir)) continue;
           if (epoch > best) best = epoch;
         }
       } else if (res.status !== null && res.status !== 0) {
@@ -404,6 +414,79 @@ export function latestUserActionEpoch(opts: UserActionSignalOptions): number | n
   if (best > 0) return best;
   if (sawError) return null;
   return 0;
+}
+
+/** Return the inclusive [1..N] line range of the YAML frontmatter block of
+ *  `content`, or null if no frontmatter delimiter pair is present. Exported
+ *  for tests — used as the boundary against which commit hunks are tested
+ *  for overlap in the AC 6 frontmatter predicate. */
+export function frontmatterRange(content: string): { start: number; end: number } | null {
+  if (!content) return null;
+  const lines = content.split("\n");
+  if (lines[0] !== "---") return null;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === "---") return { start: 1, end: i + 1 };
+  }
+  return null;
+}
+
+/** AC 6 strict predicate: did this commit modify the frontmatter region of
+ *  any `tasks/*.md` file? Returns false on read error (treats unreadable
+ *  commits as "did not touch frontmatter" — the wider non-Mag predicate
+ *  upstream already filtered to commits touching tasks/, so a read failure
+ *  here only means we conservatively drop one commit, not the whole signal).
+ *
+ *  Mechanism: for each task file the commit modified, fetch the file content
+ *  AT THAT COMMIT (`git show <sha>:<file>`), locate its frontmatter range,
+ *  then walk the commit's unified=0 hunk headers and test for overlap. */
+export function commitTouchedTaskFrontmatter(sha: string, cwd: string): boolean {
+  if (!sha) return false;
+  // List task files this commit touched. `git show --name-only` with an empty
+  // format prints just the touched paths; the `-- tasks/` pathspec limits to
+  // task files. Bare paths in output, one per line.
+  const filesRes = spawnSync("git", [
+    "show", "--name-only", "--format=", sha, "--", "tasks/",
+  ], { cwd, encoding: "utf8", timeout: 3000 });
+  if (filesRes.status !== 0 || typeof filesRes.stdout !== "string") return false;
+  const taskFiles = filesRes.stdout
+    .split("\n")
+    .map(s => s.trim())
+    .filter(f => f && f.startsWith("tasks/") && f.endsWith(".md"));
+  if (taskFiles.length === 0) return false;
+
+  for (const file of taskFiles) {
+    // File content at this commit — gives us the frontmatter range as it
+    // existed at the commit (which may differ from the working tree).
+    const contentRes = spawnSync("git", [
+      "show", `${sha}:${file}`,
+    ], { cwd, encoding: "utf8", timeout: 3000 });
+    if (contentRes.status !== 0 || typeof contentRes.stdout !== "string") continue;
+    const range = frontmatterRange(contentRes.stdout);
+    if (!range) continue;
+
+    // Unified=0 diff for this single file at this commit. Hunk headers have
+    // the shape `@@ -<old_start>[,<old_count>] +<new_start>[,<new_count>] @@`.
+    const diffRes = spawnSync("git", [
+      "show", "--unified=0", "--no-color", "--format=", sha, "--", file,
+    ], { cwd, encoding: "utf8", timeout: 3000 });
+    if (diffRes.status !== 0 || typeof diffRes.stdout !== "string") continue;
+    const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm;
+    let match: RegExpExecArray | null;
+    while ((match = hunkRe.exec(diffRes.stdout)) !== null) {
+      const newStart = Number.parseInt(match[1], 10);
+      const newCount = match[2] !== undefined ? Number.parseInt(match[2], 10) : 1;
+      if (!Number.isFinite(newStart)) continue;
+      if (newCount === 0) {
+        // Deletion-only hunk: new_start is the line preceding the deletion.
+        // If that line is within frontmatter, the deletion modified frontmatter.
+        if (newStart >= range.start && newStart <= range.end) return true;
+        continue;
+      }
+      const newEnd = newStart + newCount - 1;
+      if (newStart <= range.end && newEnd >= range.start) return true;
+    }
+  }
+  return false;
 }
 
 function readEventEpoch(parsed: Record<string, unknown>): number | null {

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -15,6 +15,13 @@ beforeEach(() => {
   // is what lets these branches reach the queueRequest calls; if it stops
   // holding, both tests fail because the queue stays empty.
   mkdirSync(join(getTmpDir(), "mag"), { recursive: true });
+  // gh-ludics-538: tryQueueFeedbackDigest now skips when feedback/ is empty.
+  // Seed a single file so the feedback-digest follow-up actually enqueues in
+  // the tests that exercise the briefing trio (briefing → feedback-digest →
+  // /compact). Tests asserting the gated-feedback-digest path can clear or
+  // ignore this seed; see the per-test setup.
+  mkdirSync(join(getTmpDir(), "feedback"), { recursive: true });
+  writeFileSync(join(getTmpDir(), "feedback", "seed.md"), "x");
 });
 
 function readQueue(): Record<string, unknown>[] {

--- a/src/mag-briefing-auto-cooldown.test.ts
+++ b/src/mag-briefing-auto-cooldown.test.ts
@@ -13,6 +13,11 @@ const getTmpDir = withSyntheticHarness(beforeEach, afterEach);
 
 beforeEach(() => {
   mkdirSync(join(getTmpDir(), "mag"), { recursive: true });
+  // gh-ludics-538: seed feedback/ so the briefing → feedback-digest →
+  // /compact trio still produces 3 queue entries. Without this seed, the
+  // new empty-feedback gate causes the digest follow-up to no-op.
+  mkdirSync(join(getTmpDir(), "feedback"), { recursive: true });
+  writeFileSync(join(getTmpDir(), "feedback", "seed.md"), "x");
 });
 
 function readQueue(): Record<string, unknown>[] {

--- a/src/mag-health-gate.test.ts
+++ b/src/mag-health-gate.test.ts
@@ -12,7 +12,7 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
     mkdirSync(join(getStateDir(), "mag"), { recursive: true });
   });
 
-  test("returns null and emits health_check_skipped when delta < 50", async () => {
+  test("returns null and emits health_check_skipped when delta < threshold", async () => {
     const stateDir = getStateDir();
     const lines = Array.from({ length: 1030 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
@@ -34,6 +34,8 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
     expect(last.currentLines).toBe(1030);
     expect(last.priorLines).toBe(1000);
     expect(last.delta).toBe(30);
+    // gh-ludics-538: unified gate-skip marker.
+    expect(last.meta?.gateSkip).toBe(true);
   });
 
   test("peek path (executeProgrammatic=false) returns skill command regardless of gate", async () => {
@@ -60,7 +62,10 @@ describe("resolveQueueRequestCommand — health-check activity gate", () => {
 
   test("delta over threshold returns skill command", async () => {
     const stateDir = getStateDir();
-    const lines = Array.from({ length: 1200 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    // Threshold bumped 50 → 300 (gh-ludics-538). Use delta=400 to stay
+    // unambiguously over the new threshold while continuing to assert
+    // "delta exceeds gate" semantics.
+    const lines = Array.from({ length: 1400 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
     writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
     writeFileSync(
       join(stateDir, "mag", "health-last.json"),

--- a/src/mag-periodic-gate.test.ts
+++ b/src/mag-periodic-gate.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync } from "fs";
+import { join } from "path";
+import { withSyntheticHarness } from "./test-utils.ts";
+
+// Note: resolveQueueRequestCommand is async-imported per-test to avoid loading
+// mag.ts side-effects until the synthetic harness is wired.
+
+function readEvents(stateDir: string): Record<string, unknown>[] {
+  const path = join(stateDir, "journal", "events.jsonl");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+}
+
+function findLastEvent(stateDir: string, type: string): Record<string, unknown> | null {
+  const evs = readEvents(stateDir);
+  for (let i = evs.length - 1; i >= 0; i--) {
+    if (evs[i]!.event_type === type) return evs[i]!;
+  }
+  return null;
+}
+
+function makeJournal(stateDir: string): void {
+  mkdirSync(join(stateDir, "journal"), { recursive: true });
+  mkdirSync(join(stateDir, "mag"), { recursive: true });
+}
+
+function nowEpoch(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function writeEvent(stateDir: string, ev: Record<string, unknown>): void {
+  const ts = new Date((ev.epoch as number) * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const line = JSON.stringify({ ts, source: "test", scope: "test", ...ev });
+  writeFileSync(join(stateDir, "journal", "events.jsonl"), line + "\n", { flag: "a" });
+}
+
+// --- Briefing Tier-1 gate arm (Step 6) ---
+
+describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("idle + no activity + prior snapshot → skip + emits briefing_skipped + does NOT precompute", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Prior briefing snapshot from many days ago — proves we've been here before.
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }));
+    // Empty events.jsonl + no tasks/ → latestUserActionEpoch returns 0.
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "briefing" }, true);
+    expect(result).toBeNull();
+
+    const last = findLastEvent(stateDir, "briefing_skipped");
+    expect(last).not.toBeNull();
+    expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+    expect(String(last!.message)).toContain("no qualifying user activity");
+
+    // Briefing precompute was NOT called — no briefing-context.md file.
+    expect(existsSync(join(stateDir, "mag", "briefing-context.md"))).toBe(false);
+  });
+
+  test("first run (no snapshot) → run (no skip event emitted)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // No snapshot, empty events → signal=0 → first-run fail-open → RUN.
+    // Precompute will partially run (and may write briefing-context.md);
+    // we only assert the skip event was NOT emitted.
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    try {
+      await resolveQueueRequestCommand({ action: "briefing" }, true);
+    } catch { /* precompute may fail in synthetic harness — that's OK */ }
+
+    const last = findLastEvent(stateDir, "briefing_skipped");
+    expect(last).toBeNull();
+    // Snapshot was refreshed on the RUN arm.
+    expect(existsSync(join(stateDir, "mag", "briefing-last.json"))).toBe(true);
+  });
+
+  test("fresh notify_incoming → run, briefing_skipped NOT emitted, snapshot refreshed", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Prior snapshot many seconds older than the fresh notify event.
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: nowEpoch() - 7200 }));
+    writeEvent(stateDir, { event_type: "notify_incoming", epoch: nowEpoch() - 60, message: "user said hi" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    try {
+      await resolveQueueRequestCommand({ action: "briefing" }, true);
+    } catch { /* precompute may fail in synthetic harness */ }
+
+    const last = findLastEvent(stateDir, "briefing_skipped");
+    expect(last).toBeNull();
+  });
+
+  test("peek path (executeProgrammatic=false) bypasses gate (AC 11)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Setup a state that WOULD skip — idle + prior snapshot.
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }));
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "briefing" }, false);
+    expect(result).toBe("/ludics-briefing");
+
+    // No skip event — gate did not run.
+    expect(findLastEvent(stateDir, "briefing_skipped")).toBeNull();
+  });
+
+  test("Mag-auto briefing queue_request does NOT advance the signal (denylist active)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }));
+    // Only Mag-auto activity in the events log — would NOT count as user-action.
+    writeEvent(stateDir, { event_type: "queue_request", epoch: nowEpoch() - 60, action: "briefing", message: "req-x" });
+    writeEvent(stateDir, { event_type: "queue_request", epoch: nowEpoch() - 30, action: "message", messageContent: "/compact", message: "req-y" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "briefing" }, true);
+    expect(result).toBeNull();
+    const last = findLastEvent(stateDir, "briefing_skipped");
+    expect(last).not.toBeNull();
+  });
+});
+
+// --- adopt-sessions Tier-1 arm (Step 7) ---
+
+describe("adopt-sessions Tier-1 arm — fingerprint gate (gh-ludics-538 AC 9)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  function writeSessionsJson(stateDir: string, unclassified: Record<string, unknown>[]): void {
+    writeFileSync(join(stateDir, "sessions.json"), JSON.stringify({ unclassified }));
+  }
+
+  test("fingerprint unchanged → skip + emits adopt_sessions_skipped + no precompute", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeSessionsJson(stateDir, [{ cwd: "/a", agents: ["claude"], ids: ["s1"] }]);
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    // First call: gate runs (first-run fail-open) → snapshot written.
+    try { await resolveQueueRequestCommand({ action: "adopt-sessions" }, true); } catch { /* ok */ }
+    // Second call with identical sessions → fingerprint unchanged → skip.
+    const result = await resolveQueueRequestCommand({ action: "adopt-sessions" }, true);
+    expect(result).toBeNull();
+
+    const last = findLastEvent(stateDir, "adopt_sessions_skipped");
+    expect(last).not.toBeNull();
+    expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+  });
+
+  test("fingerprint changed → run + snapshot refreshed", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeSessionsJson(stateDir, [{ cwd: "/a", agents: ["claude"], ids: ["s1"] }]);
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    try { await resolveQueueRequestCommand({ action: "adopt-sessions" }, true); } catch { /* ok */ }
+
+    // Change sessions content → new fingerprint.
+    writeSessionsJson(stateDir, [{ cwd: "/b", agents: ["claude"], ids: ["s2"] }]);
+    const result = await resolveQueueRequestCommand({ action: "adopt-sessions" }, true);
+    // Run-arm yields the skill command from the registry.
+    expect(typeof result).toBe("string");
+
+    expect(findLastEvent(stateDir, "adopt_sessions_skipped")).toBeNull();
+  });
+
+  test("peek path bypasses gate", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeSessionsJson(stateDir, [{ cwd: "/a", agents: ["claude"], ids: ["s1"] }]);
+    // Pre-seed snapshot so the gate would otherwise SKIP.
+    // (Compute the fingerprint by running once first.)
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    try { await resolveQueueRequestCommand({ action: "adopt-sessions" }, true); } catch { /* ok */ }
+
+    const result = await resolveQueueRequestCommand({ action: "adopt-sessions" }, false);
+    expect(typeof result).toBe("string");
+    expect(result).toContain("adopt-sessions");
+  });
+});
+
+// --- verify-completion Tier-1 arm (Step 8) ---
+
+describe("verify-completion Tier-1 arm — epoch-unchanged gate (gh-ludics-538 AC 10)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("task unchanged since prior check → skip + emits verify_completion_skipped", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Seed a prior snapshot with a known epoch.
+    mkdirSync(join(stateDir, "mag", "verify-completion-last"), { recursive: true });
+    const knownEpoch = nowEpoch();
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-foo.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: knownEpoch }));
+    // Source data: one slot_resume event at the same epoch (no advance).
+    writeEvent(stateDir, { event_type: "slot_resume", epoch: knownEpoch, task: "task-foo" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-foo" }, true);
+    expect(result).toBeNull();
+
+    const last = findLastEvent(stateDir, "verify_completion_skipped");
+    expect(last).not.toBeNull();
+    expect(last!.task).toBe("task-foo");
+    expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+  });
+
+  test("task with newer event → run + snapshot refreshed", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    mkdirSync(join(stateDir, "mag", "verify-completion-last"), { recursive: true });
+    const priorEpoch = nowEpoch() - 1000;
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-bar.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: priorEpoch }));
+    // Newer slot_resume event for the task.
+    writeEvent(stateDir, { event_type: "slot_resume", epoch: nowEpoch(), task: "task-bar" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-bar" }, true);
+    // Run-arm yields the verify-completion skill command.
+    expect(typeof result).toBe("string");
+
+    expect(findLastEvent(stateDir, "verify_completion_skipped")).toBeNull();
+    // Snapshot was refreshed (mtime > priorEpoch * 1000).
+    const sStat = statSync(join(stateDir, "mag", "verify-completion-last", "task-bar.json"));
+    expect(sStat.mtimeMs / 1000).toBeGreaterThan(priorEpoch);
+  });
+
+  test("activity on task A does NOT affect task B's snapshot (cross-task isolation)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    mkdirSync(join(stateDir, "mag", "verify-completion-last"), { recursive: true });
+    const priorEpoch = nowEpoch();
+    // Both tasks share the same prior snapshot epoch.
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-A.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: priorEpoch }));
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-B.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: priorEpoch }));
+    // A fresh event for task A only.
+    writeEvent(stateDir, { event_type: "slot_resume", epoch: nowEpoch() + 100, task: "task-A" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    // Task A → run.
+    const a = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-A" }, true);
+    expect(typeof a).toBe("string");
+    // Task B → skip (its own snapshot, no event for it).
+    const b = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-B" }, true);
+    expect(b).toBeNull();
+
+    const lastB = findLastEvent(stateDir, "verify_completion_skipped");
+    expect(lastB).not.toBeNull();
+    expect(lastB!.task).toBe("task-B");
+  });
+
+  test("first run (no snapshot) → run", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeEvent(stateDir, { event_type: "slot_resume", epoch: nowEpoch(), task: "task-new" });
+
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-new" }, true);
+    expect(typeof result).toBe("string");
+    expect(findLastEvent(stateDir, "verify_completion_skipped")).toBeNull();
+    // Snapshot now exists.
+    expect(existsSync(join(stateDir, "mag", "verify-completion-last", "task-new.json"))).toBe(true);
+  });
+});
+
+// --- Feedback-digest empty-skip via briefing's auto-followup path -------
+
+describe("feedback-digest gate emits feedback_digest_skipped on empty surface", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("manual CLI feedback-digest skips when feedback/ is empty + no cooldown mark", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    mkdirSync(join(stateDir, "feedback"), { recursive: true });
+    // No files in feedback/.
+
+    // Drive via the CLI dispatcher's "feedback-digest" entry through runMag.
+    // The dispatcher is private; use runMag via the public CLI entry.
+    const { runMag } = await import("./mag.ts");
+    // runMag(["feedback-digest"]) calls tryQueueFeedbackDigest("ludics") internally.
+    await runMag(["feedback-digest"]);
+
+    const last = findLastEvent(stateDir, "feedback_digest_skipped");
+    expect(last).not.toBeNull();
+    expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+    expect(String(last!.message)).toContain("no feedback files");
+    // Cooldown file was NOT created (the skip MUST NOT refresh the cooldown).
+    expect(existsSync(join(stateDir, "mag", "feedback-digest-last-queued.json"))).toBe(false);
+  });
+
+  test("non-empty feedback/ → queues + writes cooldown", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    mkdirSync(join(stateDir, "feedback"), { recursive: true });
+    writeFileSync(join(stateDir, "feedback", "f1.md"), "x");
+
+    const { runMag } = await import("./mag.ts");
+    await runMag(["feedback-digest"]);
+
+    expect(findLastEvent(stateDir, "feedback_digest_skipped")).toBeNull();
+    expect(existsSync(join(stateDir, "mag", "feedback-digest-last-queued.json"))).toBe(true);
+  });
+});

--- a/src/mag-periodic-gate.test.ts
+++ b/src/mag-periodic-gate.test.ts
@@ -79,7 +79,8 @@ describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", ()
     expect(last).toBeNull();
     // Snapshot was refreshed on the RUN arm.
     expect(existsSync(join(stateDir, "mag", "briefing-last.json"))).toBe(true);
-  });
+  }, 20_000); // briefing RUN arm awaits briefingPrecomputeContext, which spawns
+  // `ludics` subprocesses; the 5s default times out under full-suite load.
 
   test("fresh notify_incoming → run, briefing_skipped NOT emitted, snapshot refreshed", async () => {
     const stateDir = getStateDir();
@@ -96,7 +97,7 @@ describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", ()
 
     const last = findLastEvent(stateDir, "briefing_skipped");
     expect(last).toBeNull();
-  });
+  }, 20_000); // briefing RUN arm awaits briefingPrecomputeContext — see above.
 
   test("peek path (executeProgrammatic=false) bypasses gate (AC 11)", async () => {
     const stateDir = getStateDir();
@@ -112,6 +113,60 @@ describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", ()
 
     // No skip event — gate did not run.
     expect(findLastEvent(stateDir, "briefing_skipped")).toBeNull();
+  });
+
+  test("manual CLI `ludics mag briefing` bypasses the gate — tagged record runs the skill despite a would-skip snapshot (AC 11/15)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Would-skip world: idle (empty events → latestUserActionEpoch===0) with a
+    // prior snapshot present → activity-window gate would skip a gated request.
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }));
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    // CLI path: `ludics mag briefing` dispatches to magBriefing(true,300,{}) —
+    // opts.auto is falsy → manual invocation.
+    const { magBriefing, resolveQueueRequestCommand } = await import("./mag.ts");
+    magBriefing(false);
+
+    // The CLI handler tagged the enqueued briefing record with bypassGate.
+    const qLines = readFileSync(join(stateDir, "mag", "queue.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+    const briefingRec = qLines.find((r) => r.action === "briefing");
+    expect(briefingRec).toBeDefined();
+    expect(briefingRec!.bypassGate).toBe(true);
+
+    // Dispatch that exact record: the gate is bypassed, so NO briefing_skipped
+    // event is emitted despite the would-skip snapshot. (Precompute may throw
+    // in the synthetic harness — the skip decision is already made before it,
+    // and the negative-control test below proves this same world DOES skip a
+    // non-bypass record, so "no event" here can only mean the gate was skipped.)
+    try { await resolveQueueRequestCommand(briefingRec!, true); }
+    catch { /* precompute may fail in synthetic harness */ }
+    expect(findLastEvent(stateDir, "briefing_skipped")).toBeNull();
+  }, 20_000); // briefing RUN arm awaits briefingPrecomputeContext — see above.
+
+  test("auto trigger briefing does NOT bypass the gate — auto record stays gated and skips (AC 11 negative control)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    writeFileSync(join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }));
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    // Auto path: magBriefing(...,{ auto: true }) — the launchd-trigger shape.
+    const { magBriefing, resolveQueueRequestCommand } = await import("./mag.ts");
+    magBriefing(false, 300, { auto: true });
+
+    const qLines = readFileSync(join(stateDir, "mag", "queue.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+    const briefingRec = qLines.find((r) => r.action === "briefing");
+    expect(briefingRec).toBeDefined();
+    // Auto record carries NO bypassGate → still subject to the gate.
+    expect("bypassGate" in briefingRec!).toBe(false);
+
+    const result = await resolveQueueRequestCommand(briefingRec!, true);
+    expect(result).toBeNull();
+    expect(findLastEvent(stateDir, "briefing_skipped")).not.toBeNull();
   });
 
   test("Mag-auto briefing queue_request does NOT advance the signal (denylist active)", async () => {
@@ -155,6 +210,12 @@ describe("adopt-sessions Tier-1 arm — fingerprint gate (gh-ludics-538 AC 9)", 
     const last = findLastEvent(stateDir, "adopt_sessions_skipped");
     expect(last).not.toBeNull();
     expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+    // AC 3/12: signal pair on the skip event mirrors the health_check shape.
+    // For fingerprint gates, current === prior on the skip arm (that's why it
+    // skipped); both must be strings, not null.
+    expect(typeof last!.current).toBe("string");
+    expect(typeof last!.prior).toBe("string");
+    expect(last!.current).toBe(last!.prior);
   });
 
   test("fingerprint changed → run + snapshot refreshed", async () => {
@@ -212,6 +273,11 @@ describe("verify-completion Tier-1 arm — epoch-unchanged gate (gh-ludics-538 A
     expect(last).not.toBeNull();
     expect(last!.task).toBe("task-foo");
     expect((last!.meta as Record<string, unknown>).gateSkip).toBe(true);
+    // AC 3/12: signal pair on the skip event. epoch-unchanged carries number
+    // epochs for current and prior. Both must be numbers, not null.
+    expect(typeof last!.current).toBe("number");
+    expect(typeof last!.prior).toBe("number");
+    expect(last!.prior).toBe(knownEpoch);
   });
 
   test("task with newer event → run + snapshot refreshed", async () => {

--- a/src/mag-periodic-gate.test.ts
+++ b/src/mag-periodic-gate.test.ts
@@ -339,6 +339,55 @@ describe("verify-completion Tier-1 arm — epoch-unchanged gate (gh-ludics-538 A
     // Snapshot now exists.
     expect(existsSync(join(stateDir, "mag", "verify-completion-last", "task-new.json"))).toBe(true);
   });
+
+  test("manual CLI `ludics mag verify-completion <task>` bypasses the gate — the AC-15 peer (AC 11/15)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Would-skip world: a prior per-task snapshot exists and there is no newer
+    // activity for the task → computeTaskLastActivityEpoch returns 0 →
+    // epoch-unchanged gate would skip a gated (non-bypass) request.
+    mkdirSync(join(stateDir, "mag", "verify-completion-last"), { recursive: true });
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-peer.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: 1_700_000_000 }));
+
+    // CLI path: `ludics mag verify-completion task-peer` dispatches through
+    // runMag to the verify-completion subcommand handler.
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    await runMag(["verify-completion", "task-peer"]);
+
+    // The CLI handler tagged the enqueued record with bypassGate.
+    const qLines = readFileSync(join(stateDir, "mag", "queue.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+    const vcRec = qLines.find((r) => r.action === "verify-completion");
+    expect(vcRec).toBeDefined();
+    expect(vcRec!.task).toBe("task-peer");
+    expect(vcRec!.bypassGate).toBe(true);
+
+    // Dispatch that exact record under the would-skip snapshot: the gate is
+    // bypassed → the verify-completion skill command is returned and NO
+    // verify_completion_skipped event is emitted.
+    const result = await resolveQueueRequestCommand(vcRec!, true);
+    expect(typeof result).toBe("string");
+    expect(findLastEvent(stateDir, "verify_completion_skipped")).toBeNull();
+  });
+
+  test("auto-created verify-completion record (no bypassGate) stays gated and skips (AC 11 peer negative control)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Same would-skip world as the bypass test above.
+    mkdirSync(join(stateDir, "mag", "verify-completion-last"), { recursive: true });
+    writeFileSync(join(stateDir, "mag", "verify-completion-last", "task-peer.json"),
+      JSON.stringify({ timestamp: "2026-05-01T00:00:00Z", signal: 1_700_000_000 }));
+
+    // A record WITHOUT bypassGate — the shape an auto-enqueued verify-completion
+    // request has. Same world, only the tag differs → clean mutation pair.
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const result = await resolveQueueRequestCommand({ action: "verify-completion", task: "task-peer" }, true);
+    expect(result).toBeNull();
+    const last = findLastEvent(stateDir, "verify_completion_skipped");
+    expect(last).not.toBeNull();
+    expect(last!.task).toBe("task-peer");
+  });
 });
 
 // --- Feedback-digest empty-skip via briefing's auto-followup path -------

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -909,9 +909,36 @@ function tryQueueFeedbackDigest(repo: string): { queued: boolean; reason?: strin
   if (remaining > 0) {
     return { queued: false, reason: `cooldown active (${remaining}s remaining)` };
   }
+  // gh-ludics-538 AC 5: empty-feedback skip. Worker is never even forked
+  // when the top-level feedback/ surface is empty. The skip MUST NOT
+  // refresh the cooldown anchor (so the next non-empty feedback is queued
+  // immediately, not after the cooldown).
+  if (feedbackDirIsEmpty()) {
+    emitEvent({
+      event_type: "feedback_digest_skipped",
+      source: "mag",
+      scope: "mag",
+      message: "no feedback files",
+      repo,
+      meta: { gateSkip: true },
+    });
+    return { queued: false, reason: "no feedback files" };
+  }
   queueRequest({ action: "feedback-digest", repo });
   markFeedbackDigestQueued(repo);
   return { queued: true };
+}
+
+function feedbackDirIsEmpty(): boolean {
+  const feedbackDir = join(harnessDir(), "feedback");
+  if (!existsSync(feedbackDir)) return true;
+  try {
+    const entries = readdirSync(feedbackDir, { withFileTypes: true });
+    return !entries.some((d) => d.isFile());
+  } catch {
+    // Read error → fail open (treat as non-empty so worker still runs).
+    return false;
+  }
 }
 
 function lastCaptureHashFile(): string {
@@ -1500,9 +1527,94 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
   // Only precompute when actually dispatching, not during a peek.
   if (executeProgrammatic) {
     if (action === "briefing") {
+      // gh-ludics-538: activity gate. Run BEFORE the precompute so an
+      // idle-day skip avoids the t3code / cleanup / merge-base work too.
+      const { shouldSkipPeriodic, latestUserActionEpoch, writeGateSnapshot } = await import("./health-gate.ts");
+      const stateDir = harnessDir();
+      const now = new Date();
+      const signal = latestUserActionEpoch({ stateDir, now, lookbackHours: 48 });
+      const snapPath = briefingGateSnapshotPath();
+      const gate = shouldSkipPeriodic({
+        gateName: "briefing",
+        snapshotPath: snapPath,
+        signal,
+        threshold: 18 * 3600,
+        mode: "activity-window",
+        now,
+      });
+      if (gate.skip) {
+        emitEvent({
+          event_type: "briefing_skipped",
+          source: "mag",
+          scope: "mag",
+          message: gate.reason,
+          current: gate.current as number | null,
+          prior: gate.prior as number | null,
+          meta: { gateSkip: true },
+        });
+        return null;
+      }
+      // Gate decided RUN — refresh snapshot at point of dispatch (matches
+      // existing markBriefingQueued() semantics for cooldown anchors).
+      try { writeGateSnapshot(snapPath, signal); } catch { /* best-effort */ }
       await briefingPrecomputeContext();
     } else if (action === "adopt-sessions") {
+      // gh-ludics-538: fingerprint gate. Skip when the unclassified-sessions
+      // hash is unchanged since the last run.
+      const { shouldSkipPeriodic, writeGateSnapshot } = await import("./health-gate.ts");
+      const sessionsFile = join(harnessDir(), "sessions.json");
+      const fingerprint = adoptSessionsFingerprintData(sessionsFile);
+      if (fingerprint !== null) {
+        const snapPath = adoptSessionsGateSnapshotPath();
+        const gate = shouldSkipPeriodic({
+          gateName: "adopt-sessions",
+          snapshotPath: snapPath,
+          signal: fingerprint.hash,
+          threshold: 0,
+          mode: "fingerprint",
+        });
+        if (gate.skip) {
+          emitEvent({
+            event_type: "adopt_sessions_skipped",
+            source: "mag",
+            scope: "mag",
+            message: gate.reason,
+            meta: { gateSkip: true },
+          });
+          return null;
+        }
+        try { writeGateSnapshot(snapPath, fingerprint.hash); } catch { /* best-effort */ }
+      }
       adoptSessionsPrecomputeContext();
+    } else if (action === "verify-completion") {
+      // gh-ludics-538 AC 10: per-task epoch-unchanged gate.
+      const taskId = String(request.task ?? "");
+      if (taskId) {
+        const { shouldSkipPeriodic, writeGateSnapshot } = await import("./health-gate.ts");
+        const epoch = computeTaskLastActivityEpoch(taskId);
+        const snapPath = verifyCompletionGateSnapshotPath(taskId);
+        const gate = shouldSkipPeriodic({
+          gateName: "verify-completion",
+          snapshotPath: snapPath,
+          signal: epoch,
+          threshold: 0,
+          mode: "epoch-unchanged",
+        });
+        if (gate.skip) {
+          emitEvent({
+            event_type: "verify_completion_skipped",
+            source: "mag",
+            scope: "mag",
+            message: gate.reason,
+            task: taskId,
+            meta: { gateSkip: true },
+          });
+          return null;
+        }
+        if (epoch !== null && epoch > 0) {
+          try { writeGateSnapshot(snapPath, epoch); } catch { /* best-effort */ }
+        }
+      }
     } else if (action === "health-check") {
       const { shouldSkipHealthCheck } = await import("./health-gate.ts");
       const gate = shouldSkipHealthCheck();
@@ -1515,6 +1627,7 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
           currentLines: gate.currentLines,
           priorLines: gate.priorLines,
           delta: gate.currentLines - gate.priorLines,
+          meta: { gateSkip: true },
         });
         return null;
       }
@@ -2377,6 +2490,87 @@ ${matches}
   writeFileSync(contextFile + ".tmp", content);
   renameSync(contextFile + ".tmp", contextFile);
   console.error(`ludics: adopt-sessions context written to ${contextFile}`);
+}
+
+// --- gh-ludics-538: Tier-1 periodic gate helpers ----------------------------
+
+export function briefingGateSnapshotPath(): string {
+  return join(magStateDir(), "briefing-last.json");
+}
+
+export function adoptSessionsGateSnapshotPath(): string {
+  return join(magStateDir(), "adopt-sessions-last.json");
+}
+
+export function verifyCompletionGateSnapshotPath(taskId: string): string {
+  return join(magStateDir(), "verify-completion-last", `${encodeURIComponent(taskId)}.json`);
+}
+
+/** Compute the latest activity epoch for a verify-completion target task.
+ *  Combines:
+ *    - git HEAD commit time on the task's project worktree (resolved via
+ *      task frontmatter `project` → findProjectConfigByName.path).
+ *    - slot_resume / slot_assign event epochs scoped to this task.
+ *  Returns 0 when no activity is resolvable (the gate then fails open).
+ *  Returns null on read error (the gate also fails open).
+ *
+ *  Per docs/proposals/activity-gate-periodic-skills.md AC 10 / Gap C —
+ *  `.peer-sync/` mtime is intentionally NOT included in this PR. */
+export function computeTaskLastActivityEpoch(taskId: string): number | null {
+  if (!taskId) return null;
+  let best = 0;
+  let sawError = false;
+
+  // Source 1: project worktree git HEAD commit time.
+  try {
+    const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
+    if (existsSync(taskFile)) {
+      const fm = parseTaskFrontmatter(readFileSync(taskFile, "utf-8"));
+      const projectName = String(fm.project ?? "");
+      if (projectName) {
+        const proj = findProjectConfigByName(projectName);
+        const projPath = proj?.path
+          ? (proj.path.startsWith("~/") ? join(process.env.HOME ?? "~", proj.path.slice(2)) : proj.path)
+          : null;
+        if (projPath && existsSync(projPath)) {
+          const r = Bun.spawnSync(["git", "log", "-1", "--format=%ct", "HEAD"], { cwd: projPath });
+          if (r.exitCode === 0) {
+            const out = new TextDecoder().decode(r.stdout).trim();
+            const epoch = Number.parseInt(out, 10);
+            if (Number.isFinite(epoch) && epoch > best) best = epoch;
+          }
+        }
+      }
+    }
+  } catch {
+    sawError = true;
+  }
+
+  // Source 2: slot_resume / slot_assign events scoped to taskId.
+  try {
+    const eventsFile = join(harnessDir(), "journal", "events.jsonl");
+    if (existsSync(eventsFile)) {
+      const buf = readFileSync(eventsFile, "utf8");
+      const lines = buf.length > 0 ? buf.split("\n") : [];
+      for (const line of lines) {
+        if (!line) continue;
+        try {
+          const parsed = JSON.parse(line) as Record<string, unknown>;
+          if (parsed.task !== taskId) continue;
+          const et = typeof parsed.event_type === "string" ? parsed.event_type : "";
+          if (et !== "slot_resume" && et !== "slot_assign") continue;
+          const epoch = typeof parsed.epoch === "number" ? parsed.epoch : null;
+          if (epoch !== null && epoch > best) best = epoch;
+        } catch { /* skip malformed */ }
+      }
+    }
+  } catch {
+    sawError = true;
+  }
+
+  if (best > 0) return best;
+  if (sawError) return null;
+  return 0;
 }
 
 // --- Auto-queue proposals ---

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1525,71 +1525,86 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
 
   // Tier 1: Pre-hooks for skill actions that require context pre-computation.
   // Only precompute when actually dispatching, not during a peek.
+  // gh-ludics-538 AC 11: a queued request marked `bypassGate: true` (set by
+  // manual CLI handlers like `ludics mag briefing` — distinct from auto
+  // triggers which call magBriefing with `{ auto: true }`) skips the
+  // activity-gate checks below while still running precompute, ensuring a
+  // manual CLI invocation runs the skill regardless of the snapshot.
+  const bypassGate = request.bypassGate === true;
   if (executeProgrammatic) {
     if (action === "briefing") {
-      // gh-ludics-538: activity gate. Run BEFORE the precompute so an
-      // idle-day skip avoids the t3code / cleanup / merge-base work too.
-      const { shouldSkipPeriodic, latestUserActionEpoch, writeGateSnapshot } = await import("./health-gate.ts");
-      const stateDir = harnessDir();
-      const now = new Date();
-      const signal = latestUserActionEpoch({ stateDir, now, lookbackHours: 48 });
-      const snapPath = briefingGateSnapshotPath();
-      const gate = shouldSkipPeriodic({
-        gateName: "briefing",
-        snapshotPath: snapPath,
-        signal,
-        threshold: 18 * 3600,
-        mode: "activity-window",
-        now,
-      });
-      if (gate.skip) {
-        emitEvent({
-          event_type: "briefing_skipped",
-          source: "mag",
-          scope: "mag",
-          message: gate.reason,
-          current: gate.current as number | null,
-          prior: gate.prior as number | null,
-          meta: { gateSkip: true },
-        });
-        return null;
-      }
-      // Gate decided RUN — refresh snapshot at point of dispatch (matches
-      // existing markBriefingQueued() semantics for cooldown anchors).
-      try { writeGateSnapshot(snapPath, signal); } catch { /* best-effort */ }
-      await briefingPrecomputeContext();
-    } else if (action === "adopt-sessions") {
-      // gh-ludics-538: fingerprint gate. Skip when the unclassified-sessions
-      // hash is unchanged since the last run.
-      const { shouldSkipPeriodic, writeGateSnapshot } = await import("./health-gate.ts");
-      const sessionsFile = join(harnessDir(), "sessions.json");
-      const fingerprint = adoptSessionsFingerprintData(sessionsFile);
-      if (fingerprint !== null) {
-        const snapPath = adoptSessionsGateSnapshotPath();
+      if (!bypassGate) {
+        // gh-ludics-538: activity gate. Run BEFORE the precompute so an
+        // idle-day skip avoids the t3code / cleanup / merge-base work too.
+        const { shouldSkipPeriodic, latestUserActionEpoch, writeGateSnapshot } = await import("./health-gate.ts");
+        const stateDir = harnessDir();
+        const now = new Date();
+        const signal = latestUserActionEpoch({ stateDir, now, lookbackHours: 48 });
+        const snapPath = briefingGateSnapshotPath();
         const gate = shouldSkipPeriodic({
-          gateName: "adopt-sessions",
+          gateName: "briefing",
           snapshotPath: snapPath,
-          signal: fingerprint.hash,
-          threshold: 0,
-          mode: "fingerprint",
+          signal,
+          threshold: 18 * 3600,
+          mode: "activity-window",
+          now,
         });
         if (gate.skip) {
           emitEvent({
-            event_type: "adopt_sessions_skipped",
+            event_type: "briefing_skipped",
             source: "mag",
             scope: "mag",
             message: gate.reason,
+            current: gate.current as number | null,
+            prior: gate.prior as number | null,
             meta: { gateSkip: true },
           });
           return null;
         }
-        try { writeGateSnapshot(snapPath, fingerprint.hash); } catch { /* best-effort */ }
+        // Gate decided RUN — refresh snapshot at point of dispatch (matches
+        // existing markBriefingQueued() semantics for cooldown anchors).
+        try { writeGateSnapshot(snapPath, signal); } catch { /* best-effort */ }
+      }
+      await briefingPrecomputeContext();
+    } else if (action === "adopt-sessions") {
+      if (!bypassGate) {
+        // gh-ludics-538: fingerprint gate. Skip when the unclassified-sessions
+        // hash is unchanged since the last run.
+        const { shouldSkipPeriodic, writeGateSnapshot } = await import("./health-gate.ts");
+        const sessionsFile = join(harnessDir(), "sessions.json");
+        const fingerprint = adoptSessionsFingerprintData(sessionsFile);
+        if (fingerprint !== null) {
+          const snapPath = adoptSessionsGateSnapshotPath();
+          const gate = shouldSkipPeriodic({
+            gateName: "adopt-sessions",
+            snapshotPath: snapPath,
+            signal: fingerprint.hash,
+            threshold: 0,
+            mode: "fingerprint",
+          });
+          if (gate.skip) {
+            // AC 3/12: emit the same diagnostic minimum as health_check_skipped —
+            // `current`/`prior` carry the signal pair (fingerprint strings for
+            // adopt-sessions) so dashboard /api/gate-skips can surface them.
+            emitEvent({
+              event_type: "adopt_sessions_skipped",
+              source: "mag",
+              scope: "mag",
+              message: gate.reason,
+              current: gate.current as string | null,
+              prior: gate.prior as string | null,
+              meta: { gateSkip: true },
+            });
+            return null;
+          }
+          try { writeGateSnapshot(snapPath, fingerprint.hash); } catch { /* best-effort */ }
+        }
       }
       adoptSessionsPrecomputeContext();
     } else if (action === "verify-completion") {
       // gh-ludics-538 AC 10: per-task epoch-unchanged gate.
       const taskId = String(request.task ?? "");
-      if (taskId) {
+      if (taskId && !bypassGate) {
         const { shouldSkipPeriodic, writeGateSnapshot } = await import("./health-gate.ts");
         const epoch = computeTaskLastActivityEpoch(taskId);
         const snapPath = verifyCompletionGateSnapshotPath(taskId);
@@ -1601,11 +1616,15 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
           mode: "epoch-unchanged",
         });
         if (gate.skip) {
+          // AC 3/12: emit `current`/`prior` epoch pair so dashboard
+          // /api/gate-skips surfaces the diagnostic signal pair.
           emitEvent({
             event_type: "verify_completion_skipped",
             source: "mag",
             scope: "mag",
             message: gate.reason,
+            current: gate.current as number | null,
+            prior: gate.prior as number | null,
             task: taskId,
             meta: { gateSkip: true },
           });
@@ -1616,20 +1635,22 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
         }
       }
     } else if (action === "health-check") {
-      const { shouldSkipHealthCheck } = await import("./health-gate.ts");
-      const gate = shouldSkipHealthCheck();
-      if (gate.skip) {
-        emitEvent({
-          event_type: "health_check_skipped",
-          source: "keepalive",
-          scope: "mag",
-          message: gate.reason,
-          currentLines: gate.currentLines,
-          priorLines: gate.priorLines,
-          delta: gate.currentLines - gate.priorLines,
-          meta: { gateSkip: true },
-        });
-        return null;
+      if (!bypassGate) {
+        const { shouldSkipHealthCheck } = await import("./health-gate.ts");
+        const gate = shouldSkipHealthCheck();
+        if (gate.skip) {
+          emitEvent({
+            event_type: "health_check_skipped",
+            source: "keepalive",
+            scope: "mag",
+            message: gate.reason,
+            currentLines: gate.currentLines,
+            priorLines: gate.priorLines,
+            delta: gate.currentLines - gate.priorLines,
+            meta: { gateSkip: true },
+          });
+          return null;
+        }
       }
       try {
         const { runAllTestHealth } = await import("./health.ts");
@@ -3912,7 +3933,10 @@ export function magBriefing(
       }
     }
   }
-  const requestId = queueRequest({ action: "briefing" });
+  // gh-ludics-538 AC 11: a manual `ludics mag briefing` (opts.auto falsy)
+  // bypasses the dispatch-time activity gate; an auto trigger (opts.auto)
+  // stays gated so idle days still skip.
+  const requestId = queueRequest({ action: "briefing" }, { bypassGate: !opts.auto });
   console.log(`Queued briefing request: ${requestId}`);
 
   // Auto-queue feedback-digest once daily alongside the briefing trigger.
@@ -4092,7 +4116,8 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
       console.error("ludics: mag health-check skipped — not the cluster controller");
       return;
     }
-    queueRequest({ action: "health-check" });
+    // gh-ludics-538 AC 11: manual CLI invocation bypasses the dispatch gate.
+    queueRequest({ action: "health-check" }, { bypassGate: true });
     // /compact is enqueued by the gate-check path in resolveQueueRequestCommand
     // only when the health-check actually runs (gate did not skip). Coupling
     // /compact to a real checkpoint avoids spurious compactions on idle ticks.
@@ -4236,7 +4261,8 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
   ["verify-completion", (args) => {
     const taskId = args[0];
     if (!taskId) throw new Error("task id required");
-    queueRequest({ action: "verify-completion", task: taskId });
+    // gh-ludics-538 AC 11: manual CLI invocation bypasses the dispatch gate.
+    queueRequest({ action: "verify-completion", task: taskId }, { bypassGate: true });
     console.log(`Queued verify-completion request for ${taskId}`);
   }],
   ["verify-container-completion", (args) => {
@@ -4291,7 +4317,8 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
       return;
     }
 
-    queueRequest({ action: "adopt-sessions" });
+    // gh-ludics-538 AC 11: manual CLI invocation bypasses the dispatch gate.
+    queueRequest({ action: "adopt-sessions" }, { bypassGate: true });
     console.log(`Queued adopt-sessions request (${fingerprint.unclassifiedCount} unclassified session(s))`);
   }],
   ["process-suggestions", (args) => {

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2555,7 +2555,9 @@ export function computeTaskLastActivityEpoch(taskId: string): number | null {
       for (const line of lines) {
         if (!line) continue;
         try {
-          const parsed = JSON.parse(line) as Record<string, unknown>;
+          const raw = JSON.parse(line) as unknown;
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+          const parsed = raw as Record<string, unknown>;
           if (parsed.task !== taskId) continue;
           const et = typeof parsed.event_type === "string" ? parsed.event_type : "";
           if (et !== "slot_resume" && et !== "slot_assign") continue;

--- a/src/queue-event-payload.test.ts
+++ b/src/queue-event-payload.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { withSyntheticHarness } from "./test-utils.ts";
+import { queueRequest, queueRequestAtHead } from "./queue.ts";
+
+function readLastEvent(stateDir: string): Record<string, unknown> {
+  const evPath = join(stateDir, "journal", "events.jsonl");
+  expect(existsSync(evPath)).toBe(true);
+  const lines = readFileSync(evPath, "utf8").trim().split("\n");
+  return JSON.parse(lines[lines.length - 1]!) as Record<string, unknown>;
+}
+
+describe("queue_request event payload — messageContent field (gh-ludics-538)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("queueRequest with action=message attaches messageContent verbatim", () => {
+    queueRequest({ action: "message", content: "/compact" });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.event_type).toBe("queue_request");
+    expect(ev.action).toBe("message");
+    expect(ev.messageContent).toBe("/compact");
+  });
+
+  test("queueRequest with action=message truncates content to 200 chars", () => {
+    const long = "a".repeat(500);
+    queueRequest({ action: "message", content: long });
+    const ev = readLastEvent(getStateDir());
+    expect(typeof ev.messageContent).toBe("string");
+    expect((ev.messageContent as string).length).toBe(200);
+  });
+
+  test("queueRequest with non-message action omits messageContent", () => {
+    queueRequest({ action: "briefing" });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.event_type).toBe("queue_request");
+    expect(ev.action).toBe("briefing");
+    expect("messageContent" in ev).toBe(false);
+  });
+
+  test("queueRequestAtHead with action=message attaches messageContent", () => {
+    queueRequestAtHead({ action: "message", content: "/compact" });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.action).toBe("message");
+    expect(ev.messageContent).toBe("/compact");
+  });
+
+  test("queueRequestAtHead with non-message action omits messageContent", () => {
+    queueRequestAtHead({ action: "feedback-digest", repo: "ludics" });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.action).toBe("feedback-digest");
+    expect("messageContent" in ev).toBe(false);
+  });
+});

--- a/src/queue-event-payload.test.ts
+++ b/src/queue-event-payload.test.ts
@@ -11,6 +11,20 @@ function readLastEvent(stateDir: string): Record<string, unknown> {
   return JSON.parse(lines[lines.length - 1]!) as Record<string, unknown>;
 }
 
+function readLastQueueRecord(stateDir: string): Record<string, unknown> {
+  const qPath = join(stateDir, "mag", "queue.jsonl");
+  expect(existsSync(qPath)).toBe(true);
+  const lines = readFileSync(qPath, "utf8").trim().split("\n");
+  return JSON.parse(lines[lines.length - 1]!) as Record<string, unknown>;
+}
+
+function readFirstQueueRecord(stateDir: string): Record<string, unknown> {
+  const qPath = join(stateDir, "mag", "queue.jsonl");
+  expect(existsSync(qPath)).toBe(true);
+  const lines = readFileSync(qPath, "utf8").trim().split("\n");
+  return JSON.parse(lines[0]!) as Record<string, unknown>;
+}
+
 describe("queue_request event payload — messageContent field (gh-ludics-538)", () => {
   const getStateDir = withSyntheticHarness(beforeEach, afterEach);
 
@@ -50,5 +64,57 @@ describe("queue_request event payload — messageContent field (gh-ludics-538)",
     const ev = readLastEvent(getStateDir());
     expect(ev.action).toBe("feedback-digest");
     expect("messageContent" in ev).toBe(false);
+  });
+});
+
+// gh-ludics-538 AC 11: the additive `bypassGate` field on the queue RECORD
+// (not the event) carries CLI-bypass provenance to the dispatch-time gate.
+describe("queue record — bypassGate field (gh-ludics-538 AC 11)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("queueRequest with extras.bypassGate=true persists bypassGate on the record", () => {
+    queueRequest({ action: "briefing" }, { bypassGate: true });
+    const rec = readLastQueueRecord(getStateDir());
+    expect(rec.action).toBe("briefing");
+    expect(rec.bypassGate).toBe(true);
+  });
+
+  test("queueRequest without extras omits bypassGate (gated path stays default)", () => {
+    queueRequest({ action: "briefing" });
+    const rec = readLastQueueRecord(getStateDir());
+    expect(rec.action).toBe("briefing");
+    expect("bypassGate" in rec).toBe(false);
+  });
+
+  test("queueRequest with extras.bypassGate=false omits the field (only true is persisted)", () => {
+    queueRequest({ action: "briefing" }, { bypassGate: false });
+    const rec = readLastQueueRecord(getStateDir());
+    expect("bypassGate" in rec).toBe(false);
+  });
+
+  test("queueRequestAtHead with extras.bypassGate=true persists bypassGate", () => {
+    queueRequestAtHead({ action: "health-check" }, { bypassGate: true });
+    const rec = readFirstQueueRecord(getStateDir());
+    expect(rec.action).toBe("health-check");
+    expect(rec.bypassGate).toBe(true);
+  });
+
+  test("bypassGate survives a JSON round-trip on the queue record", () => {
+    queueRequest({ action: "verify-completion", task: "task-rt" }, { bypassGate: true });
+    const rec = readLastQueueRecord(getStateDir());
+    // Re-serialize and re-parse to prove the field is not dropped by the
+    // record's own JSON encoding (the dispatch path re-parses the record).
+    const roundTripped = JSON.parse(JSON.stringify(rec)) as Record<string, unknown>;
+    expect(roundTripped.action).toBe("verify-completion");
+    expect(roundTripped.task).toBe("task-rt");
+    expect(roundTripped.bypassGate).toBe(true);
+  });
+
+  test("bypassGate is NOT mirrored onto the queue_request event payload", () => {
+    queueRequest({ action: "briefing" }, { bypassGate: true });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.event_type).toBe("queue_request");
+    // bypassGate is record-only provenance — the event stays unchanged.
+    expect("bypassGate" in ev).toBe(false);
   });
 });

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -138,16 +138,27 @@ export type QueueAction =
   | { action: "message"; content: string }
   | { action: "adapter-followup"; task: string; adapter: string; followup_msg?: string };
 
-export function queueRequest(req: QueueAction): string {
+/** Optional side-band fields stored on the queue record alongside the
+ *  discriminated-union `QueueAction`. Kept separate from `QueueAction` so the
+ *  action types stay tight; `bypassGate` is provenance metadata, not a new
+ *  action variant. Set by manual CLI handlers in `src/mag.ts` so a queued
+ *  request from `ludics mag <skill>` skips the dispatch-time activity gate
+ *  even when the snapshot would otherwise suppress it (gh-ludics-538 AC 11). */
+export interface QueueRequestExtras {
+  bypassGate?: boolean;
+}
+
+export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): string {
   const file = queueFile();
   mkdirSync(dirname(file), { recursive: true });
 
   const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const requestId = nextRequestId();
 
-  const record = { id: requestId, ...req, timestamp };
+  const baseRecord: Record<string, unknown> = { id: requestId, ...req, timestamp };
+  if (extras?.bypassGate === true) baseRecord.bypassGate = true;
   withQueueLock(() => {
-    appendFileSync(file, JSON.stringify(record) + "\n");
+    appendFileSync(file, JSON.stringify(baseRecord) + "\n");
   });
   emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;
@@ -198,11 +209,12 @@ export function queueReinsertHead(line: string): void {
  * (e.g., health-check coupling /compact directly behind itself — see
  * docs/proposals/auto-compact-after-checkpoints.md).
  */
-export function queueRequestAtHead(req: QueueAction): string {
+export function queueRequestAtHead(req: QueueAction, extras?: QueueRequestExtras): string {
   const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const requestId = nextRequestId();
-  const record = { id: requestId, ...req, timestamp };
-  queueReinsertHead(JSON.stringify(record));
+  const baseRecord: Record<string, unknown> = { id: requestId, ...req, timestamp };
+  if (extras?.bypassGate === true) baseRecord.bypassGate = true;
+  queueReinsertHead(JSON.stringify(baseRecord));
   emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;
 }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -149,8 +149,23 @@ export function queueRequest(req: QueueAction): string {
   withQueueLock(() => {
     appendFileSync(file, JSON.stringify(record) + "\n");
   });
-  emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action: req.action, message: requestId });
+  emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;
+}
+
+/** Build the queue_request event payload. For action="message", attach a
+ *  truncated `messageContent` so the briefing user-action signal can
+ *  distinguish auto-/compact (Mag-internal) from a user message after the
+ *  queue record itself has been popped (gh-ludics-538). */
+function buildQueueRequestEvent(req: QueueAction, requestId: string): {
+  event_type: "queue_request"; source: string; scope: string;
+  action: string; message: string; messageContent?: string;
+} {
+  const base = { event_type: "queue_request" as const, source: "cli", scope: "queue", action: req.action, message: requestId };
+  if (req.action === "message") {
+    return { ...base, messageContent: String(req.content ?? "").slice(0, 200) };
+  }
+  return base;
 }
 
 function readQueueLines(): string[] {
@@ -188,7 +203,7 @@ export function queueRequestAtHead(req: QueueAction): string {
   const requestId = nextRequestId();
   const record = { id: requestId, ...req, timestamp };
   queueReinsertHead(JSON.stringify(record));
-  emitEvent({ event_type: "queue_request", source: "cli", scope: "queue", action: req.action, message: requestId });
+  emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;
 }
 

--- a/templates/dashboard/health.html
+++ b/templates/dashboard/health.html
@@ -49,6 +49,13 @@
             <div class="doctor-meta" id="doctor-timestamp"></div>
             <pre id="doctor-output">Loading...</pre>
         </div>
+
+        <h2 class="health-section-title">Skipped Periodic Skills</h2>
+        <div class="gate-skips-section" id="gate-skips">
+            <div class="content-placeholder">
+                <span class="text">No recent gate skips</span>
+            </div>
+        </div>
     </main>
 
     <footer>
@@ -80,6 +87,7 @@
                 const data = await response.json();
                 renderHealthReport(data.healthReport);
                 renderDoctor(data.doctor);
+                renderGateSkips(data.gateSkips);
                 updateTimestamp();
                 setConnectionStatus(true);
             } catch (error) {
@@ -121,6 +129,36 @@
                 const d = new Date(doctor.timestamp);
                 timestamp.textContent = 'Last run: ' + d.toLocaleString();
             }
+        }
+
+        // gh-ludics-538: render the "Skipped because X" surface (AC 13).
+        // Degrades silently when gateSkips is absent or empty.
+        function renderGateSkips(gateSkips) {
+            const container = document.getElementById('gate-skips');
+            if (!container) return;
+            const entries = gateSkips && typeof gateSkips === 'object'
+                ? Object.entries(gateSkips)
+                : [];
+            if (entries.length === 0) {
+                container.innerHTML = `
+                    <div class="content-placeholder">
+                        <span class="text">No recent gate skips</span>
+                    </div>
+                `;
+                return;
+            }
+            const rows = entries.map(([gate, info]) => {
+                const ts = info && info.timestamp ? new Date(info.timestamp).toLocaleString() : '';
+                const reason = info && info.reason ? String(info.reason) : '';
+                const safeGate = String(gate)
+                    .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                const safeReason = reason
+                    .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                const safeTs = String(ts)
+                    .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+                return `<li><strong>${safeGate}</strong> <span class="timestamp">${safeTs}</span> — ${safeReason}</li>`;
+            }).join('');
+            container.innerHTML = `<ul class="gate-skips-list">${rows}</ul>`;
         }
 
         function updateTimestamp() {


### PR DESCRIPTION
## Summary

Closes #538.

Generalizes the single-purpose health-check gate into a four-mode activity gate (`count` / `fingerprint` / `activity-window` / `epoch-unchanged`) and wires Tier-1 gate arms for briefing, adopt-sessions, verify-completion, plus a queue-side empty-feedback gate for feedback-digest. Raises `HEALTH_GATE_THRESHOLD` 50 → 300.

The proposal is at `docs/proposals/activity-gate-periodic-skills.md` (17 ACs). The merged plan that drove this PR is at `.peer-sync/plans/round-1-merged-2.md`; the AC self-check is at `.peer-sync/workflow-feedback-coder.md`.

## What ships

1. **`src/queue.ts`** — (a) additive `messageContent` field on `queue_request` events (only when `action: "message"`), truncated to 200 chars, so auto-`/compact` classification stays durable across the briefing's 48h look-back. (b) additive `bypassGate` field on the queue **record** via `QueueRequestExtras` — carries CLI-bypass provenance to the dispatch gate (AC 11).
2. **`src/health-gate.ts`** — generalized `shouldSkipPeriodic({ gateName, snapshotPath, signal, threshold, mode })` with four modes. `shouldSkipHealthCheck` preserved as thin wrapper. New helpers: `MAG_AUTO_ACTIONS`, `isMagAutoAction()`, `latestUserActionEpoch()` (three-valued: `number` / `0` / `null`), `isMagAuthoredCommit()`, `frontmatterRange()`, `commitTouchedTaskFrontmatter()`, `writeGateSnapshot()`. `epoch-unchanged` mode fails open on a future stored epoch (clock-skew defence, AC 1). `countGateEligibleLines` upgraded to a JSON-aware `meta.gateSkip === true` predicate with a legacy `GATE_INTERNAL_EVENT_MARKERS` substring fallback.
3. **`src/mag.ts`** — three new Tier-1 gate arms (briefing / adopt-sessions / verify-completion) and the queue-side feedback-digest empty-skip. All four gate-skip events (`briefing_skipped`, `adopt_sessions_skipped`, `verify_completion_skipped`, `health_check_skipped`) carry the `current`/`prior` signal pair + `meta.gateSkip: true`. CLI handlers (`briefing` non-auto / `adopt-sessions` / `verify-completion` / `health-check`) tag their enqueued record `bypassGate: true`; `resolveQueueRequestCommand` skips the per-action gate for a bypass record.
4. **Dashboard** — `generateGateSkips()` aggregator + `GET /api/gate-skips` + compact "Skipped because X" panel in `templates/dashboard/health.html`. No new persistent state file (attached to existing `health.json`).
5. **Proposal in-PR edits** — AC 3 wording fix (Gap A), AC 17 name-list extension (Gap B), AC 6 mechanism narrowed to the implemented diff-hunk overlap (Gap C). Self-applying the rule the proposal ships.

## R4 review fixes

- **AC 1/14** — `epoch-unchanged` mode now applies the future-prior clock-skew fail-open (previously only `activity-window` did).
- **AC 3/12** — `adopt_sessions_skipped` + `verify_completion_skipped` now emit the `current`/`prior` signal pair; the dashboard surfaces it instead of `null`/`null`.
- **AC 6** — source 3 of `latestUserActionEpoch` is now frontmatter-bounded: `commitTouchedTaskFrontmatter()` checks diff-hunk overlap with the YAML frontmatter range; body-only task edits no longer advance the briefing signal.
- **AC 11/15** — real CLI gate bypass via the additive `bypassGate` queue-record field; auto triggers stay gated.
- **AC 16** — the `/api/gate-skips` endpoint test covers one skip per all five committed gate names and asserts the signal pair at the HTTP boundary.
- **AC 15 (R5)** — added the "and one peer" CLI-bypass test: `runMag(["verify-completion", …])` dispatched under a would-skip snapshot, with an untagged-record negative control.

## codex review fixes

- **P1** — `activity-window` mode applied the `current === 0` zero-activity skip before the future-prior clock-skew guard; a future snapshot epoch + idle look-back could suppress briefing indefinitely. The clock-skew guard now runs first.
- **P2** — `commitTouchedTaskFrontmatter` only inspected the post-commit file, so a commit removing/breaking the frontmatter delimiters was dropped. It now also resolves the pre-image frontmatter range (`git show <sha>^:<file>`) and tests each hunk's OLD side against it.

## ⚠️ ASSUMPTION GAPS (documented in the AC self-check, resolved in-PR)

- **Gap A** — AC 3's literal condition (`(now - lastUserActionEpoch) < 18h`) was the inverse of the proposal's goal; rewrote to "skip when no progress since prior briefing AND latest activity is older than 18h".
- **Gap B** — `verify_completion_skipped` not in AC 17's committed name list; added.
- **Gap C** — RESOLVED in R4: the strict frontmatter-bounded predicate is implemented (no longer a proxy); proposal AC 6 narrowed to the diff-hunk mechanism.
- **Gap D** — `MAG_AUTO_ACTIONS` includes `verify-completion` and `sync-learnings` beyond AC 7's four-name list (both are Mag-internal).

## Behavioural changes that touched existing tests

- `src/mag-auto-compact.test.ts` and `src/mag-briefing-auto-cooldown.test.ts` seed a `feedback/seed.md` file in `beforeEach` so the briefing trio still produces 3 queue entries under the new empty-feedback gate.
- `src/mag-health-gate.test.ts` "delta over threshold" bumped from 200 → 400 (200 now skips under threshold=300).
- Three briefing RUN-arm tests in `src/mag-periodic-gate.test.ts` given a 20s timeout — `briefingPrecomputeContext` spawns `ludics` subprocesses and the 5s default flaked under full-suite load.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` (eslint) clean — also fixed 4 pre-existing eslint errors introduced by earlier rounds
- [x] `bun run build` compiles
- [x] `bun test` → 2712 pass / 0 fail
- [x] CI drift lints (`lint:cli-readme`, `lint:cli-subcommands`, `lint:no-nul-bytes`, `lint:contracts`, `lint:state-migration`, `lint:test-spawn-coverage`) all green
- [x] health-gate.test.ts covers all four modes + clock-skew fail-open + frontmatter-bounded commit source + isMagAutoAction matrix
- [x] mag-periodic-gate.test.ts covers the three Tier-1 gate arms + signal-pair emit + CLI bypass for briefing AND the verify-completion peer (each with an auto-path negative control) + cross-task isolation
- [x] queue-event-payload.test.ts covers the additive `messageContent` and `bypassGate` fields incl. JSON round-trip
- [x] dashboard.test.ts covers `gateSkips` shape, marker filtering, the 5-gate endpoint-boundary test, and empty-state degradation

## Out of scope (per proposal)

- launchd-trigger removal (the trigger still fires; the gate is the filter)
- briefing amend/new branching (separate machinery)
- `QueueAction.source` first-class field (deferred follow-up per resolved Q1)
- `.peer-sync/` mtime in verify-completion (deferred per AC 10's explicit out-of-scope note)
- The ~20-site `queueRequest` call audit (denylist handles this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


