### PR TITLE
feat(orchestration): seed origin.gh-resolved=base on worktrees (layer 2 of gh-staging-fork hardening)

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -22,6 +22,19 @@ afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
 });
 
+/** Give `repo` a real (local, file://) `origin` remote with `main` pushed, so
+ *  `remote.origin.url` is present — required for `seedGhResolvedToOrigin` to run
+ *  (it skips repos with no origin URL to avoid fabricating a phantom origin) —
+ *  and so `refreshMainBranchFromRemote`'s `git fetch origin main` succeeds
+ *  locally without network. Returns the bare repo path. */
+function addLocalOrigin(repo: string): string {
+  const originBare = `${repo}.origin.git`;
+  run(["git", "init", "--bare", "-b", "main", originBare], TMP);
+  run(["git", "remote", "add", "origin", originBare], repo);
+  run(["git", "push", "-u", "origin", "main"], repo);
+  return originBare;
+}
+
 describe("worktrees", () => {
   test("creates and links orchestration worktrees", () => {
     if (!Bun.which("git")) return;
@@ -90,9 +103,14 @@ describe("worktrees", () => {
     run(["git", "add", "README.md"], repo);
     run(["git", "commit", "-m", "init"], repo);
 
-    // Start with markers on both origin and upstream. The remotes themselves
-    // don't need to exist; gh-resolved lives under `remote.<name>.gh-resolved`
-    // in .git/config regardless of remote presence.
+    // A real (local) origin so the re-seed runs (the seed skips repos with no
+    // origin.url to avoid fabricating a phantom origin — see the no-origin
+    // regression test below).
+    addLocalOrigin(repo);
+
+    // Start with markers on both origin and upstream. The upstream marker
+    // doesn't need a real remote; gh-resolved lives under
+    // `remote.<name>.gh-resolved` in .git/config regardless of remote presence.
     run(["git", "config", "remote.origin.gh-resolved", "base"], repo);
     run(["git", "config", "remote.upstream.gh-resolved", "base"], repo);
     expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
@@ -168,6 +186,7 @@ describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", (
     if (!Bun.which("git")) return;
     const repo = join(TMP, "repo-seed-fresh");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     // No gh-resolved marker exists before; the seed must create it. Without
     // the seedGhResolvedToOrigin call this assertion fails (key absent after
@@ -185,6 +204,7 @@ describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", (
     if (!Bun.which("git")) return;
     const repo = join(TMP, "repo-seed-stale");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     // A stale/wrong value (a leftover `head`) must be replaced, not kept.
     run(["git", "config", "remote.origin.gh-resolved", "head"], repo);
@@ -202,6 +222,7 @@ describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", (
     if (!Bun.which("git")) return;
     const repo = join(TMP, "repo-seed-multi");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     run(["git", "config", "--add", "remote.origin.gh-resolved", "base"], repo);
     run(["git", "config", "--add", "remote.origin.gh-resolved", "head"], repo);
@@ -223,6 +244,7 @@ describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", (
     if (!Bun.which("git")) return;
     const repo = join(TMP, "repo-upstream-ghr");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     // A real upstream remote carrying a poisoning gh-resolved=base marker.
     run(["git", "remote", "add", "upstream", "git@github.com:ahrefs/ocannl.git"], repo);
@@ -239,6 +261,23 @@ describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", (
 
     cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
   });
+
+  test("does NOT fabricate a phantom origin when the repo has no origin.url (P2 Codex)", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-no-origin-url");
+    initRepo(repo); // local-only repo, NO origin remote
+
+    createWorktrees(repo, "seed-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    // The seed must be skipped: no `[remote "origin"]` section is created, so a
+    // later `git remote add origin <url>` still succeeds (would fail with
+    // "remote origin already exists" if the seed had fabricated the section).
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+    expect(Bun.spawnSync(["git", "remote"], { cwd: repo }).stdout.toString().split(/\s+/)).not.toContain("origin");
+    expect(Bun.spawnSync(["git", "remote", "add", "origin", "git@github.com:foo/bar.git"], { cwd: repo }).exitCode).toBe(0);
+
+    cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
+  });
 });
 
 describe("createWorktrees best-effort config lookup (no loadable config)", () => {
@@ -246,6 +285,7 @@ describe("createWorktrees best-effort config lookup (no loadable config)", () =>
     if (!Bun.which("git")) return;
     const repo = join(TMP, "repo-noconfig");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     // Point LUDICS_CONFIG at a missing path so loadConfigSync() throws inside
     // findProjectConfig. The best-effort try/catch must swallow it; without
@@ -309,6 +349,7 @@ describe("createWorktrees provisions upstream remote for upstream_repo projects"
     if (!Bun.which("git")) return;
     const repo = REPO_NO_UPSTREAM_FIELD;
     initRepo(repo);
+    addLocalOrigin(repo);
 
     createWorktrees(repo, "cfg-feat2", [{ name: "coder" }], "main", 1, "solo");
 
@@ -349,16 +390,32 @@ describe("seedGhResolvedToOrigin", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "seed-helper-fresh");
     initRepo(repo);
+    addLocalOrigin(repo);
 
     seedGhResolvedToOrigin(repo);
 
     expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
   });
 
+  test("no-ops when the repo has no origin.url (no phantom origin section) — P2 Codex", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "seed-helper-no-origin");
+    initRepo(repo); // deliberately NO origin remote
+
+    seedGhResolvedToOrigin(repo);
+
+    // The seed is skipped: no `remote.origin.*` section is fabricated, so a
+    // later real-origin setup is not blocked.
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+    expect(Bun.spawnSync(["git", "remote"], { cwd: repo }).stdout.toString().trim()).toBe("");
+    expect(Bun.spawnSync(["git", "remote", "add", "origin", "git@github.com:foo/bar.git"], { cwd: repo }).exitCode).toBe(0);
+  });
+
   test("collapses a pre-existing multi-valued key to a single base (--replace-all)", () => {
     if (!Bun.which("git")) return;
     const repo = join(TMP, "seed-helper-multi");
     initRepo(repo);
+    addLocalOrigin(repo);
     run(["git", "config", "--add", "remote.origin.gh-resolved", "head"], repo);
     run(["git", "config", "--add", "remote.origin.gh-resolved", "base"], repo);
 

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, symlinkPeerSync } from "./worktrees.ts";
-import { captureConsoleError } from "../test-utils.ts";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
+import { captureConsoleError, withSyntheticHarness } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -78,7 +78,7 @@ describe("worktrees", () => {
     cleanupWorktrees(repo, "solo-feat", [{ name: "coder" }], 5, "solo");
   });
 
-  test("createWorktrees clears gh-resolved markers on origin and upstream (defense-in-depth)", () => {
+  test("createWorktrees clears upstream gh-resolved but re-seeds origin to base (defense-in-depth)", () => {
     if (!Bun.which("git")) return;
     mkdirSync(TMP, { recursive: true });
     const repo = join(TMP, "repo-gh-resolved");
@@ -90,9 +90,9 @@ describe("worktrees", () => {
     run(["git", "add", "README.md"], repo);
     run(["git", "commit", "-m", "init"], repo);
 
-    // Simulate a poisoned state: both origin and upstream carry gh-resolved=base.
-    // (The remotes themselves don't need to exist; gh-resolved lives under
-    // `remote.<name>.gh-resolved` in .git/config regardless of remote presence.)
+    // Start with markers on both origin and upstream. The remotes themselves
+    // don't need to exist; gh-resolved lives under `remote.<name>.gh-resolved`
+    // in .git/config regardless of remote presence.
     run(["git", "config", "remote.origin.gh-resolved", "base"], repo);
     run(["git", "config", "remote.upstream.gh-resolved", "base"], repo);
     expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
@@ -100,9 +100,11 @@ describe("worktrees", () => {
 
     createWorktrees(repo, "gh-resolved-feat", [{ name: "coder" }], "main", 7, "solo");
 
-    // Both markers must be cleared from the parent repo's .git/config.
-    // (Worktrees share .git/config with the parent, so clearing once is sufficient.)
-    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+    // origin is re-seeded to `base` AFTER the clear (the pin that makes a
+    // no-`--repo` `gh pr create` resolve the PR base to origin), while upstream
+    // is cleared and never re-seeded. (Worktrees share .git/config with the
+    // parent, so writing once on the parent covers all worktrees.)
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
     expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
 
     cleanupWorktrees(repo, "gh-resolved-feat", [{ name: "coder" }], 7, "solo");
@@ -153,6 +155,254 @@ describe("worktrees", () => {
     clearGhResolvedMarkers(repo);
     clearGhResolvedMarkers(repo);
     expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer-2 pre-create defense: seed origin.gh-resolved=base + provision upstream
+// (task-2c296dc0). Config-independent origin pin + config-gated upstream remote.
+// ---------------------------------------------------------------------------
+
+describe("createWorktrees seeds origin.gh-resolved=base (config-independent)", () => {
+  test("AC1: pins remote.origin.gh-resolved=base on a fresh repo with no prior marker", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-seed-fresh");
+    initRepo(repo);
+
+    // No gh-resolved marker exists before; the seed must create it. Without
+    // the seedGhResolvedToOrigin call this assertion fails (key absent after
+    // the clear), so it pins the AC1 invariant rather than merely traversing it.
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+
+    createWorktrees(repo, "seed-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
+
+    cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
+  });
+
+  test("AC3: overwrites a stale single origin.gh-resolved value with a single base", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-seed-stale");
+    initRepo(repo);
+
+    // A stale/wrong value (a leftover `head`) must be replaced, not kept.
+    run(["git", "config", "remote.origin.gh-resolved", "head"], repo);
+
+    createWorktrees(repo, "seed-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    const values = Bun.spawnSync(["git", "config", "--get-all", "remote.origin.gh-resolved"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(values).toEqual(["base"]); // single value, no preserved `head`
+
+    cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
+  });
+
+  test("AC3: collapses a multi-valued origin.gh-resolved to a single base (no multi-valued key)", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-seed-multi");
+    initRepo(repo);
+
+    run(["git", "config", "--add", "remote.origin.gh-resolved", "base"], repo);
+    run(["git", "config", "--add", "remote.origin.gh-resolved", "head"], repo);
+    expect(
+      Bun.spawnSync(["git", "config", "--get-all", "remote.origin.gh-resolved"], { cwd: repo })
+        .stdout.toString().trim().split("\n").length,
+    ).toBe(2);
+
+    createWorktrees(repo, "seed-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    const values = Bun.spawnSync(["git", "config", "--get-all", "remote.origin.gh-resolved"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(values).toEqual(["base"]); // exactly one value
+
+    cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
+  });
+
+  test("AC2/AC4: clears remote.upstream.gh-resolved even when an upstream remote exists; origin still pinned", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-upstream-ghr");
+    initRepo(repo);
+
+    // A real upstream remote carrying a poisoning gh-resolved=base marker.
+    run(["git", "remote", "add", "upstream", "git@github.com:ahrefs/ocannl.git"], repo);
+    run(["git", "config", "remote.upstream.gh-resolved", "base"], repo);
+
+    createWorktrees(repo, "seed-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    // upstream marker cleared, never re-seeded; origin pinned; existing
+    // upstream URL untouched.
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.gh-resolved"], { cwd: repo }).exitCode).not.toBe(0);
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).stdout.toString().trim())
+      .toBe("git@github.com:ahrefs/ocannl.git");
+
+    cleanupWorktrees(repo, "seed-feat", [{ name: "coder" }], 1, "solo");
+  });
+});
+
+describe("createWorktrees best-effort config lookup (no loadable config)", () => {
+  test("still succeeds + seeds origin + fabricates no upstream when loadConfigSync would throw", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "repo-noconfig");
+    initRepo(repo);
+
+    // Point LUDICS_CONFIG at a missing path so loadConfigSync() throws inside
+    // findProjectConfig. The best-effort try/catch must swallow it; without
+    // the wrap createWorktrees would throw here.
+    const savedConfig = process.env.LUDICS_CONFIG;
+    const savedHarness = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_CONFIG = join(TMP, "does-not-exist", "config.yaml");
+    process.env.LUDICS_HARNESS_DIR = join(TMP, "does-not-exist");
+    try {
+      expect(() =>
+        createWorktrees(repo, "noconfig-feat", [{ name: "coder" }], "main", 1, "solo"),
+      ).not.toThrow();
+      // origin pin still runs (config-independent)...
+      expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
+      // ...and no upstream remote is fabricated when config can't be loaded.
+      expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).exitCode).not.toBe(0);
+    } finally {
+      if (savedConfig === undefined) delete process.env.LUDICS_CONFIG;
+      else process.env.LUDICS_CONFIG = savedConfig;
+      if (savedHarness === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = savedHarness;
+    }
+
+    cleanupWorktrees(repo, "noconfig-feat", [{ name: "coder" }], 1, "solo");
+  });
+});
+
+// Config-gated upstream provisioning. The temp repo paths are deterministic
+// module constants, so the synthetic-harness config fixture can point its
+// project `path` entries at them at registration time.
+const REPO_WITH_UPSTREAM = join(TMP, "repo-cfg-upstream");
+const REPO_NO_UPSTREAM_FIELD = join(TMP, "repo-cfg-plain");
+
+describe("createWorktrees provisions upstream remote for upstream_repo projects", () => {
+  withSyntheticHarness(beforeEach, afterEach, {
+    projects: [
+      { name: "ocannl-staging", repo: "lukstafi/ocannl-staging", path: REPO_WITH_UPSTREAM, upstream_repo: "ahrefs/ocannl" },
+      { name: "plainproj", repo: "lukstafi/plainproj", path: REPO_NO_UPSTREAM_FIELD },
+    ],
+  });
+
+  test("AC5 positive: provisions upstream (SSH URL) for a project with upstream_repo; idempotent on re-run", () => {
+    if (!Bun.which("git")) return;
+    const repo = REPO_WITH_UPSTREAM;
+    initRepo(repo);
+
+    createWorktrees(repo, "cfg-feat", [{ name: "coder" }], "main", 1, "solo");
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).stdout.toString().trim())
+      .toBe("git@github.com:ahrefs/ocannl.git");
+
+    // Idempotent: a second run leaves exactly one upstream URL, unchanged.
+    createWorktrees(repo, "cfg-feat", [{ name: "coder" }], "main", 1, "solo");
+    const urls = Bun.spawnSync(["git", "config", "--get-all", "remote.upstream.url"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(urls).toEqual(["git@github.com:ahrefs/ocannl.git"]);
+
+    cleanupWorktrees(repo, "cfg-feat", [{ name: "coder" }], 1, "solo");
+  });
+
+  test("AC5 negative control: project matched but no upstream_repo → no upstream remote fabricated", () => {
+    if (!Bun.which("git")) return;
+    const repo = REPO_NO_UPSTREAM_FIELD;
+    initRepo(repo);
+
+    createWorktrees(repo, "cfg-feat2", [{ name: "coder" }], "main", 1, "solo");
+
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).exitCode).not.toBe(0);
+    expect(Bun.spawnSync(["git", "remote"], { cwd: repo }).stdout.toString().split(/\s+/)).not.toContain("upstream");
+    // origin pin still happens regardless of config.
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
+
+    cleanupWorktrees(repo, "cfg-feat2", [{ name: "coder" }], 1, "solo");
+  });
+
+  test("preserves an existing upstream remote URL (does not rewrite or duplicate)", () => {
+    if (!Bun.which("git")) return;
+    const repo = REPO_WITH_UPSTREAM;
+    initRepo(repo);
+
+    // Operator already configured a different upstream URL; provisioning must
+    // not clobber or duplicate it.
+    run(["git", "remote", "add", "upstream", "git@github.com:someone/custom-fork.git"], repo);
+
+    createWorktrees(repo, "cfg-feat", [{ name: "coder" }], "main", 1, "solo");
+
+    const urls = Bun.spawnSync(["git", "config", "--get-all", "remote.upstream.url"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(urls).toEqual(["git@github.com:someone/custom-fork.git"]);
+
+    cleanupWorktrees(repo, "cfg-feat", [{ name: "coder" }], 1, "solo");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedGhResolvedToOrigin / ensureUpstreamRemote — direct helper unit tests
+// (so a future caller-reorder can't silently break them).
+// ---------------------------------------------------------------------------
+
+describe("seedGhResolvedToOrigin", () => {
+  test("sets remote.origin.gh-resolved=base on a fresh repo", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "seed-helper-fresh");
+    initRepo(repo);
+
+    seedGhResolvedToOrigin(repo);
+
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.origin.gh-resolved"], { cwd: repo }).stdout.toString().trim()).toBe("base");
+  });
+
+  test("collapses a pre-existing multi-valued key to a single base (--replace-all)", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "seed-helper-multi");
+    initRepo(repo);
+    run(["git", "config", "--add", "remote.origin.gh-resolved", "head"], repo);
+    run(["git", "config", "--add", "remote.origin.gh-resolved", "base"], repo);
+
+    seedGhResolvedToOrigin(repo);
+
+    const values = Bun.spawnSync(["git", "config", "--get-all", "remote.origin.gh-resolved"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(values).toEqual(["base"]);
+  });
+});
+
+describe("ensureUpstreamRemote", () => {
+  test("adds upstream with the SSH URL when absent", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "ensure-upstream-absent");
+    initRepo(repo);
+
+    ensureUpstreamRemote(repo, "ahrefs/ocannl");
+
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).stdout.toString().trim())
+      .toBe("git@github.com:ahrefs/ocannl.git");
+  });
+
+  test("no-ops when an upstream remote URL already exists (no overwrite, no duplicate)", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "ensure-upstream-existing");
+    initRepo(repo);
+    run(["git", "remote", "add", "upstream", "git@github.com:someone/other.git"], repo);
+
+    ensureUpstreamRemote(repo, "ahrefs/ocannl");
+
+    const urls = Bun.spawnSync(["git", "config", "--get-all", "remote.upstream.url"], { cwd: repo })
+      .stdout.toString().trim().split("\n");
+    expect(urls).toEqual(["git@github.com:someone/other.git"]);
+  });
+
+  test("no-ops on blank upstreamRepo", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "ensure-upstream-blank");
+    initRepo(repo);
+
+    ensureUpstreamRemote(repo, "");
+
+    expect(Bun.spawnSync(["git", "config", "--get", "remote.upstream.url"], { cwd: repo }).exitCode).not.toBe(0);
   });
 });
 

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join, resolve } from "path";
 import { PEER_SYNC_DIRNAME, peerSyncPath } from "./peer-sync.ts";
 import { slugify } from "./util.ts";
 import { safeSyncOutput } from "../spawn.ts";
+import { findProjectConfig, type ProjectConfig } from "../config.ts";
 
 export interface WorktreeSetup {
   rootWorktree: string;
@@ -598,7 +599,30 @@ export function createWorktrees(
     ensureGitExcludes(wt);
   }
 
+  // Order is load-bearing (clear-then-set, set last): the clear `--unset-all`s
+  // any stale/wrong gh-resolved value on BOTH origin and upstream; the seed
+  // then re-installs the known-good `origin.gh-resolved=base` so a no-`--repo`
+  // `gh pr create` resolves the PR base to origin (staging), not the fork
+  // parent. See seedGhResolvedToOrigin for the full rationale.
   clearGhResolvedMarkers(resolve(projectDir));
+  seedGhResolvedToOrigin(resolve(projectDir));
+
+  // Best-effort: provision an `upstream` remote for fork projects (those whose
+  // config carries `upstream_repo`). The config lookup MUST NOT throw —
+  // `findProjectConfig` calls `loadConfigSync`, which throws when no config
+  // file exists, and `createWorktrees` is otherwise config-independent (ad-hoc
+  // test repos, local-only worktrees, and CI without a config file must all
+  // still succeed). On any config-load failure we fall back to null and skip
+  // upstream provisioning; the origin pin above always runs.
+  let projectConfig: ProjectConfig | null = null;
+  try {
+    projectConfig = findProjectConfig(resolve(projectDir));
+  } catch {
+    projectConfig = null;
+  }
+  if (projectConfig?.upstream_repo) {
+    ensureUpstreamRemote(resolve(projectDir), projectConfig.upstream_repo);
+  }
 
   return { rootWorktree, peerSyncDir, agentWorktrees, branches };
 }
@@ -624,6 +648,83 @@ export function clearGhResolvedMarkers(projectDir: string): void {
     safeSyncOutput(
       ["git", "config", "--unset-all", `remote.${remote}.gh-resolved`],
       { cwd: projectDir },
+    );
+  }
+}
+
+/**
+ * Pre-create defense (layer 2 of gh-staging-fork hardening, companion to PR
+ * #554): pin `gh pr create`'s base-repo resolution to `origin` by writing
+ * `remote.origin.gh-resolved=base` on the parent repo. Worktrees share
+ * `.git/config` with the parent, so a single write covers all worktrees.
+ *
+ * `gh-resolved=base` on a remote means "this remote IS the base repo," so a
+ * no-`--repo` `gh pr create` resolves the PR base to **origin**, overriding
+ * gh's default of targeting the fork parent for a fork-of-upstream clone. This
+ * fixes the `ahrefs/ocannl#458` class of bug: after {@link clearGhResolvedMarkers}
+ * wipes any stored resolution, gh would otherwise fall back to its
+ * parent-targeting default on a fork — re-creating the wrong-repo PR.
+ *
+ * MUST run AFTER {@link clearGhResolvedMarkers} (the clear `--unset-all`s both
+ * origin and upstream; this re-installs ONLY the origin marker). Pinning is set
+ * only on origin — an `upstream.gh-resolved=base` would say "upstream is the
+ * base" and re-create the very bug we are preventing.
+ *
+ * Uses `--replace-all` so a pre-existing multi-valued key collapses to exactly
+ * one `base` value even if this helper is ever called without the preceding
+ * clear. Best-effort via `safeSyncOutput` (never throws), matching the
+ * surrounding hardening helpers — local-only or unusual repos must not abort
+ * orchestration startup.
+ *
+ * Base-for-all-projects assumption: no currently configured project wants
+ * orchestration PRs to land on the upstream parent it forked from. Fork
+ * projects (ocannl-staging) want PRs on the staging fork; all others are
+ * non-fork, where origin is already canonical and `=base` is what gh does
+ * anyway (redundant, harmless). If a future project genuinely wants
+ * upstream-targeted PRs, it must opt out deliberately (a per-project setting) —
+ * otherwise this seed silently retargets its PRs to origin. Such a project must
+ * surface as a deliberate opt-out rather than relying on gh's default fork
+ * resolution.
+ */
+export function seedGhResolvedToOrigin(projectDir: string): void {
+  safeSyncOutput(
+    ["git", "config", "--replace-all", "remote.origin.gh-resolved", "base"],
+    { cwd: projectDir },
+  );
+}
+
+/**
+ * Idempotently provision an `upstream` remote on the parent repo for fork
+ * projects (those whose config carries `upstream_repo`), so coders can pull
+ * from upstream during the work phase without manual setup. Worktrees inherit
+ * the parent's `.git/config`, so a single add covers all worktrees.
+ *
+ * No-op when `upstreamRepo` is blank or an `upstream` remote URL already exists
+ * — an operator's existing `upstream` URL is never rewritten or duplicated.
+ * Idempotency keys on `remote.upstream.url` (the URL), NOT a bare `git remote`
+ * listing: a leftover `remote.upstream.gh-resolved` key with no URL must not
+ * count as "remote exists."
+ *
+ * The upstream URL is minted in SSH form (`git@github.com:<owner>/<repo>.git`),
+ * matching how state repos are cloned elsewhere (`src/init.ts`) and the current
+ * OCANNL setup. Best-effort via `safeSyncOutput` (never throws) — a missing
+ * upstream remote is a convenience gap, not a reason to abort worktree startup.
+ * Safe alongside {@link seedGhResolvedToOrigin}: the origin pin keeps PR
+ * resolution on origin regardless of the upstream remote's presence, and
+ * {@link clearGhResolvedMarkers} has already wiped any `upstream.gh-resolved`.
+ */
+export function ensureUpstreamRemote(projectDir: string, upstreamRepo: string): void {
+  if (!upstreamRepo) return;
+  const existing = safeSyncOutput(
+    ["git", "config", "--get", "remote.upstream.url"],
+    { cwd: projectDir },
+  );
+  if (existing.ok && existing.stdout.trim().length > 0) return;
+  const url = `git@github.com:${upstreamRepo}.git`;
+  const added = safeSyncOutput(["git", "remote", "add", "upstream", url], { cwd: projectDir });
+  if (!added.ok) {
+    console.error(
+      `ludics: failed to add upstream remote (${url}) in ${projectDir}: ${added.stderr || "unknown error"}`,
     );
   }
 }

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -676,6 +676,16 @@ export function clearGhResolvedMarkers(projectDir: string): void {
  * surrounding hardening helpers — local-only or unusual repos must not abort
  * orchestration startup.
  *
+ * Gated on `remote.origin.url` being present (same guard as
+ * {@link refreshMainBranchFromRemote}): writing `remote.origin.gh-resolved`
+ * on a repo with no origin URL would CREATE a phantom `[remote "origin"]`
+ * section, after which `git remote add origin <url>` fails with "remote origin
+ * already exists" — blocking a later real-origin setup on local-only repos.
+ * Skipping when origin has no URL loses nothing: `gh pr create` cannot target a
+ * URL-less origin anyway, so there is no resolution to pin. In production the
+ * project repo is a real clone, so origin.url is always present and the seed
+ * always runs.
+ *
  * Base-for-all-projects assumption: no currently configured project wants
  * orchestration PRs to land on the upstream parent it forked from. Fork
  * projects (ocannl-staging) want PRs on the staging fork; all others are
@@ -687,6 +697,8 @@ export function clearGhResolvedMarkers(projectDir: string): void {
  * resolution.
  */
 export function seedGhResolvedToOrigin(projectDir: string): void {
+  const originUrl = safeSyncOutput(["git", "config", "--get", "remote.origin.url"], { cwd: projectDir });
+  if (!originUrl.ok || originUrl.stdout.trim().length === 0) return;
   safeSyncOutput(
     ["git", "config", "--replace-all", "remote.origin.gh-resolved", "base"],
     { cwd: projectDir },


### PR DESCRIPTION
## What

Layer 2 of the gh-staging-fork hardening (companion to merged PR #554, layer 1). Prevents orchestration coder agents from creating PRs against the wrong repository — the fork **parent** (`ahrefs/ocannl`) instead of the staging fork (`lukstafi/ocannl-staging`) — when they run `gh pr create` without `--repo`. Triggered by `ahrefs/ocannl#458`.

## Why

The existing `clearGhResolvedMarkers` defense wipes `gh-resolved` on origin+upstream. For a fork-of-upstream clone that *enables* the #458 bug: after the clear, `gh` falls back to its default of targeting the parent. The fix is to **clear then re-seed** a known-good `remote.origin.gh-resolved=base` ("origin IS the base repo") so `gh pr create` resolves the PR base to origin. Layer 1's post-hoc verify gate stays as the catch-net; this is the prevention layer in front of it.

## Changes (`src/orchestration/worktrees.ts`)

- **`seedGhResolvedToOrigin(projectDir)`** — `git config --replace-all remote.origin.gh-resolved base`, called in `createWorktrees` **after** `clearGhResolvedMarkers` (order is load-bearing). Pins only origin, never upstream. `--replace-all` collapses any pre-existing multi-valued key to a single `base`. **Gated on `remote.origin.url` being present** (same guard as `refreshMainBranchFromRemote`) so it never fabricates a phantom `[remote "origin"]` section on local-only repos. Never throws (`safeSyncOutput`). JSDoc documents the base-for-all-projects assumption.
- **`ensureUpstreamRemote(projectDir, upstreamRepo)`** — idempotently provisions an `upstream` remote (SSH form `git@github.com:<repo>.git`) for projects whose config carries `upstream_repo`. Keyed on `remote.upstream.url`; never clobbers or duplicates an existing URL.
- **Best-effort config lookup** — `findProjectConfig` calls `loadConfigSync`, which **throws** when no config file exists, and `createWorktrees` must stay config-independent (ad-hoc tests, local-only worktrees, CI). The lookup is wrapped `try/catch → null`; only upstream provisioning is gated on it. Clear + seed always run.

## Tests (`src/orchestration/worktrees.test.ts`)

Updated the clear-only test (origin now re-seeded, upstream cleared) and added AC1–AC5 coverage, the best-effort-no-config case, existing-URL preservation, no-phantom-origin regression (helper + integration level), and direct helper unit tests (via `withSyntheticHarness` config fixtures). Mutation-verified: removing the seed fails 7 tests; unguarding the config lookup fails the best-effort test; removing the origin.url guard fails both phantom-origin tests.

## Review follow-ups

- **Codex P2 (phantom origin):** seeding `remote.origin.gh-resolved` on a URL-less origin created a phantom `[remote "origin"]` that blocked a later `git remote add origin <url>` (verified exit 3). Fixed by gating the seed on `remote.origin.url` presence (`bf6cb51`), with two regression tests confirming a later `git remote add origin` still succeeds.

## Validation

- `bun run typecheck`, `eslint`, `bun run build` — green.
- `bun test src` — **2161 pass / 0 fail** (95 files). Diff scoped to the two in-scope files; layer-1 verify gate untouched.

> Note: full `bun test` does not complete on this host due to a **pre-existing, unrelated** hang in `scripts/dev-dashboard-mirror.test.ts` (spawns the mirror with `--port 99999`, which Bun 1.3.11/macOS masks to a valid port so the server never exits). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)