### PR TITLE
fix(mag): replace delivery-gate pause with per-event orphan-pop

### DIFF
--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -526,6 +526,109 @@ describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", ()
   });
 });
 
+// --- Codex P1 follow-up: orphan-pop is gated to a CONFIRMED settled turn.
+// `isMagSettled()` (the stop-hook sentinel) is proof the turn ended;
+// `isMagReady()` (pane quiet >5s) is only a heuristic — a Tier-2 skill can
+// legitimately still be running while its pane is quiet (waiting on a subagent
+// or a long Bash call). On the ready-only path an in-flight record must NOT be
+// reclassified as an orphan: clearing it + delivering the next skill would
+// break the one-in-flight serialization invariant. Instead maybeFeedMagQueue
+// returns false — a bounded pause resolved by the next stop-hook settle. ---
+
+describe("maybeFeedMagQueue — orphan-pop gated to a confirmed settled turn (Codex P1)", () => {
+  function seedInFlight(id: string, deliveredAt: string): void {
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(inFlightFilePath(id), JSON.stringify({
+      requestId: id, command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
+      deliveredAt,
+    }));
+  }
+
+  test("ready-only path + unresolved in-flight record → returns false, record kept, NO nudge, NO orphan event, NO delivery", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+
+    // Mag is NOT settled (no stop-hook sentinel) but the pane is quiet
+    // (isReady() true). The in-flight skill may still be running — its result
+    // JSON is legitimately absent. A queued skill sits behind it.
+    seedInFlight("req-INFLIGHT", "2026-05-15T08:00:00Z");
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({
+      send: (_s, cmd) => { sends.push(cmd); return true; },
+      isReady: () => true,
+    });
+
+    // Bounded pause: false, and nothing was touched.
+    expect(result).toBe(false);
+    // The in-flight record is NOT cleared — it may still be a running skill.
+    expect(existsSync(inFlightFilePath("req-INFLIGHT"))).toBe(true);
+    // No nudge sent, no skill delivered (the one-in-flight invariant holds).
+    expect(sends.length).toBe(0);
+    // The queued skill stays put — not popped, no in-flight record for it.
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
+    expect(existsSync(inFlightFilePath("req-QUEUED"))).toBe(false);
+    // No orphan-classification event — orphan-pop requires a settled turn.
+    expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(false);
+  });
+
+  test("ready-only path + NO in-flight record → normal pop + deliver still works", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+
+    // Ready-only path, nothing in flight: delivering is always safe because an
+    // in-flight record is written for every Tier-2 delivery, so "no record"
+    // means "no Tier-2 skill running".
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-NORMAL", action: "learn" }) + "\n");
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({
+      send: (_s, cmd) => { sends.push(cmd); return true; },
+      isReady: () => true,
+    });
+
+    expect(result).toBe(true);
+    expect(sends.length).toBe(1);
+    expect(readQueueIds()).toEqual([]);
+    expect(existsSync(inFlightFilePath("req-NORMAL"))).toBe(true);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_feed")).toBe(true);
+  });
+
+  test("bounded pause resolves: a later settled event with the same record still unresolved runs the orphan-pop", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-INFLIGHT", "2026-05-15T08:00:00Z");
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
+
+    // Event 1 — ready-only path: bounded pause, record untouched.
+    const sends: string[] = [];
+    const r1 = await maybeFeedMagQueue({
+      send: (_s, cmd) => { sends.push(cmd); return true; },
+      isReady: () => true,
+    });
+    expect(r1).toBe(false);
+    expect(existsSync(inFlightFilePath("req-INFLIGHT"))).toBe(true);
+    expect(sends.length).toBe(0);
+
+    // Event 2 — the stop hook now fires (settled). The same record is still
+    // unresolved → confirmed turn-end proves it is a genuine orphan, so the
+    // orphan-pop runs and clears it. This proves the pause is bounded.
+    touchSentinel(join(magDir(), "settled"));
+    const r2 = await maybeFeedMagQueue({
+      send: (_s, cmd) => { sends.push(cmd); return true; },
+    });
+    expect(r2).toBe(true);
+    expect(existsSync(inFlightFilePath("req-INFLIGHT"))).toBe(false);
+    expect(sends.length).toBe(1);
+    expect(sends[0]).toContain("req-INFLIGHT");
+    expect(sends[0]).toContain("no matching result log");
+    expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(true);
+    // The queued skill was NOT delivered on the orphan-pop event.
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
+  });
+});
+
 // --- A6: pre-send result-file dedup (Tier-2 only) ---
 
 describe("deliverPoppedSkill — pre-send dedup (A6)", () => {

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -369,6 +369,11 @@ describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", ()
     expect(existsSync(inFlightFilePath("req-QUEUED"))).toBe(false);
     // Observability event emitted.
     expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(true);
+    // The atomic claim ran before the orphan-pop, so the settled sentinel is
+    // consumed even on the orphan-pop path. The next keepalive tick will not
+    // see a stale settled state and deliver a skill into the now-busy (just
+    // nudged) Mag pane — it falls through to the isMagReady() pane check.
+    expect(existsSync(join(magDir(), "settled"))).toBe(false);
   });
 
   test("two orphans → one cleared per call; two calls clear both (each call needs a pending queue item)", async () => {

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -326,6 +326,160 @@ describe("maybeFeedMagQueue — reconcile-as-invariant for direct callers (AC 4)
   });
 });
 
