### PR TITLE
Fix deferred-cleanup drain: tolerate `can't find session` + run reaper on 4h health check

### DIFF
--- a/src/mag-periodic-gate.test.ts
+++ b/src/mag-periodic-gate.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync } from "fs";
 import { join } from "path";
 import { withSyntheticHarness } from "./test-utils.ts";
+import * as deferredCleanup from "./orchestration/deferred-cleanup.ts";
+import * as health from "./health.ts";
 
 // Note: resolveQueueRequestCommand is async-imported per-test to avoid loading
 // mag.ts side-effects until the synthetic harness is wired.
@@ -236,6 +238,90 @@ describe("briefing Tier-1 arm — activity-window gate (gh-ludics-538 AC 3)", ()
     expect(result).toBeNull();
     const last = findLastEvent(stateDir, "briefing_skipped");
     expect(last).not.toBeNull();
+  });
+});
+
+// --- health-check reaper cadence (task-703d0553 AC c) ---
+
+describe("health-check cadence drives the deferred-cleanup reaper (task-703d0553)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  // Would-skip world reused from the AC-11 health-check tests above: delta below
+  // HEALTH_GATE_THRESHOLD (300). The gate skips a non-bypass record here, so the
+  // positive case below MUST bypass to instantiate the executed path, and the
+  // negative case uses the same world to instantiate the gate-skip path.
+  function seedWouldSkipWorld(stateDir: string): void {
+    const lines = Array.from({ length: 1010 }, (_, i) => `{"n":${i}}`).join("\n") + "\n";
+    writeFileSync(join(stateDir, "journal", "events.jsonl"), lines);
+    writeFileSync(join(stateDir, "mag", "health-last.json"),
+      JSON.stringify({ timestamp: "2026-04-24T00:00:00Z", eventsJsonlLines: 1000, findings: [] }));
+  }
+
+  test("AC(c): executed health-check (gate allowed via bypassGate) invokes processDeferredCleanups exactly once", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    seedWouldSkipWorld(stateDir);
+
+    // Spy the reaper (asserts the wiring) and stub runAllTestHealth so the test
+    // does not run real test-health work in the synthetic harness. The spies sit
+    // on the same module objects mag.ts dynamically imports at dispatch time.
+    const reaperSpy = spyOn(deferredCleanup, "processDeferredCleanups").mockResolvedValue(undefined);
+    const healthSpy = spyOn(health, "runAllTestHealth").mockImplementation(() => {});
+    try {
+      const { resolveQueueRequestCommand } = await import("./mag.ts");
+      const result = await resolveQueueRequestCommand(
+        { action: "health-check", bypassGate: true, id: "hc-test-1" }, true,
+      );
+      // Sanity: the executed path returns the skill command (not a gate-skip null).
+      expect(result).toBe("/ludics-health-check");
+      // Invariant: an executed 4h health-check ticks the reaper. If the wiring
+      // were removed, this call count would drop to 0.
+      expect(reaperSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      reaperSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
+  });
+
+  test("AC(c) negative control: a gate-SKIPPED health-check does NOT invoke the reaper", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    seedWouldSkipWorld(stateDir);
+
+    const reaperSpy = spyOn(deferredCleanup, "processDeferredCleanups").mockResolvedValue(undefined);
+    const healthSpy = spyOn(health, "runAllTestHealth").mockImplementation(() => {});
+    try {
+      const { resolveQueueRequestCommand } = await import("./mag.ts");
+      // Non-bypass record in the would-skip world → the gate skips before the
+      // reaper line is reached (it returns null on the skip arm).
+      const result = await resolveQueueRequestCommand({ action: "health-check" }, true);
+      expect(result).toBeNull();
+      // Invariant: reaping rides the EXECUTED cadence only — a skipped tick must
+      // not reap. A reaper call hoisted above the gate would fail this.
+      expect(reaperSpy).not.toHaveBeenCalled();
+    } finally {
+      reaperSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
+  });
+
+  test("AC(c) negative control: the peek path (executeProgrammatic=false) does NOT invoke the reaper", async () => {
+    const stateDir = getStateDir();
+    makeJournal(stateDir);
+    seedWouldSkipWorld(stateDir);
+
+    const reaperSpy = spyOn(deferredCleanup, "processDeferredCleanups").mockResolvedValue(undefined);
+    const healthSpy = spyOn(health, "runAllTestHealth").mockImplementation(() => {});
+    try {
+      const { resolveQueueRequestCommand } = await import("./mag.ts");
+      const result = await resolveQueueRequestCommand({ action: "health-check" }, false);
+      // Peek returns the skill command for inspection without executing the body.
+      expect(result).toBe("/ludics-health-check");
+      expect(reaperSpy).not.toHaveBeenCalled();
+    } finally {
+      reaperSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
   });
 });
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1796,6 +1796,17 @@ export async function resolveQueueRequestCommand(request: Record<string, unknown
       } catch (err) {
         console.error("ludics: test health check failed:", err);
       }
+      // Process deferred artifact cleanup on the 4h health-check cadence so
+      // reaping is evenly spaced (~6×/day) rather than once/day at briefing
+      // precompute (task-703d0553). Only runs on executed, non-gate-skipped
+      // health checks — peek (executeProgrammatic=false) and gate-skip both
+      // return before reaching here. Briefing precompute keeps its own call.
+      try {
+        const { processDeferredCleanups } = await import("./orchestration/deferred-cleanup.ts");
+        await processDeferredCleanups();
+      } catch (err) {
+        console.error("ludics: deferred cleanup failed:", err);
+      }
       // Auto-compact after health-check — checkpoint compaction (task-a00fc0d9 /
       // docs/proposals/auto-compact-after-checkpoints.md). Coupled to the gate
       // here so idle ticks that skip the health-check do not also fire a

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { cleanupDelayHours } from "../config.ts";
+import * as config from "../config.ts";
 import * as t3codeServer from "../t3code/server.ts";
 
 // Redirect harnessDir() to a temp directory via env var
@@ -143,6 +144,151 @@ describe("processDeferredCleanups", () => {
     await processDeferredCleanups(25);
     // No error, manifest stays empty
     expect(loadDeferredCleanups()).toEqual([]);
+  });
+});
+
+// task-703d0553: drain resilience. The old all-or-nothing `failed` flag re-queued
+// an entire entry whenever ANY sub-step failed — overwhelmingly the t3code arm,
+// which set failed=true on every tick while t3code integration is paused (server
+// down by design, gh-ludics-539). Now an entry is retained ONLY when a genuinely
+// retryable step failed; the paused-t3code arm is a skip, and benign no-ops drain.
+describe("processDeferredCleanups drain resilience (task-703d0553)", () => {
+  test("AC(a): paused-t3code entry drains, does NOT call serverStatus, and still reaps peer-sync", async () => {
+    // Harness condition: integration PAUSED + an entry whose only un-completable
+    // step is t3code thread deletion, carrying a real reapable peer-sync link.
+    const enabledSpy = spyOn(config, "t3codeIntegrationEnabled").mockReturnValue(false);
+    let serverStatusCalls = 0;
+    const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockImplementation(async () => {
+      serverStatusCalls++;
+      return { running: false, record: null, snapshot: null, reason: "should-not-be-called" };
+    });
+
+    // Concrete reapable resource: a real file at peerSyncLink. removePeerSyncLink
+    // unlinks it — its disappearance proves reapable cleanup actually ran (guards
+    // against an implementation that skips ALL cleanup when t3code is paused).
+    const peerSyncLink = join(tmpDir, ".agent-sessions", "test-task-drain-s1.session");
+    mkdirSync(dirname(peerSyncLink), { recursive: true });
+    writeFileSync(peerSyncLink, "session-link\n");
+    expect(existsSync(peerSyncLink)).toBe(true);
+
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "test-task-drain",
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        worktreePaths: [], branches: [], tmuxSessionNames: [],
+        peerSyncLink,
+        t3codeThreadIds: ["t-1"],
+      }));
+
+      await processDeferredCleanups(25);
+
+      // (i) entry drained — not held hostage by the paused t3code arm.
+      expect(loadDeferredCleanups()).toHaveLength(0);
+      // (ii) the gate short-circuited BEFORE any server probe.
+      expect(serverStatusCalls).toBe(0);
+      // (iii) reapable work actually happened — the peer-sync link is gone.
+      expect(existsSync(peerSyncLink)).toBe(false);
+    } finally {
+      enabledSpy.mockRestore();
+      serverStatusSpy.mockRestore();
+    }
+  });
+
+  test("AC(b): t3code ENABLED + server unreachable retains the entry for a future tick", async () => {
+    // Positive control for AC(a): the SAME not-running server is a genuinely
+    // retryable failure when integration is enabled, so the entry must stay.
+    const enabledSpy = spyOn(config, "t3codeIntegrationEnabled").mockReturnValue(true);
+    const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockResolvedValue(
+      { running: false, record: null, snapshot: null, reason: "transiently-down" },
+    );
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "test-task-enabled-down",
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        worktreePaths: [], branches: [], tmuxSessionNames: [], peerSyncLink: null,
+        t3codeThreadIds: ["t-1"],
+      }));
+
+      await processDeferredCleanups(25);
+
+      const remaining = loadDeferredCleanups();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.t3codeThreadIds).toEqual(["t-1"]);
+    } finally {
+      enabledSpy.mockRestore();
+      serverStatusSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  test("benign worktree/branch/tmux no-ops do not pin an otherwise-complete entry", async () => {
+    if (!Bun.which("git")) return;
+    // Real repo; entry names a ludics/-branch that was never created (deleteBranches
+    // is a safeSyncOutput no-op), an already-absent orchestration worktree path
+    // (removeWorktreeByPath no-ops), and a tmux session name (no server running).
+    // None of these throw → none are retryable → the entry must drain.
+    const projectDir = join(tmpDir, "proj-benign-noop");
+    mkdirSync(projectDir, { recursive: true });
+    Bun.spawnSync(["git", "init", "-b", "main"], { cwd: projectDir });
+    Bun.spawnSync(["git", "config", "user.email", "test@example.com"], { cwd: projectDir });
+    Bun.spawnSync(["git", "config", "user.name", "Test User"], { cwd: projectDir });
+    writeFileSync(join(projectDir, "README.md"), "init\n");
+    Bun.spawnSync(["git", "add", "README.md"], { cwd: projectDir });
+    Bun.spawnSync(["git", "commit", "-m", "init"], { cwd: projectDir });
+
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "task-benign-noop",
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        projectDir,
+        worktreePaths: [join(dirname(projectDir), "proj-benign-noop-task-benign-noop-s1")],
+        branches: ["ludics/task-benign-noop-s1/root"],
+        tmuxSessionNames: ["ludics-task-benign-noop-s1"],
+        peerSyncLink: null,
+        t3codeThreadIds: [],
+      }));
+
+      await processDeferredCleanups(25);
+
+      expect(loadDeferredCleanups()).toHaveLength(0);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  test("AC(d) negative control: within-grace entry with t3codeThreadIds is NOT reaped early", async () => {
+    // The cutoff partition must run BEFORE any cleanup/gate work: a fresh entry
+    // (timestamp=now) is retained untouched and never probes the server.
+    let serverStatusCalls = 0;
+    const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockImplementation(async () => {
+      serverStatusCalls++;
+      return { running: true, record: null, snapshot: null, reason: "should-not-be-called" };
+    });
+    // Spy the gate too — a within-grace entry must not even reach the t3code arm.
+    const enabledSpy = spyOn(config, "t3codeIntegrationEnabled").mockReturnValue(true);
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "test-task-within-grace",
+        timestamp: new Date().toISOString(), // now → within grace
+        worktreePaths: [], branches: [], tmuxSessionNames: ["ludics-fresh-s1"],
+        peerSyncLink: null,
+        t3codeThreadIds: ["t-1"],
+      }));
+
+      await processDeferredCleanups(25);
+
+      const remaining = loadDeferredCleanups();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.taskId).toBe("test-task-within-grace");
+      // No reapable work was attempted early.
+      expect(serverStatusCalls).toBe(0);
+    } finally {
+      serverStatusSpy.mockRestore();
+      enabledSpy.mockRestore();
+    }
   });
 });
 
