### PR TITLE
Outbound staging-ff: classify workflow-scope push rejection distinctly (task-35e74651)

### DIFF
--- a/src/briefing-lag.test.ts
+++ b/src/briefing-lag.test.ts
@@ -297,10 +297,15 @@ describe("briefing-lag", () => {
     return file;
   }
 
+  // Event epoch must be NEWER than the sentinel mtime (the stale sentinel is
+  // ~50h old) for the annotation to apply — see the obsolete-event control
+  // below. Use ~1h ago.
+  const recentEpoch = () => Math.floor((Date.now() - 1 * 3600 * 1000) / 1000);
+
   test("formatUpstreamLagSection: stale outbound note includes workflow-scope cause/remedy", () => {
     const { dir, sentinelDir, rg } = staleOutboundSetup();
     const eventsFile = writeEvents([
-      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: recentEpoch(), message: "ocannl: x" },
     ]);
     const out = formatUpstreamLagSection(
       [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: dir } as ProjectConfig],
@@ -314,7 +319,7 @@ describe("briefing-lag", () => {
   test("formatUpstreamLagSection: stale outbound note includes credentials cause/remedy", () => {
     const { dir, sentinelDir, rg } = staleOutboundSetup();
     const eventsFile = writeEvents([
-      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: recentEpoch(), message: "ocannl: x" },
     ]);
     const out = formatUpstreamLagSection(
       [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: dir } as ProjectConfig],
@@ -346,5 +351,27 @@ describe("briefing-lag", () => {
     );
     expect(out2).toContain("outbound sentinel is");
     expect(out2).not.toContain("cause:");
+  });
+
+  test("formatUpstreamLagSection: obsolete auth event predating the sentinel is NOT annotated (Codex PR #557 P2)", () => {
+    // The reviewer scenario: a workflow-scope failure was fixed (a later
+    // success touched the sentinel), then the sentinel went stale for an
+    // unrelated reason (missed keepalive ticks). The old auth event still sits
+    // in events.jsonl but predates the sentinel mtime, so it must NOT surface
+    // an obsolete remedy. The sentinel here is ~50h old; the event is ~100h
+    // old (older than the sentinel mtime). Mutation: drop the `sinceEpoch`
+    // filter and this annotation reappears, failing the assertion.
+    const { dir, sentinelDir, rg } = staleOutboundSetup();
+    const hundredHoursAgo = Math.floor((Date.now() - 100 * 3600 * 1000) / 1000);
+    const eventsFile = writeEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: hundredHoursAgo, message: "ocannl: x" },
+    ]);
+    const out = formatUpstreamLagSection(
+      [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: dir } as ProjectConfig],
+      { now: new Date(), runGit: rg, sentinelDir, eventsFile },
+    );
+    expect(out).toContain("outbound sentinel is");
+    expect(out).not.toContain("cause:");
+    expect(out).not.toContain("remedy:");
   });
 });

--- a/src/briefing-lag.test.ts
+++ b/src/briefing-lag.test.ts
@@ -269,4 +269,82 @@ describe("briefing-lag", () => {
     );
     expect(sentinelDirNoFile).not.toContain("outbound sentinel is");
   });
+
+  // task-35e74651: stale outbound-sentinel note carries a cause + remedy
+  // annotation read from the latest outbound push-auth event for the project.
+  function staleOutboundSetup(): { dir: string; sentinelDir: string; rg: RunGit } {
+    const dir = tmp();
+    const sentinelDir = mkdtempSync("/tmp/outbound-sentinel-");
+    mkdirSync(join(dir, ".git"), { recursive: true });
+    const sentinel = join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch");
+    writeFileSync(sentinel, "");
+    const fiftyHoursAgo = new Date(Date.now() - 50 * 3600 * 1000);
+    utimesSync(sentinel, fiftyHoursAgo, fiftyHoursAgo);
+    const rg = fakeGit([
+      { match: ["remote"], stdout: "origin\nupstream\n" },
+      { match: ["symbolic-ref", "refs/remotes/origin/HEAD"], stdout: "refs/remotes/origin/master\n" },
+      { match: ["symbolic-ref", "refs/remotes/upstream/HEAD"], stdout: "refs/remotes/upstream/master\n" },
+      { match: ["rev-list"], stdout: "0\t0\n" },
+      { match: ["log"], stdout: "abc 2026-01-01 hi\n" },
+    ]);
+    return { dir, sentinelDir, rg };
+  }
+
+  function writeEvents(lines: Record<string, unknown>[]): string {
+    const evDir = mkdtempSync("/tmp/outbound-events-");
+    const file = join(evDir, "events.jsonl");
+    writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+    return file;
+  }
+
+  test("formatUpstreamLagSection: stale outbound note includes workflow-scope cause/remedy", () => {
+    const { dir, sentinelDir, rg } = staleOutboundSetup();
+    const eventsFile = writeEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+    ]);
+    const out = formatUpstreamLagSection(
+      [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: dir } as ProjectConfig],
+      { now: new Date(), runGit: rg, sentinelDir, eventsFile },
+    );
+    expect(out).toContain("outbound sentinel is");
+    expect(out).toContain("cause: push token lacks `workflow` scope");
+    expect(out).toContain("remedy: gh auth refresh -h github.com -s workflow");
+  });
+
+  test("formatUpstreamLagSection: stale outbound note includes credentials cause/remedy", () => {
+    const { dir, sentinelDir, rg } = staleOutboundSetup();
+    const eventsFile = writeEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+    ]);
+    const out = formatUpstreamLagSection(
+      [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: dir } as ProjectConfig],
+      { now: new Date(), runGit: rg, sentinelDir, eventsFile },
+    );
+    expect(out).toContain("cause: missing/invalid push credentials");
+    expect(out).toContain("remedy:");
+  });
+
+  test("formatUpstreamLagSection: stale outbound note is unannotated when no relevant event / no eventsFile", () => {
+    // Arm 1: eventsFile present but no matching event → base note only.
+    const a = staleOutboundSetup();
+    const eventsFile = writeEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 100, message: "ocannl: pushed" },
+    ]);
+    const out1 = formatUpstreamLagSection(
+      [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: a.dir } as ProjectConfig],
+      { now: new Date(), runGit: a.rg, sentinelDir: a.sentinelDir, eventsFile },
+    );
+    expect(out1).toContain("outbound sentinel is");
+    expect(out1).not.toContain("cause:");
+    expect(out1).not.toContain("remedy:");
+
+    // Arm 2: eventsFile omitted entirely → base note only (back-compat).
+    const b = staleOutboundSetup();
+    const out2 = formatUpstreamLagSection(
+      [{ name: "ocannl", repo: "o/r", upstream_repo: "u/r", path: b.dir } as ProjectConfig],
+      { now: new Date(), runGit: b.rg, sentinelDir: b.sentinelDir },
+    );
+    expect(out2).toContain("outbound sentinel is");
+    expect(out2).not.toContain("cause:");
+  });
 });

