### PR TITLE
Precompute the Needs Confirmation list in briefing-context.md

### DIFF
--- a/skills/ludics-briefing.md
+++ b/skills/ludics-briefing.md
@@ -48,6 +48,7 @@ The context file contains these sections:
 - **Flow: Ready Queue**: Priority-sorted ready tasks
 - **Flow: Critical Items**: Deadlines, high-priority ready
 - **Tasks Needing Elaboration**: Task IDs that lack elaboration
+- **Needs Confirmation**: Tasks with `status: needs-confirmation`, projected as `<id> (<priority>) [<project>] "<title>"` (or `None` when there are none)
 - **Recent Journal**: Last 20 journal entries
 
 Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
@@ -82,9 +83,16 @@ Also read `$LUDICS_STATE_PATH/tasks/*.md` for full task details.
      - Use the Task tool to invoke `/ludics-elaborate <task-id>` (parallel)
 
 <!-- section:scan-needs-confirmation -->
-4. **Scan for needs-confirmation tasks**:
-   - Check task files for `status: needs-confirmation`
-   - For each, note the task ID, title, priority, and `relates_to` source task
+4. **Collect needs-confirmation tasks**:
+   - Read the precomputed `## Needs Confirmation` section of
+     `$LUDICS_STATE_PATH/mag/briefing-context.md`. Do **not** hand-scan
+     `tasks/*.md` for this list — the precomputed section is status-verified,
+     so long-done tasks can't carry over from a prior `briefing.md`.
+   - A body of `None` means there are no needs-confirmation tasks; in that
+     case omit the briefing's "Needs Confirmation" output section entirely.
+   - Otherwise each line is `<id> (<priority>) [<project>] "<title>"`.
+   - For the `-- from <source>` attribution, read `relates_to` from each
+     listed task's file — only for the IDs in the precomputed section.
    - These will be included in a dedicated "Needs Confirmation" section
 
 <!-- section:analyze-work -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ Commands:
   tasks files                  List individual task files
   tasks samples                Create sample tasks for testing
   tasks needs-elaboration      List tasks needing elaboration
+  tasks needs-confirmation     List tasks awaiting confirmation
   tasks queue-elaborations     Queue elaboration for unprocessed ready tasks
   tasks check <id>             Check if task needs elaboration
   tasks merge <target> <src..> Merge source task(s) into target

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -826,6 +826,146 @@ describe("briefingPrecomputeContext — orphan absorption (A9)", () => {
   });
 });
 