+// --- gh-ludics-535 follow-up: maybeFeedMagQueue orphan-pop (no permanent
+// wedge) — the deliveryGateBlocked() pause is gone. An unresolved in-flight
+// record observed while Mag is idle is a genuine orphan; each queue event
+// pops exactly one orphan and nudges, so the queue always drains. ---
+
+describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", () => {
+  function seedInFlight(id: string, deliveredAt: string): void {
+    mkdirSync(inFlightDirPath(), { recursive: true });
+    writeFileSync(inFlightFilePath(id), JSON.stringify({
+      requestId: id, command: "/ludics-learn",
+      line: JSON.stringify({ id, action: "learn" }),
+      deliveredAt,
+    }));
+  }
+
+  test("one unresolved orphan + Mag idle → clears that record, sends one nudge, returns true, delivers NO queued skill", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
+    // A queued skill sits behind the orphan — it must NOT be delivered this tick.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
+    touchSentinel(join(magDir(), "settled"));
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(result).toBe(true);
+    // Orphan record cleared.
+    expect(existsSync(inFlightFilePath("req-ORPHAN"))).toBe(false);
+    // Exactly one send — the nudge — and it is NOT a skill delivery.
+    expect(sends.length).toBe(1);
+    expect(sends[0]).toContain("req-ORPHAN");
+    expect(sends[0]).toContain("no matching result log");
+    // The queued skill is untouched (not popped, no in-flight record).
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
+    expect(existsSync(inFlightFilePath("req-QUEUED"))).toBe(false);
+    // Observability event emitted.
+    expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(true);
+  });
+
+  test("two orphans → one cleared per call; two calls clear both", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-OLD", "2026-05-15T08:00:00Z");
+    seedInFlight("req-NEW", "2026-05-15T09:00:00Z");
+
+    // First call: oldest orphan cleared.
+    touchSentinel(join(magDir(), "settled"));
+    const r1 = await maybeFeedMagQueue({ send: () => true });
+    expect(r1).toBe(true);
+    expect(existsSync(inFlightFilePath("req-OLD"))).toBe(false);
+    expect(existsSync(inFlightFilePath("req-NEW"))).toBe(true);
+
+    // Second call: remaining orphan cleared.
+    touchSentinel(join(magDir(), "settled"));
+    const r2 = await maybeFeedMagQueue({ send: () => true });
+    expect(r2).toBe(true);
+    expect(existsSync(inFlightFilePath("req-NEW"))).toBe(false);
+  });
+
+  test("orphan present but request queue empty → orphan still cleared (runs before the queue-empty early return)", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
+    // No queue file at all — a bare keepalive tick.
+    touchSentinel(join(magDir(), "settled"));
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(result).toBe(true);
+    expect(existsSync(inFlightFilePath("req-ORPHAN"))).toBe(false);
+    expect(sends.length).toBe(1);
+  });
+
+  test("nudge is sent exactly once per orphan — a follow-up call finds no record and does not re-nudge", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
+
+    const sends: string[] = [];
+    touchSentinel(join(magDir(), "settled"));
+    await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+    // Record gone — a second tick must not re-nudge the same orphan.
+    touchSentinel(join(magDir(), "settled"));
+    await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]).toContain("req-ORPHAN");
+  });
+
+  test("no orphans → normal pop+deliver still works (regression check)", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    // No in-flight records. One queued skill.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-NORMAL", action: "learn" }) + "\n");
+    touchSentinel(join(magDir(), "settled"));
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(result).toBe(true);
+    // The queued skill was delivered: sent once, popped from the queue, and
+    // an in-flight record written for it (Tier-2 contract).
+    expect(sends.length).toBe(1);
+    expect(readQueueIds()).toEqual([]);
+    expect(existsSync(inFlightFilePath("req-NORMAL"))).toBe(true);
+    expect(readEvents().some((e) => e.event_type === "mag_queue_feed")).toBe(true);
+  });
+
+  test("resolved record is reconciled away, then normal delivery proceeds (no false orphan-pop)", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    // A delivered skill whose result JSON has landed — must be reconciled,
+    // NOT treated as an orphan.
+    seedInFlight("req-DONE", "2026-05-15T08:00:00Z");
+    writeFileSync(resultFile("req-DONE"), JSON.stringify({ id: "req-DONE", status: "ok" }));
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-NEXT", action: "learn" }) + "\n");
+    touchSentinel(join(magDir(), "settled"));
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(result).toBe(true);
+    expect(existsSync(inFlightFilePath("req-DONE"))).toBe(false);
+    // The resolved record was not an orphan — normal delivery happened.
+    expect(readQueueIds()).toEqual([]);
+    expect(existsSync(inFlightFilePath("req-NEXT"))).toBe(true);
+    expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(false);
+  });
+
+  test("Mag not idle → no orphan-pop (genuinely in-flight delivery is left alone)", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+
+    // An in-flight record but NO settled sentinel — Mag may be mid-turn, so
+    // its result JSON is legitimately absent. maybeFeedMagQueue must bail at
+    // the idle precondition without touching the record.
+    seedInFlight("req-INFLIGHT", "2026-05-15T08:00:00Z");
+
+    const sends: string[] = [];
+    const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+
+    expect(result).toBe(false);
+    expect(existsSync(inFlightFilePath("req-INFLIGHT"))).toBe(true);
+    expect(sends.length).toBe(0);
+  });
+});
+
 // --- A6: pre-send result-file dedup (Tier-2 only) ---
 
 describe("deliverPoppedSkill — pre-send dedup (A6)", () => {

--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -327,9 +327,13 @@ describe("maybeFeedMagQueue — reconcile-as-invariant for direct callers (AC 4)
 });
 
 // --- gh-ludics-535 follow-up: maybeFeedMagQueue orphan-pop (no permanent
-// wedge) — the deliveryGateBlocked() pause is gone. An unresolved in-flight
-// record observed while Mag is idle is a genuine orphan; each queue event
-// pops exactly one orphan and nudges, so the queue always drains. ---
+// wedge) — the deliveryGateBlocked() pause is gone. The orphan-pop fires at
+// the pop site only: when Mag is idle AND a pending skill item would
+// otherwise be popped. An unresolved in-flight record observed at that point
+// is a genuine orphan; that event pops exactly one orphan and nudges instead
+// of delivering, so the queue always drains. With an empty queue there is no
+// pop opportunity, so a lingering orphan is left untouched (it wedges
+// nothing) and cleared lazily on the next event with a real pending item. ---
 
 describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", () => {
   function seedInFlight(id: string, deliveredAt: string): void {
@@ -367,41 +371,73 @@ describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", ()
     expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(true);
   });
 