--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -14,6 +14,7 @@ import { existsSync, statSync } from "fs";
 import { join } from "path";
 import type { ProjectConfig } from "./config.ts";
 import { detectDefaultBranches, expandHome, hasRemote, type RunGit } from "./git-runner.ts";
+import { latestOutboundCauseRemedy } from "./staging-event-meta.ts";
 
 export interface FormatLagOptions {
   now: Date;
@@ -30,6 +31,15 @@ export interface FormatLagOptions {
   sentinelDir?: string;
   /** Outbound sentinel age threshold for the stale annotation. Default 48h. gh-ludics-540. */
   outboundSentinelStaleSeconds?: number;
+  /**
+   * Path to the JSONL events file (`journal/events.jsonl`). When set, a stale
+   * outbound-sentinel note is annotated with the cause + remedy of the most
+   * recent outbound push-auth event for the project (workflow-scope /
+   * credentials). When omitted, the note is emitted without the annotation —
+   * backward-compatible with callers/tests that don't surface event data.
+   * task-35e74651.
+   */
+  eventsFile?: string;
 }
 
 /**
@@ -79,6 +89,7 @@ function outboundSentinelStaleNote(
   project: string,
   now: Date,
   stale: number,
+  eventsFile?: string,
 ): string | null {
   const sentinel = join(sentinelDir, `last-outbound-fast-forward-${project}.epoch`);
   if (!existsSync(sentinel)) return null;
@@ -87,7 +98,17 @@ function outboundSentinelStaleNote(
     const ageSec = Math.max(0, Math.floor((now.getTime() - mtime) / 1000));
     if (ageSec < stale) return null;
     const hours = Math.round(ageSec / 3600);
-    return `(outbound sentinel is ~${hours}h old; upstream push may be overdue)`;
+    let note = `(outbound sentinel is ~${hours}h old; upstream push may be overdue)`;
+    // task-35e74651: when the latest outbound push-auth event names a cause +
+    // remedy (workflow-scope / credentials), append it so the operator sees
+    // the copy-pasteable fix next to the stale-sentinel warning.
+    if (eventsFile) {
+      const annotation = latestOutboundCauseRemedy(eventsFile, project);
+      if (annotation) {
+        note += ` — cause: ${annotation.cause}; remedy: ${annotation.remedy}`;
+      }
+    }
+    return note;
   } catch {
     return null;
   }
@@ -156,7 +177,7 @@ export function formatUpstreamLagSection(
     // only creates it for opt-in projects).
     if (opts.sentinelDir) {
       const outboundStale = opts.outboundSentinelStaleSeconds ?? 48 * 3600;
-      const outboundNote = outboundSentinelStaleNote(opts.sentinelDir, name, opts.now, outboundStale);
+      const outboundNote = outboundSentinelStaleNote(opts.sentinelDir, name, opts.now, outboundStale, opts.eventsFile);
       if (outboundNote) lines.push(`- ${outboundNote}`);
     }
     lines.push("");

--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -101,9 +101,15 @@ function outboundSentinelStaleNote(
     let note = `(outbound sentinel is ~${hours}h old; upstream push may be overdue)`;
     // task-35e74651: when the latest outbound push-auth event names a cause +
     // remedy (workflow-scope / credentials), append it so the operator sees
-    // the copy-pasteable fix next to the stale-sentinel warning.
+    // the copy-pasteable fix next to the stale-sentinel warning. Only consider
+    // events newer than the sentinel mtime (the last successful/error tick):
+    // an auth failure that predates a later success — or a sentinel that went
+    // stale for an unrelated reason such as missed keepalive ticks — must not
+    // surface an obsolete remedy (Codex PR #557 P2).
     if (eventsFile) {
-      const annotation = latestOutboundCauseRemedy(eventsFile, project);
+      const annotation = latestOutboundCauseRemedy(eventsFile, project, {
+        sinceEpoch: Math.floor(mtime / 1000),
+      });
       if (annotation) {
         note += ` — cause: ${annotation.cause}; remedy: ${annotation.remedy}`;
       }

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -1302,7 +1302,114 @@ function ocannlProject(opts: { enabled?: boolean | undefined; path?: string }): 
   return base;
 }
 
+// task-35e74651: RunGit driver that reaches step (E)'s push and returns a
+// given push result. remote/status/branch-detect/fetch/local-ff/ancestry all
+// succeed so the push is the only failure point.
+function pushPathRunGit(push: { stdout?: string; stderr?: string; exitCode?: number }): RunGit {
+  return (args) => {
+    const key = args[0] ?? "";
+    if (key === "remote") return { stdout: "origin\nupstream\n", exitCode: 0 };
+    if (key === "status") return { stdout: "", exitCode: 0 };
+    if (key === "symbolic-ref") {
+      const ref = args[1] ?? "";
+      if (ref.endsWith("/origin/HEAD")) return { stdout: "refs/remotes/origin/master\n", exitCode: 0 };
+      if (ref.endsWith("/upstream/HEAD")) return { stdout: "refs/remotes/upstream/master\n", exitCode: 0 };
+      return { stdout: "", exitCode: 128 };
+    }
+    if (key === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "master\n", exitCode: 0 };
+    if (key === "checkout") return { stdout: "", exitCode: 0 };
+    if (key === "fetch") return { stdout: "", exitCode: 0 };
+    if (key === "merge" && args[1] === "--ff-only") return { stdout: "Already up to date.\n", exitCode: 0 };
+    if (key === "rev-list" && args[1] === "--count") return { stdout: "5\n", exitCode: 0 };
+    if (key === "merge-base" && args[1] === "--is-ancestor") return { stdout: "", exitCode: 0 };
+    if (key === "push") return { stdout: push.stdout ?? "", stderr: push.stderr, exitCode: push.exitCode ?? 0 };
+    return { stdout: "", exitCode: 0 };
+  };
+}
+
+const WORKFLOW_SCOPE_STDERR =
+  "! [remote rejected] origin/master -> master (refusing to allow an OAuth App to create or update workflow `.github/workflows/gh-pages-docs.yml` without `workflow` scope)";
+
 describe("runStagingOutboundPushTick", () => {
+  test("task-35e74651: workflow-scope push rejection persists event with structured project + remedy", () => {
+    const harnessRoot = mkdtempSync("/tmp/mag-outbound-wfscope-harness-");
+    const checkoutDir = mkdtempSync("/tmp/mag-outbound-wfscope-checkout-");
+    const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+    process.env.LUDICS_HARNESS_DIR = harnessRoot;
+    try {
+      const cfg = {
+        projects: [{
+          name: "ocannl",
+          repo: "lukstafi/ocannl-staging",
+          upstream_repo: "ahrefs/ocannl",
+          outbound_sync_enabled: true,
+          path: checkoutDir,
+        }],
+      } as unknown as LudicsFullConfig;
+      const results = runStagingOutboundPushTick({
+        isController: () => true,
+        runGit: pushPathRunGit({ stderr: WORKFLOW_SCOPE_STDERR, exitCode: 128 }),
+        config: cfg,
+        now: new Date(),
+        // sentinelDir omitted → emitEvent writes under env-overridden harnessRoot.
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.outcome).toBe("skipped-no-workflow-scope");
+
+      const eventsFile = join(harnessRoot, "journal", "events.jsonl");
+      expect(existsSync(eventsFile)).toBe(true);
+      const lines = readFileSync(eventsFile, "utf-8").trim().split("\n").filter(Boolean);
+      const wf = lines
+        .map((l) => JSON.parse(l) as Record<string, unknown>)
+        .filter((e) => e.event_type === "staging_outbound_workflow_scope_missing");
+      expect(wf).toHaveLength(1);
+      // Mutation guard for the new `project: ev.project` adapter line: drop it
+      // and this assertion fails (the annotation lookup would then have to
+      // parse the message prefix).
+      expect(wf[0]!.project).toBe("ocannl");
+      expect(String(wf[0]!.message)).toContain("gh auth refresh -h github.com -s workflow");
+    } finally {
+      if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+      else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+      rmSync(harnessRoot, { recursive: true, force: true });
+      rmSync(checkoutDir, { recursive: true, force: true });
+    }
+  });
+
+  test("task-35e74651: skipped-no-workflow-scope outcome is logged to stderr", () => {
+    const sentinelDir = mkdtempSync("/tmp/outbound-wfscope-stderr-");
+    const checkoutDir = mkdtempSync("/tmp/outbound-wfscope-stderr-checkout-");
+    const cfg = {
+      projects: [{
+        name: "ocannl",
+        repo: "lukstafi/ocannl-staging",
+        upstream_repo: "ahrefs/ocannl",
+        outbound_sync_enabled: true,
+        path: checkoutDir,
+      }],
+    } as unknown as LudicsFullConfig;
+    const spy = spyOn(console, "error").mockImplementation(() => {});
+    let logged: string[];
+    try {
+      const results = runStagingOutboundPushTick({
+        isController: () => true,
+        runGit: pushPathRunGit({ stderr: WORKFLOW_SCOPE_STDERR, exitCode: 128 }),
+        config: cfg,
+        sentinelDir,
+        now: new Date(),
+      });
+      expect(results[0]!.outcome).toBe("skipped-no-workflow-scope");
+      // Capture before restore (bun:test mockRestore wipes call history).
+      logged = spy.mock.calls.map((c) => String(c[0]));
+    } finally {
+      spy.mockRestore();
+      rmSync(sentinelDir, { recursive: true, force: true });
+      rmSync(checkoutDir, { recursive: true, force: true });
+    }
+    expect(logged.some((l) => l.includes("outbound-staging-ff ocannl: skipped-no-workflow-scope"))).toBe(true);
+  });
+
+
   test("controller-gate: short-circuits with zero git invocations when isController() returns false", () => {
     const { run, calls } = recordingRunGit();
     const sentinelDir = mkdtempSync("/tmp/outbound-gate-");

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2071,13 +2071,14 @@ function runStagingFastForwardTick(): void {
       runGit: defaultRunGit,
       sentinelDir,
       emitEvent: (ev) => {
-        // Same `extra` forwarding as outbound — keeps the inbound and
-        // outbound adapter paths symmetric so future structured fields
-        // on the inbound flow (none today) don't get silently dropped.
+        // Same `extra` + `project` forwarding as outbound — keeps the inbound
+        // and outbound adapter paths symmetric so structured fields don't get
+        // silently dropped.
         emitEvent({
           event_type: ev.type,
           source: "mag",
           scope: "project",
+          project: ev.project,
           message: ev.message,
           ...(ev.extra ?? {}),
         });
@@ -2138,6 +2139,10 @@ export function runStagingOutboundPushTick(opts?: {
           event_type: ev.type,
           source: "mag",
           scope: "project",
+          // task-35e74651: persist the structured project so the briefing-lag
+          // cause/remedy annotation can match the latest outbound auth event
+          // by field instead of parsing the `${project}:` message prefix.
+          project: ev.project,
           message: ev.message,
           ...(ev.extra ?? {}),
         });
@@ -2148,6 +2153,7 @@ export function runStagingOutboundPushTick(opts?: {
         r.outcome === "pushed" ||
         r.outcome === "skipped-not-fast-forward" ||
         r.outcome === "skipped-no-push-credentials" ||
+        r.outcome === "skipped-no-workflow-scope" ||
         r.outcome === "skipped-local-staging-behind" ||
         r.outcome === "error"
       ) {
@@ -2275,6 +2281,10 @@ export async function briefingPrecomputeContext(opts?: { runGit?: RunGit }): Pro
     // "outbound sentinel stale > 48h" annotation alongside the
     // existing FETCH_HEAD freshness note.
     sentinelDir: join(harnessDir(), "mag"),
+    // task-35e74651: source for the cause/remedy annotation appended to a
+    // stale outbound-sentinel note (latest workflow-scope / credentials
+    // outbound event for the project).
+    eventsFile: join(harnessDir(), "journal", "events.jsonl"),
   });
   const upstreamLagSection = upstreamLag
     ? `## Upstream vs Staging Lag\n\n${upstreamLag.trimEnd()}\n\n`

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  OUTBOUND_EVENT_CAUSE_REMEDY,
+  latestOutboundCauseRemedy,
+} from "./staging-event-meta.ts";
+
+function tmpEvents(lines: Record<string, unknown>[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "staging-event-meta-"));
+  const file = join(dir, "events.jsonl");
+  writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return file;
+}
+
+describe("OUTBOUND_EVENT_CAUSE_REMEDY", () => {
+  test("workflow-scope entry names the gh auth refresh remedy", () => {
+    const meta = OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!;
+    expect(meta.cause).toContain("workflow");
+    expect(meta.remedy).toBe("gh auth refresh -h github.com -s workflow");
+  });
+
+  test("credentials entry names the credential-refresh remedy", () => {
+    const meta = OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!;
+    expect(meta.cause).toContain("credentials");
+    expect(meta.remedy.toLowerCase()).toContain("credentials");
+  });
+});
+
+describe("latestOutboundCauseRemedy", () => {
+  test("returns workflow-scope cause/remedy for a structured-project event", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 100, message: "x" },
+    ]);
+    const got = latestOutboundCauseRemedy(file, "ocannl");
+    expect(got).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!);
+  });
+
+  test("returns credentials cause/remedy for a structured-project event", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 100, message: "x" },
+    ]);
+    const got = latestOutboundCauseRemedy(file, "ocannl");
+    expect(got).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!);
+  });
+
+  test("ordering: newest epoch wins when both classes are present", () => {
+    // Credentials event is older; workflow-scope is newer → workflow-scope wins.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 100, message: "x" },
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 200, message: "x" },
+    ]);
+    const got = latestOutboundCauseRemedy(file, "ocannl");
+    expect(got).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!);
+
+    // Reverse the epochs → credentials (now newest) wins. This is the
+    // assertion that fails if the reader returns first-match instead of the
+    // newest-epoch match.
+    const file2 = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 300, message: "x" },
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 200, message: "x" },
+    ]);
+    const got2 = latestOutboundCauseRemedy(file2, "ocannl");
+    expect(got2).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!);
+  });
+
+  test("project filter: an event for another project does not match", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "other-proj", epoch: 100, message: "other-proj: x" },
+    ]);
+    expect(latestOutboundCauseRemedy(file, "ocannl")).toBeNull();
+  });
+
+  test("legacy fallback: matches via `${project}:` message prefix when structured project absent", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", epoch: 100, message: "ocannl: outbound push failed (credentials)" },
+    ]);
+    const got = latestOutboundCauseRemedy(file, "ocannl");
+    expect(got).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!);
+  });
+
+  test("control: no matching event → null", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 100, message: "ocannl: pushed" },
+      { event_type: "some_other_event", project: "ocannl", epoch: 200, message: "ocannl: noise" },
+    ]);
+    expect(latestOutboundCauseRemedy(file, "ocannl")).toBeNull();
+  });
+
+  test("missing file → null (best-effort, never throws)", () => {
+    expect(latestOutboundCauseRemedy(join(tmpdir(), "does-not-exist-xyz", "events.jsonl"), "ocannl")).toBeNull();
+  });
+});

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -80,6 +80,29 @@ describe("latestOutboundCauseRemedy", () => {
     expect(got).toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!);
   });
 
+  test("sinceEpoch: events older than the boundary are ignored (Codex PR #557 P2)", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+    ]);
+    // Boundary above the event → dropped.
+    expect(latestOutboundCauseRemedy(file, "ocannl", { sinceEpoch: 200 })).toBeNull();
+    // Boundary at/below the event → kept.
+    expect(latestOutboundCauseRemedy(file, "ocannl", { sinceEpoch: 100 }))
+      .toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!);
+    expect(latestOutboundCauseRemedy(file, "ocannl", { sinceEpoch: 50 }))
+      .toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!);
+  });
+
+  test("sinceEpoch: a newer matching event wins even when an older one predates the boundary", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 100, message: "ocannl: old" },
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 300, message: "ocannl: new" },
+    ]);
+    // Boundary 200 drops the credentials event but keeps the workflow one.
+    expect(latestOutboundCauseRemedy(file, "ocannl", { sinceEpoch: 200 }))
+      .toEqual(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!);
+  });
+
   test("control: no matching event → null", () => {
     const file = tmpEvents([
       { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 100, message: "ocannl: pushed" },

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -47,13 +47,24 @@ export const OUTBOUND_EVENT_CAUSE_REMEDY: Record<string, OutboundCauseRemedy> = 
  * The newest qualifying event wins (max numeric `epoch`; later line breaks
  * ties / missing epochs).
  *
+ * `opts.sinceEpoch`: when set, events with `epoch < sinceEpoch` are ignored.
+ * Callers pass the outbound sentinel mtime here so a stale sentinel is only
+ * annotated with an auth failure that occurred *after* the last successful /
+ * error tick — an obsolete failure that predates a later success (and a
+ * sentinel that went stale for an unrelated reason, e.g. missed keepalive
+ * ticks) must not surface a no-longer-applicable remedy. An event with no
+ * usable `epoch` (treated as 0) is dropped under a positive `sinceEpoch`,
+ * since it cannot be proven newer than the boundary.
+ *
  * Best-effort: a missing/empty/unparseable file yields `null` rather than
  * throwing — this feeds an informational briefing annotation, never a gate.
  */
 export function latestOutboundCauseRemedy(
   eventsFile: string,
   project: string,
+  opts?: { sinceEpoch?: number },
 ): OutboundCauseRemedy | null {
+  const sinceEpoch = opts?.sinceEpoch;
   let content: string;
   try {
     if (!existsSync(eventsFile)) return null;
@@ -83,6 +94,10 @@ export function latestOutboundCauseRemedy(
     const matches = structured === project || message.startsWith(`${project}:`);
     if (!matches) continue;
     const epoch = typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch) ? parsed.epoch : 0;
+    // Drop failures that predate the sentinel boundary (last successful/error
+    // tick) — they're obsolete once a later success or unrelated staleness
+    // occurred. `order++` still advances so tie-break ordering is unaffected.
+    if (sinceEpoch !== undefined && epoch < sinceEpoch) { order++; continue; }
     const cur = { epoch, order: order++, type };
     if (
       best === null ||

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -1,0 +1,97 @@
+// Shared cause/remedy metadata + latest-event reader for outbound
+// staging→upstream push failures (task-35e74651).
+//
+// Neutral module: imports only `fs` + the pure `isPlainObject` helper. It
+// deliberately does NOT import `./events.ts` (and is not imported by it) or
+// `./briefing-lag.ts` (which `./staging-ff.ts` already imports — a cycle).
+// Both the event emitter (`src/staging-ff.ts`) and the annotator
+// (`src/briefing-lag.ts`) import the cause/remedy map from here so the
+// strings stay in sync, keyed by event type.
+
+import { existsSync, readFileSync } from "fs";
+import { isPlainObject } from "./json.ts";
+
+export interface OutboundCauseRemedy {
+  cause: string;
+  remedy: string;
+}
+
+/**
+ * Cause + remedy strings for the two surfaced outbound push-auth failure
+ * classes, keyed by the persisted event type. The emitter builds its event
+ * message from these (so the remedy is copy-pasteable in the events log) and
+ * the briefing-lag stale-sentinel annotation reads the same strings — a
+ * single source of truth keeps the two surfaces in sync.
+ */
+export const OUTBOUND_EVENT_CAUSE_REMEDY: Record<string, OutboundCauseRemedy> = {
+  staging_outbound_workflow_scope_missing: {
+    cause: "push token lacks `workflow` scope",
+    remedy: "gh auth refresh -h github.com -s workflow",
+  },
+  staging_outbound_credentials_missing: {
+    cause: "missing/invalid push credentials",
+    remedy: "refresh the push credentials (gh auth login / update the stored token)",
+  },
+};
+
+/**
+ * Return the cause/remedy for the most recent outbound push-auth event for
+ * `project` in the JSONL events file at `eventsFile`, or `null` when none
+ * matches.
+ *
+ * Matching: an event qualifies when its `event_type` is one of the keys of
+ * `OUTBOUND_EVENT_CAUSE_REMEDY` AND it belongs to `project`. Project match
+ * prefers the structured `project` field (persisted by the Mag adapter in
+ * `runStagingOutboundPushTick`); it falls back to a `"<project>:"` message
+ * prefix so events emitted before the structured field existed still resolve.
+ * The newest qualifying event wins (max numeric `epoch`; later line breaks
+ * ties / missing epochs).
+ *
+ * Best-effort: a missing/empty/unparseable file yields `null` rather than
+ * throwing — this feeds an informational briefing annotation, never a gate.
+ */
+export function latestOutboundCauseRemedy(
+  eventsFile: string,
+  project: string,
+): OutboundCauseRemedy | null {
+  let content: string;
+  try {
+    if (!existsSync(eventsFile)) return null;
+    content = readFileSync(eventsFile, "utf-8");
+  } catch {
+    return null;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+
+  let best: { epoch: number; order: number; type: string } | null = null;
+  let order = 0;
+  for (const line of trimmed.split("\n")) {
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) continue;
+    const type = typeof parsed.event_type === "string" ? parsed.event_type : "";
+    if (!(type in OUTBOUND_EVENT_CAUSE_REMEDY)) continue;
+    // Project match: structured field first, message-prefix fallback.
+    const structured = typeof parsed.project === "string" ? parsed.project : null;
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    const matches = structured === project || message.startsWith(`${project}:`);
+    if (!matches) continue;
+    const epoch = typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch) ? parsed.epoch : 0;
+    const cur = { epoch, order: order++, type };
+    if (
+      best === null ||
+      cur.epoch > best.epoch ||
+      (cur.epoch === best.epoch && cur.order > best.order)
+    ) {
+      best = cur;
+    }
+  }
+  if (!best) return null;
+  return OUTBOUND_EVENT_CAUSE_REMEDY[best.type] ?? null;
+}

--- a/src/staging-ff.test.ts
+++ b/src/staging-ff.test.ts
@@ -502,6 +502,41 @@ describe("classifyPushFailure", () => {
       .toBe("credentials");
   });
 
+  // task-35e74651: workflow-scope rejection is its own class, matched BEFORE
+  // credentials so the more specific/actionable class wins.
+  test("classifies OAuth-App workflow-scope rejection as workflow-scope", () => {
+    const oauthStderr =
+      "! [remote rejected] origin/master -> master (refusing to allow an OAuth App to create or update workflow `.github/workflows/gh-pages-docs.yml` without `workflow` scope)";
+    expect(classifyPushFailure("", oauthStderr)).toBe("workflow-scope");
+  });
+
+  test("classifies ASCII-quote PAT variant `without 'workflow' scope` as workflow-scope", () => {
+    expect(classifyPushFailure("", "remote: refusing to update workflow without 'workflow' scope"))
+      .toBe("workflow-scope");
+  });
+
+  test("classifies backtick-quote variant ``without `workflow` scope`` as workflow-scope", () => {
+    expect(classifyPushFailure("", "remote: refusing to update workflow without `workflow` scope"))
+      .toBe("workflow-scope");
+  });
+
+  test("workflow-scope wins even when the blob also contains error: 403", () => {
+    // Ordering invariant: a workflow-scope rejection that ALSO carries an
+    // `error: 403` token (which the credentials regex matches) must still
+    // classify as workflow-scope, not credentials. This assertion fails if
+    // the workflow-scope check is moved below the credentials check.
+    const mixed = [
+      "remote: refusing to allow an OAuth App to create or update workflow `f.yml` without `workflow` scope",
+      "fatal: unable to access '...': The requested URL returned error: 403",
+    ].join("\n");
+    expect(classifyPushFailure("", mixed)).toBe("workflow-scope");
+  });
+
+  test("generic non-fast-forward remote rejection stays 'other' (workflow matcher is narrow)", () => {
+    expect(classifyPushFailure("", "! [remote rejected] origin/master -> master (non-fast-forward)"))
+      .toBe("other");
+  });
+
   test("network classifier still wins for legitimate transient shapes (no 403 / no denial)", () => {
     // Negative control: a generic 'unable to access' WITHOUT any
     // credentials marker (no 403, no denial, no Write access line) must
@@ -537,6 +572,64 @@ describe("classifyPushFailure end-to-end (Codex PR #544 review)", () => {
     // The key invariant Codex flagged: sentinel must NOT exist so the
     // stale-sentinel signal fires fast.
     expect(existsSync(join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch"))).toBe(false);
+  });
+});
+
+describe("workflow-scope push rejection end-to-end (task-35e74651)", () => {
+  test("positive: workflow-scope rejection → skipped-no-workflow-scope, event with remedy, sentinel NOT touched", () => {
+    const dir = mkdtempSync("/tmp/outbound-checkout-wfscope-");
+    const sentinelDir = mkdtempSync("/tmp/outbound-sentinel-wfscope-");
+    const wfStderr =
+      "! [remote rejected] origin/master -> master (refusing to allow an OAuth App to create or update workflow `.github/workflows/gh-pages-docs.yml` without `workflow` scope)";
+    const events: Array<{ type: string; project: string; message: string }> = [];
+    const { run, calls } = outboundFakeGit({
+      ancestry: { exitCode: 0 },
+      revListCount: { stdout: "5\n" },
+      push: { stdout: "", stderr: wfStderr, exitCode: 128 },
+    });
+    const res = syncUpstreamMainFromStaging(
+      [project("ocannl", dir)],
+      {
+        now: new Date(),
+        runGit: run,
+        sentinelDir,
+        emitEvent: (ev) => events.push({ type: ev.type, project: ev.project, message: ev.message }),
+      },
+    );
+    expect(res[0]!.outcome).toBe("skipped-no-workflow-scope");
+    expect(calls.some((c) => c[0] === "push")).toBe(true);
+    // Event emitted, names the cause + copy-pasteable remedy.
+    const ev = events.find((e) => e.type === "staging_outbound_workflow_scope_missing");
+    expect(ev).toBeDefined();
+    expect(ev!.project).toBe("ocannl");
+    expect(ev!.message).toContain("gh auth refresh -h github.com -s workflow");
+    // Core invariant: sentinel NOT touched → next tick retries + stale signal stays armed.
+    expect(existsSync(join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch"))).toBe(false);
+  });
+
+  test("negative control: plain non-fast-forward rejection → error, generic event, sentinel TOUCHED", () => {
+    const dir = mkdtempSync("/tmp/outbound-checkout-nff-");
+    const sentinelDir = mkdtempSync("/tmp/outbound-sentinel-nff-");
+    const nffStderr = "! [remote rejected] origin/master -> master (non-fast-forward)";
+    const events: Array<{ type: string; project: string }> = [];
+    const { run } = outboundFakeGit({
+      ancestry: { exitCode: 0 },
+      revListCount: { stdout: "5\n" },
+      push: { stdout: "", stderr: nffStderr, exitCode: 128 },
+    });
+    const res = syncUpstreamMainFromStaging(
+      [project("ocannl", dir)],
+      {
+        now: new Date(),
+        runGit: run,
+        sentinelDir,
+        emitEvent: (ev) => events.push({ type: ev.type, project: ev.project }),
+      },
+    );
+    expect(res[0]!.outcome).toBe("error");
+    expect(events).toContainEqual({ type: "staging_outbound_error", project: "ocannl" });
+    // Genuinely-stuck case keeps the 24h throttle: sentinel DOES exist.
+    expect(existsSync(join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch"))).toBe(true);
   });
 });
 

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -17,6 +17,7 @@ import {
   type RunGit,
 } from "./git-runner.ts";
 import { parseLeftRightCount } from "./briefing-lag.ts";
+import { OUTBOUND_EVENT_CAUSE_REMEDY } from "./staging-event-meta.ts";
 import { sentinelFresh, touchSentinel } from "./sentinel.ts";
 import type { ProjectConfig } from "./config.ts";
 
@@ -215,6 +216,7 @@ export type OutboundPushOutcome =
   | "skipped-no-staging-commits"
   | "skipped-not-fast-forward"
   | "skipped-no-push-credentials"
+  | "skipped-no-workflow-scope"
   | "skipped-local-staging-behind"
   | "pushed"
   | "error";
@@ -245,8 +247,23 @@ export function outboundSentinelFile(dir: string, project: string): string {
 export function classifyPushFailure(
   stdout: string,
   stderr?: string,
-): "credentials" | "network" | "other" {
+): "workflow-scope" | "credentials" | "network" | "other" {
   const blob = `${stdout}\n${stderr ?? ""}`.toLowerCase();
+  // Workflow-scope rejection MUST be checked before credentials: GitHub's
+  // refusal is technically a 403/permission event and could partially match
+  // the credentials regex below, but this class is more specific and more
+  // actionable (the remedy is `gh auth refresh -s workflow`, not a full
+  // credential reset). The literal is:
+  //   ! [remote rejected] origin/master -> master (refusing to allow an
+  //   OAuth App to create or update workflow `…` without `workflow` scope)
+  // Lowercasing handles case; the char class tolerates ASCII single-quote vs
+  // backtick around `workflow`; `create or update workflow` is a
+  // quote-agnostic anchor that also covers the fine-grained-PAT phrasing.
+  // The bare word `workflow` alone is deliberately NOT matched (too broad —
+  // a generic remote hook failure mentioning "workflow" must stay `other`).
+  if (/create or update workflow|without ['`]?workflow['`]? scope/.test(blob)) {
+    return "workflow-scope";
+  }
   // Credentials patterns. The first three are the AC-named SSH /
   // HTTPS-credential shapes. The remaining four catch GitHub's
   // 403/401 push-denial shapes — which would otherwise fall through to
@@ -503,7 +520,23 @@ export function syncUpstreamMainFromStaging(
 
         const kind = classifyPushFailure(pushed.stdout, pushed.stderr);
         const detailBlob = `push: ${(pushed.stderr ?? pushed.stdout).trim().slice(0, 200)}`;
-        if (kind === "credentials") {
+        if (kind === "workflow-scope") {
+          // Workflow-scope rejection: a commit in the FF range edited a
+          // .github/workflows/ file and the push token lacks the `workflow`
+          // scope. Fixable in seconds (gh auth refresh -s workflow), so we do
+          // NOT touch the sentinel — the next tick retries and the
+          // stale-sentinel health signal stays armed. The event message names
+          // the cause + remedy so the events log / briefing surfaces carry the
+          // copy-pasteable fix.
+          const meta = OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!;
+          out.push({ project, outcome: "skipped-no-workflow-scope", detail: detailBlob });
+          opts.emitEvent?.({
+            type: "staging_outbound_workflow_scope_missing",
+            project,
+            message: `${project}: outbound push failed — ${meta.cause}; remedy: ${meta.remedy}`,
+          });
+          // NO sentinel touch.
+        } else if (kind === "credentials") {
           out.push({ project, outcome: "skipped-no-push-credentials", detail: detailBlob });
           opts.emitEvent?.({
             type: "staging_outbound_credentials_missing",


### PR DESCRIPTION
## Summary

When the outbound staging→upstream fast-forward push (`syncUpstreamMainFromStaging` step E) is rejected by GitHub because the push token lacks the `workflow` OAuth/PAT scope (a commit in the FF range edits `.github/workflows/`), it was misclassified as the catch-all `"other"` → outcome `error`, which **touches the sentinel** (24h throttle) and emits a generic `staging_outbound_error` event — hiding a fix that takes seconds (`gh auth refresh -s workflow`).

This mirrors the existing credentials "don't-throttle + surface" path:

1. **`classifyPushFailure`** gains a `"workflow-scope"` class, matched **before** `credentials` (a 403 can partially match credentials; the more specific/actionable class must win). Quote-tolerant matcher (`'workflow'` / `` `workflow` ``) + quote-agnostic `create or update workflow` anchor; the bare word `workflow` is deliberately not matched.
2. **Step (E)** new branch → outcome `skipped-no-workflow-scope` + `staging_outbound_workflow_scope_missing` event whose message names the cause + remedy (`gh auth refresh -h github.com -s workflow`), and **does not** touch the sentinel (next tick retries, stale-sentinel signal stays armed).
3. **`runStagingOutboundPushTick`** logs the new outcome to stderr and persists a structured `project` field on outbound (and symmetrically inbound) events.
4. **`src/briefing-lag.ts`** stale outbound-sentinel note now appends the cause + remedy read from the latest matching outbound event — covering the symmetric credentials gap too (proposal Q2). Shared map + reader live in new `src/staging-event-meta.ts`. The annotation only fires for an auth failure **newer than the sentinel mtime**, so an obsolete (already-fixed) failure on a sentinel that went stale for an unrelated reason is not surfaced (Codex P2, commit cc2fb31).

## AC4 health-check surface — documented gap

The `outbound-staging-ff-stale:<project>` finding is computed inline in `skills/ludics-health-check.md` bash with no `src/` precompute to attach data to. Per the proposal's flagged ambiguity (Scope lines 209–223), the annotation is scoped to the briefing-lag programmatic surface and the skill markdown stays **byte-unchanged**. The health-check-side wiring is an accepted-risk follow-up.

## Scope expansion

`src/staging-event-meta.ts` (NEW) — the proposal floated `events.ts`; a neutral module avoids the `staging-ff ↔ briefing-lag` import cycle and preserves staging-ff's `events.ts` decoupling.

## Tests

- Classifier: OAuth-App / ASCII-quote / backtick variants, 403-ordering (workflow-scope wins), non-ff control stays `other`.
- E2E: positive (`skipped-no-workflow-scope`, event with remedy, sentinel NOT touched) + negative control (non-ff → `error`, sentinel touched).
- Reader: ordering (newest epoch), project filter, legacy message-prefix fallback, `sinceEpoch` boundary (drop-below / keep-at-or-above / newer-wins), no-match → null.
- Annotation: workflow + credentials → cause/remedy; dual control (no event / no eventsFile) → unannotated; obsolete-event-predating-sentinel control → unannotated.
- Mag: workflow-scope event reaches `journal/events.jsonl` with structured `project` + remedy; stderr logging.

Full suite **2845 pass / 0 fail** (baseline 2821; +24). typecheck, build, and all 17 CI lints green.