@@ -462,6 +608,10 @@ describe("explicit harnessDir argument (isolation)", () => {
   // Uses the spyOn() pattern (see docs/testing-patterns.md) so the
   // replacement does not leak across test files in the Bun runner.
   test("processDeferredCleanups(_, ISO) passes ISO to serverStatus({ harnessDir }) in the t3codeThreadIds branch", async () => {
+    // task-703d0553: under the paused-skip gate, serverStatus is only reached when
+    // integration is ENABLED. Enable it so this test exercises the harnessDir
+    // threading + retain-on-not-running path it was written to cover.
+    const enabledSpy = spyOn(config, "t3codeIntegrationEnabled").mockReturnValue(true);
     const capturedHarnessDirs: string[] = [];
     const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockImplementation(
       async (options: { harnessDir?: string } = {}) => {
@@ -488,13 +638,15 @@ describe("explicit harnessDir argument (isolation)", () => {
       expect(capturedHarnessDirs[0]).toBe(ISO);
       expect(capturedHarnessDirs[0]).not.toBe(tmpDir);
 
-      // Because the stub returned {running: false}, the branch marks failed=true and the
-      // entry remains in the ISO manifest (proves the path-handling also threaded ISO).
+      // Because the stub returned {running: false} with integration enabled, the
+      // branch marks retryableFailure=true and the entry remains in the ISO manifest
+      // (proves the path-handling also threaded ISO).
       const remaining = loadDeferredCleanups(ISO);
       expect(remaining).toHaveLength(1);
       expect(remaining[0]!.t3codeThreadIds).toEqual(["thread-abc", "thread-def"]);
     } finally {
       serverStatusSpy.mockRestore();
+      enabledSpy.mockRestore();
     }
   });
 });

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "path";
 import { cleanupDelayHours } from "../config.ts";
 import * as config from "../config.ts";
 import * as t3codeServer from "../t3code/server.ts";
+import * as spawn from "../spawn.ts";
 
 // Redirect harnessDir() to a temp directory via env var
 const tmpDir = join(import.meta.dir, ".test-tmp-deferred-cleanup");
@@ -26,6 +27,7 @@ import {
   buildCleanupEntry,
   cancelDeferredCleanup,
   cleanupPendingPath,
+  isBenignTmuxKillStderr,
   loadDeferredCleanups,
   processDeferredCleanups,
   recordDeferredCleanup,
@@ -289,6 +291,88 @@ describe("processDeferredCleanups drain resilience (task-703d0553)", () => {
       serverStatusSpy.mockRestore();
       enabledSpy.mockRestore();
     }
+  });
+
+  test("a NON-benign tmux kill failure retains the entry for a future tick", async () => {
+    // Positive control for the benign-no-op drain: the tmux step must still
+    // pin an entry when the kill fails for a reason that is NOT "session
+    // already gone" (e.g. a permission error). Forcing safeSyncOutput to a
+    // non-benign stderr is the only way to instantiate this deterministically
+    // — a real `tmux kill-session` against a host can only produce the benign
+    // shapes. Without this control, isBenignTmuxKillStderr could be loosened
+    // to a blanket pass and every drain test would still go green.
+    const killSpy = spyOn(spawn, "safeSyncOutput").mockReturnValue({
+      ok: false, exitCode: 1, stdout: "", stderr: "some other tmux error", timedOut: false,
+    });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "task-nonbenign-tmux",
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        worktreePaths: [], branches: [], peerSyncLink: null,
+        tmuxSessionNames: ["ludics-task-nonbenign-tmux-s1"],
+        t3codeThreadIds: [],
+      }));
+
+      await processDeferredCleanups(25);
+
+      const remaining = loadDeferredCleanups();
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.taskId).toBe("task-nonbenign-tmux");
+    } finally {
+      killSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  test("explicit harnessDir flows into serverStatus({ harnessDir }) when t3code is enabled", async () => {
+    // Guards the harness-dir threading: processDeferredCleanups(thresholdHours,
+    // harnessDir) must hand the SAME harnessDir to the t3code server probe, not
+    // fall back to the default. If the threading regressed, serverStatus would
+    // receive the process-default dir and this assertion would fail.
+    const customHarness = join(tmpDir, "custom-harness");
+    mkdirSync(join(customHarness, "mag"), { recursive: true });
+
+    const enabledSpy = spyOn(config, "t3codeIntegrationEnabled").mockReturnValue(true);
+    let observedHarnessDir: string | undefined;
+    const serverStatusSpy = spyOn(t3codeServer, "serverStatus").mockImplementation(async (opts) => {
+      observedHarnessDir = opts?.harnessDir;
+      // Return not-running so no real client is constructed; entry is retained.
+      return { running: false, record: null, snapshot: null, reason: "probe-only" };
+    });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      recordDeferredCleanup(makeEntry({
+        taskId: "task-harnessdir-thread",
+        timestamp: new Date(Date.now() - 30 * 3600000).toISOString(),
+        worktreePaths: [], branches: [], tmuxSessionNames: [], peerSyncLink: null,
+        t3codeThreadIds: ["t-1"],
+      }), customHarness);
+
+      await processDeferredCleanups(25, customHarness);
+
+      expect(observedHarnessDir).toBe(customHarness);
+    } finally {
+      enabledSpy.mockRestore();
+      serverStatusSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+});
+
+describe("isBenignTmuxKillStderr", () => {
+  test("tolerates all three 'session already gone' shapes", () => {
+    expect(isBenignTmuxKillStderr("no server running on /tmp/tmux-501/default")).toBe(true);
+    expect(isBenignTmuxKillStderr("session not found: ludics-task-x-s1")).toBe(true);
+    // The dev-box-with-live-server shape that previously pinned entries forever.
+    expect(isBenignTmuxKillStderr("can't find session: ludics-task-x-s1")).toBe(true);
+  });
+
+  test("does NOT tolerate non-benign failures or empty stderr", () => {
+    expect(isBenignTmuxKillStderr("permission denied")).toBe(false);
+    expect(isBenignTmuxKillStderr("some other tmux error")).toBe(false);
+    expect(isBenignTmuxKillStderr("")).toBe(false);
+    expect(isBenignTmuxKillStderr(undefined)).toBe(false);
   });
 });
 

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -4,7 +4,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { join } from "path";
 import { harnessDir as defaultHarnessDir, cleanupDelayHours } from "../config.ts";
-import { safeSyncOutput } from "../spawn.ts";
+import * as spawn from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
 import { removeWorktreeByPath, deleteBranches, orchBranchName, purgeOrphanDirIfRecoverable } from "./worktrees.ts";
 import { removePeerSyncLink } from "./peer-sync.ts";
@@ -25,6 +25,33 @@ export interface CleanupEntry {
 
 export function cleanupPendingPath(harnessDir: string = defaultHarnessDir()): string {
   return join(harnessDir, "mag", "cleanup-pending.json");
+}
+
+/**
+ * Whether a non-zero `tmux kill-session` exit is a *benign* "the session is
+ * already gone" outcome — i.e. cleanup succeeded by virtue of the target not
+ * existing, and the entry must NOT be retained as a retryable failure.
+ *
+ * tmux reports an absent session three different ways depending on server
+ * state and version, so all three must be tolerated as a class (not just the
+ * one a given host happens to emit):
+ *   - `no server running on /tmp/tmux-.../default` — no tmux server at all
+ *     (the shape CI sees, since CI has no running server).
+ *   - `session not found: <name>`                 — some tmux builds.
+ *   - `can't find session: <name>`                — server up, session gone
+ *     (the shape a dev box with a live tmux server emits — previously NOT
+ *     tolerated, which pinned otherwise-complete entries in the queue forever).
+ *
+ * Any other stderr (permission errors, malformed args, unexpected failures)
+ * is a genuine failure worth retaining for a future tick.
+ */
+export function isBenignTmuxKillStderr(stderr: string | undefined): boolean {
+  if (!stderr) return false;
+  return (
+    stderr.includes("no server running") ||
+    stderr.includes("session not found") ||
+    stderr.includes("can't find session")
+  );
 }
 
 export function loadDeferredCleanups(harnessDir: string = defaultHarnessDir()): CleanupEntry[] {
@@ -189,8 +216,8 @@ export async function processDeferredCleanups(
 
     // 3. Kill tmux sessions
     for (const name of entry.tmuxSessionNames) {
-      const result = safeSyncOutput(["tmux", "kill-session", "-t", name]);
-      if (!result.ok && !result.stderr?.includes("no server running") && !result.stderr?.includes("session not found")) {
+      const result = spawn.safeSyncOutput(["tmux", "kill-session", "-t", name]);
+      if (!result.ok && !isBenignTmuxKillStderr(result.stderr)) {
         console.error(`ludics: deferred tmux kill-session failed for ${name}: ${result.stderr ?? "unknown"}`);
         retryableFailure = true;
       }

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -151,7 +151,12 @@ export async function processDeferredCleanups(
       continue;
     }
 
-    let failed = false;
+    // Retain the entry for a future tick ONLY when a genuinely retryable
+    // cleanup step failed (transient, worth another attempt). Benign no-ops
+    // (already-gone worktree/branch, missing tmux session) and the paused-t3code
+    // skip do NOT set this — so an entry drains once nothing reapable remains,
+    // instead of being held hostage by an un-completable sub-step forever.
+    let retryableFailure = false;
 
     // 1. Remove worktrees
     for (const path of entry.worktreePaths) {
@@ -159,7 +164,7 @@ export async function processDeferredCleanups(
         removeWorktreeByPath(entry.projectDir, path);
       } catch (err) {
         console.error(`ludics: deferred worktree removal failed for ${path}:`, err);
-        failed = true;
+        retryableFailure = true;
       }
       // Defense-in-depth: if `removeWorktreeByPath` no-op'd because git no longer
       // registered the path (e.g. a prior `git worktree prune` swept the admin
@@ -179,7 +184,7 @@ export async function processDeferredCleanups(
       deleteBranches(entry.projectDir, entry.branches);
     } catch (err) {
       console.error(`ludics: deferred branch deletion failed:`, err);
-      failed = true;
+      retryableFailure = true;
     }
 
     // 3. Kill tmux sessions
@@ -187,7 +192,7 @@ export async function processDeferredCleanups(
       const result = safeSyncOutput(["tmux", "kill-session", "-t", name]);
       if (!result.ok && !result.stderr?.includes("no server running") && !result.stderr?.includes("session not found")) {
         console.error(`ludics: deferred tmux kill-session failed for ${name}: ${result.stderr ?? "unknown"}`);
-        failed = true;
+        retryableFailure = true;
       }
     }
 
@@ -197,54 +202,66 @@ export async function processDeferredCleanups(
         removePeerSyncLink(entry.peerSyncLink);
       } catch (err) {
         console.error(`ludics: deferred peer-sync removal failed:`, err);
-        failed = true;
+        retryableFailure = true;
       }
     }
 
     // 5. Delete t3code threads
     if (entry.t3codeThreadIds && entry.t3codeThreadIds.length > 0) {
-      try {
-        const { serverStatus } = await import("../t3code/server.ts");
-        const { T3CodeClient } = await import("../t3code/client.ts");
-        const { makeId, isoNow } = await import("./util.ts");
-        const status = await serverStatus({ harnessDir });
-        if (!status.running || !status.record) {
-          console.error("ludics: deferred t3code cleanup: server not running, will retry");
-          failed = true;
-        } else {
-          const client = new T3CodeClient({ url: status.record.wsUrl, token: status.record.authToken });
-          try {
-            for (const threadId of entry.t3codeThreadIds) {
-              try {
-                await client.dispatchCommand({
-                  type: "thread.session.stop",
-                  commandId: makeId("cmd"),
-                  threadId,
-                  createdAt: isoNow(),
-                });
-              } catch { /* session may already be stopped */ }
-              try {
-                await client.dispatchCommand({
-                  type: "thread.delete",
-                  commandId: makeId("cmd"),
-                  threadId,
-                });
-              } catch (err) {
-                console.error(`ludics: deferred t3code thread.delete failed for ${threadId}:`, err);
-                failed = true;
+      // gh-ludics-539: when t3code integration is paused, the server is down by
+      // design and the threads die with it — so thread deletion is a SKIP, not a
+      // failure. Explicitly consult the gate BEFORE probing the server: do not
+      // import serverStatus, do not construct a client, and do not mark a retry.
+      // This is the dominant backlog driver — entries carrying t3codeThreadIds
+      // previously re-queued forever because the (intentionally-down) server set
+      // failed=true on every tick.
+      const { t3codeIntegrationEnabled } = await import("../config.ts");
+      if (!t3codeIntegrationEnabled()) {
+        console.error(`ludics: deferred t3code cleanup skipped (integration paused) for task ${entry.taskId} slot ${entry.slot}`);
+      } else {
+        try {
+          const { serverStatus } = await import("../t3code/server.ts");
+          const { T3CodeClient } = await import("../t3code/client.ts");
+          const { makeId, isoNow } = await import("./util.ts");
+          const status = await serverStatus({ harnessDir });
+          if (!status.running || !status.record) {
+            console.error("ludics: deferred t3code cleanup: server not running, will retry");
+            retryableFailure = true;
+          } else {
+            const client = new T3CodeClient({ url: status.record.wsUrl, token: status.record.authToken });
+            try {
+              for (const threadId of entry.t3codeThreadIds) {
+                try {
+                  await client.dispatchCommand({
+                    type: "thread.session.stop",
+                    commandId: makeId("cmd"),
+                    threadId,
+                    createdAt: isoNow(),
+                  });
+                } catch { /* session may already be stopped */ }
+                try {
+                  await client.dispatchCommand({
+                    type: "thread.delete",
+                    commandId: makeId("cmd"),
+                    threadId,
+                  });
+                } catch (err) {
+                  console.error(`ludics: deferred t3code thread.delete failed for ${threadId}:`, err);
+                  retryableFailure = true;
+                }
               }
+            } finally {
+              client.close();
             }
-          } finally {
-            client.close();
           }
+        } catch (err) {
+          console.error(`ludics: deferred t3code thread deletion failed:`, err);
+          retryableFailure = true;
         }
-      } catch (err) {
-        console.error(`ludics: deferred t3code thread deletion failed:`, err);
-        failed = true;
       }
     }
 
-    if (failed) {
+    if (retryableFailure) {
       remaining.push(entry);
     } else {
       console.error(`ludics: deferred cleanup completed for task ${entry.taskId} slot ${entry.slot}`);


### PR DESCRIPTION
## Summary

Fixes the deferred-cleanup queue (`mag/cleanup-pending.json`) never draining — orphan tmux sessions / worktrees / branches from long-merged tasks piled up (360-entry backlog going back to 2026-05-14). Two defects:

1. **Drain resilience** — the reaper re-queued the *whole* entry whenever *any* sub-step failed. The dominant driver was the t3code arm marking failure while integration is paused (server intentionally down, gh-ludics-539). Replaced the all-or-nothing `failed` flag with a per-step `retryableFailure`, and made the paused-t3code arm a **skip, not a failure** (consults `t3codeIntegrationEnabled()` before probing the server).

2. **Cadence** — the reaper ran from only one place (briefing precompute, ~1×/day). Added a second trigger on the executed **4h health-check** path so reaping is evenly spaced; the briefing call is preserved.

## The round-1 completion (this PR's delta)

The above shipped in the first commit but left a host-dependent gap: `tmux kill-session -t <missing>` returns `can't find session: <name>` when a tmux server **is** running (dev/worker box), which the benign matcher (`no server running` / `session not found`) did **not** tolerate — so a benign no-op flipped `retryableFailure` and pinned otherwise-complete entries forever (green in CI, red on a live host). This PR:

- Extracts an exported `isBenignTmuxKillStderr` helper tolerating all three "session already gone" shapes as a class.
- Refactors the single `safeSyncOutput` call in `deferred-cleanup.ts` to a namespace import so the non-benign retain path is spy-testable.
- Adds the AC(c) health-check tests (executed path invokes the reaper once; gate-skip and peek paths do **not**).

## Tests

- `isBenignTmuxKillStderr` — all three benign shapes + non-benign/empty negatives
- benign worktree/branch/tmux no-op drains (was failing); non-benign tmux failure retains
- paused-t3code drains without probing the server; enabled+unreachable retains; explicit `harnessDir` threads into `serverStatus({ harnessDir })`; within-grace not reaped early
- health-check cadence: executed → reaper called once; gate-skip / peek → not called

Full suite **2870 pass / 0 fail** (was 2862 / 1). `typecheck`, all 15 CI lints, and `bun run build` clean.

## Scope

No manual edit of `mag/cleanup-pending.json` — the backlog self-drains once the fix ships. No change to `cleanup_delay_hours` / 25h default / 72h cap. t3code stays paused. No data-shape change (`CleanupEntry` unchanged).

Proposal: `docs/proposals/deferred-cleanup-drain-and-cadence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)