### PR TITLE
fix(dashboard-server): validate port before Bun.serve (fixes full bun test hang)

### DIFF
--- a/scripts/dev-dashboard-mirror.test.ts
+++ b/scripts/dev-dashboard-mirror.test.ts
@@ -62,10 +62,15 @@ describe("dev-dashboard-mirror.ts CLI argument validation", () => {
 describe("dev-dashboard-mirror.ts startup-failure cleanup", () => {
   // Codex P3 review (PR #452): if startDashboardServer throws before
   // SIGINT/SIGTERM handlers are registered/run, the mirror dir leaks.
-  // We force a startup failure by invoking the script with an invalid
-  // numeric port literal that Bun.serve rejects ("99999" is out of range
-  // for TCP). The argv validator above only catches non-finite Number();
-  // 99999 is finite, so it reaches startDashboardServer and throws.
+  // We force a startup failure by invoking the script with an out-of-range
+  // numeric port literal ("99999"). The throw comes from startDashboardServer's
+  // explicit range guard (!Number.isInteger(port) || port < 0 || port > 65535),
+  // NOT from Bun.serve / the OS — on Bun 1.3.11 / macOS Bun.serve silently
+  // coerces 99999 to 65535 and would listen forever (the hang this test once
+  // suffered). The argv validator above only catches non-finite Number(); 99999
+  // is finite, so it reaches startDashboardServer, the guard throws, and the
+  // script's catch block rmSync's the temp dir and re-throws before any
+  // listener is bound.
   test("removes mirror dir when server start throws", () => {
     const before = existsSync("/tmp")
       ? new Set(readdirSync("/tmp").filter((n) => n.startsWith("ludics-dash-mirror-")))

--- a/src/dashboard-server.test.ts
+++ b/src/dashboard-server.test.ts
@@ -15,18 +15,19 @@ const TTL = 3600;
 describe("startDashboardServer port validation", () => {
   withSyntheticHarness(beforeEach, afterEach);
   const servers: Array<ReturnType<typeof startDashboardServer>> = [];
-  let dir = "";
+  const dirs: string[] = [];
 
   afterEach(() => {
     for (const s of servers.splice(0)) void s.stop(true);
-    if (dir) {
-      rmSync(dir, { recursive: true, force: true });
-      dir = "";
-    }
+    // Tests may call makeDir() more than once (e.g. the boundary test creates
+    // one dir per startDashboardServer call), so clean up every created dir,
+    // not just the latest.
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
   });
 
   function makeDir(): string {
-    dir = mkdtempSync("/tmp/ludics-dashsrv-test-");
+    const dir = mkdtempSync("/tmp/ludics-dashsrv-test-");
+    dirs.push(dir);
     return dir;
   }
 

--- a/src/dashboard-server.test.ts
+++ b/src/dashboard-server.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { startDashboardServer } from "./dashboard-server.ts";
+import { withSyntheticHarness } from "./test-utils.ts";
+
+// Regression for task-7c3ec5c9: startDashboardServer must validate the port
+// BEFORE calling Bun.serve. On Bun 1.3.11 / macOS Bun.serve silently coerces
+// out-of-range / non-integer ports to a listenable one (99999 → 65535, -1/NaN
+// → a random free port, 1.5 → 1) instead of rejecting, so the server would
+// listen on a port different from the one requested — and the dev mirror's
+// spawnSync would hang forever waiting on the never-exiting listener.
+
+const TTL = 3600;
+
+describe("startDashboardServer port validation", () => {
+  withSyntheticHarness(beforeEach, afterEach);
+  const servers: Array<ReturnType<typeof startDashboardServer>> = [];
+  let dir = "";
+
+  afterEach(() => {
+    for (const s of servers.splice(0)) void s.stop(true);
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = "";
+    }
+  });
+
+  function makeDir(): string {
+    dir = mkdtempSync("/tmp/ludics-dashsrv-test-");
+    return dir;
+  }
+
+  // Each value below is coerced (not rejected) by Bun.serve on this host; the
+  // guard must reject every one of them. If the guard were removed, the call
+  // would bind a real listener (leaking a server / a coerced port) instead of
+  // throwing — that is the invariant these assertions enforce.
+  for (const bad of [99999, 70000, 65536, -1, 1.5, NaN, Infinity]) {
+    test(`rejects out-of-range / non-integer port ${bad}`, () => {
+      expect(() => startDashboardServer(bad, makeDir(), TTL)).toThrow(RangeError);
+    });
+  }
+
+  test("inclusive upper bound: guard admits 65535 (uses > not >=), rejects 65536", () => {
+    // Mutation guard for `port > 65535`: flipping it to `>= 65535` would make
+    // 65535 throw a RangeError, which this test would catch. Binding 65535 may
+    // fail with EADDRINUSE on a busy host — that is NOT a guard rejection — so
+    // the guard assertion checks only that no RangeError is raised for 65535
+    // (honoring AC6: the test must not depend on any specific port being free).
+    let server: ReturnType<typeof startDashboardServer> | undefined;
+    let raised: unknown;
+    try {
+      server = startDashboardServer(65535, makeDir(), TTL);
+    } catch (e) {
+      raised = e;
+    }
+    if (server) {
+      servers.push(server);
+      // When binding succeeds, the valid port is honored verbatim (no coercion).
+      expect(server.port).toBe(65535);
+    }
+    expect(raised).not.toBeInstanceOf(RangeError);
+    expect(() => startDashboardServer(65536, makeDir(), TTL)).toThrow(RangeError);
+  });
+
+  test("error names the offending port value and the valid range", () => {
+    let err: unknown;
+    try {
+      startDashboardServer(99999, makeDir(), TTL);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RangeError);
+    const msg = (err as Error).message;
+    expect(msg).toContain("99999");
+    expect(msg).toContain("65535");
+  });
+
+  test("port 0 stays valid and auto-selects a free OS port", () => {
+    const server = startDashboardServer(0, makeDir(), TTL);
+    servers.push(server);
+    // 0 means "pick a free port"; Bun reports the actual bound port (> 0).
+    expect(server.port).toBeGreaterThan(0);
+  });
+
+});

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -946,6 +946,17 @@ export function startDashboardServer(
   dashboardDir: string,
   ttlSeconds: number,
 ): ReturnType<typeof Bun.serve> {
+  // Validate the port before handing it to Bun.serve. On Bun 1.3.11 / macOS
+  // Bun.serve silently coerces out-of-range / non-integer ports to a
+  // listenable one (99999 → 65535, -1/NaN → a random free port, 1.5 → 1)
+  // instead of rejecting, so without this guard the server would listen on a
+  // port *different* from the one requested. port === 0 stays valid: it is the
+  // documented "auto-select a free port" request.
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new RangeError(
+      `dashboard server port ${port} is invalid: expected an integer in [0, 65535] (0 auto-selects a free port)`,
+    );
+  }
   const server = Bun.serve({
     port,
     fetch: buildHandlers({ dashboardDir, ttlSeconds }),


### PR DESCRIPTION
## Summary

Fixes the `scripts/dev-dashboard-mirror.test.ts > "removes mirror dir when server start throws"` hang that blocked the full `bun test` suite on Bun 1.3.11 / macOS, and closes the latent footgun behind it.

`startDashboardServer` (`src/dashboard-server.ts`) now validates the port **before** calling `Bun.serve`, throwing a `RangeError` for out-of-range / non-integer values. The predicate is exactly `!Number.isInteger(port) || port < 0 || port > 65535`; `port === 0` stays valid (auto-select a free port).

Root cause: on Bun 1.3.11 / macOS, `Bun.serve` *silently coerces* every invalid port to a listenable one (`99999` → `65535`, `-1`/`NaN` → a random free port, `1.5` → `1`) instead of rejecting. So the mirror script's `--port 99999` started a real listener that never exits, the parent `Bun.spawnSync` blocked with no timeout, and every coder fell back to `bun test src` (silently skipping `scripts/` coverage). The same coercion meant the production dashboard CLI could silently listen on a port *different* from the one requested.

`scripts/dev-dashboard-mirror.ts` is **unchanged** — it inherits the guard at its existing `startDashboardServer(...)` call inside the `try` block: `--port 99999` now throws, the `catch` rmSync's the temp dir and re-throws, and the process exits non-zero with no listener bound.

## Changes

- `src/dashboard-server.ts` — port-range guard with an informative `RangeError` (names the offending value and the `[0, 65535]` range) before `Bun.serve`.
- `src/dashboard-server.test.ts` (new) — covers rejection of coerced-on-this-host values, the inclusive `65535` bound (mutation-tested `>` vs `>=`), the informative error, and the `port === 0` auto-select path. Uses `withSyntheticHarness` for test isolation.
- `scripts/dev-dashboard-mirror.test.ts` — rewrites the stale "99999 is out of range for TCP → Bun.serve rejects" comment to describe the real mechanism (`startDashboardServer`-level range validation). Test body unchanged.

## Verification

- Full `bun test`: **2822 pass / 0 fail**, 60.83s (previously an infinite hang).
- `bun run typecheck` and `bun run lint` clean.
- Boundary mutation-tested: flipping `>` → `>=` fails the suite; restored → green.
- AC self-check (all 7 proposal ACs): `.peer-sync/workflow-feedback-coder.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)