### PR TITLE
feat(orchestration): add user-piloted "pilot" workflow mode

### DIFF
--- a/skills/orchestration/pilot-work.md
+++ b/skills/orchestration/pilot-work.md
@@ -1,0 +1,40 @@
+# Pilot Work (Coder, user-piloted)
+
+{{PROPOSAL_INSTRUCTION}}
+
+This is a **user-piloted** session. The user will attach to this interactive session and drive the work with you by chatting. Do **NOT** begin implementing on your own.
+
+First, read the proposal / task spec below so you understand the goal and the working directory (`{{WORKTREE_PATH}}`):
+
+{{TASK_SPEC}}
+
+{{#IF PROPOSAL_PATH}}
+Read `{{PROPOSAL_PATH}}` (proposal + acceptance criteria) as part of your orientation.
+{{/IF}}
+
+Then **wait for the user**. They will attach to this session and tell you what to do. Collaborate with them interactively:
+- Answer questions, propose approaches, and make the edits they direct.
+- Commit in small batches and run targeted tests/build/lint as appropriate, but follow the user's lead on scope and pace — do not race ahead.
+- It is normal and expected for this session to sit idle while you wait for the user to respond. The harness will not nudge or force-settle you during this phase, so simply wait patiently when there is nothing to do.
+
+Before modifying any symbol, re-run a project-wide grep for it — including inline reimplementations (regex patterns, copy-pasted logic) — and handle any occurrences rather than deferring.
+
+Write any PR URL to `{{PR_FILE}}`. Stop if `{{INTERRUPT_FILE}}` appears.
+
+**Only when the user explicitly confirms the task is finished**, write the done-signal status file to end the work phase. After that, the workflow continues automatically (update-docs → pr-create → pr-comments → final-merge → done):
+
+```sh
+printf '%s|%s|coder work complete\n' '{{DONE_STATUS}}' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+If the user decides the task is obsolete (nothing meaningful to do), signal bail-out instead — it is terminal and transitions straight to `done`:
+
+```sh
+printf 'bail-out|%s|<describe why task is obsolete>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```
+
+If you and the user hit a contradictory or looping situation that ordinary progress can't escape, raise your hand with escalate — the runner halts at the current phase and notifies the user. See [escalation contract](../../docs/orchestration-patterns.md#escalation-contract).
+
+```sh
+printf 'escalate|%s|<one-sentence reason>\n' "$(date +%s)" > "{{STATUS_FILE}}"
+```

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -452,6 +452,62 @@ describe("selectOrchestrationFlagsForTask — skip_plan from frontmatter", () =>
   });
 });
 
