### PR TITLE
Recognize orchestration worktrees in findProjectConfig

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -422,3 +422,135 @@ projects:
     expect(proj!.requires_t3code === true).toBe(false);
   });
 });
+
+describe("findProjectConfig: orchestration worktree resolution", () => {
+  // Regression: orchestration slots run inside per-task worktrees named
+  // `<projectBasename>-<feature-slug>[-s<N>]` as siblings of the configured
+  // project path. Without explicit sibling matching, findProjectConfig
+  // returned null for these paths, silently disabling the wrong-base-repo
+  // gate in `runner.verifyPhaseOutcome` (no projectRepo → guarded skip).
+  // PR #458 to ahrefs/ocannl from an `ocannl-staging-task-...-s1` worktree
+  // landed on upstream instead of the fork because of this.
+
+  test("matches the exact configured path", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    const proj = findProjectConfig(join(TMP, "ocannl-staging"), loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+  });
+
+  test("matches a subdirectory of the configured path", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    const proj = findProjectConfig(join(TMP, "ocannl-staging", "tensor"), loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+  });
+
+  test("matches an orchestration worktree sibling (the regression)", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    const proj = findProjectConfig(join(TMP, "ocannl-staging-task-71e28eb1-s1"), loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+    expect(proj?.repo).toBe("lukstafi/ocannl-staging");
+  });
+
+  test("matches per-agent worktree sibling (duo mode: `<base>-<task>-s<N>-coder`)", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: alpha
+    repo: owner/alpha
+    path: ~/alpha
+`);
+    const proj = findProjectConfig(join(TMP, "alpha-task-deadbeef-s2-coder"), loadConfigSync());
+    expect(proj?.name).toBe("alpha");
+  });
+
+  test("tolerates trailing slash on the projectDir argument", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    const proj = findProjectConfig(join(TMP, "ocannl-staging-task-abc-s1") + "/", loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+  });
+
+  test("does NOT match a sibling that shares a prefix without the dash separator", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    // No `-` between "ocannl-staging" and the suffix — must not match.
+    const proj = findProjectConfig(join(TMP, "ocannl-stagingextra"), loadConfigSync());
+    expect(proj).toBeNull();
+  });
+
+  test("does NOT match a directory in a different parent", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: ~/ocannl-staging
+`);
+    // Different parent directory — sibling-match guard requires identical parents.
+    mkdirSync(join(TMP, "elsewhere"), { recursive: true });
+    const proj = findProjectConfig(join(TMP, "elsewhere", "ocannl-staging-task-abc-s1"), loadConfigSync());
+    expect(proj).toBeNull();
+  });
+
+  test("falls back to basename match when no path is configured", async () => {
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+`);
+    const proj = findProjectConfig("/tmp/ocannl-staging", loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+  });
+
+  test("worktree-sibling match does not depend on the configured path existing on disk", async () => {
+    // Defensive: lookup should be purely lexical so that lookups in tests
+    // and in production environments without checkouts still resolve.
+    const { loadConfigSync, findProjectConfig } = await import("./config.ts");
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+projects:
+  - name: ocannl
+    repo: lukstafi/ocannl-staging
+    path: /nonexistent/ocannl-staging
+`);
+    const proj = findProjectConfig("/nonexistent/ocannl-staging-task-71e28eb1-s1", loadConfigSync());
+    expect(proj?.name).toBe("ocannl");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 // Config reading for ludics (Phase 2: native YAML parsing)
 
 import { existsSync, readFileSync, statSync } from "fs";
-import { basename, join } from "path";
+import { basename, dirname, join } from "path";
 import YAML from "yaml";
 import { atomicWriteFileSync, isPlainObject } from "./json.ts";
 import { PRIORITY_INCREASE, priorityValue } from "./tasks/markdown.ts";
@@ -295,22 +295,46 @@ export function globalAdapter(): GlobalAdapterMode {
 
 /**
  * Find the ProjectConfig entry matching a given project directory.
- * Match semantics: explicit `path` match (with ~/… expansion and worktree prefix),
- * then fallback to basename match against project name or repo tail.
+ * Match semantics, tried in order against each configured project's `path`:
+ * - Exact match against the configured path (with `~/` expansion).
+ * - The directory is a subdirectory of the configured path (`<path>/...`).
+ * - The directory is an orchestration worktree sibling of the configured
+ *   path: same parent directory, basename prefixed with the project's
+ *   directory basename plus `-` (e.g. `~/ocannl-staging` matches
+ *   `~/ocannl-staging-task-71e28eb1-s1`). Without this branch the
+ *   wrong-base-repo gate in `verifyPhaseOutcome` silently no-ops for every
+ *   orchestration slot, because slots always run inside such worktrees.
+ *
+ * Falls back to basename match against project name or repo tail when no
+ * `path` is configured (or none of the path branches match).
  */
 export function findProjectConfig(
   projectDir: string,
   config?: LudicsFullConfig,
 ): ProjectConfig | null {
   const cfg = config ?? loadConfigSync();
+  const normalized = projectDir.replace(/\/+$/, "");
   return (cfg.projects ?? []).find((p) => {
     if (p.path) {
       const expanded = (String(p.path).startsWith("~/")
         ? join(process.env.HOME ?? "~", String(p.path).slice(2))
         : String(p.path)).replace(/\/+$/, "");
-      if (projectDir === expanded || projectDir.startsWith(expanded + "/")) return true;
+      if (normalized === expanded || normalized.startsWith(expanded + "/")) return true;
+      // Orchestration worktree sibling: same parent, basename prefixed with
+      // the configured project's basename + "-". The "-" separator anchors
+      // the match so a sibling project literally named `<base>extra/` (no
+      // dash) does not false-positive.
+      const expandedParent = dirname(expanded);
+      const expandedBase = basename(expanded);
+      if (
+        expandedBase.length > 0 &&
+        dirname(normalized) === expandedParent &&
+        basename(normalized).startsWith(expandedBase + "-")
+      ) {
+        return true;
+      }
     }
-    const dir = basename(projectDir).toLowerCase();
+    const dir = basename(normalized).toLowerCase();
     const repoTail = String(p.repo ?? "").split("/").pop()?.toLowerCase() ?? "";
     return dir === String(p.name ?? "").toLowerCase() || dir === repoTail;
   }) ?? null;


### PR DESCRIPTION
## Summary

- Add a third match branch to `findProjectConfig`: same parent directory AND basename prefixed with the configured project's basename + `-`. Covers orchestration worktrees like `~/ocannl-staging-task-71e28eb1-s1` which are siblings of `~/ocannl-staging`.
- The `-` separator anchors the match so a sibling literally named `<base>extra/` (no dash) does not false-positive.
- 9 new tests in `src/config.test.ts` covering exact-path, subdirectory, sibling-worktree, per-agent duo worktree, trailing slash, prefix-without-dash negative, different-parent negative, basename fallback, and lexical-only invariant.

## Why

Orchestration slots run inside worktrees named `<projectBasename>-<feature-slug>[-s<N>]` (per `orchWorktreeStem` in `src/orchestration/worktrees.ts`). `findProjectConfig` previously only matched the exact path or a subdirectory — sibling worktrees returned null.

The wrong-base-repo gate in `runner.verifyPhaseOutcome` reads `findProjectConfig(state.projectDir)?.repo`; when the lookup returns null, `projectRepo` is undefined and the gate silently no-ops (the AC5 fallback for unconfigured projects). The lookup miss made AC5 fire for every configured project running under orchestration, defeating the gate.

The recent merge of [ahrefs/ocannl#458](https://github.com/ahrefs/ocannl/pull/458) from a coder agent working in `~/ocannl-staging-task-71e28eb1-s1` was the visible failure: the agent ran `gh pr create` without `--repo`, gh defaulted to the fork-parent (`ahrefs/ocannl`), and the gate didn't catch it because the lookup at the worktree path resolved to no project. After this fix the gate resolves the worktree to the configured `ocannl` project (whose `repo` is `lukstafi/ocannl-staging`) and would have surfaced the wrong-repo mismatch.

This is layer 1 of a two-layer fix. Layer 2 — a pre-create defense (remote URL rewrite or `gh-resolved` config inside the worktree) so wrong-repo PRs are prevented at creation time rather than caught after the fact — is being filed as a separate ludics task.

## Test plan

- [x] `bun test src/config.test.ts` — 31 pass (9 new findProjectConfig tests + existing).
- [x] `bun test src/orchestration/runner.verification.test.ts` — 77 pass (gate consumer).
- [x] `bun test src/orchestration/skills.test.ts` — full pass (skill renderer consumer).
- [x] `bun test src/orchestration/` — 820 pass.
- [x] `bun run build` + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)