+// gh-ludics-547: the briefing-context generator emits a precomputed
+// `## Needs Confirmation` section so the briefing skill reads a
+// status-verified list instead of hand-scanning tasks/*.md (which let three
+// long-`done` tasks carry over into the 2026-05-20 briefing).
+describe("briefingPrecomputeContext — Needs Confirmation section (gh-ludics-547)", () => {
+  let tmpHome: string;
+  let tmpConfig: string;
+  let tmpHarness: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  function snapshotEnv(keys: string[]) {
+    for (const k of keys) savedEnv[k] = process.env[k];
+  }
+  function restoreEnv() {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "mag-needsconf-home-"));
+    tmpHarness = mkdtempSync(join(tmpdir(), "mag-needsconf-harness-"));
+    tmpConfig = join(tmpHome, "config.yaml");
+    snapshotEnv(["LUDICS_CONFIG", "LUDICS_HARNESS_DIR"]);
+    process.env.LUDICS_CONFIG = tmpConfig;
+    process.env.LUDICS_HARNESS_DIR = tmpHarness;
+    mkdirSync(join(tmpHarness, "tasks"), { recursive: true });
+    writeFileSync(tmpConfig, [
+      "state_repo: test/testrepo",
+      "state_path: harness",
+      "mag:",
+      "  ensure_t3code: false",
+      "projects: []",
+    ].join("\n"));
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(tmpHarness, { recursive: true, force: true });
+  });
+
+  const noopRunGit: RunGit = () => ({ stdout: "", exitCode: 0 });
+
+  function contextFile(): string {
+    return join(tmpHarness, "mag", "briefing-context.md");
+  }
+
+  function writeTask(
+    id: string,
+    status: string,
+    opts: { priority?: string; project?: string; title?: string } = {},
+  ): void {
+    const { priority = "B", project = "ludics", title = id } = opts;
+    writeFileSync(
+      join(tmpHarness, "tasks", `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nproject: ${project}\nstatus: ${status}\npriority: ${priority}\n---\n\n# ${title}\n`,
+    );
+  }
+
+  /** The trimmed body between `## Needs Confirmation` and the next `## ` header. */
+  function needsConfirmationBody(content: string): string {
+    const header = "## Needs Confirmation";
+    const start = content.indexOf(header);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const after = content.slice(start + header.length);
+    const next = after.indexOf("\n## ");
+    return (next >= 0 ? after.slice(0, next) : after).trim();
+  }
+
+  test("#547 regression: lists the needs-confirmation task, excludes done/abandoned/merged", async () => {
+    // Harness condition: a needs-confirmation task coexists with one task in
+    // each terminal status. Pre-fix, step 4 hand-scanned tasks/*.md and
+    // carried long-`done` tasks forward. Invariant: the precomputed section
+    // is populated by exact status-match. Mutation — relaxing the predicate
+    // to a non-terminal inverse filter readmits the terminal-status ids and
+    // the three `not.toContain` assertions below fail.
+    writeTask("task-nc-live", "needs-confirmation");
+    writeTask("task-done-stale", "done");
+    writeTask("task-abandoned-stale", "abandoned");
+    writeTask("task-merged-stale", "merged");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+    const content = readFileSync(contextFile(), "utf-8");
+    const body = needsConfirmationBody(content);
+
+    expect(body).toContain("task-nc-live");
+    expect(body).not.toContain("task-done-stale");
+    expect(body).not.toContain("task-abandoned-stale");
+    expect(body).not.toContain("task-merged-stale");
+  });
+
+  test("section sits between Tasks Needing Elaboration and Recent Journal", async () => {
+    writeTask("task-nc-pos", "needs-confirmation");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+    const content = readFileSync(contextFile(), "utf-8");
+
+    const elabIdx = content.indexOf("## Tasks Needing Elaboration");
+    const ncIdx = content.indexOf("## Needs Confirmation");
+    const journalIdx = content.indexOf("## Recent Journal");
+    expect(elabIdx).toBeGreaterThan(0);
+    expect(ncIdx).toBeGreaterThan(elabIdx);
+    expect(journalIdx).toBeGreaterThan(ncIdx);
+    // Exactly one occurrence of the header.
+    expect(content.split("## Needs Confirmation").length).toBe(2);
+  });
+
+  test("projects id, priority, project, title — deterministically ordered by priority", async () => {
+    // Harness condition: two needs-confirmation tasks whose insertion order
+    // (alphabetical id) is the inverse of their priority order. Invariant:
+    // the section is stably ordered (AC 6) and carries all four projected
+    // fields (AC 3).
+    writeTask("task-zlow", "needs-confirmation", { priority: "C", project: "ocannl", title: "Low priority confirm" });
+    writeTask("task-ahigh", "needs-confirmation", { priority: "A", project: "ludics", title: "High priority confirm" });
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+    const body = needsConfirmationBody(readFileSync(contextFile(), "utf-8"));
+
+    expect(body).toBe(
+      'task-ahigh (A) [ludics] "High priority confirm"\n'
+      + 'task-zlow (C) [ocannl] "Low priority confirm"',
+    );
+  });
+
+  test("renders the empty marker `None` when no task is in needs-confirmation status", async () => {
+    // Harness condition: only a done task exists. Invariant: the section is
+    // still present with an explicit empty marker (AC 4) so the briefing
+    // skill can tell "no such tasks" from "section missing".
+    writeTask("task-done-only", "done");
+
+    await briefingPrecomputeContext({ runGit: noopRunGit });
+    const content = readFileSync(contextFile(), "utf-8");
+
+    expect(content).toContain("## Needs Confirmation");
+    expect(needsConfirmationBody(content)).toBe("None");
+  });
+});
+
 describe("stale settled sentinel detection", () => {
   // Migrated to call the production clearStaleSettled() directly (task-1b44d17b).
   // Tests drive the function via injected { nowMs, graceMs, currentHash } and

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -936,19 +936,27 @@ describe("briefingPrecomputeContext — Needs Confirmation section (gh-ludics-54
   });
 
   test("projects id, priority, project, title — deterministically ordered by priority", async () => {
-    // Harness condition: two needs-confirmation tasks whose insertion order
-    // (alphabetical id) is the inverse of their priority order. Invariant:
-    // the section is stably ordered (AC 6) and carries all four projected
-    // fields (AC 3).
-    writeTask("task-zlow", "needs-confirmation", { priority: "C", project: "ocannl", title: "Low priority confirm" });
-    writeTask("task-ahigh", "needs-confirmation", { priority: "A", project: "ludics", title: "High priority confirm" });
+    // Harness condition: three tasks whose id alphabetical order AND their
+    // creation order are both the *inverse* of their priority order —
+    // `task-a-low` (priority C) is created first / sorts alphabetically first
+    // but must render last; `task-z-high` (priority A) is created last but
+    // must render first. Invariant: the section is stably priority-ordered
+    // (AC 6), not readdir/creation-ordered, and carries all four projected
+    // fields (AC 3). Mutation — removing the production sort yields
+    // readdir order, which on an alphabetical-readdir or insertion-order
+    // (tmpfs) filesystem is [task-a-low, task-m-mid, task-z-high], the exact
+    // reverse of this expected body.
+    writeTask("task-a-low", "needs-confirmation", { priority: "C", project: "ocannl", title: "Low priority confirm" });
+    writeTask("task-m-mid", "needs-confirmation", { priority: "B", project: "ludics", title: "Mid priority confirm" });
+    writeTask("task-z-high", "needs-confirmation", { priority: "A", project: "ludics", title: "High priority confirm" });
 
     await briefingPrecomputeContext({ runGit: noopRunGit });
     const body = needsConfirmationBody(readFileSync(contextFile(), "utf-8"));
 
     expect(body).toBe(
-      'task-ahigh (A) [ludics] "High priority confirm"\n'
-      + 'task-zlow (C) [ocannl] "Low priority confirm"',
+      'task-z-high (A) [ludics] "High priority confirm"\n'
+      + 'task-m-mid (B) [ludics] "Mid priority confirm"\n'
+      + 'task-a-low (C) [ocannl] "Low priority confirm"',
     );
   });
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -22,7 +22,7 @@ import { journalAppend } from "./journal.ts";
 import { emitEvent } from "./events.ts";
 import { readOrchestrationState } from "./orchestration/state.ts";
 import { isElaborated } from "./tasks/elaboration.ts";
-import { tasksAbandon } from "./tasks/index.ts";
+import { tasksAbandon, tasksNeedsConfirmationList } from "./tasks/index.ts";
 import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
 import {
   notifyOutgoing,
@@ -2108,6 +2108,18 @@ export async function briefingPrecomputeContext(opts?: { runGit?: RunGit }): Pro
   const needsElabR = safeSyncOutput(ludicsSelfCommand(["tasks", "needs-elaboration"]));
   const needsElabOutput = needsElabR.ok && needsElabR.stdout ? needsElabR.stdout : "None";
 
+  // Needs Confirmation — precomputed, status-verified projection of tasks
+  // whose frontmatter status is exactly `needs-confirmation` (gh-ludics-547).
+  // Calls tasksNeedsConfirmationList directly in-process rather than via a
+  // `ludics tasks needs-confirmation` sub-invocation: under `bun test` a
+  // ludicsSelfCommand sub-invocation re-runs the test file (process.argv[1])
+  // and yields no output, which would make the section untestable. The CLI
+  // sub-command and this section share the same helper, so they stay in sync.
+  const needsConfirmationLines = tasksNeedsConfirmationList(join(harness, "tasks"));
+  const needsConfirmationOutput = needsConfirmationLines.length
+    ? needsConfirmationLines.join("\n")
+    : "None";
+
   // Recent journal
   const journalR = safeSyncOutput(ludicsSelfCommand(["journal", "recent", "20"]));
   const journalOutput = journalR.ok ? journalR.stdout : "(no journal entries)";
@@ -2224,6 +2236,10 @@ ${flowCriticalOutput}
 ## Tasks Needing Elaboration
 
 ${needsElabOutput}
+
+## Needs Confirmation
+
+${needsConfirmationOutput}
 
 ## Recent Journal
 

--- a/src/tasks/index.test.ts
+++ b/src/tasks/index.test.ts
@@ -110,21 +110,45 @@ describe("tasksNeedsConfirmationList (gh-ludics-547)", () => {
     expect(lines).toEqual(['task-proj (A) [ocannl] "Confirm the tensor refactor"']);
   });
 
-  test("orders deterministically by priority, then project, then id", () => {
-    // Harness condition: three needs-confirmation tasks whose insertion order
-    // (alphabetical id) differs from the expected priority order. Invariant:
-    // a regression test can assert on the section stably (AC 6). Mutation —
-    // removing the sort yields readdir order, failing this exact equality.
-    writeTask("task-c", "needs-confirmation", { priority: "C" });
-    writeTask("task-a", "needs-confirmation", { priority: "A" });
-    writeTask("task-b", "needs-confirmation", { priority: "B" });
+  test("orders by priority — expected order is the inverse of alphabetical/readdir order", () => {
+    // Harness condition: IDs whose alphabetical order is the *inverse* of
+    // their priority order — `task-a-low` (priority C) sorts alphabetically
+    // first but must render last; `task-z-high` (priority A) sorts
+    // alphabetically last but must render first. Invariant: output order is
+    // priority-driven, not readdir order (AC 6). Mutation — removing the
+    // production sort yields alphabetical readdir order
+    // [task-a-low, task-m-mid, task-z-high], the exact reverse of this
+    // expected array, so the assertion flips even on an alphabetical-readdir
+    // filesystem.
+    writeTask("task-a-low", "needs-confirmation", { priority: "C" });
+    writeTask("task-m-mid", "needs-confirmation", { priority: "B" });
+    writeTask("task-z-high", "needs-confirmation", { priority: "A" });
 
     const lines = tasksNeedsConfirmationList(tasksDir());
 
     expect(lines).toEqual([
-      'task-a (A) [ludics] "task-a"',
-      'task-b (B) [ludics] "task-b"',
-      'task-c (C) [ludics] "task-c"',
+      'task-z-high (A) [ludics] "task-z-high"',
+      'task-m-mid (B) [ludics] "task-m-mid"',
+      'task-a-low (C) [ludics] "task-a-low"',
+    ]);
+  });
+
+  test("breaks a priority tie by project, then id", () => {
+    // Harness condition: three tasks all at priority B. Alphabetical id order
+    // is [task-p1, task-p2, task-p3]; the project tiebreaker must instead
+    // group `alpha` before `beta`, putting task-p1 (project beta) last.
+    // Mutation — dropping the project tiebreaker leaves [task-p1, task-p2,
+    // task-p3] (id-only order), which differs from this expected array.
+    writeTask("task-p1", "needs-confirmation", { priority: "B", project: "beta" });
+    writeTask("task-p2", "needs-confirmation", { priority: "B", project: "alpha" });
+    writeTask("task-p3", "needs-confirmation", { priority: "B", project: "alpha" });
+
+    const lines = tasksNeedsConfirmationList(tasksDir());
+
+    expect(lines).toEqual([
+      'task-p2 (B) [alpha] "task-p2"',
+      'task-p3 (B) [alpha] "task-p3"',
+      'task-p1 (B) [beta] "task-p1"',
     ]);
   });
 

--- a/src/tasks/index.test.ts
+++ b/src/tasks/index.test.ts
@@ -1,0 +1,175 @@
+// gh-ludics-547 — `tasksNeedsConfirmationList` helper + `ludics tasks
+// needs-confirmation` CLI sub-command.
+//
+// The helper is the single source of truth shared by the CLI sub-command and
+// the briefing-context generator (`briefingPrecomputeContext` in src/mag.ts).
+// These tests pin its status-exact filter (the #547 stale-carry-over bug was
+// a long-`done` task surviving into the briefing), its id/priority/project/
+// title projection, and its deterministic ordering.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { runTasks, tasksNeedsConfirmationList } from "./index.ts";
+import { captureConsoleLog } from "../test-utils.ts";
+
+const TMP = join(import.meta.dir, ".test-tmp-needs-confirmation-cli");
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+
+function writeConfig(homeDir: string): string {
+  const configDir = join(homeDir, ".config", "ludics");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, "config.yaml");
+  writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+`);
+  return configPath;
+}
+
+function harness(): string {
+  return join(TMP, "ludics-state", "harness");
+}
+
+function tasksDir(): string {
+  return join(harness(), "tasks");
+}
+
+/** Write a task file. Omit a field by passing `null` to exercise the
+ *  parser's defaults + the helper's display fallbacks. */
+function writeTask(
+  id: string,
+  status: string,
+  opts: { priority?: string | null; project?: string | null; title?: string | null; mergedInto?: string } = {},
+): void {
+  mkdirSync(tasksDir(), { recursive: true });
+  const lines = [`id: ${id}`];
+  if (opts.title !== null) lines.push(`title: "${opts.title ?? id}"`);
+  if (opts.project !== null) lines.push(`project: ${opts.project ?? "ludics"}`);
+  lines.push(`status: ${status}`);
+  if (opts.priority !== null) lines.push(`priority: ${opts.priority ?? "B"}`);
+  if (opts.mergedInto) lines.push(`merged_into: ${opts.mergedInto}`);
+  writeFileSync(join(tasksDir(), `${id}.md`), `---\n${lines.join("\n")}\n---\n\n# ${id}\n`);
+}
+
+beforeEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+  mkdirSync(TMP, { recursive: true });
+  process.env.HOME = TMP;
+  process.env.LUDICS_CONFIG = writeConfig(TMP);
+  process.env.LUDICS_HARNESS_DIR = harness();
+  mkdirSync(harness(), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("tasksNeedsConfirmationList (gh-ludics-547)", () => {
+  test("lists only status: needs-confirmation tasks; ready and every terminal status are excluded", () => {
+    // Harness condition: one needs-confirmation task alongside one task in
+    // each non-matching status. Invariant: membership is exact-match on
+    // `needs-confirmation`. Mutation — relaxing the predicate to a
+    // "non-terminal" inverse filter would readmit `ready`; dropping
+    // exact-match would readmit `done`/`abandoned`/`merged`.
+    writeTask("task-nc", "needs-confirmation");
+    writeTask("task-ready", "ready");
+    writeTask("task-done", "done");
+    writeTask("task-abandoned", "abandoned");
+    writeTask("task-merged", "merged", { mergedInto: "task-nc" });
+
+    const lines = tasksNeedsConfirmationList(tasksDir());
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("task-nc");
+    // Each excluded status gets its own assertion (AC names done/abandoned/merged).
+    const joined = lines.join("\n");
+    expect(joined).not.toContain("task-ready");
+    expect(joined).not.toContain("task-done");
+    expect(joined).not.toContain("task-abandoned");
+    expect(joined).not.toContain("task-merged");
+  });
+
+  test("projects id, priority, project, and title in `<id> (<priority>) [<project>] \"<title>\"` shape", () => {
+    // Invariant: all four fields the briefing needs are present so the skill
+    // renders entries without re-reading task files (AC 3).
+    writeTask("task-proj", "needs-confirmation", {
+      priority: "A",
+      project: "ocannl",
+      title: "Confirm the tensor refactor",
+    });
+
+    const lines = tasksNeedsConfirmationList(tasksDir());
+
+    expect(lines).toEqual(['task-proj (A) [ocannl] "Confirm the tensor refactor"']);
+  });
+
+  test("orders deterministically by priority, then project, then id", () => {
+    // Harness condition: three needs-confirmation tasks whose insertion order
+    // (alphabetical id) differs from the expected priority order. Invariant:
+    // a regression test can assert on the section stably (AC 6). Mutation —
+    // removing the sort yields readdir order, failing this exact equality.
+    writeTask("task-c", "needs-confirmation", { priority: "C" });
+    writeTask("task-a", "needs-confirmation", { priority: "A" });
+    writeTask("task-b", "needs-confirmation", { priority: "B" });
+
+    const lines = tasksNeedsConfirmationList(tasksDir());
+
+    expect(lines).toEqual([
+      'task-a (A) [ludics] "task-a"',
+      'task-b (B) [ludics] "task-b"',
+      'task-c (C) [ludics] "task-c"',
+    ]);
+  });
+
+  test("applies display defaults when optional frontmatter fields are absent", () => {
+    // Harness condition: a needs-confirmation task with no priority/project/
+    // title fields. Invariant: a malformed-but-present task never crashes the
+    // briefing context and still renders with conservative placeholders.
+    writeTask("task-bare", "needs-confirmation", { priority: null, project: null, title: null });
+
+    const lines = tasksNeedsConfirmationList(tasksDir());
+
+    expect(lines).toEqual(['task-bare (B) [unknown] "(untitled)"']);
+  });
+
+  test("returns [] for an absent tasks directory", () => {
+    expect(tasksNeedsConfirmationList(join(harness(), "no-such-dir"))).toEqual([]);
+  });
+
+  test("returns [] when no task is in needs-confirmation status", () => {
+    writeTask("task-done", "done");
+    expect(tasksNeedsConfirmationList(tasksDir())).toEqual([]);
+  });
+});
+
+describe("ludics tasks needs-confirmation CLI sub-command (gh-ludics-547)", () => {
+  test("prints one projected line per needs-confirmation task", async () => {
+    writeTask("task-cli-nc", "needs-confirmation", { priority: "S", project: "ludics", title: "Confirm me" });
+    writeTask("task-cli-done", "done");
+
+    // The needs-confirmation dispatch case is synchronous, so console.log
+    // fires before captureConsoleLog restores; await the returned promise to
+    // settle the runTasks dispatcher cleanly.
+    const { lines, value } = captureConsoleLog(() => runTasks(["needs-confirmation"]));
+    await value;
+
+    expect(lines).toContain('task-cli-nc (S) [ludics] "Confirm me"');
+    expect(lines.join("\n")).not.toContain("task-cli-done");
+  });
+
+  test("prints nothing when there are no needs-confirmation tasks", async () => {
+    writeTask("task-cli-ready", "ready");
+
+    const { lines, value } = captureConsoleLog(() => runTasks(["needs-confirmation"]));
+    await value;
+
+    expect(lines).toEqual([]);
+  });
+});

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -231,6 +231,53 @@ function tasksNeedsElaboration(): void {
   }
 }
 
+/**
+ * Projected lines for every task whose frontmatter status is exactly
+ * `needs-confirmation`: `<id> (<priority>) [<project>] "<title>"`.
+ * Deterministically sorted by priority, then project, then id. Returns `[]`
+ * when the tasks directory is absent or no task matches.
+ *
+ * Shared by the `tasks needs-confirmation` CLI sub-command and the
+ * briefing-context generator (`briefingPrecomputeContext` in `src/mag.ts`),
+ * so both surfaces project an identical, status-verified list. (gh-ludics-547)
+ *
+ * The predicate is exact-match `status === "needs-confirmation"` (mirrors
+ * `needsConfirmationConfig` in `src/dashboard.ts`). It must NOT be expressed
+ * as an "exclude TERMINAL_STATUSES" inverse filter: `needs-confirmation` is
+ * itself a non-terminal status, and an inverse filter would wrongly admit
+ * `ready` / `in-progress` / etc. Exact-match also excludes `merged` tasks and
+ * any task carrying `merged_into` (their status is `merged`, not
+ * `needs-confirmation`).
+ */
+export function tasksNeedsConfirmationList(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  const rows: Array<{ id: string; priority: string; project: string; title: string }> = [];
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".md")) continue;
+    const fm = parseTaskFrontmatter(readFileSync(join(dir, f), "utf-8"));
+    if ((fm.status ?? "") !== "needs-confirmation") continue;
+    if (!fm.id) continue; // skip malformed files (matches tasksDuplicates / tasksNeedsElaborationList)
+    rows.push({
+      id: fm.id,
+      priority: fm.priority || "B",
+      project: fm.project || "unknown",
+      title: fm.title || "(untitled)",
+    });
+  }
+  rows.sort((a, b) =>
+    priorityValue(a.priority) - priorityValue(b.priority)
+    || a.project.localeCompare(b.project)
+    || a.id.localeCompare(b.id),
+  );
+  return rows.map((r) => `${r.id} (${r.priority}) [${r.project}] "${r.title}"`);
+}
+
+function tasksNeedsConfirmation(): void {
+  for (const line of tasksNeedsConfirmationList(tasksDir())) {
+    console.log(line);
+  }
+}
+
 function tasksCheckElaboration(taskId: string): void {
   const dir = tasksDir();
   const file = join(dir, `${taskId}.md`);
@@ -747,6 +794,9 @@ export async function runTasks(args: string[]): Promise<void> {
     case "needs-elaboration":
       tasksNeedsElaboration();
       break;
+    case "needs-confirmation":
+      tasksNeedsConfirmation();
+      break;
     case "queue-elaborations":
       tasksQueueElaborations();
       break;
@@ -866,7 +916,7 @@ export async function runTasks(args: string[]): Promise<void> {
     }
     default:
       throw new Error(
-        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, queue-elaborations, check, merge, unmerge, duplicates, abandon, priority, status, migrate-refs, migrate-deferred)`,
+        `unknown tasks subcommand: ${sub} (use: sync, list, show, convert, update, create, files, samples, needs-elaboration, needs-confirmation, queue-elaborations, check, merge, unmerge, duplicates, abandon, priority, status, migrate-refs, migrate-deferred)`,
       );
   }
 }


### PR DESCRIPTION
## Summary

Fixes #547 — the 2026-05-20 morning briefing listed three Ludics tasks
(`task-5ef3ac11`, `gh-ludics-167`, `task-7ae99643`) under **Needs
Confirmation** that had been `status: done` for weeks. Step 4 of
`skills/ludics-briefing.md` was the only strategic list the briefing skill
derived by hand-scanning `tasks/*.md`, so the agent copied a stale list
forward from the prior `briefing.md` without re-checking `status:`.

This precomputes the list — like every other strategic section — into
`mag/briefing-context.md`, where it is status-verified by construction.

## Changes

- **`src/tasks/index.ts`** — `tasksNeedsConfirmationList(dir)`: an exact-match
  (`status === "needs-confirmation"`) projection to
  `<id> (<priority>) [<project>] "<title>"`, deterministically sorted by
  priority → project → id. Shared by the CLI and the briefing generator.
- **`src/tasks/index.ts` / `src/index.ts`** — a `ludics tasks
  needs-confirmation` sub-command (dispatch case, unknown-subcommand listing,
  USAGE line).
- **`src/mag.ts`** — a `## Needs Confirmation` section in
  `briefingPrecomputeContext`, right after `## Tasks Needing Elaboration`,
  with a `None` empty marker. It calls the helper **directly in-process**
  rather than via a `ludicsSelfCommand` sub-invocation, which is inert under
  `bun test` and would make the section untestable.
- **`skills/ludics-briefing.md`** — step 4 repointed at the precomputed
  section; the precomputed-context section list updated.

## Tests

- **`src/tasks/index.test.ts`** (new) — helper + CLI sub-command: exact-match
  filter (excludes `ready` and every terminal status), id/priority/project/
  title projection, deterministic ordering, project/id tie-breakers, display
  defaults, absent/empty directory.
- **`src/mag.test.ts`** — new `briefingPrecomputeContext — Needs Confirmation
  section` describe block: the #547 regression (seeds a needs-confirmation
  task plus done/abandoned/merged, asserts only the former reaches the
  section), section placement, projection + ordering, and the `None` empty
  marker.

Ordering fixtures use ids whose alphabetical **and** creation order are the
inverse of the expected priority order; mutation-verified — neutering the
comparator (`rows.sort(() => 0)`) fails all three ordering tests.

## Validation

`bun run typecheck`, `bun run build`, `bun run lint`,
`bun run lint:cli-subcommands`, `bun run lint:skill-cli-refs`,
`bun run lint:skill-shell`, `bun run lint:test-isolation` — all pass.
`bun test`: 2764 pass, 0 fail (122 files).

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)