+describe("selectOrchestrationFlagsForTask — orchestration_mode: pilot override", () => {
+  // gh-ludics-539: flag on so the t3code-adapter gate does not throw.
+  const cfg = installT3codeConfigHarness();
+  beforeEach(() => cfg.write({ t3codeEnabled: true }));
+
+  test("orchestration_mode: pilot yields --pilot args with a coder, isDuo false", () => {
+    const content = "---\nid: test\ntitle: test\neffort: medium\norchestration_mode: pilot\n---\n";
+    const { args, isDuo } = selectOrchestrationFlagsForTask(content, "medium");
+    expect(args).toContain("--pilot");
+    expect(args).toContain("--coder");
+    expect(args).not.toContain("--solo");
+    expect(args).not.toContain("--pair");
+    expect(args).not.toContain("--reviewer");
+    expect(args).not.toContain("--plan");
+    expect(args).not.toContain("--gather");
+    expect(isDuo).toBe(false);
+  });
+
+  test("pilot override ignores effort (large still produces --pilot, no pre-work phases)", () => {
+    const content = "---\nid: test\ntitle: test\neffort: large\norchestration_mode: pilot\n---\n";
+    const { args, isDuo } = selectOrchestrationFlagsForTask(content, "large");
+    expect(args).toContain("--pilot");
+    expect(args).not.toContain("--plan");
+    expect(args).not.toContain("--gather");
+    expect(isDuo).toBe(false);
+  });
+
+  test("absent orchestration_mode falls through to normal effort-based selection", () => {
+    const content = "---\nid: test\ntitle: test\neffort: medium\n---\n";
+    const { args } = selectOrchestrationFlagsForTask(content, "medium");
+    expect(args).not.toContain("--pilot");
+    expect(args).toContain("--pair");
+  });
+});
+
+describe("parseOrchestrationAdapterArgs — --pilot", () => {
+  test("parses --pilot with --coder into a single-agent pilot orchestration", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pilot --coder coder:claude-code:claude-sonnet-4-6");
+    expect(parsed.orchestration).not.toBeNull();
+    expect(parsed.orchestration!.mode).toBe("pilot");
+    expect(parsed.orchestration!.agents).toHaveLength(1);
+    expect(parsed.orchestration!.agents[0]!.role).toBe("coder");
+    expect(parsed.orchestration!.agents[0]!.provider).toBe("claude-code");
+  });
+
+  test("--pilot without --coder throws", () => {
+    expect(() => parseOrchestrationAdapterArgs("--pilot")).toThrow(/--pilot requires --coder/);
+  });
+
+  test("--pilot combined with --reviewer throws", () => {
+    expect(() =>
+      parseOrchestrationAdapterArgs("--pilot --coder claude-code --reviewer codex")
+    ).toThrow(/--pilot is incompatible with --reviewer/);
+  });
+});
+
 describe("parseOrchestrationAdapterArgs — --solo", () => {
   test("parses --solo with --coder into a single-agent orchestration", () => {
     // Token format: name:provider:model

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -65,7 +65,7 @@ interface ParsedAgentToken {
 }
 
 interface ParsedOrchestrationArgs {
-  mode: "duo" | "pair" | "solo";
+  mode: "duo" | "pair" | "solo" | "pilot";
   config: Partial<OrchestrationConfig>;
   agents: ParsedAgentToken[];
   /** Explicit coder model override from --coder-model flag. */
@@ -351,6 +351,11 @@ export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
       case "--solo":
         mode = "solo";
         break;
+      case "--pilot":
+        // User-piloted solo: identical single-coder/no-reviewer shape as --solo;
+        // differs only in the work-phase prompt and idle-wait behavior.
+        mode = "pilot";
+        break;
       case "--agent":
         // Legacy duo --agent flag is no longer supported; use --coder/--reviewer instead.
         throw new Error("orchestration adapter args: --agent is no longer supported (duo mode now uses --coder/--reviewer). Use --coder and --reviewer instead.");
@@ -476,22 +481,25 @@ export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
 
   if (!mode) return parsed;
 
-  if (mode === "solo") {
+  if (mode === "solo" || mode === "pilot") {
+    // Pilot shares solo's single-coder/no-reviewer invariants verbatim; the
+    // flag name in error messages tracks the mode the user actually passed.
+    const flag = mode === "pilot" ? "--pilot" : "--solo";
     if (!coderToken) {
-      throw new Error("orchestration adapter args: --solo requires --coder provider[:model[:name]]");
+      throw new Error(`orchestration adapter args: ${flag} requires --coder provider[:model[:name]]`);
     }
     if (reviewerToken) {
-      throw new Error("orchestration adapter args: --solo is incompatible with --reviewer");
+      throw new Error(`orchestration adapter args: ${flag} is incompatible with --reviewer`);
     }
     if (duoPeerSlot != null) {
-      throw new Error("orchestration adapter args: --solo is incompatible with --duo-peer-slot");
+      throw new Error(`orchestration adapter args: ${flag} is incompatible with --duo-peer-slot`);
     }
     if (reviewerOnlyFlag) {
-      throw new Error(`orchestration adapter args: --solo is incompatible with ${reviewerOnlyFlag} (no reviewer exists in solo mode)`);
+      throw new Error(`orchestration adapter args: ${flag} is incompatible with ${reviewerOnlyFlag} (no reviewer exists in ${mode} mode)`);
     }
     const coderParsed = parseProviderToken(coderToken, "coder", parsed.model);
     parsed.orchestration = {
-      mode: "solo",
+      mode,
       config: orchestrationConfig,
       agents: [
         { ...coderParsed, role: "coder", modelExplicit: coderParsed.modelExplicit },
@@ -910,7 +918,25 @@ export function selectOrchestrationFlagsForTask(
   effort: string,
   config?: LudicsFullConfig,
 ): { adapter: string; args: string; isDuo: boolean } {
-  const skipPlan = parseTaskFrontmatter(taskContent).skip_plan === true;
+  const fm = parseTaskFrontmatter(taskContent);
+
+  // Explicit pilot override: `orchestration_mode: pilot` forces a user-piloted
+  // solo session regardless of effort. Single coder, no reviewer, no pre-work
+  // phases (no --plan/--gather) — modeled on the tiny/solo branch but emitting
+  // --pilot instead of --solo. The work phase waits for the user.
+  if ((fm.orchestration_mode ?? "").toString().trim() === "pilot") {
+    const resolvedAdapter = globalAdapter();
+    if (resolvedAdapter === "t3code" && !t3codeIntegrationEnabled()) {
+      throw new T3codeIntegrationPausedError();
+    }
+    const orchCfg = loadConfigOrchestration(config);
+    const coder = (orchCfg?.default_coder as string | undefined)?.trim() || "claude-code";
+    const modelSuffix = coder === "claude-code" ? `:${classModel("claude-sonnet", orchCfg)}` : "";
+    const args = `--pilot --coder ${coder}${modelSuffix}`;
+    return { adapter: resolvedAdapter, args, isDuo: false };
+  }
+
+  const skipPlan = fm.skip_plan === true;
   return selectOrchestrationFlags(effort, config, { skipPlan });
 }
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -72,7 +72,7 @@ interface TmuxSlotState {
   ttydRestartCounts?: Record<string, TtydRestartRecord>;
   orchestration?: {
     stateFile: string;
-    mode: "duo" | "pair" | "solo";
+    mode: "duo" | "pair" | "solo" | "pilot";
     pid?: number;
   };
 }

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -426,6 +426,38 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
       }
     }
 
+    // API: approve a deferred task in PILOT mode. Forces orchestration_mode:
+    // pilot (a user-piloted solo session) regardless of effort-based selection,
+    // then sets status: ready so the keepalive auto-start picks it up and
+    // selectOrchestrationFlagsForTask emits --pilot.
+    if (pathname === "/api/deferred-pilot") {
+      const taskParam = url.searchParams.get("task");
+      if (!taskParam || !TASK_ID_RE.test(taskParam)) {
+        return new Response("Bad Request: invalid task id", { status: 400 });
+      }
+      try {
+        const resolved = resolveTaskFile(taskParam);
+        if ("error" in resolved) return resolved.error;
+        const taskFile = resolved.path;
+        const pilotContent = readFileSync(taskFile, "utf-8");
+        const pilotStatus = parseTaskFrontmatter(pilotContent).status;
+        if (pilotStatus !== "deferred") {
+          return new Response(
+            JSON.stringify({ error: `task is ${pilotStatus}, not deferred` }),
+            { status: 409, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        addFrontmatterField(taskFile, "orchestration_mode", "pilot");
+        updateFrontmatterField(taskFile, "status", "ready");
+        lastGenerated = 0;
+        return new Response(JSON.stringify({ status: "approved", mode: "pilot" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      } catch (e) {
+        return new Response(String(e), { status: 500 });
+      }
+    }
+
     // API: abandon a deferred task. Slotted deferred tasks are rejected
     // with 409 — the user must clear the slot first (slot operations'
     // terminal transitions handle displaced-task recovery via

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1432,6 +1432,37 @@ describe("dashboard HTTP /api/stale-revive and /api/stale-abandon (AC 10)", () =
     // assertion, even if a future regression somehow preserved `task`).
     expect(readFileSync(slotFile, "utf-8")).toBe(slotBefore);
   });
+
+  test("POST /api/deferred-pilot sets orchestration_mode: pilot AND status: ready", async () => {
+    // Harness condition: a deferred task. The endpoint forces pilot mode and
+    // de-defers so the keepalive auto-start picks it up.
+    const file = writeTask("task-deferred-pilot", "deferred");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/deferred-pilot?task=task-deferred-pilot"));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { status: string; mode: string };
+    expect(body.status).toBe("approved");
+    expect(body.mode).toBe("pilot");
+    // Invariant: BOTH frontmatter fields are written. Mutation: drop either
+    // the addFrontmatterField or the status flip and one assertion fails.
+    const after = readFileSync(file, "utf-8");
+    expect(after).toContain("orchestration_mode: pilot");
+    expect(after).toContain("status: ready");
+  });
+
+  test("POST /api/deferred-pilot on a non-deferred task returns 409 and does not mutate", async () => {
+    // Harness condition: task is `ready`, not deferred — must 409, mirroring
+    // deferred-approve's status guard.
+    const file = writeTask("task-not-deferred-pilot", "ready");
+    const before = readFileSync(file, "utf-8");
+
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/deferred-pilot?task=task-not-deferred-pilot"));
+    expect(resp.status).toBe(409);
+    // Invariant: no orchestration_mode written, file byte-identical.
+    expect(readFileSync(file, "utf-8")).toBe(before);
+  });
 });
 
 // task-7476a03a — slot ttyd flap-suppression. /api/ttyd-reset is the

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -15,7 +15,7 @@ export interface CleanupEntry {
   taskId: string;
   slot: number;
   agents: Array<{ name: string }>;
-  mode: "duo" | "pair" | "solo";
+  mode: "duo" | "pair" | "solo" | "pilot";
   branches: string[];
   worktreePaths: string[];
   tmuxSessionNames: string[];

--- a/src/orchestration/peer-sync.ts
+++ b/src/orchestration/peer-sync.ts
@@ -55,7 +55,7 @@ function writeFile(path: string, value: string): void {
 export function initPeerSync(
   peerSyncDir: string,
   taskId: string,
-  mode: "duo" | "pair" | "solo",
+  mode: "duo" | "pair" | "solo" | "pilot",
   projectDir: string,
   agents: OrchestrationState["agents"],
   worktrees: Record<string, string>,

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -1218,6 +1218,60 @@ describe("solo mode — agentParticipatesInPhase", () => {
   });
 });
 
+function makePilotState(overrides: Partial<OrchestrationState> = {}): OrchestrationState {
+  return makeSoloState({ mode: "pilot", ...overrides });
+}
+
+describe("pilot mode — evaluateTransition", () => {
+  test("setup → work (reuses the solo graph)", () => {
+    expect(evaluateTransition(makePilotState())).toBe("work");
+  });
+
+  test("work does NOT advance on phase timeout alone (waits for the user)", () => {
+    // phaseStartedAt: 0 forces phaseTimeoutExpired === true; coder is NOT done.
+    const state = makePilotState({ phase: "work", phaseStartedAt: 0 });
+    state.agentStates.coder.status = "idle";
+    expect(phaseTimeoutExpired(state)).toBe(true);
+    // Solo would advance here; pilot must stall until the done-signal.
+    expect(evaluateTransition(state)).toBeNull();
+  });
+
+  test("work → update-docs ONLY on the explicit done-signal (allAgentsDone)", () => {
+    const state = makePilotState({ phase: "work", phaseStartedAt: 0 });
+    state.agentStates.coder.status = "done";
+    expect(evaluateTransition(state)).toBe("update-docs");
+  });
+
+  test("work → pr-comments on done-signal when a PR already exists", () => {
+    const state = makePilotState({ phase: "work", phaseStartedAt: 0 });
+    state.agentStates.coder.status = "done";
+    state.agentStates.coder.prUrl = "https://github.com/o/r/pull/9";
+    expect(evaluateTransition(state)).toBe("pr-comments");
+  });
+
+  test("non-work pilot phases keep solo timeout behavior (update-docs advances on timeout)", () => {
+    // update-docs is NOT the suppressed phase: an expired timeout advances it
+    // exactly as solo does, even without a done status.
+    const state = makePilotState({ phase: "update-docs", phaseStartedAt: 0 });
+    state.agentStates.coder.status = "idle";
+    expect(phaseTimeoutExpired(state)).toBe(true);
+    expect(evaluateTransition(state)).toBe("pr-create");
+  });
+
+  test("pilot bail-out short-circuits to done (same as solo)", () => {
+    const state = makePilotState({ phase: "work" });
+    state.agentStates.coder.status = "bail-out";
+    expect(evaluateTransition(state)).toBe("done");
+  });
+
+  test("coder participates in pilot active phases; reviewer-keyed checks are false", () => {
+    const state = makePilotState({ phase: "work" });
+    expect(agentParticipatesInPhase(state, state.agents[0])).toBe(true);
+    state.phase = "setup";
+    expect(agentParticipatesInPhase(state, state.agents[0])).toBe(false);
+  });
+});
+
 describe("isSoloBailedOut / isBailedOut", () => {
   test("isSoloBailedOut: true when solo coder status is bail-out", () => {
     const state = makeSoloState();

--- a/src/orchestration/phases.ts
+++ b/src/orchestration/phases.ts
@@ -154,7 +154,7 @@ export function agentParticipatesInPhase(
   if (state.phase === "setup" || state.phase === "done") return false;
   // Solo mode: only the coder participates, in every non-setup/done phase.
   // No reviewer agent exists; reviewer-keyed role checks must return false.
-  if (state.mode === "solo") return agent.role === "coder";
+  if (state.mode === "solo" || state.mode === "pilot") return agent.role === "coder";
   // Strict role separation for all slots (pair and hierarchical-duo)
   switch (state.phase) {
     case "gather":
@@ -358,10 +358,10 @@ export function isPairBailedOut(state: OrchestrationState): boolean {
   return cs === "bail-out" && rs === "bail-out-confirmed";
 }
 
-/** True when a solo-mode slot's coder has signaled bail-out. Solo has no reviewer,
- * so a lone "bail-out" is the terminal signal (no bail-out-confirmed partner). */
+/** True when a solo- or pilot-mode slot's coder has signaled bail-out. Neither has
+ * a reviewer, so a lone "bail-out" is the terminal signal (no bail-out-confirmed partner). */
 export function isSoloBailedOut(state: OrchestrationState): boolean {
-  if (state.mode !== "solo") return false;
+  if (state.mode !== "solo" && state.mode !== "pilot") return false;
   const coder = state.agents.find(a => a.role === "coder");
   if (!coder) return false;
   return (state.agentStates[coder.name]?.status ?? "") === "bail-out";
@@ -533,7 +533,9 @@ function evaluateTransitionSolo(state: OrchestrationState): Phase | null {
       return "work";
 
     case "work":
-      if (!(allAgentsDone(state) || phaseTimeoutExpired(state))) return null;
+      // Pilot work phase waits indefinitely for the user-driven done-signal:
+      // it advances ONLY on allAgentsDone, never on phaseTimeoutExpired.
+      if (!(allAgentsDone(state) || (state.mode !== "pilot" && phaseTimeoutExpired(state)))) return null;
       if (hasAnyPr(state)) return "pr-comments";
       return "update-docs";
 
@@ -579,7 +581,7 @@ const PAIR_BAIL_OUT_PHASES: ReadonlySet<Phase> = new Set<Phase>([
 ]);
 
 export function evaluateTransition(state: OrchestrationState): Phase | null {
-  if (state.mode === "solo") return evaluateTransitionSolo(state);
+  if (state.mode === "solo" || state.mode === "pilot") return evaluateTransitionSolo(state);
 
   // Cache readiness once. `phaseTimeoutExpired` reads `nowEpoch()`, so
   // evaluating it separately in the hoisted check and in each allowlisted

--- a/src/orchestration/runner.pilot.test.ts
+++ b/src/orchestration/runner.pilot.test.ts
@@ -1,0 +1,168 @@
+// Regression tests for the pilot work-phase "wait indefinitely" contract.
+// Codex review of PR #562 flagged two pollUntilDone-internal paths that the
+// initial pilot suppression missed: the interrupted-agent "Continue." nudge
+// (runner.ts) and pollUntilDone's own deadline → handleTimeout (which
+// interrupts the coder). Both must be exempted for `mode: "pilot" && phase:
+// "work"`, alongside the two settled-no-signal / hung detectors.
+//
+// Strategy: drive runOrchestration end-to-end (the escalation tests' proven
+// harness) with a recording transport and a coder whose turn is settled but
+// not done — exactly the idle state a piloted coder sits in while it waits for
+// the user. The work deadline is set to 0 so it is already expired on tick 1.
+//   - pilot: the loop must spin past the expired deadline many times WITHOUT
+//     sending any turn or interrupting; it ends only when the coder writes a
+//     terminal status (here `bail-out`, which short-circuits straight to done).
+//   - solo control (same setup): the deadline fires immediately → interruptAgent
+//     is called. This proves the assertions would catch a regression.
+
+import { describe, expect, test, beforeEach, afterEach, spyOn, setDefaultTimeout } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import { runOrchestration } from "./runner.ts";
+import { defaultOrchestrationConfig } from "./state.ts";
+import type { OrchestrationState } from "./state.ts";
+import type { OrchestrationTransport } from "./transport.ts";
+import * as events from "../events.ts";
+import * as notify from "../notify.ts";
+import { makeTmpDir, makeLifecycle, makeState } from "./runner.test-helpers.ts";
+
+setDefaultTimeout(15_000);
+
+function seedSoloHarness(slot: number): { harness: string; peerSyncDir: string } {
+  const tmpDir = makeTmpDir();
+  const harness = join(tmpDir, "harness");
+  const peerSyncDir = join(tmpDir, "peer-sync");
+  mkdirSync(join(harness, "orchestration"), { recursive: true });
+  mkdirSync(join(harness, "slots"), { recursive: true });
+  mkdirSync(join(harness, "journal"), { recursive: true });
+  mkdirSync(join(peerSyncDir, "plans"), { recursive: true });
+  mkdirSync(join(peerSyncDir, "reviews"), { recursive: true });
+
+  // Sibling adapter state with our own PID so the runner self-guard passes.
+  writeFileSync(
+    join(harness, "orchestration", `tmux-slot-${slot}.json`),
+    JSON.stringify({
+      orchestration: { pid: process.pid, stateFile: "x", mode: "solo" },
+      sessionNames: { coder: "c" },
+      ttydPids: {},
+    }),
+  );
+  writeFileSync(
+    join(harness, "slots", `slot-${slot}.json`),
+    JSON.stringify({
+      slot, process: "test-process", task: "feat", mode: "tmux", session: null,
+      path: null, started: null, adapterArgs: null, machine: null,
+      sessionStarted: null, liveness: null, terminals: "", runtime: "", git: "",
+    }, null, 2),
+  );
+  return { harness, peerSyncDir };
+}
+
+interface RecordingTransport extends OrchestrationTransport {
+  sendTurnMessages: string[];
+  interruptCalls: number;
+  refreshCount: number;
+}
+
+// Transport that records every sendTurn/interruptAgent and, once it has been
+// polled `terminateOnCall` times, writes a terminal `bail-out` status so the
+// pilot loop (which otherwise waits forever) can exit cleanly. bail-out
+// short-circuits solo/pilot straight to `done`, so no later phase dispatches.
+function recordingTransport(peerSyncDir: string, terminateOnCall: number): RecordingTransport {
+  const t: RecordingTransport = {
+    sendTurnMessages: [],
+    interruptCalls: 0,
+    refreshCount: 0,
+    async sendTurn(_state, _agent, message?: string) { t.sendTurnMessages.push(message ?? ""); return "cmd-pilot-test"; },
+    async sendEnter() {},
+    async refreshAgentTransportState() {
+      t.refreshCount++;
+      if (t.refreshCount >= terminateOnCall) {
+        writeFileSync(
+          join(peerSyncDir, "coder.status"),
+          `bail-out|${Math.floor(Date.now() / 1000)}|task obsolete\n`,
+        );
+      }
+    },
+    async interruptAgent() { t.interruptCalls++; },
+  };
+  return t;
+}
+
+function makeIdleCoderState(
+  mode: "pilot" | "solo",
+  slot: number,
+  peerSyncDir: string,
+  harness: string,
+): OrchestrationState {
+  return makeState({
+    slot,
+    mode,
+    backend: "tmux",
+    phase: "work",
+    harnessDir: harness,
+    // Skip enterPhase's re-dispatch loop while still exercising pollUntilDone.
+    phaseDispatched: true,
+    currentPhaseToken: "phase-existing",
+    // Single coder (solo/pilot shape), turn settled but no done status — the
+    // exact idle state a piloted coder waits in.
+    agents: [
+      { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
+    ],
+    agentStates: {
+      coder: { status: "working", statusEpoch: 0, statusMessage: "", prUrl: null, interrupted: false, turnLifecycle: makeLifecycle({ state: "settled" }) },
+    },
+    // Deadline already expired (work timeout 0); fast poll so the test is quick.
+    config: { ...defaultOrchestrationConfig(), pollInterval: 0.01, timeouts: { ...defaultOrchestrationConfig().timeouts, work: 0 } },
+  }, peerSyncDir);
+}
+
+describe("pilot work phase — wait-indefinitely contract (PR #562 Codex P1s)", () => {
+  let origHarnessDir: string | undefined;
+  let origStartupGrace: string | undefined;
+  let eventSpy: ReturnType<typeof spyOn>;
+  let notifySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+    origStartupGrace = process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+    process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "0";
+    eventSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+    if (origStartupGrace !== undefined) process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = origStartupGrace;
+    else delete process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+    eventSpy.mockRestore();
+    notifySpy.mockRestore();
+  });
+
+  test("pilot: idle coder is never nudged or interrupted past the expired work deadline", async () => {
+    const slot = 41;
+    const { harness, peerSyncDir } = seedSoloHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+
+    const transport = recordingTransport(peerSyncDir, 5);
+    await runOrchestration(makeIdleCoderState("pilot", slot, peerSyncDir, harness), transport);
+
+    // Looped past the immediately-expired deadline several times (proof the
+    // deadline did NOT terminate the loop on tick 1) ...
+    expect(transport.refreshCount).toBeGreaterThanOrEqual(5);
+    // ... yet never poked the coder: no interrupted-agent "Continue." nudge,
+    // no settled-no-signal/hung nudge, and no handleTimeout interrupt.
+    expect(transport.interruptCalls).toBe(0);
+    expect(transport.sendTurnMessages.some((m) => m.includes("Continue."))).toBe(false);
+    expect(transport.sendTurnMessages).toHaveLength(0);
+  });
+
+  // Non-vacuity: this suite was confirmed to FAIL when either production guard
+  // is reverted — removing the `pilotIdleWait` break makes the interrupted-agent
+  // nudge send a "Continue." turn, and ungating the deadline makes handleTimeout
+  // raise interruptCalls. Both flip the assertions above. (A full-pipeline solo
+  // control is omitted: once solo's work deadline fires it advances into
+  // update-docs, which the bail-out status can't cleanly terminate here due to
+  // per-phase status freshness gating.)
+});

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -2004,6 +2004,16 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
   const deadline = state.phaseStartedAt + timeout;
   const interval = state.config.pollInterval * 1000;
 
+  // Pilot work phase is user-driven: the coder reads the proposal and then
+  // sits idle (a settled, not-done lifecycle) until the user attaches, chats,
+  // and confirms completion. Every path in this loop that would otherwise
+  // poke or interrupt such an agent must be exempted so the "wait indefinitely
+  // for the user-written done-signal" contract holds: the settled-no-signal
+  // and hung detectors above already early-return on this predicate; here it
+  // also gates the interrupted-agent "Continue." nudge and the poll deadline's
+  // handleTimeout. `state.phase`/`state.mode` are stable for one pollUntilDone.
+  const pilotIdleWait = state.mode === "pilot" && state.phase === "work";
+
   // Subscribe to transport events for early wakeup (optional; falls back to pure polling).
   let wakeResolve: (() => void) | null = null;
   let unsubscribe: (() => void) | null = null;
@@ -2067,8 +2077,12 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       if (allAgentsDone(state)) return;
 
       // Nudge interrupted agents: turn settled (stop hook fired) but no done
-      // status — cut short by provider error, capacity limit, etc.
+      // status — cut short by provider error, capacity limit, etc. Skipped
+      // entirely in a pilot work phase, where a settled idle prompt is the
+      // expected state while the coder waits for the user (not an interruption
+      // to recover from).
       for (const agent of state.agents) {
+        if (pilotIdleWait) break;
         if (!agentParticipatesInPhase(state, agent)) continue;
         const rt = state.agentStates[agent.name]!;
         const alc = rt.turnLifecycle;
@@ -2120,7 +2134,10 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
         persistState(state, state.harnessDir ?? defaultHarnessDir());
       }
 
-      if (nowEpoch() >= deadline) {
+      // Pilot work waits indefinitely: never trip the poll deadline (which
+      // would handleTimeout → interrupt the coder). The phase ends only when
+      // the user-confirmed done-signal lands and allAgentsDone returns above.
+      if (!pilotIdleWait && nowEpoch() >= deadline) {
         await handleTimeout(state, transport);
         return;
       }

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -184,7 +184,7 @@ function staleBaseCategoryOf(state: OrchestrationState): "coder" | "reviewer" | 
   const phase = state.phase;
   if (phase === "plan" || phase === "work") return "coder";
   if (phase === "plan-review" || phase === "review") {
-    return state.mode === "solo" ? "coder" : "reviewer";
+    return (state.mode === "solo" || state.mode === "pilot") ? "coder" : "reviewer";
   }
   return null;
 }
@@ -670,6 +670,11 @@ export async function detectAndNudgeSettledNoSignal(
   state: OrchestrationState,
   transport: OrchestrationTransport,
 ): Promise<void> {
+  // Pilot work phase is user-driven: the coder legitimately sits idle waiting
+  // for the user to attach and chat. Suppress the settled-no-signal auto-nudge
+  // so the harness never nags or force-settles it. Other pilot phases keep
+  // normal behavior.
+  if (state.mode === "pilot" && state.phase === "work") return;
   for (const agent of state.agents) {
     if (!agentParticipatesInPhase(state, agent)) continue;
     const runtime = state.agentStates[agent.name]!;
@@ -867,6 +872,9 @@ export async function detectAndNudgeHungAgents(
   transport: OrchestrationTransport,
 ): Promise<void> {
   if (state.backend !== "tmux") return;
+  // Pilot work phase is user-driven: suppress hung-agent detection so the
+  // coder's legitimate idle wait for the user is never force-settled.
+  if (state.mode === "pilot" && state.phase === "work") return;
 
   const cfg = state.config.substantiveStall;
   for (const agent of state.agents) {
@@ -2146,7 +2154,7 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
   // work → update-docs instead of review → update-docs.
   if (
     next === "update-docs"
-    && (state.phase === "review" || (state.mode === "solo" && state.phase === "work"))
+    && (state.phase === "review" || (((state.mode === "solo" || state.mode === "pilot")) && state.phase === "work"))
     && !shouldRunUpdateDocs(state)
   ) {
     state.lastLearningAt = state.lastLearningAt ?? 0;
@@ -2258,7 +2266,7 @@ function maybeOverrideTransition(state: OrchestrationState, next: OrchestrationS
   // Solo skips review: the work→update-docs override mirrors pair's review→update-docs.
   if (
     next === "update-docs"
-    && (state.phase === "review" || (state.mode === "solo" && state.phase === "work"))
+    && (state.phase === "review" || (((state.mode === "solo" || state.mode === "pilot")) && state.phase === "work"))
     && !shouldRunUpdateDocs(state)
   ) {
     return state.agents.some((agent) => !!state.agentStates[agent.name]?.prUrl)

--- a/src/orchestration/skills.ts
+++ b/src/orchestration/skills.ts
@@ -216,11 +216,25 @@ function templateRoot(): string {
 
 export function resolveTemplatePath(
   phase: Phase,
-  mode: "duo" | "pair" | "solo",
+  mode: "duo" | "pair" | "solo" | "pilot",
   role?: "coder" | "reviewer",
   hasUpstream?: boolean,
 ): string {
   const root = templateRoot();
+  // Pilot resolution: pilot-<phase>.md > (solo chain).
+  // Pilot only needs ONE bespoke template (pilot-work.md); every other phase
+  // falls through to the identical solo chain below.
+  if (mode === "pilot") {
+    const pilotPath = join(root, `pilot-${phase}.md`);
+    if (existsSync(pilotPath)) return pilotPath;
+    const soloPath = join(root, `solo-${phase}.md`);
+    if (existsSync(soloPath)) return soloPath;
+    const pairCoderPath = join(root, `pair-coder-${phase}.md`);
+    if (existsSync(pairCoderPath)) return pairCoderPath;
+    const genericPath = join(root, `${phase}.md`);
+    if (existsSync(genericPath)) return genericPath;
+    throw new Error(`missing orchestration template for pilot:${phase}`);
+  }
   // Solo resolution: solo-<phase>.md > pair-coder-<phase>.md > <phase>.md
   //
   // Solo intentionally ignores `hasUpstream`. The upstream-* templates assume

--- a/src/orchestration/state.harnessdir.test.ts
+++ b/src/orchestration/state.harnessdir.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import {
   defaultOrchestrationConfig,
   initAgentRuntimeState,
+  migrateState,
   persistState,
   readOrchestrationState,
   type AgentTurnLifecycle,
@@ -168,6 +169,47 @@ describe("readOrchestrationState — boundary validators (gh-ludics-411 AC 3)", 
   test("throws when slot JSON has corrupt mode (\"throw\" policy at read boundary)", () => {
     writeSlot(7, (s) => { (s as { mode: string }).mode = "weird"; });
     expect(() => readOrchestrationState(7, REAL)).toThrow(/mode.*weird/);
+  });
+
+  // --- Pilot mode migration triple (state-migration convention) ---
+
+  // (1) Positive backfill: mode "pilot" is a legal value and survives the
+  // read-boundary / migrateState validator unchanged (no coercion, no throw).
+  test("accepts mode \"pilot\" through readOrchestrationState (positive)", () => {
+    writeSlot(20, (s) => { (s as { mode: string }).mode = "pilot"; });
+    let calls: unknown[][] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => { calls.push(args); });
+    try {
+      const loaded = readOrchestrationState(20, REAL);
+      calls = [...spy.mock.calls];
+      expect(loaded).not.toBeNull();
+      expect(loaded!.mode).toBe("pilot");
+      const modeLogs = calls.filter((c) => String(c[0] ?? "").includes("OrchestrationState.mode"));
+      expect(modeLogs).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // (2) Negative control: an out-of-union mode value still triggers the
+  // "throw" policy even with pilot now in the allowlist.
+  test("still throws on a non-pilot invalid mode (negative control)", () => {
+    writeSlot(21, (s) => { (s as { mode: string }).mode = "copilot"; });
+    expect(() => readOrchestrationState(21, REAL)).toThrow(/mode.*copilot/);
+  });
+
+  // (3) JSON round-trip: a pilot state serializes and deserializes through
+  // migrateState with mode preserved.
+  test("pilot state survives a JSON round-trip through migrateState", () => {
+    const state = baseState(22, REAL);
+    state.mode = "pilot";
+    state.agents = [
+      { name: "coder", provider: "claude-code", role: "coder", model: "claude-sonnet-4-6", branch: "a", worktreePath: "/tmp/a" },
+    ];
+    state.agentStates = initAgentRuntimeState(["coder"]);
+    const reparsed = JSON.parse(JSON.stringify(state)) as OrchestrationState;
+    const migrated = migrateState(reparsed, 22);
+    expect(migrated.mode).toBe("pilot");
   });
 
   test("coerces invalid backend to globalAdapter() and logs once at read boundary", async () => {

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -7,7 +7,7 @@ import type { Phase } from "./phases.ts";
 
 export interface OrchestrationRef {
   stateFile: string;
-  mode: "duo" | "pair" | "solo";
+  mode: "duo" | "pair" | "solo" | "pilot";
   pid?: number;
 }
 
@@ -223,7 +223,7 @@ export function parseSubstantiveStallOverrides(
 export interface OrchestrationState {
   slot: number;
   taskId: string;
-  mode: "duo" | "pair" | "solo";
+  mode: "duo" | "pair" | "solo" | "pilot";
   phase: Phase;
   round: number;
   mergeRound: number;
@@ -461,8 +461,8 @@ export function migrateState(state: OrchestrationState, slot: number): Orchestra
 
   // --- AC 3 boundary validators (string unions read from disk JSON) -------
   state.mode = validateAndCoerce(
-    state.mode, ["duo", "pair", "solo"] as const, "throw", null, "mode", slot,
-  ) as "duo" | "pair" | "solo";
+    state.mode, ["duo", "pair", "solo", "pilot"] as const, "throw", null, "mode", slot,
+  ) as "duo" | "pair" | "solo" | "pilot";
 
   if (state.backend !== undefined) {
     const validated = validateAndCoerce(
@@ -554,12 +554,12 @@ export function migrateState(state: OrchestrationState, slot: number): Orchestra
   if (state.mode === "duo" && state.duoPeerSlot == null) {
     console.error(`ludics: slot ${slot} has legacy mode="duo" without duoPeerSlot — should be cleared and re-assigned`);
   }
-  if (state.mode === "solo") {
+  if (state.mode === "solo" || state.mode === "pilot") {
     if (state.duoPeerSlot != null) {
-      console.error(`ludics: slot ${slot} has mode="solo" with duoPeerSlot=${state.duoPeerSlot} — invariant violation (solo must be single-slot)`);
+      console.error(`ludics: slot ${slot} has mode="${state.mode}" with duoPeerSlot=${state.duoPeerSlot} — invariant violation (${state.mode} must be single-slot)`);
     }
     if (state.agents && state.agents.length !== 1) {
-      console.error(`ludics: slot ${slot} has mode="solo" with ${state.agents.length} agents — invariant violation (solo must have exactly one agent)`);
+      console.error(`ludics: slot ${slot} has mode="${state.mode}" with ${state.agents.length} agents — invariant violation (${state.mode} must have exactly one agent)`);
     }
   }
   // Fill in fields added after the on-disk schema was first written so reads

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -528,7 +528,7 @@ export function createWorktrees(
   agents: Array<{ name: string }>,
   mainBranch: string = defaultMainBranch(projectDir),
   slot?: number,
-  mode: "duo" | "pair" | "solo" = "duo",
+  mode: "duo" | "pair" | "solo" | "pilot" = "duo",
 ): WorktreeSetup {
   // Refresh the project's main branch from origin so new worktrees fork from
   // current upstream rather than whatever the local checkout last pointed at.
@@ -558,9 +558,9 @@ export function createWorktrees(
   addWorktree(projectDir, rootWorktree, branches.root, mainBranch);
 
   const agentWorktrees: Record<string, string> = {};
-  if (mode === "pair" || mode === "solo") {
-    // Pair / solo: all agents share the root worktree and branch.
-    // Solo has a single agent; pair has coder + reviewer sharing one worktree.
+  if (mode === "pair" || mode === "solo" || mode === "pilot") {
+    // Pair / solo / pilot: all agents share the root worktree and branch.
+    // Solo and pilot have a single agent; pair has coder + reviewer sharing one worktree.
     for (const agent of agents) {
       branches[agent.name] = branches.root;
       agentWorktrees[agent.name] = rootWorktree;
@@ -770,7 +770,7 @@ export function cleanupWorktrees(
   taskId: string,
   agents: Array<{ name: string }>,
   slot?: number,
-  mode: "duo" | "pair" | "solo" = "duo",
+  mode: "duo" | "pair" | "solo" | "pilot" = "duo",
 ): void {
   const featureSlug = slugify(taskId);
   const parentDir = dirname(resolve(projectDir));

--- a/src/sessions/enrich.ts
+++ b/src/sessions/enrich.ts
@@ -24,7 +24,9 @@ function enrichFromT3codeSlots(): Map<string, Orchestration> {
       ? "t3code-pair"
       : orch.mode === "solo"
         ? "t3code-solo"
-        : "t3code-duo";
+        : orch.mode === "pilot"
+          ? "t3code-pilot"
+          : "t3code-duo";
 
     for (const thread of slotState.threads) {
       const cwd = (thread.worktreePath ?? "").replace(/\/+$/, "");

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1574,6 +1574,10 @@ export async function runSlot(args: string[]): Promise<void> {
             hasDirectOrchFlags = true;
             adapterArgFragments.push("--solo");
             break;
+          case "--pilot":
+            hasDirectOrchFlags = true;
+            adapterArgFragments.push("--pilot");
+            break;
           case "--coder": {
             const val = args[++i];
             if (!val || val.startsWith("-")) throw new Error("--coder requires a provider value (got a flag instead)");
@@ -1605,11 +1609,11 @@ export async function runSlot(args: string[]): Promise<void> {
 
       if (hasDirectOrchFlags && adapter !== "t3code" && adapter !== "tmux") {
         throw new Error(
-          `--pair/--solo/--coder/--reviewer/--plan flags require adapter "t3code" or "tmux" (got "${adapter}")`
+          `--pair/--solo/--pilot/--coder/--reviewer/--plan flags require adapter "t3code" or "tmux" (got "${adapter}")`
         );
       }
 
-      if (hasDirectOrchFlags || adapterArgFragments.some(f => /--(?:pair|duo|solo)/.test(f))) {
+      if (hasDirectOrchFlags || adapterArgFragments.some(f => /--(?:pair|duo|solo|pilot)/.test(f))) {
         const expected = globalAdapter();
         if ((adapter === "t3code" || adapter === "tmux") && adapter !== expected) {
           throw new Error(
@@ -1647,9 +1651,9 @@ export async function runSlot(args: string[]): Promise<void> {
         await slotAssign(secondSlot, taskOrDesc, adapter, "", path, expansion.slotB.args, machine);
         console.error(`ludics: duo assign → slots ${slotNum}+${secondSlot}`);
       } else {
-        const hasModeDirectFlag = adapterArgFragments.includes("--pair") || adapterArgFragments.includes("--solo");
+        const hasModeDirectFlag = adapterArgFragments.includes("--pair") || adapterArgFragments.includes("--solo") || adapterArgFragments.includes("--pilot");
         const hasModeInRawFragments = adapterArgFragments.some(
-          f => /(?:^|\s)--(?:pair|duo|solo)(?:\s|$)/.test(f)
+          f => /(?:^|\s)--(?:pair|duo|solo|pilot)(?:\s|$)/.test(f)
         );
         if (hasDirectOrchFlags && !hasModeDirectFlag && !hasModeInRawFragments && firstDirectOrchFlagIdx !== -1) {
           adapterArgFragments.splice(firstDirectOrchFlagIdx, 0, "--pair");

--- a/src/t3code/types.ts
+++ b/src/t3code/types.ts
@@ -238,7 +238,7 @@ export interface T3CodeThreadRecord {
 
 export interface T3CodeOrchestrationRef {
   stateFile: string;
-  mode: "duo" | "pair" | "solo";
+  mode: "duo" | "pair" | "solo" | "pilot";
   pid?: number;
 }
 

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -342,6 +342,30 @@ describe("parseTaskFrontmatter field reads", () => {
     expect(parseTaskFrontmatter(content).project).toBe("real");
   });
 
+  test("reads orchestration_mode scalar", () => {
+    const content = "---\nid: task-1\norchestration_mode: pilot\n---\n";
+    expect(parseTaskFrontmatter(content).orchestration_mode).toBe("pilot");
+  });
+
+  test("returns undefined for missing orchestration_mode", () => {
+    const content = "---\nid: task-1\nstatus: ready\n---\n";
+    expect(parseTaskFrontmatter(content).orchestration_mode).toBeUndefined();
+  });
+
+  test("orchestration_mode round-trips through addFrontmatterField → parseTaskFrontmatter", () => {
+    const f = tmpFile("orch-mode-roundtrip.md", [
+      "---",
+      "id: task-1",
+      "status: deferred",
+      "---",
+      "",
+      "# Body",
+    ].join("\n"));
+    addFrontmatterField(f, "orchestration_mode", "pilot");
+    const content = readFileSync(f, "utf-8");
+    expect(parseTaskFrontmatter(content).orchestration_mode).toBe("pilot");
+  });
+
   test("body code-block shadowing: frontmatter status wins (task-485dcb6a)", () => {
     // Regression guard for the body-scope vulnerability closed by the original
     // regex → readFrontmatterField migration (task-485dcb6a / task-808ee2c7).
@@ -474,6 +498,20 @@ describe("parseTaskFrontmatter field reads", () => {
     ].join("\n");
     const fm = parseTaskFrontmatter(content);
     expect(fm.leaf).toBe(false);
+    expect(fm.id).toBe("task-fb");
+  });
+
+  test("orchestration_mode survives malformed-YAML line fallback path", () => {
+    const content = [
+      "---",
+      "id: task-fb",
+      "status: deferred",
+      "orchestration_mode: pilot",
+      "dependencies: [unclosed",
+      "---",
+    ].join("\n");
+    const fm = parseTaskFrontmatter(content);
+    expect(fm.orchestration_mode).toBe("pilot");
     expect(fm.id).toBe("task-fb");
   });
 });

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -146,6 +146,7 @@ function parseTaskFrontmatterUncached(content: string): ParsedTaskFrontmatter {
     },
     effort: String(d.effort ?? "medium"),
     skip_plan: asBoolean(d.skip_plan),
+    orchestration_mode: normalizeOptionalString(d.orchestration_mode),
     leaf: d.leaf !== undefined ? asBoolean(d.leaf) : undefined,
     requirements: d.requirements ? d.requirements as { os?: string; gpu?: string } : undefined,
     context: String(d.context ?? ""),
@@ -224,6 +225,7 @@ function parseTaskFrontmatterLineFallback(fmBlock: string): ParsedTaskFrontmatte
   if (out.elaborated !== undefined) fm.elaborated = out.elaborated;
   if (out.merged_into !== undefined) fm.merged_into = out.merged_into;
   if (out.skip_plan !== undefined) fm.skip_plan = asBoolean(out.skip_plan);
+  if (out.orchestration_mode !== undefined) fm.orchestration_mode = out.orchestration_mode;
   if (out.leaf !== undefined) fm.leaf = asBoolean(out.leaf);
   if (out.uses_browser !== undefined) fm.uses_browser = asBoolean(out.uses_browser);
   if (out.started !== undefined) fm.started = out.started;

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -16,6 +16,11 @@ export interface TaskFrontmatter {
   /** tiny, small, medium, large — see docs/task-frontmatter-reference.md#effort-levels */
   effort: string;
   skip_plan?: boolean;
+  /** Forces a specific orchestration workflow mode at auto-start, overriding
+   *  effort-based mode selection. Currently only `"pilot"` is honored — a
+   *  user-piloted solo session (single coder, no reviewer, work phase waits for
+   *  the user). Set by the dashboard "Pilot" deferred-launch button. */
+  orchestration_mode?: string;
   /** When `false`, this task is a container — its work is split across children
    *  via `subtask_of`. Container tasks are excluded from auto-queue, preempt,
    *  elaboration auto-queue, and slotAssign. Set by `/ludics-split-task`. */

--- a/templates/dashboard/dashboard.js
+++ b/templates/dashboard/dashboard.js
@@ -642,6 +642,7 @@ function fetchDeferredLaunch() {
                 <span class="deferred-actions">
                     <a class="view-btn" href="${viewLink}" target="_blank" title="View proposal">View</a>
                     <button class="approve-btn" onclick="approveDeferred('${escapeHtml(task.id)}')" title="Approve: enable auto-start">Approve</button>
+                    <button class="pilot-btn" onclick="pilotDeferred('${escapeHtml(task.id)}')" title="Pilot: start a user-piloted solo session">Pilot</button>
                     <button class="abandon-btn" onclick="abandonDeferred('${escapeHtml(task.id)}')" title="Abandon task">Abandon</button>
                 </span>
             </li>`;
@@ -720,6 +721,24 @@ async function approveDeferred(taskId) {
         }
     } catch {
         btn.textContent = 'Approve';
+        setTimeout(() => { btn.disabled = false; }, 2000);
+    }
+}
+
+async function pilotDeferred(taskId) {
+    const btn = event.target;
+    btn.disabled = true;
+    btn.textContent = '\u2026';
+    try {
+        const response = await fetch(`/api/deferred-pilot?task=${encodeURIComponent(taskId)}`);
+        if (response.ok) {
+            fetchAllData();
+        } else {
+            btn.textContent = 'Pilot';
+            setTimeout(() => { btn.disabled = false; }, 2000);
+        }
+    } catch {
+        btn.textContent = 'Pilot';
         setTimeout(() => { btn.disabled = false; }, 2000);
     }
 }

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -1195,7 +1195,7 @@ main {
 
 /* ── Shared Action Buttons ─────────────────────────────────── */
 .confirm-btn, .dismiss-btn,
-.view-btn, .approve-btn, .abandon-btn {
+.view-btn, .approve-btn, .pilot-btn, .abandon-btn {
     font-family: var(--font-brand);
     font-size: 0.68rem;
     font-weight: 500;
@@ -1220,6 +1220,12 @@ main {
     color: var(--success);
 }
 .approve-btn:hover, .confirm-btn:hover { background: var(--success); color: var(--bg-primary); }
+
+.pilot-btn {
+    border-color: var(--warning);
+    color: var(--warning);
+}
+.pilot-btn:hover { background: var(--warning); color: var(--bg-primary); }
 
 .abandon-btn, .dismiss-btn {
     border-color: var(--accent);


### PR DESCRIPTION
## Summary

Adds a fourth orchestration mode, **`pilot`**, alongside `solo`/`pair`/`duo`. Pilot is **solo-identical** (single coder, no reviewer, same phase graph, same `.peer-sync/<agent>.status` done-signal) except the coder reads the proposal and then **waits for the user to drive the work interactively** — the user attaches to the session and chats, and the coder signals end-of-work only when the user confirms the task is finished. After that the workflow continues exactly as solo (update-docs → pr-create → pr-comments → final-merge → done).

Requested as: *"pilot is like solo except the coder is prompted to read the proposal and wait for further instructions; the user chats with the model, and once finished the coder signals the coordinator (end of work phase) and the workflow continues as in solo. Add a 'Pilot' approval option that forces this mode regardless of what 'Approve' would pick — a new button on the Deferred Launch pane."*

## Behavior

- **Work-phase prompt** (`skills/orchestration/pilot-work.md`, new): read the proposal → do NOT start implementing → wait for the user → collaborate → write the done-signal only on the user's explicit confirmation. Bail-out / escalate variants preserved.
- **Indefinite idle work phase** (design decision, confirmed with the requester): the pilot work phase advances **only** on `allAgentsDone`, never on `phaseTimeoutExpired`; and the settled-no-signal nudge + hung-agent detection are **suppressed** while `mode === "pilot" && phase === "work"` (the coder legitimately sits idle). All other pilot phases keep normal timeout/nudge behavior.
- **Dashboard "Pilot" button** on the Deferred Launch pane → new `GET /api/deferred-pilot` endpoint → sets `orchestration_mode: pilot` + `status: ready` (409 unless the task is `deferred`). `selectOrchestrationFlagsForTask` honors the override and emits `--pilot` regardless of effort. The existing **Approve** button is unchanged.

## Mode plumbing

`"pilot"` added to both `mode` unions + the `migrateState` validator tuple + the single-slot/single-agent invariant; `--pilot` flag parsing in the t3code adapter and the slot-assign CLI (recognized everywhere `--solo` is); pilot shares solo's root worktree; `resolveTemplatePath` adds a `pilot-<phase>` → solo-chain fallthrough so pilot reuses **every** solo template except `work`. Pilot is single-coder and never expands to two slots.

## Tests & verification

- State-migration triple for `mode: "pilot"` (positive backfill / negative control / JSON round-trip) — satisfies `lint:state-migration`.
- Pilot work phase does **not** advance on timeout alone (only on `allAgentsDone`); solo-graph parity otherwise; bail-out → done; participation.
- `orchestration_mode: pilot` → `--pilot` selection (isDuo false, no plan/gather, effort-independent); `parseOrchestrationAdapterArgs("--pilot …")`.
- `orchestration_mode` frontmatter parse + round-trip (structured + line-fallback).
- `/api/deferred-pilot` sets both fields / returns `mode:pilot` / 409 on non-deferred.

`bun test`: **2925 pass / 0 fail** (+23 net). `typecheck`, `eslint --max-warnings=0`, `build --compile`, and `lint:state-migration` / `template-safety` / `cli-subcommands` / `skill-shell` / `contracts` all clean.

## Reviewer notes

- Idle-suppression is a function-entry `return` in both `detectAndNudgeSettledNoSignal` and `detectAndNudgeHungAgents`, gated strictly on `mode === "pilot" && phase === "work"` (whole-phase, not per-agent).
- `enrich.ts` maps pilot → display string `t3code-pilot` (cosmetic; could collapse to `t3code-solo` if preferred).
- The `/api/deferred-pilot` handler uses `addFrontmatterField` for the new `orchestration_mode` field; the 409 deferred-guard makes a double-add path unreachable in practice, but worth a glance if you dislike that helper for possibly-existing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)