### PR TITLE
fix(mag): couple briefing /compact follow-up to the dispatch gate

### DIFF
--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -144,6 +144,46 @@ describe("magBriefing auto-compact follow-up", () => {
     expect(items[1]!.content).toBe("/compact");
   });
 
+  test("repeated dispatch of the same briefing request does not double-queue /compact (Codex PR #552 review)", async () => {
+    // Models deliverPoppedSkill's send-failure rollback loop: when the Mag
+    // pane is unreachable, the popped briefing is reinserted at the queue
+    // head and the next keepalive tick pops the same request id again. The
+    // /compact follow-up must dedup on the second resolve, otherwise each
+    // failed delivery attempt leaves an extra /compact tagged with the same
+    // triggeredBy on the tail.
+    const { magBriefing, resolveQueueRequestCommand } = await import("./mag.ts");
+    const { queuePopExpected, queueReinsertHead } = await import("./queue.ts");
+    magBriefing(false);
+
+    // First pop + resolve — /compact gets appended.
+    const popped1 = queuePopExpected();
+    if (popped1.status !== "popped") throw new Error(`expected popped, got ${popped1.status}`);
+    try {
+      await resolveQueueRequestCommand(popped1.request!, true);
+    } catch { /* precompute may throw in synthetic harness */ }
+
+    // Simulate send-failure rollback: put the briefing back at the head with
+    // the verbatim line (same id). deliverPoppedSkill does exactly this via
+    // queueReinsertHead(popped.line).
+    queueReinsertHead(popped1.line);
+
+    // Second pop + resolve — must NOT add a second /compact for this trigger.
+    const popped2 = queuePopExpected();
+    if (popped2.status !== "popped") throw new Error(`expected popped, got ${popped2.status}`);
+    expect((popped2.request as { id: string }).id).toBe((popped1.request as { id: string }).id);
+    try {
+      await resolveQueueRequestCommand(popped2.request!, true);
+    } catch { /* precompute may throw in synthetic harness */ }
+
+    const items = readQueue();
+    const compactItems = items.filter(
+      (r) => r.action === "message" && r.content === "/compact",
+    );
+    // Exactly one /compact across both dispatch attempts.
+    expect(compactItems).toHaveLength(1);
+    expect(compactItems[0]!.triggeredBy).toBe((popped1.request as { id: string }).id);
+  });
+
   test("gate-skipped briefing delivery does not append /compact", async () => {
     // Idle world with a prior briefing snapshot → activity-window gate
     // skips the dispatched briefing record. The /compact enqueue lives
@@ -235,6 +275,35 @@ describe("runMag health-check auto-compact follow-up", () => {
     expect(items[0]!.action).toBe("message");
     expect(items[0]!.content).toBe("/compact");
     expect(items[1]!.action).toBe("elaborate");
+  });
+
+  test("repeated dispatch of the same health-check request does not double-queue /compact (Codex PR #552 review)", async () => {
+    // Symmetric to the briefing case: deliverPoppedSkill's send-failure
+    // rollback reinserts the popped health-check at the queue head with the
+    // verbatim line; the next dispatch resolves the same request id again.
+    // The /compact follow-up must dedup on the second resolve.
+    const { runMag, resolveQueueRequestCommand } = await import("./mag.ts");
+    const { queuePopExpected, queueReinsertHead } = await import("./queue.ts");
+    await runMag(["health-check"]);
+
+    const popped1 = queuePopExpected();
+    if (popped1.status !== "popped") throw new Error(`expected popped, got ${popped1.status}`);
+    await resolveQueueRequestCommand(popped1.request!, true);
+
+    // Simulate the rollback that deliverPoppedSkill performs on send failure.
+    queueReinsertHead(popped1.line);
+
+    const popped2 = queuePopExpected();
+    if (popped2.status !== "popped") throw new Error(`expected popped, got ${popped2.status}`);
+    expect((popped2.request as { id: string }).id).toBe((popped1.request as { id: string }).id);
+    await resolveQueueRequestCommand(popped2.request!, true);
+
+    const items = readQueue();
+    const compactItems = items.filter(
+      (r) => r.action === "message" && r.content === "/compact",
+    );
+    expect(compactItems).toHaveLength(1);
+    expect(compactItems[0]!.triggeredBy).toBe((popped1.request as { id: string }).id);
   });
 
   test("gate-skipped delivery does not append /compact", async () => {

--- a/src/mag-auto-compact.test.ts
+++ b/src/mag-auto-compact.test.ts
@@ -34,30 +34,25 @@ function readQueue(): Record<string, unknown>[] {
 }
 
 describe("magBriefing auto-compact follow-up", () => {
-  test("enqueues /compact as the final item, with feedback-digest between briefing and /compact", async () => {
-    // Harness condition: clean state — no pre-existing pending feedback-digest
-    // in queue.jsonl, no cooldown state file. The synthetic harness creates a
-    // fresh tmp dir each test, so both gates open and tryQueueFeedbackDigest
-    // actually enqueues. If that condition stops holding, items[1] would not be
-    // "feedback-digest" and the middle-slot assertion would fail loudly.
+  test("magBriefing enqueues briefing + feedback-digest only; /compact is appended later by the gate-check path", async () => {
+    // Coupling change (fix-briefing-compact-gate): /compact is no longer
+    // enqueued at magBriefing time. It's gated on the dispatch-time
+    // activity gate to avoid paying a cache-miss cost on idle ticks that
+    // skip the briefing. The CLI-time queue is therefore the briefing
+    // and (when ungated) the feedback-digest follow-up only.
     const { magBriefing } = await import("./mag.ts");
     magBriefing(false);
 
     const items = readQueue();
-    // briefing → feedback-digest → /compact. /compact must always land last
-    // (the AC's invariant); feedback-digest in the middle is the ungated path.
-    expect(items).toHaveLength(3);
+    expect(items).toHaveLength(2);
     expect(items[0]!.action).toBe("briefing");
     expect(items[1]!.action).toBe("feedback-digest");
-    expect(items[items.length - 1]!.action).toBe("message");
-    expect(items[items.length - 1]!.content).toBe("/compact");
   });
 
-  test("when feedback-digest is gated, queue is briefing → /compact (length 2)", async () => {
+  test("when feedback-digest is gated, magBriefing enqueues briefing only", async () => {
     // Harness condition: pre-seed queue.jsonl with a pending feedback-digest
     // entry for "ludics" so queueHasPendingFeedbackDigest() returns true and
-    // tryQueueFeedbackDigest short-circuits with { queued: false }. Without
-    // this seed, digest would fire and the length-2 assertion would fail.
+    // tryQueueFeedbackDigest short-circuits with { queued: false }.
     const qf = join(getTmpDir(), "mag", "queue.jsonl");
     writeFileSync(
       qf,
@@ -70,29 +65,21 @@ describe("magBriefing auto-compact follow-up", () => {
     const items = readQueue();
     // Drop the pre-seeded sentinel; only assert on what magBriefing wrote.
     const written = items.slice(1);
-    expect(written).toHaveLength(2);
+    expect(written).toHaveLength(1);
     expect(written[0]!.action).toBe("briefing");
-    expect(written[1]!.action).toBe("message");
-    expect(written[1]!.content).toBe("/compact");
-    // /compact must be last regardless of digest gating.
-    expect(items[items.length - 1]!.action).toBe("message");
-    expect(items[items.length - 1]!.content).toBe("/compact");
   });
 
-  test("/compact still enqueues when feedback-digest enqueue throws", async () => {
-    // Harness condition: spy on queue.queueRequest to throw on the
-    // feedback-digest action only (simulating a queue-lock timeout or
-    // state-file write failure inside tryQueueFeedbackDigest). Without the
-    // try/catch around the digest call, the throw would propagate out of
-    // magBriefing before /compact is enqueued, leaving the queue with only
-    // the briefing entry. Mutation: removing the try/catch makes this test
-    // fail because /compact never lands and `errSpy` never sees the warning.
+  test("magBriefing tolerates a feedback-digest enqueue throw and still reaches markBriefingQueued", async () => {
+    // Regression guard for the try/catch around tryQueueFeedbackDigest: a
+    // queue-lock timeout or state-file write error from the digest enqueue
+    // must not propagate out of magBriefing before the cooldown sentinel is
+    // refreshed. /compact is no longer involved in this coupling — it's
+    // appended at dispatch time by resolveQueueRequestCommand once the gate
+    // passes.
     const queueMod = await import("./queue.ts");
     const origQueueRequest = queueMod.queueRequest;
-    let calls = 0;
     const requestSpy = spyOn(queueMod, "queueRequest").mockImplementation(
       ((req: Parameters<typeof origQueueRequest>[0]) => {
-        calls++;
         if (req.action === "feedback-digest") {
           throw new Error("simulated queue-lock timeout");
         }
@@ -106,18 +93,83 @@ describe("magBriefing auto-compact follow-up", () => {
       magBriefing(false);
 
       const items = readQueue();
-      // briefing was queued (call 1), feedback-digest threw (call 2),
-      // /compact still queued (call 3). On disk: briefing + /compact only.
-      expect(calls).toBeGreaterThanOrEqual(3);
-      expect(items).toHaveLength(2);
+      // briefing was queued (call 1), feedback-digest threw (call 2). On
+      // disk: briefing only — /compact is deferred to the dispatch path.
+      expect(items).toHaveLength(1);
       expect(items[0]!.action).toBe("briefing");
-      expect(items[1]!.action).toBe("message");
-      expect(items[1]!.content).toBe("/compact");
       const errLines = errSpy.mock.calls.map((c) => String(c[0] ?? ""));
       expect(errLines.some((l) => l.includes("feedback-digest enqueue failed"))).toBe(true);
+      // Cooldown sentinel must have been refreshed — proof that magBriefing
+      // ran to completion past the digest throw.
+      const sentinel = join(getTmpDir(), "mag", "briefing-last-queued.epoch");
+      const { existsSync } = await import("fs");
+      expect(existsSync(sentinel)).toBe(true);
     } finally {
       requestSpy.mockRestore();
       errSpy.mockRestore();
+    }
+  });
+
+  test("non-skipped briefing delivery appends /compact at the queue tail (after pending feedback-digest)", async () => {
+    // Production flow: magBriefing enqueues briefing + feedback-digest,
+    // then the queue-pop layer dispatches the briefing. The gate's RUN
+    // arm appends /compact to the queue tail (not head — feedback-digest
+    // must run BEFORE /compact so the digest can consume the briefing's
+    // in-flight context per task-304a02a6). With no prior briefing
+    // snapshot the gate fails open (first-run), so /compact is appended.
+    const { magBriefing, resolveQueueRequestCommand } = await import("./mag.ts");
+    const { queuePopExpected } = await import("./queue.ts");
+    magBriefing(false);
+
+    const popped = queuePopExpected();
+    if (popped.status !== "popped") throw new Error(`expected popped, got ${popped.status}`);
+    expect((popped.request as { action: string }).action).toBe("briefing");
+
+    try {
+      await resolveQueueRequestCommand(popped.request!, true);
+    } catch {
+      // briefingPrecomputeContext may throw in the synthetic harness — the
+      // /compact enqueue happens before it, so the queue contract still
+      // holds for our assertions below. The race-tail of the precompute
+      // failure landing /compact correctly is exercised by mag-periodic-gate.
+    }
+
+    const items = readQueue();
+    // After dispatch: feedback-digest first (still pending from enqueue
+    // time), /compact appended at the tail. /compact must come AFTER
+    // feedback-digest, not before.
+    expect(items).toHaveLength(2);
+    expect(items[0]!.action).toBe("feedback-digest");
+    expect(items[1]!.action).toBe("message");
+    expect(items[1]!.content).toBe("/compact");
+  });
+
+  test("gate-skipped briefing delivery does not append /compact", async () => {
+    // Idle world with a prior briefing snapshot → activity-window gate
+    // skips the dispatched briefing record. The /compact enqueue lives
+    // after the skip-return in resolveQueueRequestCommand, so it must
+    // not fire. This is the bug the fix-briefing-compact-gate change
+    // targets.
+    const { resolveQueueRequestCommand } = await import("./mag.ts");
+    const stateDir = getTmpDir();
+    mkdirSync(join(stateDir, "journal"), { recursive: true });
+    // Prior snapshot present + empty events.jsonl + no recent activity →
+    // latestUserActionEpoch returns 0 → gate skips.
+    writeFileSync(
+      join(stateDir, "mag", "briefing-last.json"),
+      JSON.stringify({ timestamp: "2026-04-01T00:00:00Z", signal: 1_000_000_000 }),
+    );
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), "");
+
+    const result = await resolveQueueRequestCommand({ action: "briefing" }, true);
+    expect(result).toBeNull();
+
+    // Nothing was enqueued by the skipped briefing dispatch — queue.jsonl
+    // either doesn't exist (nothing ever called queueRequest) or is empty.
+    const qf = join(stateDir, "mag", "queue.jsonl");
+    const { existsSync } = await import("fs");
+    if (existsSync(qf)) {
+      expect(readQueue()).toHaveLength(0);
     }
   });
 });

--- a/src/mag-briefing-auto-cooldown.test.ts
+++ b/src/mag-briefing-auto-cooldown.test.ts
@@ -4,18 +4,20 @@ import { join } from "path";
 import { withSyntheticHarness } from "./test-utils.ts";
 
 // Regression test: when invoked with { auto: true }, magBriefing skips the
-// briefing → feedback-digest → /compact sequence if the previous sequence
-// was queued less than 90 minutes ago. Manual (auto: false / undefined)
-// invocations always queue and reset the cooldown timestamp.
+// briefing + feedback-digest enqueue if the previous sequence was queued
+// less than 90 minutes ago. Manual (auto: false / undefined) invocations
+// always queue and reset the cooldown timestamp. /compact is no longer
+// enqueued at magBriefing time — it's coupled to the dispatch-time
+// activity gate (see fix-briefing-compact-gate / mag-auto-compact.test.ts).
 
 const COOLDOWN_SECONDS = 90 * 60;
 const getTmpDir = withSyntheticHarness(beforeEach, afterEach);
 
 beforeEach(() => {
   mkdirSync(join(getTmpDir(), "mag"), { recursive: true });
-  // gh-ludics-538: seed feedback/ so the briefing → feedback-digest →
-  // /compact trio still produces 3 queue entries. Without this seed, the
-  // new empty-feedback gate causes the digest follow-up to no-op.
+  // gh-ludics-538: seed feedback/ so the briefing + feedback-digest pair
+  // still produces 2 queue entries. Without this seed, the
+  // empty-feedback gate causes the digest follow-up to no-op.
   mkdirSync(join(getTmpDir(), "feedback"), { recursive: true });
   writeFileSync(join(getTmpDir(), "feedback", "seed.md"), "x");
 });
@@ -66,11 +68,11 @@ describe("magBriefing auto-cooldown gate", () => {
     magBriefing(false, 300, { auto: true });
 
     const items = readQueue();
-    // Full trio queued; mirrors the contract from mag-auto-compact.test.ts.
-    expect(items).toHaveLength(3);
+    // Briefing + feedback-digest pair; /compact is appended later at
+    // dispatch time by the gate-pass branch in resolveQueueRequestCommand.
+    expect(items).toHaveLength(2);
     expect(items[0]!.action).toBe("briefing");
-    expect(items[items.length - 1]!.action).toBe("message");
-    expect(items[items.length - 1]!.content).toBe("/compact");
+    expect(items[1]!.action).toBe("feedback-digest");
 
     // Cooldown sentinel was advanced.
     const after = Number.parseInt(readFileSync(epochFile(), "utf-8").trim(), 10);
@@ -84,7 +86,7 @@ describe("magBriefing auto-cooldown gate", () => {
     const { magBriefing } = await import("./mag.ts");
     magBriefing(false, 300, { auto: true });
 
-    expect(readQueue()).toHaveLength(3);
+    expect(readQueue()).toHaveLength(2);
     expect(existsSync(epochFile())).toBe(true);
   });
 
@@ -96,7 +98,7 @@ describe("magBriefing auto-cooldown gate", () => {
     const { magBriefing } = await import("./mag.ts");
     magBriefing(false); // no opts → auto: undefined → not auto
 
-    expect(readQueue()).toHaveLength(3);
+    expect(readQueue()).toHaveLength(2);
     const after = Number.parseInt(readFileSync(epochFile(), "utf-8").trim(), 10);
     // Manual run also resets the timer so a follow-up auto trigger waits its full window.
     expect(after).toBeGreaterThan(recent);

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -11,7 +11,7 @@ import { atomicWriteFileSync, isPlainObject, writeJsonFile, writeJsonFileCompact
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queueRequestAtHead, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults } from "./queue.ts";
+import { queueRequest, queueRequestAtHead, queueHasCompactForTrigger, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -1666,7 +1666,17 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
       // briefing → feedback-digest → /compact ordering — feedback-digest must
       // run before /compact so the digest can consume the briefing's
       // in-flight context (task-304a02a6).
-      queueRequest({ action: "message", content: "/compact" });
+      // Tag with `triggeredBy: <briefing-id>` and dedup on retry: when
+      // deliverPoppedSkill's send fails it reinserts the briefing at the
+      // queue head, and the next dispatch resolves the same request id; the
+      // dedup check stops the second /compact from landing on the tail
+      // (PR #552 review by Codex).
+      const briefingId = String(request.id ?? "");
+      if (briefingId && !queueHasCompactForTrigger(briefingId)) {
+        queueRequest({ action: "message", content: "/compact" }, { triggeredBy: briefingId });
+      } else if (!briefingId) {
+        queueRequest({ action: "message", content: "/compact" });
+      }
     } else if (action === "adopt-sessions") {
       if (!bypassGate) {
         // gh-ludics-538: fingerprint gate. Skip when the unclassified-sessions
@@ -1765,7 +1775,14 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
       // no-op /compact. Head-insert (not tail-append) preserves the
       // health-check → /compact → next ordering even when other requests
       // landed on the queue tail between health-check enqueue and dispatch.
-      queueRequestAtHead({ action: "message", content: "/compact" });
+      // Tag with `triggeredBy: <health-check-id>` and dedup on retry: same
+      // shape as the briefing branch above (PR #552 review by Codex).
+      const healthCheckId = String(request.id ?? "");
+      if (healthCheckId && !queueHasCompactForTrigger(healthCheckId)) {
+        queueRequestAtHead({ action: "message", content: "/compact" }, { triggeredBy: healthCheckId });
+      } else if (!healthCheckId) {
+        queueRequestAtHead({ action: "message", content: "/compact" });
+      }
     }
   }
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1658,6 +1658,15 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
         try { writeGateSnapshot(snapPath, signal); } catch { /* best-effort */ }
       }
       await briefingPrecomputeContext();
+      // Auto-compact after briefing — checkpoint compaction (task-a00fc0d9 /
+      // docs/proposals/auto-compact-after-checkpoints.md). Coupled to the
+      // gate here so idle ticks that skip the briefing do not also fire a
+      // no-op /compact paying a cache-miss cost. Tail-append (not head-insert
+      // as in the health-check path) preserves the
+      // briefing → feedback-digest → /compact ordering — feedback-digest must
+      // run before /compact so the digest can consume the briefing's
+      // in-flight context (task-304a02a6).
+      queueRequest({ action: "message", content: "/compact" });
     } else if (action === "adopt-sessions") {
       if (!bypassGate) {
         // gh-ludics-538: fingerprint gate. Skip when the unclassified-sessions
@@ -4070,9 +4079,6 @@ export function magBriefing(
   // Auto-queue feedback-digest once daily alongside the briefing trigger.
   // Lands before /compact so digest can consume the briefing's in-flight
   // context (task-304a02a6 / docs/proposals/task-304a02a6-reorder-briefing-auto-queue.md).
-  // Wrapped so a digest enqueue failure (queue-lock timeout, state-file write
-  // error) cannot suppress the unconditional /compact below — the auto-compact
-  // contract (task-a00fc0d9) requires /compact after every briefing.
   try {
     const fdResult = tryQueueFeedbackDigest("ludics");
     if (fdResult.queued) {
@@ -4083,11 +4089,11 @@ export function magBriefing(
     console.error(`ludics: feedback-digest enqueue failed: ${msg}`);
   }
 
-  // Auto-compact after briefing — checkpoint compaction (task-a00fc0d9 /
-  // docs/proposals/auto-compact-after-checkpoints.md). Enqueued unconditionally
-  // as the LAST follow-up so the next session starts fresh, after
-  // feedback-digest has had a chance to consume the briefing context.
-  queueRequest({ action: "message", content: "/compact" });
+  // /compact is appended at dispatch time by resolveQueueRequestCommand's
+  // briefing branch once the activity gate decides to RUN. That coupling
+  // avoids the cache-miss cost of a /compact on idle ticks where the
+  // briefing itself was skipped (mirrors the health-check path established
+  // in PR #550 / fix-health-compact-couple).
 
   markBriefingQueued();
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -143,9 +143,14 @@ export type QueueAction =
  *  action types stay tight; `bypassGate` is provenance metadata, not a new
  *  action variant. Set by manual CLI handlers in `src/mag.ts` so a queued
  *  request from `ludics mag <skill>` skips the dispatch-time activity gate
- *  even when the snapshot would otherwise suppress it (gh-ludics-538 AC 11). */
+ *  even when the snapshot would otherwise suppress it (gh-ludics-538 AC 11).
+ *  `triggeredBy` records the request id that caused a follow-up enqueue
+ *  (e.g. the briefing/health-check that gated a /compact) so retried
+ *  dispatches can dedup against an already-queued follow-up (PR #552 review
+ *  by Codex: send-failure rollback used to double-queue /compact). */
 export interface QueueRequestExtras {
   bypassGate?: boolean;
+  triggeredBy?: string;
 }
 
 export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): string {
@@ -157,6 +162,9 @@ export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): str
 
   const baseRecord: Record<string, unknown> = { id: requestId, ...req, timestamp };
   if (extras?.bypassGate === true) baseRecord.bypassGate = true;
+  if (typeof extras?.triggeredBy === "string" && extras.triggeredBy.length > 0) {
+    baseRecord.triggeredBy = extras.triggeredBy;
+  }
   withQueueLock(() => {
     appendFileSync(file, JSON.stringify(baseRecord) + "\n");
   });
@@ -214,9 +222,36 @@ export function queueRequestAtHead(req: QueueAction, extras?: QueueRequestExtras
   const requestId = nextRequestId();
   const baseRecord: Record<string, unknown> = { id: requestId, ...req, timestamp };
   if (extras?.bypassGate === true) baseRecord.bypassGate = true;
+  if (typeof extras?.triggeredBy === "string" && extras.triggeredBy.length > 0) {
+    baseRecord.triggeredBy = extras.triggeredBy;
+  }
   queueReinsertHead(JSON.stringify(baseRecord));
   emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;
+}
+
+/** True iff the queue already contains a `/compact` follow-up tagged with
+ *  the given `triggeredBy` request id. Used by the briefing/health-check
+ *  dispatch branches to dedup their `/compact` enqueue on send-failure
+ *  rollback retries (PR #552 review by Codex). */
+export function queueHasCompactForTrigger(triggerId: string): boolean {
+  if (!triggerId) return false;
+  for (const line of readQueueLines()) {
+    let rec: Record<string, unknown>;
+    try {
+      rec = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (
+      rec.action === "message" &&
+      rec.content === "/compact" &&
+      rec.triggeredBy === triggerId
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Mirrors PR #550's health-check coupling for the briefing path: `/compact` is enqueued at dispatch time after the activity gate decides RUN, not at `magBriefing()` call time.
- Idle ticks that skip the briefing no longer fire a no-op `/compact` paying a cache-miss cost.
- Uses tail-append (not head-insert as in the health-check path) so the existing `briefing → feedback-digest → /compact` ordering survives — the digest must consume the briefing's in-flight context (task-304a02a6).

## Why

Spotted by Lukasz from session telemetry: post-compaction wake-ups were landing on otherwise idle days where the briefing gate had just returned `null`. The trailing `/compact` was enqueued by `magBriefing()` (line 4090) before the gate ran, and `resolveQueueRequestCommand` returned `null` for the briefing without touching the queued `/compact`. PR #550 fixed this for `health-check`; this PR fixes the symmetric briefing case.

## Test plan

- [x] `bun test src/mag-auto-compact.test.ts src/mag-briefing-auto-cooldown.test.ts src/mag-periodic-gate.test.ts src/health-gate.test.ts src/queue-event-payload.test.ts src/mag.test.ts` — 203 pass, 0 fail
- [x] `bun run build` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` (full suite) — in progress at PR-open time; I'll follow up if anything unexpected surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)