### PR TITLE
fix(mag): gate periodic health-check behind activity threshold

### DIFF
--- a/src/mag-periodic-gate.test.ts
+++ b/src/mag-periodic-gate.test.ts
@@ -169,6 +169,59 @@ describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", ()
     expect(findLastEvent(stateDir, "briefing_skipped")).not.toBeNull();
   });
 
+  test("manual CLI `ludics mag health-check` bypasses the gate — enqueued record carries bypassGate:true (AC 11)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Would-skip world: delta below HEALTH_GATE_THRESHOLD (300). A gated record
+    // dispatched here would skip; the bypass flag overrides that.
+    const lines = Array.from({ length: 1010 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "2026-04-24T00:00:00Z", eventsJsonlLines: 1000, findings: [] }));
+
+    // CLI path: `ludics mag health-check` (no --auto) — manual invocation.
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    await runMag(["health-check"]);
+
+    // The CLI handler tagged the enqueued health-check record with bypassGate.
+    const qLines = readFileSync(join(stateDir, "mag", "queue.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+    const hcRec = qLines.find((r) => r.action === "health-check");
+    expect(hcRec).toBeDefined();
+    expect(hcRec!.bypassGate).toBe(true);
+
+    // Dispatch that exact record: the gate is bypassed despite the would-skip
+    // delta, so the skill command is returned and no skip event is emitted.
+    const result = await resolveQueueRequestCommand(hcRec!, true);
+    expect(result).toBe("/ludics-health-check");
+    expect(findLastEvent(stateDir, "health_check_skipped")).toBeNull();
+  });
+
+  test("auto trigger `ludics mag health-check --auto` does NOT bypass the gate — record stays gated and skips (AC 11 negative control)", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    // Same would-skip world as the bypass test above.
+    const lines = Array.from({ length: 1010 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "2026-04-24T00:00:00Z", eventsJsonlLines: 1000, findings: [] }));
+
+    // Auto path: the launchd-trigger shape — `mag health-check --auto`.
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    await runMag(["health-check", "--auto"]);
+
+    const qLines = readFileSync(join(stateDir, "mag", "queue.jsonl"), "utf8")
+      .trim().split("\n").map((l) => JSON.parse(l) as Record<string, unknown>);
+    const hcRec = qLines.find((r) => r.action === "health-check");
+    expect(hcRec).toBeDefined();
+    // Auto record carries bypassGate:false → still subject to the gate.
+    expect(hcRec!.bypassGate).toBeFalsy();
+
+    const result = await resolveQueueRequestCommand(hcRec!, true);
+    expect(result).toBeNull();
+    expect(findLastEvent(stateDir, "health_check_skipped")).not.toBeNull();
+  });
+
   test("Mag-auto briefing queue_request does NOT advance the signal (denylist active)", async () => {
     const stateDir = getStateDir();
     makeJournal(stateDir);

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -4147,13 +4147,15 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
     queueRequest({ action: "sync-learnings" });
     console.log("Queued sync-learnings request");
   }],
-  ["health-check", () => {
+  ["health-check", (args) => {
     if (!clusterIsController()) {
       console.error("ludics: mag health-check skipped — not the cluster controller");
       return;
     }
-    // gh-ludics-538 AC 11: manual CLI invocation bypasses the dispatch gate.
-    queueRequest({ action: "health-check" }, { bypassGate: true });
+    // gh-ludics-538 AC 11: a manual `ludics mag health-check` (no --auto)
+    // bypasses the dispatch-time activity gate; an automated trigger
+    // (`mag health-check --auto`) stays gated so quiet 4-hour windows skip.
+    queueRequest({ action: "health-check" }, { bypassGate: !args.includes("--auto") });
     // /compact is enqueued by the gate-check path in resolveQueueRequestCommand
     // only when the health-check actually runs (gate did not skip). Coupling
     // /compact to a real checkpoint avoids spurious compactions on idle ticks.

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -240,7 +240,7 @@ triggers:
       - { hour: 14, minute: 20 }
       - { hour: 20, minute: 20 }
       - { hour: 2,  minute: 20 }
-    action: mag health-check
+    action: mag health-check --auto
 
   # Periodic session discovery + adoption (assign orphaned sessions to slots)
   sessions:

--- a/templates/harness/config.yaml
+++ b/templates/harness/config.yaml
@@ -103,7 +103,7 @@ triggers:
       - { hour: 14, minute: 20 }
       - { hour: 20, minute: 20 }
       - { hour: 2,  minute: 20 }
-    action: mag health-check
+    action: mag health-check --auto
 
   sessions-sweep:
     enabled: false


### PR DESCRIPTION
## Bug

`shouldSkipHealthCheck()` (`src/health-gate.ts`) is supposed to skip the
4-hourly automated health-check when fewer than `HEALTH_GATE_THRESHOLD = 300`
gate-eligible events have accrued since the last run. But `resolveQueueRequestCommand`
only consults the gate `if (!bypassGate)`, and the `health-check` CLI handler
enqueued **unconditionally** with `bypassGate: true`.

That single handler serves both the manual `ludics mag health-check` and the
automated 4-hourly trigger (`action: mag health-check`). Result: the periodic
health-check **always ran**, never reaching the activity gate.

## Fix

Mirror the `briefing` handler, which already does this correctly:

- The `health-check` CLI handler now accepts `args` and enqueues with
  `bypassGate: !args.includes("--auto")`.
  - Manual `ludics mag health-check` -> `bypassGate: true` (bypass, unchanged).
  - Automated `ludics mag health-check --auto` -> `bypassGate: false` (gated).
- The health-check trigger in both config templates
  (`templates/harness/config.yaml`, `templates/config.reference.yaml`) now uses
  `action: mag health-check --auto`.

`src/triggers.ts` splits the trigger `action:` string on whitespace
(`action.split(" ")`), and `runMag` passes `args.slice(1)` to the subcommand
handler, so `mag health-check --auto` correctly dispatches subcommand
`health-check` with args `["--auto"]`.

## Tests

Two tests added to `src/mag-periodic-gate.test.ts`, mirroring the existing
briefing CLI-handler bypass pair:

- `ludics mag health-check` (no `--auto`) -> enqueued record has
  `bypassGate: true`; dispatching it returns the skill command despite a
  would-skip delta.
- `ludics mag health-check --auto` -> enqueued record has falsy `bypassGate`;
  dispatching it in the same would-skip world returns `null` and emits
  `health_check_skipped`.

`bun run build` clean; affected test files pass (95 in periodic/health-gate
files + 96 in mag.test.ts, 0 failures).