### PR TITLE
Resolve orchestration default models to latest-within-class via config table

### DIFF
--- a/scripts/lint-config-reference.test.ts
+++ b/scripts/lint-config-reference.test.ts
@@ -296,6 +296,18 @@ describe("runLint — adapter-call-site direction (gh-ludics-496)", () => {
     }
   });
 
+  test("task-c48b7beb — real repo: model_classes is covered (not inert), lint exits 0", () => {
+    // World-sanity probe against the live repo: the new mag.orchestration.model_classes
+    // leaf must be documented in templates/config.reference.yaml AND read via a
+    // literal orchCfg?.model_classes in an adapter source. If the read seam is
+    // ever DRY-refactored out of t3code.ts, model_classes turns inert and this
+    // assertion (plus lint:config-reference) fails.
+    const root = join(import.meta.dir, "..");
+    const result = runLint(root);
+    expect(result.inertYamlKeys).not.toContain("model_classes");
+    expect(result.exitCode).toBe(0);
+  });
+
   test("AC8 inert key — documented key not read by either adapter → exit 1", () => {
     const { root, cleanup } = makeFixture({
       "src/config.ts": TS_INTERFACE_WITH_ORCH,

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError } from "./t3code.ts";
+import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError, resolveAgentModel, classModel, providerDefaultModel } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -38,7 +38,16 @@ function installT3codeConfigHarness(): {
       writeFileSync(
         cfgPath,
         `state_repo: owner/ludics-state\nstate_path: harness\nadapter: ${adapter}\n`
-          + `mag:\n  t3code_integration_enabled: ${t3codeEnabled}\n`,
+          + `mag:\n  t3code_integration_enabled: ${t3codeEnabled}\n`
+          // task-c48b7beb: latest-within-class table is the single source of
+          // truth; selectOrchestrationFlags / resolveAgentModel now resolve
+          // through it and throw when a tracked class is absent, so the test
+          // harness must populate it (mirrors a real config.yaml).
+          + `  orchestration:\n`
+          + `    model_classes:\n`
+          + `      codex: gpt-5.5\n`
+          + `      claude-opus: claude-opus-4-8\n`
+          + `      claude-sonnet: claude-sonnet-4-6\n`,
       );
       process.env.LUDICS_CONFIG = cfgPath;
     },
@@ -542,7 +551,7 @@ describe("selectOrchestrationFlags — tiny effort", () => {
 
   test("tiny effort ignores orchCfg.default_mode (forces solo)", () => {
     const fakeConfig = {
-      mag: { orchestration: { default_mode: "pair", default_coder: "claude-code", default_reviewer: "codex" } },
+      mag: { orchestration: { default_mode: "pair", default_coder: "claude-code", default_reviewer: "codex", model_classes: { codex: "gpt-5.5", "claude-opus": "claude-opus-4-8", "claude-sonnet": "claude-sonnet-4-6" } } },
     } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
     const { args, isDuo } = selectOrchestrationFlags("tiny", fakeConfig);
     expect(args).toContain("--solo");
@@ -665,5 +674,123 @@ describe("t3code adapter cold-start DesiredThreadConfig", () => {
     expect(desiredReviewer.branch).toBe("ludics/task-cs/reviewer");
     expect(desiredCoder.provider).toBe("claude-code");
     expect(desiredReviewer.provider).toBe("codex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task-c48b7beb — latest-within-class default model resolution.
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentModel — override precedence ladder (AC4)", () => {
+  // Invariant: the unspecified-default tier (latest-within-class table) sits
+  // BELOW every task-1fbd4edf override and ABOVE the provider's own default.
+  // Each test sets up exactly the state that makes one tier win and asserts the
+  // tiers below it do NOT leak through. The new (lowest) tier is the table.
+  const TABLE = { codex: "gpt-5.5", "claude-opus": "claude-opus-4-8", "claude-sonnet": "claude-sonnet-4-6" };
+  const bareCodex = { name: "reviewer", provider: "codex" as const, model: "", modelExplicit: false, role: "reviewer" as const };
+
+  test("tier 1 — --reviewer-model flag wins over everything below", () => {
+    const orchCfg = { reviewer_model: "cfg-rev", model_classes: TABLE };
+    expect(resolveAgentModel(bareCodex, 1, orchCfg, undefined, "flag-rev")).toBe("flag-rev");
+  });
+
+  test("tier 2 — explicit token model wins over config + table", () => {
+    const explicit = { ...bareCodex, model: "tok-model", modelExplicit: true };
+    const orchCfg = { reviewer_model: "cfg-rev", model_classes: TABLE };
+    expect(resolveAgentModel(explicit, 1, orchCfg, undefined, undefined)).toBe("tok-model");
+  });
+
+  test("tier 3 — reviewer_model config wins over the table", () => {
+    const orchCfg = { reviewer_model: "cfg-rev", model_classes: TABLE };
+    expect(resolveAgentModel(bareCodex, 1, orchCfg, undefined, undefined)).toBe("cfg-rev");
+  });
+
+  test("tier 4 — class table resolves the latest codex when nothing above is set", () => {
+    // Harness: bare codex token, no flag, no reviewer_model — only the table.
+    // Mutation: re-pinning DEFAULT_MODEL would make this a literal, not gpt-5.5.
+    const orchCfg = { model_classes: TABLE };
+    expect(resolveAgentModel(bareCodex, 1, orchCfg, undefined, undefined)).toBe("gpt-5.5");
+  });
+
+  test("class table picks the configured value, not a hardcoded string", () => {
+    const orchCfg = { model_classes: { ...TABLE, codex: "gpt-9.9-custom" } };
+    expect(resolveAgentModel(bareCodex, 1, orchCfg, undefined, undefined)).toBe("gpt-9.9-custom");
+  });
+});
+
+describe("resolveAgentModel — runtime-path fails loudly when the class table is unset (AC3)", () => {
+  // Runtime path (not the pure helper): resolveAgentModel is the function that
+  // start() calls per agent BEFORE createWorktrees. Harness: a bare codex agent
+  // with an orchCfg whose model_classes omits "codex" → the resolver throws,
+  // so a misconfigured slot never silently runs a stale default.
+  const bareCodex = { name: "reviewer", provider: "codex" as const, model: "", modelExplicit: false, role: "reviewer" as const };
+
+  test("throws when model_classes is entirely absent", () => {
+    expect(() => resolveAgentModel(bareCodex, 1, {}, undefined, undefined)).toThrow(
+      /mag\.orchestration\.model_classes\.codex is required/,
+    );
+  });
+
+  test("throws when the codex class is missing from the table", () => {
+    const orchCfg = { model_classes: { "claude-opus": "claude-opus-4-8" } };
+    expect(() => resolveAgentModel(bareCodex, 1, orchCfg, undefined, undefined)).toThrow(
+      /mag\.orchestration\.model_classes\.codex is required/,
+    );
+  });
+
+  test("classModel / providerDefaultModel throw on a missing class too", () => {
+    expect(() => classModel("claude-opus", {})).toThrow(/model_classes\.claude-opus is required/);
+    expect(() => providerDefaultModel("claude-code", {})).toThrow(/model_classes\.claude-sonnet is required/);
+  });
+});
+
+describe("parseOrchestrationAdapterArgs — pair fallback tokens carry no baked version", () => {
+  test("--pair with no --coder/--reviewer yields empty, non-explicit models", () => {
+    // Mutation: re-introducing "coder:codex:gpt-5.4" sets a non-empty model and
+    // flips these assertions; the empty model is what defers resolution to the
+    // config table so role config overrides can still win (edge case 4).
+    const parsed = parseOrchestrationAdapterArgs("--pair");
+    expect(parsed.orchestration!.agents).toHaveLength(2);
+    for (const agent of parsed.orchestration!.agents) {
+      expect(agent.provider).toBe("codex");
+      expect(agent.model).toBe("");
+      expect(agent.modelExplicit).toBe(false);
+    }
+  });
+});
+
+describe("selectOrchestrationFlags — coder model suffix sourced from the config table (AC1)", () => {
+  // gh-ludics-539 gate: flag on so the t3code-adapter selection does not throw.
+  // The harness config carries model_classes, so the claude-code coder suffix
+  // is the table value — not a hardcoded constant.
+  const cfg = installT3codeConfigHarness();
+  beforeEach(() => cfg.write({ t3codeEnabled: true }));
+
+  test("medium effort claude-code coder emits the opus class suffix", () => {
+    const { args } = selectOrchestrationFlags("medium");
+    expect(args).toContain(":claude-opus-4-8");
+  });
+
+  test("tiny effort claude-code coder emits the sonnet class suffix", () => {
+    const { args } = selectOrchestrationFlags("tiny");
+    expect(args).toContain(":claude-sonnet-4-6");
+  });
+
+  test("a config override of model_classes.claude-opus flows into the medium suffix", () => {
+    // Gate reads the real (harness) config; orchCfg reads the passed fakeConfig.
+    const fakeConfig = {
+      mag: { orchestration: { default_coder: "claude-code", default_reviewer: "codex", model_classes: { codex: "gpt-5.5", "claude-opus": "opus-test-override", "claude-sonnet": "claude-sonnet-4-6" } } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    const { args } = selectOrchestrationFlags("medium", fakeConfig);
+    expect(args).toContain(":opus-test-override");
+  });
+
+  test("missing model_classes makes selection throw before any side effect", () => {
+    const fakeConfig = {
+      mag: { orchestration: { default_coder: "claude-code", default_reviewer: "codex" } },
+    } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
+    expect(() => selectOrchestrationFlags("medium", fakeConfig)).toThrow(
+      /mag\.orchestration\.model_classes\.claude-opus is required/,
+    );
   });
 });

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError, resolveAgentModel, classModel, providerDefaultModel } from "./t3code.ts";
+import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError, resolveAgentModel, classModel, providerDefaultModel, singleThreadCodexModel } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -741,6 +741,30 @@ describe("resolveAgentModel — runtime-path fails loudly when the class table i
   test("classModel / providerDefaultModel throw on a missing class too", () => {
     expect(() => classModel("claude-opus", {})).toThrow(/model_classes\.claude-opus is required/);
     expect(() => providerDefaultModel("claude-code", {})).toThrow(/model_classes\.claude-sonnet is required/);
+  });
+});
+
+describe("singleThreadCodexModel — non-orchestration path degrades, never throws (PR #561 codex P2)", () => {
+  // Regression: the non-orchestration single-thread t3code start (startSingleThread /
+  // ensureThread fallback) must NOT hard-require the orchestration-only model_classes
+  // table — a plain `slot start` against a minimal/legacy config previously opened
+  // with the built-in codex default. Harness: an orchCfg with NO model_classes table.
+  // Mutation: routing the single-thread fallback back through classModel() (which
+  // throws) flips the first two assertions to a thrown error.
+  test("absent table → '' (provider/CLI default), does not throw", () => {
+    expect(singleThreadCodexModel(undefined)).toBe("");
+    expect(singleThreadCodexModel({})).toBe("");
+    expect(singleThreadCodexModel({ model_classes: {} })).toBe("");
+  });
+
+  test("present codex class → the configured value (table still preferred)", () => {
+    expect(singleThreadCodexModel({ model_classes: { codex: "gpt-5.5" } })).toBe("gpt-5.5");
+    expect(singleThreadCodexModel({ model_classes: { codex: "  gpt-5.5  " } })).toBe("gpt-5.5");
+  });
+
+  test("contrast: orchestration resolution still throws on the same table-less config", () => {
+    // The loud failure is reserved for orchestration defaults — same input, opposite contract.
+    expect(() => classModel("codex", {})).toThrow(/model_classes\.codex is required/);
   });
 });
 

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -932,8 +932,8 @@ export function resolveAgentModel(
   if (agent.model.trim()) return agent.model;
 
   // Lowest tier: latest-within-class default from the config table. Throws
-  // loudly when the resolved class is unset (task-c48b7beb) — replaces the old
-  // pinned DEFAULT_MODEL / DEFAULT_CLAUDE_MODEL constants.
+  // loudly when the resolved class is unset (task-c48b7beb) — replaces the
+  // pinned per-class default constants removed in this task.
   return providerDefaultModel(agent.provider, orchCfg);
 }
 

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -49,6 +49,11 @@ import { initPeerSync, writeAgentMarkerFiles } from "../orchestration/peer-sync.
 import { createWorktrees, symlinkPeerSync } from "../orchestration/worktrees.ts";
 import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/deferred-cleanup.ts";
 import { isoNow, makeId, nowEpoch } from "../orchestration/util.ts";
+import {
+  classForProvider,
+  resolveModelClass,
+  type ModelClass,
+} from "../orchestration/model-defaults.ts";
 
 interface ParsedAgentToken {
   name: string;
@@ -93,8 +98,22 @@ export interface DesiredThreadConfig {
   branch?: string | null;
 }
 
-const DEFAULT_MODEL = "gpt-5.4";
-const DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6";
+/**
+ * Resolve a model class from a parsed `mag.orchestration` config block. The
+ * literal `orchCfg?.model_classes` read lives here (in an adapter file) so the
+ * config-reference lint's adapter-read scan (Direction 4) sees `model_classes`
+ * as covered; the throw-on-unset logic is centralized in `resolveModelClass`.
+ */
+export function classModel(cls: ModelClass, orchCfg: Record<string, unknown> | undefined): string {
+  return resolveModelClass(orchCfg?.model_classes as Record<string, unknown> | undefined, cls);
+}
+
+/** Latest-within-class default model for a provider when no explicit model was
+ *  given (codex → codex class; claude-code → claude-sonnet). Throws when the
+ *  resolved class has no entry in the config table. */
+export function providerDefaultModel(provider: string, orchCfg: Record<string, unknown> | undefined): string {
+  return classModel(classForProvider(provider), orchCfg);
+}
 
 function normalizeWorkspacePath(ctx: AdapterContext): string {
   const raw = ctx.path && ctx.path !== "null"
@@ -217,8 +236,11 @@ function parseProviderToken(raw: string, defaultName: string, defaultModel: stri
     if (provider !== "codex" && provider !== "claude-code") {
       throw new Error(`orchestration adapter args: unsupported provider ${provider}`);
     }
-    const model = provider === "claude-code" ? DEFAULT_CLAUDE_MODEL : defaultModel;
-    return { name: defaultName, provider, model, modelExplicit: false };
+    // No concrete default baked here — bare provider tokens carry an empty
+    // model and resolve through the latest-within-class table later, in
+    // resolveAgentModel (task-c48b7beb). `defaultModel` (now "" by default) is
+    // honoured if a caller passes an explicit one.
+    return { name: defaultName, provider, model: defaultModel, modelExplicit: false };
   }
 
   if (parts.length === 2) {
@@ -239,7 +261,7 @@ function parseProviderToken(raw: string, defaultName: string, defaultModel: stri
 export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
   const args = parseArgs(raw);
   const parsed: ParsedAdapterArgs = {
-    model: DEFAULT_MODEL,
+    model: "",
     runtimeMode: "full-access",
     interactionMode: "default",
     orchestration: null,
@@ -468,8 +490,15 @@ export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
 
   // For pair mode: modelExplicit is only true when the user explicitly provided the token
   // (i.e. --coder/--reviewer flag was given) AND that token included an explicit model.
-  const coderParsed = parseProviderToken(coderToken ?? "coder:codex:gpt-5.4", "coder", parsed.model);
-  const reviewerParsed = parseProviderToken(reviewerToken ?? "reviewer:codex:gpt-5.4", "reviewer", parsed.model);
+  // When a role token is absent, the default agent is codex with an empty model
+  // (resolved through the latest-within-class table in resolveAgentModel) — no
+  // concrete version is baked into the fallback (task-c48b7beb).
+  const coderParsed = coderToken
+    ? parseProviderToken(coderToken, "coder", parsed.model)
+    : { name: "coder", provider: "codex" as T3ProviderKind, model: "", modelExplicit: false };
+  const reviewerParsed = reviewerToken
+    ? parseProviderToken(reviewerToken, "reviewer", parsed.model)
+    : { name: "reviewer", provider: "codex" as T3ProviderKind, model: "", modelExplicit: false };
   parsed.orchestration = {
     mode,
     config: orchestrationConfig,
@@ -557,7 +586,7 @@ async function ensureThread(
   desired: DesiredThreadConfig,
   existingRecord: T3CodeThreadRecord | null | undefined,
 ): Promise<T3CodeThreadRecord> {
-  const model = desired.model || DEFAULT_MODEL;
+  const model = desired.model || classModel("codex", loadConfigOrchestration());
   const createdAt = isoNow();
 
   const existingThread = existingRecord ? findThread(snapshot, existingRecord.threadId) : null;
@@ -698,7 +727,7 @@ async function startSingleThread(
 
   return await withClient(record, async (client) => {
     const snapshot = await client.getSnapshot();
-    const defaultModelSelection: T3ModelSelection = { provider: "codex", model: options.model || DEFAULT_MODEL };
+    const defaultModelSelection: T3ModelSelection = { provider: "codex", model: options.model || classModel("codex", loadConfigOrchestration()) };
     const projectId = await ensureProject(client, snapshot, workspaceRoot, defaultModelSelection);
     const threadRecord = await ensureThread(
       client,
@@ -729,8 +758,6 @@ function loadConfigOrchestration(config?: LudicsFullConfig): Record<string, unkn
     return undefined;
   }
 }
-
-const CLAUDE_OPUS_MODEL = "claude-opus-4-6";
 
 /**
  * Thrown by `selectOrchestrationFlags()` when the t3code integration is paused
@@ -809,7 +836,7 @@ export function selectOrchestrationFlags(
   // `tiny` effort implies solo mode unconditionally (ignores orchCfg.default_mode).
   // Single coder, no pre-work phases, Sonnet for claude-code providers.
   if (norm === "tiny") {
-    const modelSuffix = coder === "claude-code" ? `:${DEFAULT_CLAUDE_MODEL}` : "";
+    const modelSuffix = coder === "claude-code" ? `:${classModel("claude-sonnet", orchCfg)}` : "";
     const args = `--solo --coder ${coder}${modelSuffix}`;
     return { adapter: resolvedAdapter, args, isDuo: false };
   }
@@ -817,13 +844,15 @@ export function selectOrchestrationFlags(
   const phaseFlags: string[] = [];
 
   // Only apply effort-based model selection for Claude providers; other providers
-  // use their own defaults (Codex picks gpt-5.4, etc.).
+  // (codex) carry no suffix and resolve their latest-within-class default later
+  // in resolveAgentModel. claude-code coders resolve to the opus class for
+  // medium/large effort, the sonnet class otherwise (task-c48b7beb).
   let coderModelSuffix = "";
   if (coder === "claude-code") {
     if (norm === "large" || norm === "medium") {
-      coderModelSuffix = `:${CLAUDE_OPUS_MODEL}`;
+      coderModelSuffix = `:${classModel("claude-opus", orchCfg)}`;
     } else {
-      coderModelSuffix = `:${DEFAULT_CLAUDE_MODEL}`;
+      coderModelSuffix = `:${classModel("claude-sonnet", orchCfg)}`;
     }
   }
 
@@ -868,8 +897,10 @@ export function selectOrchestrationFlagsForTask(
   return selectOrchestrationFlags(effort, config, { skipPlan });
 }
 
-/** Resolve the final model for an agent, applying config and adapter arg overrides. */
-function resolveAgentModel(
+/** Resolve the final model for an agent, applying config and adapter arg overrides.
+ *  Exported as a test seam: the latest-within-class fallback tier is the runtime
+ *  path that must throw loudly when the config table is missing a tracked class. */
+export function resolveAgentModel(
   agent: ParsedAgentToken,
   index: number,
   orchCfg: Record<string, unknown> | undefined,
@@ -896,8 +927,14 @@ function resolveAgentModel(
     if (cfgModel?.trim()) return cfgModel.trim();
   }
 
-  // Fallback: provider default from --coder / --reviewer token
-  return agent.model;
+  // Explicit-but-unflagged token model (e.g. `--coder claude-code:some-model`
+  // already handled above via modelExplicit; this guards any non-empty model).
+  if (agent.model.trim()) return agent.model;
+
+  // Lowest tier: latest-within-class default from the config table. Throws
+  // loudly when the resolved class is unset (task-c48b7beb) — replaces the old
+  // pinned DEFAULT_MODEL / DEFAULT_CLAUDE_MODEL constants.
+  return providerDefaultModel(agent.provider, orchCfg);
 }
 
 /** Resolve effort level for an agent, applying config and adapter arg overrides. Defaults to "high". */
@@ -969,6 +1006,19 @@ async function startOrchestratedThreads(
     };
   }
 
+  // Resolve models up-front, BEFORE createWorktrees, so a missing/blank
+  // model_classes entry throws loudly before any worktree / thread / runner
+  // side effect is created (task-c48b7beb).
+  const resolvedModels = orchestration.agents.map((agent, index) =>
+    resolveAgentModel(
+      agent,
+      index,
+      orchCfg,
+      orchestration.coderModelOverride,
+      orchestration.reviewerModelOverride,
+    ),
+  );
+
   const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
 
@@ -976,13 +1026,7 @@ async function startOrchestratedThreads(
     name: agent.name,
     provider: agent.provider,
     role: agent.role,
-    model: resolveAgentModel(
-      agent,
-      index,
-      orchCfg,
-      orchestration.coderModelOverride,
-      orchestration.reviewerModelOverride,
-    ),
+    model: resolvedModels[index]!,
     thinkingEffort: resolveAgentThinkingEffort(
       agent,
       index,
@@ -1011,10 +1055,10 @@ async function startOrchestratedThreads(
 
   const slotThreads = await withClient(record, async (client) => {
     const snapshot = await client.getSnapshot();
-    const firstAgent = orchestration.agents[0];
+    const firstAgent = agents[0];
     const defaultModelSelection: T3ModelSelection = {
       provider: firstAgent?.provider ? toWireProvider(firstAgent.provider) : "codex",
-      model: firstAgent?.model ?? options.model ?? DEFAULT_MODEL,
+      model: firstAgent?.model ?? options.model ?? classModel("codex", orchCfg),
     };
     const projectId = await ensureProject(client, snapshot, projectDir, defaultModelSelection);
     const created: T3CodeThreadRecord[] = [];

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -115,6 +115,23 @@ export function providerDefaultModel(provider: string, orchCfg: Record<string, u
   return classModel(classForProvider(provider), orchCfg);
 }
 
+/**
+ * Codex-class default for the NON-orchestration single-thread t3code path.
+ * Unlike `classModel()`, this never throws: a plain `slot start` against a
+ * minimal/legacy config that lacks the orchestration-only `model_classes`
+ * table must still open (it previously used a built-in codex default), so an
+ * absent table degrades to "" — letting the provider/codex CLI pick its own
+ * default rather than failing the start. The loud missing-table throw is
+ * reserved for orchestration default resolution (`resolveAgentModel` /
+ * `selectOrchestrationFlags`), where the table is the documented source of
+ * truth. Exported as a test seam.
+ */
+export function singleThreadCodexModel(orchCfg: Record<string, unknown> | undefined): string {
+  const table = orchCfg?.model_classes as Record<string, unknown> | undefined;
+  const v = table?.codex;
+  return typeof v === "string" && v.trim() ? v.trim() : "";
+}
+
 function normalizeWorkspacePath(ctx: AdapterContext): string {
   const raw = ctx.path && ctx.path !== "null"
     ? ctx.path
@@ -586,7 +603,7 @@ async function ensureThread(
   desired: DesiredThreadConfig,
   existingRecord: T3CodeThreadRecord | null | undefined,
 ): Promise<T3CodeThreadRecord> {
-  const model = desired.model || classModel("codex", loadConfigOrchestration());
+  const model = desired.model || singleThreadCodexModel(loadConfigOrchestration());
   const createdAt = isoNow();
 
   const existingThread = existingRecord ? findThread(snapshot, existingRecord.threadId) : null;
@@ -727,7 +744,7 @@ async function startSingleThread(
 
   return await withClient(record, async (client) => {
     const snapshot = await client.getSnapshot();
-    const defaultModelSelection: T3ModelSelection = { provider: "codex", model: options.model || classModel("codex", loadConfigOrchestration()) };
+    const defaultModelSelection: T3ModelSelection = { provider: "codex", model: options.model || singleThreadCodexModel(loadConfigOrchestration()) };
     const projectId = await ensureProject(client, snapshot, workspaceRoot, defaultModelSelection);
     const threadRecord = await ensureThread(
       client,

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -603,3 +603,34 @@ describe("tmux adapter cold-start CWD", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// task-c48b7beb — tmux resolveAgentModel resolves the latest-within-class
+// default via the shared providerDefaultModel, with the same override
+// precedence and the same loud failure as the t3code adapter.
+// ---------------------------------------------------------------------------
+describe("tmux resolveAgentModel — latest-within-class default", () => {
+  const TABLE = { codex: "gpt-5.5", "claude-opus": "claude-opus-4-8", "claude-sonnet": "claude-sonnet-4-6" };
+  const bareCodex = { name: "reviewer", provider: "codex", model: "", modelExplicit: false, role: "reviewer" as const };
+
+  test("bare codex agent with no overrides resolves to the table's codex value", async () => {
+    const { resolveAgentModel } = await import("./tmux-adapter.ts");
+    // Harness: no flag override, no reviewer_model config — only the table.
+    // Mutation: dropping the providerDefaultModel tier returns "" instead.
+    expect(resolveAgentModel(bareCodex, 1, { model_classes: TABLE }, undefined, undefined)).toBe("gpt-5.5");
+  });
+
+  test("non-blank reviewer_model config still wins over the class default", async () => {
+    const { resolveAgentModel } = await import("./tmux-adapter.ts");
+    expect(
+      resolveAgentModel(bareCodex, 1, { reviewer_model: "cfg-rev", model_classes: TABLE }, undefined, undefined),
+    ).toBe("cfg-rev");
+  });
+
+  test("throws loudly when the resolved class is absent from the table", async () => {
+    const { resolveAgentModel } = await import("./tmux-adapter.ts");
+    expect(() => resolveAgentModel(bareCodex, 1, { model_classes: {} }, undefined, undefined)).toThrow(
+      /mag\.orchestration\.model_classes\.codex is required/,
+    );
+  });
+});

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -36,7 +36,7 @@ import { createWorktrees, symlinkPeerSync } from "../orchestration/worktrees.ts"
 import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/deferred-cleanup.ts";
 import { isoNow, nowEpoch } from "../orchestration/util.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
-import { parseOrchestrationAdapterArgs } from "./t3code.ts";
+import { parseOrchestrationAdapterArgs, providerDefaultModel } from "./t3code.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -201,7 +201,7 @@ interface ParsedAgentToken {
   role?: "coder" | "reviewer";
 }
 
-function resolveAgentModel(
+export function resolveAgentModel(
   agent: ParsedAgentToken,
   index: number,
   orchCfg: Record<string, unknown> | undefined,
@@ -221,7 +221,10 @@ function resolveAgentModel(
     const cfgModel = orchCfg?.reviewer_model as string | undefined;
     if (cfgModel?.trim()) return cfgModel.trim();
   }
-  return agent.model;
+  if (agent.model.trim()) return agent.model;
+  // Lowest tier: latest-within-class default from the config table (shared with
+  // t3code). Throws loudly when the resolved class is unset (task-c48b7beb).
+  return providerDefaultModel(agent.provider, orchCfg);
 }
 
 function resolveAgentThinkingEffort(
@@ -591,6 +594,18 @@ async function start(ctx: AdapterContext): Promise<string> {
     };
   }
 
+  // Resolve models up-front, BEFORE createWorktrees / tmux sessions, so a
+  // missing/blank model_classes entry throws before any side effect (task-c48b7beb).
+  const resolvedModels = orchestration.agents.map((agent, index) =>
+    resolveAgentModel(
+      agent as ParsedAgentToken,
+      index,
+      orchCfg,
+      orchestration.coderModelOverride,
+      orchestration.reviewerModelOverride,
+    ),
+  );
+
   const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
 
@@ -598,13 +613,7 @@ async function start(ctx: AdapterContext): Promise<string> {
     name: agent.name,
     provider: agent.provider,
     role: agent.role,
-    model: resolveAgentModel(
-      agent as ParsedAgentToken,
-      index,
-      orchCfg,
-      orchestration.coderModelOverride,
-      orchestration.reviewerModelOverride,
-    ),
+    model: resolvedModels[index]!,
     thinkingEffort: resolveAgentThinkingEffort(
       agent as ParsedAgentToken,
       index,

--- a/src/orchestration-defaults.test.ts
+++ b/src/orchestration-defaults.test.ts
@@ -202,7 +202,8 @@ describe("AC 13a asymmetry pin — selectOrchestrationFlags coerces explicit nul
   test("default_coder: null in fake config → --coder claude-code", async () => {
     const { selectOrchestrationFlags } = await import("./adapters/t3code.ts");
     const fakeConfig = {
-      mag: { orchestration: { default_coder: null, default_reviewer: null } },
+      // task-c48b7beb: claude-code coder resolution now reads the class table.
+      mag: { orchestration: { default_coder: null, default_reviewer: null, model_classes: { codex: "gpt-5.5", "claude-opus": "claude-opus-4-8", "claude-sonnet": "claude-sonnet-4-6" } } },
     } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
     const { args } = selectOrchestrationFlags("tiny", fakeConfig);
     // Asymmetry: null at the YAML layer collapses to the hard-coded literal.
@@ -213,7 +214,7 @@ describe("AC 13a asymmetry pin — selectOrchestrationFlags coerces explicit nul
   test("default_reviewer: null in fake config → --reviewer codex on non-tiny effort", async () => {
     const { selectOrchestrationFlags } = await import("./adapters/t3code.ts");
     const fakeConfig = {
-      mag: { orchestration: { default_coder: null, default_reviewer: null, default_mode: "pair" } },
+      mag: { orchestration: { default_coder: null, default_reviewer: null, default_mode: "pair", model_classes: { codex: "gpt-5.5", "claude-opus": "claude-opus-4-8", "claude-sonnet": "claude-sonnet-4-6" } } },
     } as unknown as Parameters<typeof selectOrchestrationFlags>[1];
     const { args } = selectOrchestrationFlags("medium", fakeConfig);
     expect(args).toContain("--reviewer codex");

--- a/src/orchestration/model-defaults.test.ts
+++ b/src/orchestration/model-defaults.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TRACKED_MODEL_CLASSES,
+  classForProvider,
+  resolveModelClass,
+  type ModelClass,
+} from "./model-defaults.ts";
+
+// A fully-populated table — the positive control for each per-class throw test.
+const FULL_TABLE: Record<string, string> = {
+  codex: "gpt-5.5",
+  "claude-opus": "claude-opus-4-8",
+  "claude-sonnet": "claude-sonnet-4-6",
+};
+
+describe("resolveModelClass — returns the configured value", () => {
+  test("returns the table value for each tracked class", () => {
+    expect(resolveModelClass(FULL_TABLE, "codex")).toBe("gpt-5.5");
+    expect(resolveModelClass(FULL_TABLE, "claude-opus")).toBe("claude-opus-4-8");
+    expect(resolveModelClass(FULL_TABLE, "claude-sonnet")).toBe("claude-sonnet-4-6");
+  });
+
+  test("trims surrounding whitespace from a configured value", () => {
+    expect(resolveModelClass({ codex: "  gpt-5.5  " }, "codex")).toBe("gpt-5.5");
+  });
+});
+
+describe("resolveModelClass — fails loudly when a tracked class is unset (AC3)", () => {
+  // AC3: a test fails loudly if a tracked class has no resolved model in the
+  // config table. Harness condition: the table is constructed to OMIT exactly
+  // the class under test (or set it blank/non-string), so the assertion only
+  // passes because the throw fired for THAT class — not because some other key
+  // is missing. Mutation: deleting the `throw` in resolveModelClass makes it
+  // return undefined, so every `toThrow` below flips to a failure.
+
+  test("throws when the whole table is undefined", () => {
+    expect(() => resolveModelClass(undefined, "codex")).toThrow(
+      /mag\.orchestration\.model_classes\.codex is required/,
+    );
+  });
+
+  test("throws when the whole table is empty", () => {
+    expect(() => resolveModelClass({}, "claude-opus")).toThrow(
+      /mag\.orchestration\.model_classes\.claude-opus is required/,
+    );
+  });
+
+  // Per-class enumeration (AC names three tracked classes): each must throw
+  // when ITS OWN key is the one missing, with the other two present.
+  for (const cls of TRACKED_MODEL_CLASSES) {
+    test(`throws for missing key "${cls}" with the other classes present`, () => {
+      const partial: Record<string, string> = { ...FULL_TABLE };
+      delete partial[cls];
+      // Positive control: the present classes still resolve.
+      for (const other of TRACKED_MODEL_CLASSES) {
+        if (other === cls) continue;
+        expect(resolveModelClass(partial, other)).toBe(FULL_TABLE[other]);
+      }
+      // The omitted class throws, naming its own full key.
+      expect(() => resolveModelClass(partial, cls)).toThrow(
+        new RegExp(`mag\\.orchestration\\.model_classes\\.${cls} is required`),
+      );
+    });
+  }
+
+  test("throws for a blank value", () => {
+    expect(() => resolveModelClass({ codex: "" }, "codex")).toThrow(/is required/);
+  });
+
+  test("throws for a whitespace-only value", () => {
+    expect(() => resolveModelClass({ codex: "   " }, "codex")).toThrow(/is required/);
+  });
+
+  test("throws for a non-string value", () => {
+    expect(() => resolveModelClass({ codex: 123 as unknown as string }, "codex")).toThrow(
+      /is required/,
+    );
+    expect(() => resolveModelClass({ codex: null as unknown as string }, "codex")).toThrow(
+      /is required/,
+    );
+  });
+});
+
+describe("classForProvider", () => {
+  test("codex provider → codex class", () => {
+    expect(classForProvider("codex")).toBe<ModelClass>("codex");
+  });
+
+  test("claude-code provider → claude-sonnet class (generic claude default)", () => {
+    expect(classForProvider("claude-code")).toBe<ModelClass>("claude-sonnet");
+  });
+
+  test("unknown provider falls to claude-sonnet (non-codex default)", () => {
+    expect(classForProvider("whatever")).toBe<ModelClass>("claude-sonnet");
+  });
+});

--- a/src/orchestration/model-defaults.ts
+++ b/src/orchestration/model-defaults.ts
@@ -1,0 +1,54 @@
+// Latest-within-class default-model resolution for orchestration (task-c48b7beb).
+//
+// The per-class "latest" mapping is the SINGLE SOURCE OF TRUTH in the global
+// config file under `mag.orchestration.model_classes` — NOT a hardcoded
+// constant. The resolver below reads that table and THROWS LOUDLY when a
+// tracked class is missing, blank, or non-string, so staleness /
+// misconfiguration surfaces immediately (before any orchestration side
+// effect) rather than silently running a stale pin.
+//
+// HOW TO BUMP: when a new minor ships, edit the value in `config.yaml`
+// (`mag.orchestration.model_classes.<class>`). That is a config edit, not a
+// code change — see templates/config.reference.yaml for the documented table.
+
+/** The model classes resolved from `mag.orchestration.model_classes`. Provider
+ *  is NOT class: `claude-code` resolves to `claude-opus` (medium/large coder)
+ *  or `claude-sonnet` (tiny/small coder + the generic claude default). */
+export const TRACKED_MODEL_CLASSES = ["codex", "claude-opus", "claude-sonnet"] as const;
+export type ModelClass = (typeof TRACKED_MODEL_CLASSES)[number];
+
+/**
+ * Resolve the latest-within-class model for `cls` from the
+ * `mag.orchestration.model_classes` table. Throws a clear, actionable error
+ * naming the full config key when the table is absent, the class key is
+ * missing, or the value is non-string / blank / whitespace-only.
+ *
+ * The throw is deliberate (AC3): the config table is the single source of
+ * truth, so an unset tracked class is a configuration error that must fail
+ * loudly, never a silent fallback to a built-in default (which would
+ * reintroduce the staleness this task removes).
+ *
+ * @param table the parsed `mag.orchestration.model_classes` object (i.e.
+ *              `orchCfg?.model_classes`), or undefined when absent.
+ */
+export function resolveModelClass(
+  table: Record<string, unknown> | undefined,
+  cls: ModelClass,
+): string {
+  const v = table?.[cls];
+  if (typeof v === "string" && v.trim()) return v.trim();
+  throw new Error(
+    `mag.orchestration.model_classes.${cls} is required — set the latest ${cls} ` +
+      `model in config.yaml (see templates/config.reference.yaml).`,
+  );
+}
+
+/**
+ * Map a provider to its default model class when no explicit model is given.
+ * `codex` → `codex`; everything else (`claude-code`) → `claude-sonnet`, the
+ * generic claude default. Effort-specific Opus selection for `claude-code`
+ * coders happens earlier, in `selectOrchestrationFlags`.
+ */
+export function classForProvider(provider: string): ModelClass {
+  return provider === "codex" ? "codex" : "claude-sonnet";
+}

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -37,8 +37,16 @@ slots:
   count: 2
 `;
   if (t3codeEnabled) {
+    // task-c48b7beb: selectOrchestrationFlags resolves the claude-code coder
+    // model through mag.orchestration.model_classes and throws when a tracked
+    // class is absent, so the auto-fill config must carry the table.
     yaml += `mag:
   t3code_integration_enabled: true
+  orchestration:
+    model_classes:
+      codex: gpt-5.5
+      claude-opus: claude-opus-4-8
+      claude-sonnet: claude-sonnet-4-6
 `;
   }
   if (cluster) {

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -116,10 +116,22 @@ mag:
     default_mode: pair           # pair = one slot per task; duo = hierarchical duo (two pair slots per task with swapped roles)
     default_coder: claude-code   # Default coder provider for auto-selected sessions: claude-code | codex
     default_reviewer: codex      # Default reviewer provider for auto-selected sessions: codex | claude-code
-    coder_model: ""              # Model ID for the coder agent (e.g. claude-opus-4-6); empty = provider default
+    coder_model: ""              # Model ID for the coder agent (e.g. claude-opus-4-8); empty = provider default
     reviewer_model: ""           # Model ID for the reviewer agent; empty = provider default
     coder_effort: "high"         # Effort level for the coder: low | medium | high | xhigh | max; default: high
     reviewer_effort: "high"      # Effort level for the reviewer: low | medium | high | xhigh | max; default: high
+    # Latest-within-class default models — the SINGLE SOURCE OF TRUTH for the
+    # model an unspecified orchestration session runs. HOW TO BUMP: when a new
+    # minor ships, change the value here — this is a config edit, NOT a code
+    # change. A missing/blank tracked class FAILS LOUDLY at session start,
+    # before any worktree/session is created (resolveModelClass in
+    # src/orchestration/model-defaults.ts). Provider is not class: a
+    # claude-code coder resolves to claude-opus for medium/large effort and
+    # claude-sonnet otherwise; codex coder/reviewer resolve to the codex class.
+    model_classes:
+      codex: gpt-5.5                    # latest GPT-5 (codex coder/reviewer default)
+      claude-opus: claude-opus-4-8      # latest Opus 4 (medium/large claude-code coder)
+      claude-sonnet: claude-sonnet-4-6  # latest Sonnet 4 (tiny/small coder + claude-code default)
     # Unified ladder — same rung means same relative budget across providers.
     # Per-provider CLI/wire mapping:
     #   unified  | claude-code --effort | codex model_reasoning_effort

--- a/templates/harness/config.yaml
+++ b/templates/harness/config.yaml
@@ -44,6 +44,14 @@ mag:
   session: ludics-mag
   ttyd_port: 7679
 
+  # Orchestration default models — bump a value when a new minor ships (config
+  # edit, not a code change). A missing/blank class fails loudly at session start.
+  orchestration:
+    model_classes:
+      codex: gpt-5.5
+      claude-opus: claude-opus-4-8
+      claude-sonnet: claude-sonnet-4-6
+
   autonomy_level:
     elaborate_tasks: auto
     infer_dependencies: auto


### PR DESCRIPTION
## Summary

Orchestration sessions that start with no explicit model previously inherited hardcoded minor-version pins in `src/adapters/t3code.ts` (`DEFAULT_MODEL = "gpt-5.4"`, `CLAUDE_OPUS_MODEL = "claude-opus-4-6"`, fallback tokens `coder:codex:gpt-5.4` / `reviewer:codex:gpt-5.4`). These went stale as new minors shipped. This implements **approach B** from the proposal: a single per-class `model_classes` table in `config.yaml` under `mag.orchestration` is the source of truth, and the code resolves each unspecified default by reading it — so bumping a class is a config edit, not a code change.

Implements `docs/proposals/resolve-default-models-latest-within-class.md` (task-c48b7beb).

## What changed

- **New `src/orchestration/model-defaults.ts`** — `TRACKED_MODEL_CLASSES`, `resolveModelClass(table, cls)` (throws loudly on missing/blank/non-string — no silent fallback), `classForProvider`.
- **`src/adapters/t3code.ts`** — removed the three pinned constants + two fallback tokens; `classModel`/`providerDefaultModel` read `orchCfg?.model_classes` (the `lint:config-reference` adapter-read seam); `resolveAgentModel`'s lowest tier resolves the table (below every `task-1fbd4edf` override); `selectOrchestrationFlags` sources the claude-code suffix from the table; models are **pre-resolved before `createWorktrees`** so a missing class throws before any side effect.
- **`src/adapters/tmux-adapter.ts`** — shares the resolver via `providerDefaultModel`; same pre-resolve ordering.
- **`templates/config.reference.yaml` + `templates/harness/config.yaml`** — documented `model_classes` table (codex→gpt-5.5, claude-opus→claude-opus-4-8, claude-sonnet→claude-sonnet-4-6) + a "how to bump" comment.
- **Single-thread carve-out** (codex review follow-up, c8537d3) — the loud missing-table throw is reserved for orchestration resolution; the non-orchestration `slot start` path uses `singleThreadCodexModel()`, which degrades to the provider default (never throws, no hardcoded version) so minimal/legacy configs without the table still open.

## Precedence (unchanged, no regression)

adapter-arg flag (`--coder-model`/`--reviewer-model`) > explicit token model > `coder_model`/`reviewer_model` config > **`model_classes` table** > provider default.

## Tests

- `src/orchestration/model-defaults.test.ts` — per-class loud-failure enumeration (missing/blank/whitespace/non-string).
- `src/adapters/t3code.test.ts` — precedence ladder, runtime-path throw, table-sourced suffix, empty fallback tokens, single-thread non-throwing carve-out.
- `src/adapters/tmux-adapter.test.ts` — shared resolver parity + loud failure.
- `scripts/lint-config-reference.test.ts` — `model_classes` covered (not inert) against the live repo.
- Full suite: **2878 pass / 0 fail**; all lints + typecheck + build green. Stale-version and constants-name greps clean in non-test `src/`.

## Verification

`orch status` evidence for a no-explicit-model session resolving from the config table: coder `claude-code` → `claude-opus-4-8`, reviewer `codex` → `gpt-5.5` (tiny → `claude-sonnet-4-6`).

> Note: the live state-repo `config.yaml` (`~/<state-repo>/harness/config.yaml`) must carry the `model_classes` block for the running harness; the deployed config in this environment was updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)