-  test("two orphans → one cleared per call; two calls clear both", async () => {
+  test("two orphans → one cleared per call; two calls clear both (each call needs a pending queue item)", async () => {
     const { maybeFeedMagQueue } = await import("./mag.ts");
     const { touchSentinel } = await import("./sentinel.ts");
 
     seedInFlight("req-OLD", "2026-05-15T08:00:00Z");
     seedInFlight("req-NEW", "2026-05-15T09:00:00Z");
+    // A pending skill item must be present for the pop site to be reached;
+    // it stays unpopped while an orphan is cleared instead.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
 
-    // First call: oldest orphan cleared.
+    // First call: oldest orphan cleared, queued item untouched.
     touchSentinel(join(magDir(), "settled"));
     const r1 = await maybeFeedMagQueue({ send: () => true });
     expect(r1).toBe(true);
     expect(existsSync(inFlightFilePath("req-OLD"))).toBe(false);
     expect(existsSync(inFlightFilePath("req-NEW"))).toBe(true);
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
 
-    // Second call: remaining orphan cleared.
+    // Second call: remaining orphan cleared, queued item still untouched.
     touchSentinel(join(magDir(), "settled"));
     const r2 = await maybeFeedMagQueue({ send: () => true });
     expect(r2).toBe(true);
     expect(existsSync(inFlightFilePath("req-NEW"))).toBe(false);
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
   });
 
-  test("orphan present but request queue empty → orphan still cleared (runs before the queue-empty early return)", async () => {
+  test("orphan present but request queue EMPTY → in-flight record untouched, no nudge, returns false (no pop opportunity)", async () => {
     const { maybeFeedMagQueue } = await import("./mag.ts");
     const { touchSentinel } = await import("./sentinel.ts");
 
     seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
-    // No queue file at all — a bare keepalive tick.
+    // No queue file at all — a bare keepalive tick. With nothing to pop there
+    // is no pop site, so the orphan-pop must NOT run; the orphan is left for a
+    // later event where a real pending item is waiting (it wedges nothing).
     touchSentinel(join(magDir(), "settled"));
 
     const sends: string[] = [];
     const result = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
+    expect(existsSync(inFlightFilePath("req-ORPHAN"))).toBe(true);
+    expect(sends.length).toBe(0);
+    expect(readEvents().some((e) => e.event_type === "mag_in_flight_orphan_cleared")).toBe(false);
+  });
+
+  test("orphan lingering with an empty queue is cleared lazily on the next event that has a pending item", async () => {
+    const { maybeFeedMagQueue } = await import("./mag.ts");
+    const { touchSentinel } = await import("./sentinel.ts");
+
+    seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
+
+    // First event: empty queue → orphan untouched.
+    touchSentinel(join(magDir(), "settled"));
+    const sends: string[] = [];
+    const r1 = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+    expect(r1).toBe(false);
+    expect(existsSync(inFlightFilePath("req-ORPHAN"))).toBe(true);
+    expect(sends.length).toBe(0);
+
+    // Second event: a real pending item arrives → orphan-pop fires now.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
+    touchSentinel(join(magDir(), "settled"));
+    const r2 = await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
+    expect(r2).toBe(true);
     expect(existsSync(inFlightFilePath("req-ORPHAN"))).toBe(false);
     expect(sends.length).toBe(1);
+    expect(readQueueIds()).toEqual(["req-QUEUED"]);
   });
 
   test("nudge is sent exactly once per orphan — a follow-up call finds no record and does not re-nudge", async () => {
@@ -409,6 +445,9 @@ describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", ()
     const { touchSentinel } = await import("./sentinel.ts");
 
     seedInFlight("req-ORPHAN", "2026-05-15T08:00:00Z");
+    // A pending item is required for the pop site (and thus the orphan-pop)
+    // to be reached.
+    writeFileSync(queueFile(), JSON.stringify({ id: "req-QUEUED", action: "learn" }) + "\n");
 
     const sends: string[] = [];
     touchSentinel(join(magDir(), "settled"));
@@ -417,8 +456,10 @@ describe("maybeFeedMagQueue — orphan-pop replaces the delivery-gate pause", ()
     touchSentinel(join(magDir(), "settled"));
     await maybeFeedMagQueue({ send: (_s, cmd) => { sends.push(cmd); return true; } });
 
-    expect(sends.length).toBe(1);
-    expect(sends[0]).toContain("req-ORPHAN");
+    // Two sends total: the one-time orphan nudge, then the normal delivery of
+    // the queued item once the orphan is gone. The nudge text appears once.
+    expect(sends.filter((c) => c.includes("no matching result log")).length).toBe(1);
+    expect(sends.filter((c) => c.includes("req-ORPHAN")).length).toBe(1);
   });
 
   test("no orphans → normal pop+deliver still works (regression check)", async () => {

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -562,19 +562,40 @@ export function deliverPoppedSkill(
  * runs only at the pop site (after the `queuePending()` early-returns and
  * `drainProgrammaticQueueHead()`), so an orphan lingering with an empty queue
  * is left untouched — it wedges nothing — and is cleared lazily on the next
- * event where a real pending item is waiting. The Mag-idle precondition
- * (`!isMagSettled() && !isMagReady()`) is the discriminator: an unresolved
- * in-flight record observed while Mag is idle is a genuine orphan (Mag finished
- * its turn yet produced no result), so it is safe to pop one orphan per event
- * instead of stalling.
+ * event where a real pending item is waiting.
+ *
+ * Orphan classification requires a CONFIRMED settled turn. An in-flight record
+ * may only be reclassified as a genuine orphan when `isMagSettled()` is true —
+ * the stop hook fired, so Mag's turn definitely ended yet it produced no result
+ * JSON. `isMagReady()` is only a heuristic (pane quiet >5s); a Tier-2 skill can
+ * legitimately still be running while its pane is quiet (waiting on a subagent
+ * or a long Bash call). On that ready-only path (`isMagReady()` true,
+ * `isMagSettled()` false) an in-flight record must NOT be cleared and NO other
+ * skill may be delivered — doing so would break the one-in-flight
+ * serialization invariant. Instead the function returns false: a BOUNDED pause,
+ * not the old permanent wedge — every Mag turn ends with a stop hook → a
+ * settled state, at which point this same code path runs the orphan-pop and
+ * resolves it. When there is NO in-flight record, normal pop + deliver proceeds
+ * on both paths: an in-flight record is written for every Tier-2 delivery, so
+ * "no record" reliably means "no Tier-2 skill running" and delivering is safe.
  */
 export async function maybeFeedMagQueue(
-  opts: { send?: (session: string, cmd: string) => boolean } = {},
+  opts: {
+    send?: (session: string, cmd: string) => boolean;
+    /**
+     * @internal Test-only override for the `isMagReady()` heuristic. The
+     * heuristic reads a real tmux pane, which is absent under `bun test`;
+     * supplying this lets a test exercise the ready-only path (Mag NOT
+     * settled but pane-quiet) deterministically. Production callers omit it.
+     */
+    isReady?: () => boolean;
+  } = {},
 ): Promise<boolean> {
+  const ready = opts.isReady ?? isMagReady;
   // Mag-idle precondition — the discriminator. Only act when Mag has no
   // turn in progress, so we never pop a record for a skill Mag is actively
   // running (its result JSON would still be legitimately absent mid-turn).
-  if (!isMagSettled() && !isMagReady()) return false;
+  if (!isMagSettled() && !ready()) return false;
 
   const send = opts.send ?? triggerSkill;
 
@@ -589,6 +610,11 @@ export async function maybeFeedMagQueue(
   // nothing auto-requeues.
   reconcileInFlight();
 
+  // Capture the confirmed-settled state once. `settled` gates both the atomic
+  // claim and the orphan-pop classification below — they must agree on a
+  // single observation of the sentinel for the turn to be claimed coherently.
+  const settled = isMagSettled();
+
   // Atomic claim — must run BEFORE the orphan-pop. Consuming the settled
   // sentinel here makes BOTH the orphan-pop and the normal delivery
   // downstream run as a single claimed turn. If it ran only on the delivery
@@ -598,10 +624,10 @@ export async function maybeFeedMagQueue(
   // a skill into a mid-turn Mag. With the claim first, the sentinel is gone
   // after an orphan-pop, so the next tick falls through to isMagReady(),
   // which observes the busy pane and correctly declines. In the ready-only
-  // path there's no sentinel to consume (the `if (isMagSettled())` guard
-  // skips the claim); we rely on queuePopSkill's atomic dequeue below (and
-  // on the harness' single-writer invariant under federation v2).
-  if (isMagSettled()) {
+  // path there's no sentinel to consume (the `if (settled)` guard skips the
+  // claim); we rely on queuePopSkill's atomic dequeue below (and on the
+  // harness' single-writer invariant under federation v2).
+  if (settled) {
     const claimPath = settledSentinelFile() + ".claiming";
     try {
       renameSync(settledSentinelFile(), claimPath);
@@ -615,16 +641,23 @@ export async function maybeFeedMagQueue(
   // `if (deliveryGateBlocked()) return false;` pause. We have reached the
   // exact point where the request queue would otherwise be popped: Mag is
   // idle (precondition above) and a pending skill item is waiting. After
-  // reconciliation, any remaining unresolved in-flight record is a genuine
-  // orphan — Mag finished its turn yet produced no result JSON. Pop exactly
-  // ONE — the oldest (listInFlightDeliveries is sorted oldest-first) — clear
-  // its record, and send a one-time nudge instead of delivering the queued
-  // item this event. The record is cleared first, so the nudge fires exactly
-  // once per orphan; the orphaned request is NOT re-enqueued. When the queue
-  // is empty there is no pop opportunity, so a lingering orphan is left
-  // untouched and cleared lazily on the next event with a real pending item.
+  // reconciliation, any remaining unresolved in-flight record may be a genuine
+  // orphan — but ONLY a confirmed settled turn proves it. Two sub-cases:
+  //  - `!settled` (ready-only path: pane quiet >5s but no stop hook): the
+  //    skill may still be running. Do NOT clear its record and do NOT deliver
+  //    another skill — that would break the one-in-flight serialization
+  //    invariant. Return false: a bounded pause resolved by the next stop-hook
+  //    settle, when this same path runs the orphan-pop with `settled` true.
+  //  - `settled` (stop hook fired — turn definitely ended yet no result JSON):
+  //    a genuine orphan. Pop exactly ONE — the oldest (listInFlightDeliveries
+  //    is sorted oldest-first) — clear its record, send a one-time nudge. The
+  //    record is cleared first, so the nudge fires exactly once per orphan;
+  //    the orphaned request is NOT re-enqueued. When the queue is empty there
+  //    is no pop opportunity, so a lingering orphan is left untouched and
+  //    cleared lazily on the next event with a real pending item.
   const orphans = listInFlightDeliveries();
   if (orphans.length > 0) {
+    if (!settled) return false; // ready-only + skill in flight → bounded pause
     const orphan = orphans[0]!;
     clearInFlight(orphan.requestId);
     send(

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -589,6 +589,28 @@ export async function maybeFeedMagQueue(
   // nothing auto-requeues.
   reconcileInFlight();
 
+  // Atomic claim — must run BEFORE the orphan-pop. Consuming the settled
+  // sentinel here makes BOTH the orphan-pop and the normal delivery
+  // downstream run as a single claimed turn. If it ran only on the delivery
+  // path, an orphan-pop would `return true` (nudging Mag, making it busy)
+  // while leaving a stale sentinel on disk; the next keepalive tick's
+  // `!isMagSettled()` precondition would still see settled=true and deliver
+  // a skill into a mid-turn Mag. With the claim first, the sentinel is gone
+  // after an orphan-pop, so the next tick falls through to isMagReady(),
+  // which observes the busy pane and correctly declines. In the ready-only
+  // path there's no sentinel to consume (the `if (isMagSettled())` guard
+  // skips the claim); we rely on queuePopSkill's atomic dequeue below (and
+  // on the harness' single-writer invariant under federation v2).
+  if (isMagSettled()) {
+    const claimPath = settledSentinelFile() + ".claiming";
+    try {
+      renameSync(settledSentinelFile(), claimPath);
+    } catch {
+      return false; // another tick already claimed
+    }
+    try { unlinkSync(claimPath); } catch { /* ignore */ }
+  }
+
   // Orphan-pop step — the in-place replacement of the old
   // `if (deliveryGateBlocked()) return false;` pause. We have reached the
   // exact point where the request queue would otherwise be popped: Mag is
@@ -619,22 +641,10 @@ export async function maybeFeedMagQueue(
       message: `cleared orphan ${orphan.requestId} (${orphan.command}, delivered ${orphan.deliveredAt})`,
     });
     // This event's action was the orphan-pop; do not also deliver a queued
-    // skill on the same event.
+    // skill on the same event. The settled sentinel was already consumed by
+    // the atomic claim above, so the next tick won't see a stale settled
+    // state and deliver into the now-busy (nudged) Mag pane.
     return true;
-  }
-
-  // Atomic claim: if settled, consume the sentinel so concurrent ticks
-  // see !settled. In the ready-only path there's no sentinel to consume;
-  // we rely on queuePopSkill's atomic dequeue below (and on the harness'
-  // single-writer invariant under federation v2).
-  if (isMagSettled()) {
-    const claimPath = settledSentinelFile() + ".claiming";
-    try {
-      renameSync(settledSentinelFile(), claimPath);
-    } catch {
-      return false; // another tick already claimed
-    }
-    try { unlinkSync(claimPath); } catch { /* ignore */ }
   }
 
   const popped = await queuePopSkill();

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -469,10 +469,12 @@ export function reconcileInFlight(): void {
 }
 
 /** True when at least one in-flight record exists with no matching result
- *  JSON — i.e. a Tier-2 delivery is still genuinely in flight. While this
- *  holds, `maybeFeedMagQueue` must not deliver the next skill (gh-ludics-535
- *  A3 — same serialization invariant as gh-ludics-526's gate, minus the
- *  age check that fed the now-removed auto-retry loop). */
+ *  JSON — i.e. a Tier-2 delivery is still genuinely in flight. Retained as a
+ *  read-only status helper for the dashboard's "Unresolved deliveries" panel.
+ *  It no longer gates `maybeFeedMagQueue`: the gh-ludics-535 follow-up
+ *  replaced the pause with a per-event orphan-pop, because an orphaned record
+ *  (result JSON never written) made this predicate true forever and
+ *  permanently wedged the queue. */
 export function deliveryGateBlocked(): boolean {
   return listInFlight().some(r => !existsSync(magResultFile(r.requestId)));
 }
@@ -548,31 +550,69 @@ export function deliverPoppedSkill(
  * to have fired, e.g. for queue requests arriving during idle periods
  * where clearStaleSettled has cleared the sentinel). Returns true if a
  * command was dispatched.
+ *
+ * Forward-progress invariant (gh-ludics-535 follow-up): on every queue
+ * event where Mag is available this function makes progress — it clears a
+ * resolved record, clears+nudges an orphan, drains a programmatic item, or
+ * delivers a queued skill. The old `deliveryGateBlocked()` pause could wedge
+ * the queue permanently when an in-flight record's result JSON never
+ * appeared (Mag mishandled the request); gh-ludics-535 deliberately removed
+ * timeout/auto-retry so there was no self-healing. The Mag-idle precondition
+ * (`!isMagSettled() && !isMagReady()`) is now the sole discriminator: an
+ * unresolved in-flight record observed while Mag is idle is a genuine orphan
+ * (Mag finished its turn yet produced no result), so it is safe to pop one
+ * orphan per event instead of stalling.
  */
 export async function maybeFeedMagQueue(
   opts: { send?: (session: string, cmd: string) => boolean } = {},
 ): Promise<boolean> {
+  // Mag-idle precondition — the discriminator. Only act when Mag has no
+  // turn in progress, so we never pop a record for a skill Mag is actively
+  // running (its result JSON would still be legitimately absent mid-turn).
   if (!isMagSettled() && !isMagReady()) return false;
+
+  const send = opts.send ?? triggerSkill;
+
+  // Passively reconcile every in-flight record: clear the ones whose result
+  // JSON has appeared (the normal happy path). Nothing auto-times-out,
+  // nothing auto-requeues.
+  reconcileInFlight();
+
+  // Orphan-pop step. After reconciliation, any remaining unresolved in-flight
+  // record is a genuine orphan: Mag is idle (precondition above) yet produced
+  // no result JSON. Pop exactly ONE — the oldest (listInFlightDeliveries is
+  // sorted oldest-first) — clear its record, and send a one-time nudge. The
+  // record is cleared first, so the nudge fires exactly once per orphan. The
+  // orphaned request is NOT re-enqueued. This step runs BEFORE any
+  // queue-empty early return: a lingering orphan must clear even on a
+  // keepalive tick with an empty request queue.
+  const orphans = listInFlightDeliveries();
+  if (orphans.length > 0) {
+    const orphan = orphans[0]!;
+    clearInFlight(orphan.requestId);
+    send(
+      MAG_SESSION_NAME,
+      `Queue note: request ${orphan.requestId} (${orphan.command}, delivered ${orphan.deliveredAt}) `
+        + `has no matching result log. Its in-flight record has been cleared so the queue can resume; `
+        + `the request was NOT re-enqueued. If it still needs handling, re-fire it from the dashboard.`,
+    );
+    emitEvent({
+      event_type: "mag_in_flight_orphan_cleared",
+      source: "keepalive",
+      scope: "mag",
+      status: "warning",
+      message: `cleared orphan ${orphan.requestId} (${orphan.command}, delivered ${orphan.deliveredAt})`,
+    });
+    // This event's action was the orphan-pop; do not also deliver a queued
+    // skill on the same event.
+    return true;
+  }
+
   if (!queuePending()) return false;
 
-  // Drain programmatic entries first (they don't need a Mag turn)
+  // Drain programmatic entries first (they don't need a Mag turn).
   await drainProgrammaticQueueHead();
   if (!queuePending()) return false;
-
-  // Delivery-gate invariant (gh-ludics-526 + gh-ludics-535): passively
-  // reconcile every in-flight record before any pop, so every caller of
-  // maybeFeedMagQueue — the keepalive tick AND the direct callers
-  // (fresh-start ready path, on-stop hook, dashboard /api/queue-deliver
-  // and /api/queue) — clears records whose result JSON has appeared before
-  // it can deliver the next item. Passive only: nothing auto-times-out,
-  // nothing auto-requeues. The dashboard's "Unresolved deliveries" panel
-  // is the user's recovery path for records that never resolve.
-  reconcileInFlight();
-  // Gate: do not deliver the next skill while a delivery is still in flight
-  // (any record present without a matching result JSON). reconcileInFlight
-  // above has already cleared resolved records, so a block here means a
-  // genuinely unresolved delivery.
-  if (deliveryGateBlocked()) return false;
 
   // Atomic claim: if settled, consume the sentinel so concurrent ticks
   // see !settled. In the ready-only path there's no sentinel to consume;

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -551,17 +551,22 @@ export function deliverPoppedSkill(
  * where clearStaleSettled has cleared the sentinel). Returns true if a
  * command was dispatched.
  *
- * Forward-progress invariant (gh-ludics-535 follow-up): on every queue
- * event where Mag is available this function makes progress — it clears a
- * resolved record, clears+nudges an orphan, drains a programmatic item, or
- * delivers a queued skill. The old `deliveryGateBlocked()` pause could wedge
- * the queue permanently when an in-flight record's result JSON never
- * appeared (Mag mishandled the request); gh-ludics-535 deliberately removed
- * timeout/auto-retry so there was no self-healing. The Mag-idle precondition
- * (`!isMagSettled() && !isMagReady()`) is now the sole discriminator: an
- * unresolved in-flight record observed while Mag is idle is a genuine orphan
- * (Mag finished its turn yet produced no result), so it is safe to pop one
- * orphan per event instead of stalling.
+ * Forward-progress invariant (gh-ludics-535 follow-up): whenever the request
+ * queue would otherwise be popped — Mag is idle and a pending skill item is
+ * waiting — this function makes progress: it delivers the queued skill, or, if
+ * an unresolved in-flight record remains, pops ONE orphan + nudges instead.
+ * The old `deliveryGateBlocked()` pause could wedge the queue permanently when
+ * an in-flight record's result JSON never appeared (Mag mishandled the
+ * request); gh-ludics-535 deliberately removed timeout/auto-retry so there was
+ * no self-healing. The orphan-pop is the in-place replacement of that pause: it
+ * runs only at the pop site (after the `queuePending()` early-returns and
+ * `drainProgrammaticQueueHead()`), so an orphan lingering with an empty queue
+ * is left untouched — it wedges nothing — and is cleared lazily on the next
+ * event where a real pending item is waiting. The Mag-idle precondition
+ * (`!isMagSettled() && !isMagReady()`) is the discriminator: an unresolved
+ * in-flight record observed while Mag is idle is a genuine orphan (Mag finished
+ * its turn yet produced no result), so it is safe to pop one orphan per event
+ * instead of stalling.
  */
 export async function maybeFeedMagQueue(
   opts: { send?: (session: string, cmd: string) => boolean } = {},
@@ -573,19 +578,29 @@ export async function maybeFeedMagQueue(
 
   const send = opts.send ?? triggerSkill;
 
+  if (!queuePending()) return false;
+
+  // Drain programmatic entries first (they don't need a Mag turn).
+  await drainProgrammaticQueueHead();
+  if (!queuePending()) return false;
+
   // Passively reconcile every in-flight record: clear the ones whose result
   // JSON has appeared (the normal happy path). Nothing auto-times-out,
   // nothing auto-requeues.
   reconcileInFlight();
 
-  // Orphan-pop step. After reconciliation, any remaining unresolved in-flight
-  // record is a genuine orphan: Mag is idle (precondition above) yet produced
-  // no result JSON. Pop exactly ONE — the oldest (listInFlightDeliveries is
-  // sorted oldest-first) — clear its record, and send a one-time nudge. The
-  // record is cleared first, so the nudge fires exactly once per orphan. The
-  // orphaned request is NOT re-enqueued. This step runs BEFORE any
-  // queue-empty early return: a lingering orphan must clear even on a
-  // keepalive tick with an empty request queue.
+  // Orphan-pop step — the in-place replacement of the old
+  // `if (deliveryGateBlocked()) return false;` pause. We have reached the
+  // exact point where the request queue would otherwise be popped: Mag is
+  // idle (precondition above) and a pending skill item is waiting. After
+  // reconciliation, any remaining unresolved in-flight record is a genuine
+  // orphan — Mag finished its turn yet produced no result JSON. Pop exactly
+  // ONE — the oldest (listInFlightDeliveries is sorted oldest-first) — clear
+  // its record, and send a one-time nudge instead of delivering the queued
+  // item this event. The record is cleared first, so the nudge fires exactly
+  // once per orphan; the orphaned request is NOT re-enqueued. When the queue
+  // is empty there is no pop opportunity, so a lingering orphan is left
+  // untouched and cleared lazily on the next event with a real pending item.
   const orphans = listInFlightDeliveries();
   if (orphans.length > 0) {
     const orphan = orphans[0]!;
@@ -607,12 +622,6 @@ export async function maybeFeedMagQueue(
     // skill on the same event.
     return true;
   }
-
-  if (!queuePending()) return false;
-
-  // Drain programmatic entries first (they don't need a Mag turn).
-  await drainProgrammaticQueueHead();
-  if (!queuePending()) return false;
 
   // Atomic claim: if settled, consume the sentinel so concurrent ticks
   // see !settled. In the ready-only path there's no sentinel to consume;


### PR DESCRIPTION
## Summary

The queue could permanently wedge. `maybeFeedMagQueue` called
`deliveryGateBlocked()` and returned early whenever any `mag/in-flight/<id>.json`
record lacked a matching `mag/results/<id>.json`. When a Tier-2 skill was
delivered but its result JSON was never written (Mag mishandled the request),
that in-flight record became an orphan: the gate stayed blocked **forever**,
every subsequent queue event returned at the pause, and the queue stopped
draining with no recovery — gh-ludics-535 had deliberately removed
timeout/auto-retry, so there was no self-healing. This happened in production.

This PR removes the pause and guarantees forward progress at the queue-pop site.

- The Mag-idle precondition (`!isMagSettled() && !isMagReady()`) is the
  discriminator — it ensures we never act mid-turn, so an unresolved in-flight
  record observed while Mag is idle is a candidate orphan.
- The orphan-pop is the **in-place replacement of the old
  `if (deliveryGateBlocked()) return false;` line**. It sits **at the pop
  site**: after the `queuePending()` early-returns and
  `drainProgrammaticQueueHead()`, immediately before the settled-claim and
  `queuePopSkill`. It therefore runs **only when the request queue would
  otherwise be popped** — Mag idle **and** a pending skill item waiting.
- At that point, after `reconcileInFlight()` (the happy path — clears records
  whose result JSON appeared), if any orphan remains and the turn is
  confirmed-settled: pop exactly one (oldest first), clear its record, send a
  **one-time nudge** to the Mag pane, emit `mag_in_flight_orphan_cleared`, and
  return — the queued item is **not** delivered that event. The record is
  cleared first, so the nudge fires exactly once per orphan. The orphaned
  request is **not** re-enqueued.
- When the request queue is **empty** there is no pop opportunity, so a
  lingering orphan is **left untouched** — it wedges nothing — and is cleared
  lazily on the next event where a real pending item is waiting.
- `deliveryGateBlocked` / `listInFlightDeliveries` stay exported — the dashboard
  "Unresolved deliveries" panel (`dashboard-server.ts`) still uses them.
  `deliveryGateBlocked` is now a read-only status helper only.

## Codex P1 follow-up: orphan-pop gated to a confirmed settled turn

The Codex review flagged a valid P1: `maybeFeedMagQueue` is entered via either
`isMagSettled()` (the stop-hook sentinel — a **confirmed** turn-end) or
`isMagReady()` (a heuristic: pane quiet >5s). The orphan-pop originally ran on
**both** entry paths, which is wrong for the ready-only path. A Tier-2 skill
can legitimately still be running while its pane is quiet (waiting on a subagent
or a long Bash call): `isMagReady()` true, `isMagSettled()` false. Clearing that
skill's in-flight record + nudging would misclassify a running skill as an
orphan, and a later tick could then deliver the next skill while the first is
still running — breaking the one-in-flight serialization invariant.

Fix: an in-flight record may only be reclassified as a genuine orphan when Mag
has a **confirmed settled turn** (the stop hook fired ⇒ the turn definitely
ended). `settled = isMagSettled()` is captured once and gates both the atomic
claim and the orphan-pop:

- `!settled` (ready-only path) **with an in-flight record** → `return false`.
  A **bounded** pause, not the old permanent wedge: every Mag turn ends with a
  stop hook → a settled state, at which point this same code path runs the
  orphan-pop and resolves it.
- `settled` **with an in-flight record** → genuine orphan: clear oldest, nudge
  once, emit `mag_in_flight_orphan_cleared`, return true.
- **No** in-flight record → normal pop + deliver proceeds on **both** paths
  (an in-flight record is written for every Tier-2 delivery, so "no record"
  reliably means "no Tier-2 skill running").

Corrected `maybeFeedMagQueue` structure:

```
if (!isMagSettled() && !isMagReady()) return false;
if (!queuePending()) return false;
await drainProgrammaticQueueHead();
if (!queuePending()) return false;
reconcileInFlight();
const settled = isMagSettled();
if (settled) { /* atomic claim: renameSync sentinel, return false on race */ }
const orphans = listInFlightDeliveries();
if (orphans.length > 0) {
  if (!settled) return false;          // ready-only + skill in flight → bounded pause
  clear oldest; nudge once; emit; return true;
}
const popped = await queuePopSkill();
if (!popped) return false;
return deliverPoppedSkill(popped, { send });
```

Invariant: whenever the request queue would otherwise be popped, the system
makes forward progress — it delivers the queued skill, pops one orphan + nudges
(on a confirmed settled turn), or takes a bounded pause that the next stop-hook
settle resolves. No permanent wedge is possible.

## Test plan

- [x] `bun run build` — clean
- [x] `bun run lint --max-warnings=0` — clean
- [x] Updated `mag-delivery-confirmation.test.ts`: orphan present + pending
      queue item + Mag idle clears one record / one nudge / returns true /
      delivers no skill; two orphans cleared one-per-call (each call seeds a
      pending item); **orphan + empty queue leaves the record untouched
      (returns false, no nudge)**; **orphan lingering with an empty queue is
      cleared lazily on the next event with a pending item**; nudge fires
      exactly once per orphan; no-orphan normal pop+deliver regression;
      resolved record reconciled (not false-orphaned); Mag-not-idle leaves the
      record alone.
- [x] New Codex-P1 tests in `mag-delivery-confirmation.test.ts`: **ready-only
      path + unresolved in-flight record → returns false, record kept, no
      nudge, no `mag_in_flight_orphan_cleared` event, no delivery**;
      **ready-only path + no in-flight record → normal pop + deliver still
      works**; **bounded pause resolves — a follow-up settled event with the
      same record still unresolved runs the orphan-pop**.
- [x] `bun test` — full suite, 2775 pass / 0 fail
