### PR TITLE
Refresh main from origin before forking orchestration worktrees

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -1362,3 +1362,136 @@ function safeRun(cmd: string[], cwd: string): void {
     env: process.env as Record<string, string>,
   });
 }
+
+/** Set up an origin/clone pair with one commit on `main`, then add one commit
+ *  on `origin/main` so the clone is exactly one commit behind. Returns the
+ *  clone path (the "project repo") and the resolved upstream HEAD sha. */
+function setupOriginAhead(rootDir: string): { repo: string; upstreamSha: string } {
+  const origin = join(rootDir, "origin.git");
+  const repo = join(rootDir, "repo");
+  // Bare origin
+  run(["git", "init", "--bare", "-b", "main", origin], rootDir);
+  // Seed via a throwaway working clone so origin has a starting commit on main.
+  const seed = join(rootDir, "seed");
+  run(["git", "clone", origin, seed], rootDir);
+  run(["git", "config", "user.email", "test@example.com"], seed);
+  run(["git", "config", "user.name", "Test User"], seed);
+  writeFileSync(join(seed, "README.md"), "seed\n");
+  run(["git", "add", "README.md"], seed);
+  run(["git", "commit", "-m", "seed"], seed);
+  run(["git", "push", "origin", "main"], seed);
+  // Project repo — clone of origin, will lag.
+  run(["git", "clone", origin, repo], rootDir);
+  run(["git", "config", "user.email", "test@example.com"], repo);
+  run(["git", "config", "user.name", "Test User"], repo);
+  // Advance origin past the project repo.
+  writeFileSync(join(seed, "added.txt"), "from upstream\n");
+  run(["git", "add", "added.txt"], seed);
+  run(["git", "commit", "-m", "upstream advance"], seed);
+  run(["git", "push", "origin", "main"], seed);
+  const upstreamSha = Bun.spawnSync(["git", "rev-parse", "main"], { cwd: seed }).stdout.toString().trim();
+  return { repo, upstreamSha };
+}
+
+function headSha(repo: string): string {
+  return Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repo }).stdout.toString().trim();
+}
+
+describe("refreshMainBranchFromRemote", () => {
+  test("fast-forwards local main when origin is ahead", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo, upstreamSha } = setupOriginAhead(TMP);
+    // Sanity: clone HEAD is behind origin/main.
+    expect(headSha(repo)).not.toBe(upstreamSha);
+    refreshMainBranchFromRemote(repo, "main");
+    expect(headSha(repo)).toBe(upstreamSha);
+    // The new file from origin is visible.
+    expect(existsSync(join(repo, "added.txt"))).toBe(true);
+  });
+
+  test("skips silently when no origin remote exists", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const repo = join(TMP, "repo-no-origin");
+    mkdirSync(repo, { recursive: true });
+    run(["git", "init", "-b", "main"], repo);
+    run(["git", "config", "user.email", "test@example.com"], repo);
+    run(["git", "config", "user.name", "Test User"], repo);
+    writeFileSync(join(repo, "README.md"), "hi\n");
+    run(["git", "add", "README.md"], repo);
+    run(["git", "commit", "-m", "init"], repo);
+    const beforeSha = headSha(repo);
+    const { lines: captured } = captureConsoleError(() => {
+      refreshMainBranchFromRemote(repo, "main");
+    });
+    expect(headSha(repo)).toBe(beforeSha);
+    // Skip is silent — no warning when origin is simply absent.
+    expect(captured.find((l) => l.includes("refreshMainBranchFromRemote"))).toBeUndefined();
+  });
+
+  test("skips when working tree is on a different branch", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo, upstreamSha } = setupOriginAhead(TMP);
+    run(["git", "checkout", "-b", "feature"], repo);
+    const beforeSha = headSha(repo);
+    expect(beforeSha).not.toBe(upstreamSha);
+    refreshMainBranchFromRemote(repo, "main");
+    // main was not touched (we're on feature) — main ref should still lag origin.
+    const mainSha = Bun.spawnSync(["git", "rev-parse", "main"], { cwd: repo }).stdout.toString().trim();
+    expect(mainSha).not.toBe(upstreamSha);
+    expect(headSha(repo)).toBe(beforeSha);
+  });
+
+  test("skips when working tree has uncommitted changes", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo, upstreamSha } = setupOriginAhead(TMP);
+    writeFileSync(join(repo, "dirty.txt"), "uncommitted\n");
+    const beforeSha = headSha(repo);
+    refreshMainBranchFromRemote(repo, "main");
+    expect(headSha(repo)).toBe(beforeSha);
+    expect(headSha(repo)).not.toBe(upstreamSha);
+    // The dirty file is preserved.
+    expect(readFileSync(join(repo, "dirty.txt"), "utf8")).toBe("uncommitted\n");
+  });
+
+  test("warns and skips when local has diverged from origin (non-ff)", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginAhead(TMP);
+    // Diverge: commit on local main without pulling.
+    writeFileSync(join(repo, "local.txt"), "local-only\n");
+    run(["git", "add", "local.txt"], repo);
+    run(["git", "commit", "-m", "local divergence"], repo);
+    const beforeSha = headSha(repo);
+    const { lines: captured } = captureConsoleError(() => {
+      refreshMainBranchFromRemote(repo, "main");
+    });
+    // Local commit preserved — no force, no reset.
+    expect(headSha(repo)).toBe(beforeSha);
+    expect(existsSync(join(repo, "local.txt"))).toBe(true);
+    // Warning was emitted so the operator can see why ff failed.
+    expect(captured.some((l) => l.includes("ff-only merge") && l.includes("diverged"))).toBe(true);
+  });
+});
+
+describe("createWorktrees refreshes main before forking", () => {
+  test("integration: stale local main is advanced before worktree branches off", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo, upstreamSha } = setupOriginAhead(TMP);
+    // Confirm precondition: local main is behind.
+    expect(headSha(repo)).not.toBe(upstreamSha);
+    const setup = createWorktrees(repo, "feat", [{ name: "agent1" }], "main", 7);
+    // After createWorktrees, local main has advanced to upstream …
+    const mainSha = Bun.spawnSync(["git", "rev-parse", "main"], { cwd: repo }).stdout.toString().trim();
+    expect(mainSha).toBe(upstreamSha);
+    // … and the new worktree carries the upstream commit.
+    const worktreeSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: setup.rootWorktree }).stdout.toString().trim();
+    expect(worktreeSha).toBe(upstreamSha);
+    expect(existsSync(join(setup.rootWorktree, "added.txt"))).toBe(true);
+    cleanupWorktrees(repo, "feat", [{ name: "agent1" }], 7);
+  });
+});

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -443,6 +443,51 @@ export function defaultMainBranch(projectDir: string): string {
 }
 
 /**
+ * Fast-forward the project's main branch from `origin/<mainBranch>` so that
+ * worktrees forked from it inherit fresh upstream state instead of whatever
+ * the local checkout happened to point at. Without this, a stale local main
+ * (e.g. user has not pulled in a while) silently propagates into every new
+ * orchestration worktree.
+ *
+ * Best-effort and silent on graceful skip:
+ * - No `origin` remote (e.g. local-only test repos): skip.
+ * - Working tree is checked out to a different branch than `mainBranch`: skip
+ *   (we don't switch branches under the user).
+ * - Working tree has uncommitted changes: skip (we don't risk perturbing
+ *   in-flight work, even though merge --ff-only would normally be safe).
+ * - `git fetch` fails (network outage etc.): warn, skip — slot startup must
+ *   not block on remote reachability.
+ * - `git merge --ff-only` fails because local diverged from origin: warn,
+ *   skip. We never force; divergence means the user has committed work
+ *   directly on main and that work must be preserved.
+ *
+ * Never throws.
+ */
+export function refreshMainBranchFromRemote(projectDir: string, mainBranch: string): void {
+  const dir = resolve(projectDir);
+  // `git remote` may list a name purely from leftover `remote.<name>.*`
+  // config keys even when no URL is set; require `remote.origin.url` so we
+  // never try to fetch a phantom remote (this would otherwise produce a
+  // noisy warning in test repos that set `remote.origin.gh-resolved` without
+  // a real remote URL).
+  const originUrl = safeSyncOutput(["git", "config", "--get", "remote.origin.url"], { cwd: dir });
+  if (!originUrl.ok || originUrl.stdout.trim().length === 0) return;
+  const current = maybeGit(dir, ["branch", "--show-current"]).trim();
+  if (current !== mainBranch) return;
+  const dirty = maybeGit(dir, ["status", "--porcelain"]).trim();
+  if (dirty.length > 0) return;
+  const fetchResult = safeSyncOutput(["git", "fetch", "origin", mainBranch], { cwd: dir });
+  if (!fetchResult.ok) {
+    console.error(`ludics: refreshMainBranchFromRemote: git fetch origin ${mainBranch} failed in ${dir} — continuing with stale local state`);
+    return;
+  }
+  const mergeResult = safeSyncOutput(["git", "merge", "--ff-only", `origin/${mainBranch}`], { cwd: dir });
+  if (!mergeResult.ok) {
+    console.error(`ludics: refreshMainBranchFromRemote: ff-only merge of origin/${mainBranch} failed in ${dir} — local branch has diverged from origin, continuing with stale local state`);
+  }
+}
+
+/**
  * Count commits on the worktree's HEAD ahead of `origin/<base>` where base is
  * resolved from `projectDir` (shared remote refs). Returns `null` on any git
  * error — callers should treat this as "cannot compare" and skip, not as zero.
@@ -484,6 +529,13 @@ export function createWorktrees(
   slot?: number,
   mode: "duo" | "pair" | "solo" = "duo",
 ): WorktreeSetup {
+  // Refresh the project's main branch from origin so new worktrees fork from
+  // current upstream rather than whatever the local checkout last pointed at.
+  // Best-effort: any reason this can't proceed (no origin, wrong branch
+  // checked out, dirty working tree, network failure, or local divergence) is
+  // logged and skipped — see refreshMainBranchFromRemote for details.
+  refreshMainBranchFromRemote(projectDir, mainBranch);
+
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));
   const stem = orchWorktreeStem(repoName, taskId, slot);


### PR DESCRIPTION
## Summary

- New helper `refreshMainBranchFromRemote(projectDir, mainBranch)` called at the top of `createWorktrees`, before the first `addWorktree`.
- Worktrees no longer inherit a stale local main: if the user hasn't pulled, the function fast-forwards local main from `origin/<mainBranch>` so the new worktree branches off current upstream.
- Best-effort and never throws; warns on operator-visible failure modes (fetch failure, non-ff divergence) and is silent on graceful skips (no origin URL, wrong branch checked out, dirty tree).

## Why

A slot started on a project whose local checkout was 4 commits behind `origin/master`. The slot worktree branched off the stale local master, so the reviewer couldn't see a proposal file that existed on `origin/master`. Repaired manually with `git pull --ff-only` + `git merge --ff-only master` in the worktree; this PR automates the prevention.

## Behavior

| Condition | Action |
|---|---|
| `remote.origin.url` not configured | skip silently (covers local-only test repos) |
| Working tree on a different branch | skip silently (never switch under the user) |
| Working tree dirty | skip silently (never perturb in-flight work) |
| `git fetch origin <main>` fails (offline, etc.) | log warning, skip — slot startup must not block on remote reachability |
| `git merge --ff-only origin/<main>` fails (local diverged) | log warning, skip — local commits on main are preserved, never forced |
| Happy path | local main fast-forwards; new worktrees branch off current upstream |

## Test plan

- [x] `refreshMainBranchFromRemote` unit tests: happy path advances local, plus one negative test per skip branch (no origin, wrong branch, dirty tree, diverged).
- [x] Diverged case: `expect(captured.some((l) => l.includes("ff-only merge") && l.includes("diverged"))).toBe(true)` — warning is operator-visible.
- [x] Integration test: `createWorktrees` against a stale-clone-of-origin advances local `main` and the resulting worktree carries the upstream commit.
- [x] `bun test src/orchestration/` — 826 pass.
- [x] `bun test src/adapters/` — 165 pass.
- [x] `bun run build` + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)