### PR TITLE
feat: add claude-fable as a selectable high-end model class for coder/reviewer roles

### DIFF
--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -858,7 +858,11 @@ describe("integration", () => {
     expect(result.errorCount).toBe(0);
     // 19 after gh-ludics-524 deleted src/adapters/agent-session.test.ts,
     // which contributed one rule-N warning.
-    const expectedWarningCount = 19;
+    // 20 after task-13dee93b added src/orchestration/transport-t3code.test.ts —
+    // a pure-unit AC9 test (spies readServerRecord + the t3code client prototype)
+    // that transitively imports src/events.ts via transport-t3code.ts, so it
+    // trips rule-3 despite needing no real harness.
+    const expectedWarningCount = 20;
     if (result.warningCount !== expectedWarningCount) {
       throw new Error(formatWarningCountHeuristic(result.warningCount));
     }

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError, resolveAgentModel, classModel, providerDefaultModel, singleThreadCodexModel } from "./t3code.ts";
+import { buildOrchestratedDesiredThreadConfig, canReuseSlotThread, ensureThread, orchestratedThreadTitle, parseOrchestrationAdapterArgs, startOrchestrationProcess, stop, selectOrchestrationFlags, selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError, resolveAgentModel, classModel, providerDefaultModel, singleThreadCodexModel } from "./t3code.ts";
 import type { T3CodeThreadRecord } from "../t3code/types.ts";
 import { mergeAdapterState } from "../slots/markdown.ts";
 import { emptySlotData } from "../slots/json.ts";
@@ -872,5 +872,125 @@ describe("selectOrchestrationFlags — coder model suffix sourced from the confi
     expect(() => selectOrchestrationFlags("medium", fakeConfig)).toThrow(
       /mag\.orchestration\.model_classes\.claude-opus is required/,
     );
+  });
+});
+
+describe("selectOrchestrationFlags — per-role high-end class (task-13dee93b AC3/5/6)", () => {
+  // Gate reads the real (harness) config; orchCfg reads the passed fakeConfig.
+  const cfg = installT3codeConfigHarness();
+  beforeEach(() => cfg.write({ t3codeEnabled: true }));
+
+  const TABLE = {
+    codex: "gpt-5.5",
+    "claude-opus": "claude-opus-4-8",
+    "claude-sonnet": "claude-sonnet-4-6",
+    "claude-fable": "claude-fable-5",
+  };
+  const cfgWith = (orch: Record<string, unknown>) =>
+    ({ mag: { orchestration: { model_classes: TABLE, ...orch } } } as unknown as Parameters<
+      typeof selectOrchestrationFlags
+    >[1]);
+
+  test("coder_class: claude-fable → medium coder runs claude-fable-5, NOT opus (AC5, no fallback)", () => {
+    const { args } = selectOrchestrationFlags(
+      "medium",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex", coder_class: "claude-fable" }),
+    );
+    expect(args).toContain("--coder claude-code:claude-fable-5");
+    expect(args).not.toContain(":claude-opus");
+  });
+
+  test("coder_class absent / claude-opus → medium coder stays claude-opus-4-8 (default preserved)", () => {
+    const dflt = selectOrchestrationFlags(
+      "medium",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex" }),
+    );
+    expect(dflt.args).toContain("--coder claude-code:claude-opus-4-8");
+    const opus = selectOrchestrationFlags(
+      "medium",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex", coder_class: "claude-opus" }),
+    );
+    expect(opus.args).toContain("--coder claude-code:claude-opus-4-8");
+  });
+
+  test("reviewer_class: claude-fable + claude-code reviewer → medium reviewer runs claude-fable-5 (AC3)", () => {
+    const { args } = selectOrchestrationFlags(
+      "medium",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "claude-code", reviewer_class: "claude-fable" }),
+    );
+    expect(args).toContain("--reviewer claude-code:claude-fable-5");
+  });
+
+  test("codex reviewer carries no class suffix even with reviewer_class set", () => {
+    const { args } = selectOrchestrationFlags(
+      "medium",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex", reviewer_class: "claude-fable" }),
+    );
+    expect(args).toContain("--reviewer codex");
+    expect(args).not.toContain("--reviewer codex:");
+  });
+
+  // AC6 mutation guard: the Sonnet low-effort floor must ignore the high-end class.
+  test("coder_class: claude-fable + tiny effort still emits Sonnet (AC6)", () => {
+    const { args } = selectOrchestrationFlags(
+      "tiny",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex", coder_class: "claude-fable" }),
+    );
+    expect(args).toContain(":claude-sonnet-4-6");
+    expect(args).not.toContain(":claude-fable-5");
+  });
+
+  test("coder_class: claude-fable + small effort still emits Sonnet (AC6)", () => {
+    const { args } = selectOrchestrationFlags(
+      "small",
+      cfgWith({ default_coder: "claude-code", default_reviewer: "codex", coder_class: "claude-fable" }),
+    );
+    expect(args).toContain("--coder claude-code:claude-sonnet-4-6");
+    expect(args).not.toContain(":claude-fable-5");
+  });
+});
+
+describe("ensureThread — Fable-unavailable hard error (task-13dee93b AC9)", () => {
+  const baseDesired = {
+    worktreePath: "/tmp/wt-coder",
+    title: "task-x-coder",
+    provider: "claude-code" as const,
+    runtimeMode: "full-access" as const,
+    interactionMode: "default" as const,
+    branch: null,
+  };
+
+  test("a Fable thread.create failure rethrows naming coder_class + claude-opus, preserving the original", async () => {
+    const client = {
+      dispatchCommand: () => Promise.reject(new Error("server: model claude-fable-5 not available on plan")),
+    } as unknown as Parameters<typeof ensureThread>[0];
+    const p = ensureThread(
+      client,
+      {} as unknown as Parameters<typeof ensureThread>[1],
+      2,
+      "project-1",
+      { ...baseDesired, model: "claude-fable-5", role: "coder" },
+      undefined,
+    );
+    await expect(p).rejects.toThrow(/mag\.orchestration\.coder_class/);
+    await expect(p).rejects.toThrow(/claude-opus/);
+    await expect(p).rejects.toThrow(/not available on plan/); // original preserved
+  });
+
+  test("a non-Fable thread.create failure is NOT relabeled (mutation guard)", async () => {
+    const original = new Error("transient ws disconnect");
+    const client = {
+      dispatchCommand: () => Promise.reject(original),
+    } as unknown as Parameters<typeof ensureThread>[0];
+    const p = ensureThread(
+      client,
+      {} as unknown as Parameters<typeof ensureThread>[1],
+      2,
+      "project-1",
+      { ...baseDesired, model: "claude-opus-4-8", role: "coder" },
+      undefined,
+    );
+    await expect(p).rejects.toThrow(/transient ws disconnect/);
+    await expect(p).rejects.not.toThrow(/mag\.orchestration/);
   });
 });

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -51,6 +51,8 @@ import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/defer
 import { isoNow, makeId, nowEpoch } from "../orchestration/util.ts";
 import {
   classForProvider,
+  dispatchWithFableContext,
+  normalizeHighEndClass,
   resolveModelClass,
   type ModelClass,
 } from "../orchestration/model-defaults.ts";
@@ -93,6 +95,10 @@ export interface DesiredThreadConfig {
   title: string;
   model: string;
   provider?: T3ProviderKind;
+  /** Orchestration role, threaded through so a Fable-model launch failure can
+   *  name the exact config key (`coder_class`/`reviewer_class`) in its hard error
+   *  (task-13dee93b AC9). Transient dispatch field — not persisted state. */
+  role?: "coder" | "reviewer";
   runtimeMode: T3RuntimeMode;
   interactionMode: T3InteractionMode;
   branch?: string | null;
@@ -166,6 +172,7 @@ export function buildOrchestratedDesiredThreadConfig(
     title: orchestratedThreadTitle(slot, agent.role ?? agent.name, taskId),
     model: agent.model,
     provider: agent.provider,
+    role: agent.role === "coder" || agent.role === "reviewer" ? agent.role : undefined,
     runtimeMode: options.runtimeMode,
     interactionMode: options.interactionMode,
     branch: agent.branch,
@@ -603,7 +610,10 @@ async function ensureProject(
   return projectId;
 }
 
-async function ensureThread(
+/** Exported as a test seam (mirrors `resolveAgentModel`): lets a regression test
+ *  drive a mocked `dispatchCommand` failure and assert the task-13dee93b AC9
+ *  Fable-unavailable rethrow without standing up a real t3code server. */
+export async function ensureThread(
   client: T3CodeClient,
   snapshot: T3Snapshot,
   slot: number,
@@ -656,19 +666,28 @@ async function ensureThread(
   const threadId = makeId(`thread-slot-${slot}`);
   const wireProvider = desired.provider ? toWireProvider(desired.provider) : "codex";
   const modelSelection: T3ModelSelection = { provider: wireProvider, model };
-  await client.dispatchCommand({
-    type: "thread.create",
-    commandId: makeId("cmd"),
-    threadId,
-    projectId,
-    title: desired.title,
-    modelSelection,
-    runtimeMode: desired.runtimeMode,
-    interactionMode: desired.interactionMode,
-    branch: desired.branch ?? null,
-    worktreePath: desired.worktreePath,
-    createdAt,
-  });
+  // task-13dee93b AC9: a claude-fable thread.create that fails (model unreachable
+  // on the active plan) is rethrown with the actionable config-key remediation;
+  // non-Fable failures pass through unchanged. No silent fallback.
+  await dispatchWithFableContext(
+    () =>
+      client.dispatchCommand({
+        type: "thread.create",
+        commandId: makeId("cmd"),
+        threadId,
+        projectId,
+        title: desired.title,
+        modelSelection,
+        runtimeMode: desired.runtimeMode,
+        interactionMode: desired.interactionMode,
+        branch: desired.branch ?? null,
+        worktreePath: desired.worktreePath,
+        createdAt,
+      }),
+    model,
+    desired.role,
+    loadConfigOrchestration(),
+  );
 
   return {
     threadId,
@@ -870,15 +889,27 @@ export function selectOrchestrationFlags(
 
   // Only apply effort-based model selection for Claude providers; other providers
   // (codex) carry no suffix and resolve their latest-within-class default later
-  // in resolveAgentModel. claude-code coders resolve to the opus class for
-  // medium/large effort, the sonnet class otherwise (task-c48b7beb).
+  // in resolveAgentModel. claude-code coders resolve to their per-role high-end
+  // class (claude-opus by default, claude-fable when selected — task-13dee93b) for
+  // medium/large effort, the sonnet class otherwise (task-c48b7beb). The literal
+  // `orchCfg?.coder_class` / `orchCfg?.reviewer_class` reads below also satisfy the
+  // config-reference lint's Direction-4 adapter-read scan for those keys.
   let coderModelSuffix = "";
   if (coder === "claude-code") {
     if (norm === "large" || norm === "medium") {
-      coderModelSuffix = `:${classModel("claude-opus", orchCfg)}`;
+      coderModelSuffix = `:${classModel(normalizeHighEndClass(orchCfg?.coder_class), orchCfg)}`;
     } else {
       coderModelSuffix = `:${classModel("claude-sonnet", orchCfg)}`;
     }
+  }
+
+  // Reviewer high-end class: today a claude-code reviewer carries no model suffix
+  // (resolving to the Sonnet generic default). To make `reviewer_class` meaningful
+  // (AC3/AC5), emit the per-role high-end class suffix for medium/large effort
+  // claude-code reviewers; tiny/small reviewers (if any) and codex stay unchanged.
+  let reviewerModelSuffix = "";
+  if (reviewer === "claude-code" && (norm === "large" || norm === "medium")) {
+    reviewerModelSuffix = `:${classModel(normalizeHighEndClass(orchCfg?.reviewer_class), orchCfg)}`;
   }
 
   // Small / tiny / unknown effort: never run pre-work phases.
@@ -897,7 +928,7 @@ export function selectOrchestrationFlags(
   const modeArgs = [
     "--pair",
     `--coder ${coder}${coderModelSuffix}`,
-    `--reviewer ${reviewer}`,
+    `--reviewer ${reviewer}${reviewerModelSuffix}`,
   ];
 
   const args = [...modeArgs, ...phaseFlags].join(" ");

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -662,6 +662,31 @@ describe("agentCliCommand — passes --model + Fable remediation (task-13dee93b 
     expect(cmd).not.toContain("coder_class");
   });
 
+  // Codex PR review (P2): the remediation must follow a config-bumped Fable id,
+  // not the hardcoded claude-fable-5. Resolve the class from orchCfg.model_classes.
+  test("a config-bumped Fable model id still triggers the remediation (via orchCfg)", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const orchCfg = { model_classes: { "claude-fable": "claude-fable-6-future" } };
+    const cmd = agentCliCommand(
+      { provider: "claude-code", model: "claude-fable-6-future", role: "coder" },
+      orchCfg,
+    );
+    expect(cmd).toContain("--model claude-fable-6-future");
+    expect(cmd).toContain("claude-fable unavailable");
+    expect(cmd).toContain("coder_class");
+  });
+
+  test("a non-Fable model with the same orchCfg gets NO remediation (mutation guard)", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const orchCfg = { model_classes: { "claude-fable": "claude-fable-6-future" } };
+    const cmd = agentCliCommand(
+      { provider: "claude-code", model: "claude-opus-4-8", role: "coder" },
+      orchCfg,
+    );
+    expect(cmd).toContain("--model claude-opus-4-8");
+    expect(cmd).not.toContain("claude-fable unavailable");
+  });
+
   test("no --model is emitted when model is absent", async () => {
     const { agentCliCommand } = await import("./tmux-adapter.ts");
     expect(agentCliCommand({ provider: "claude-code" })).not.toContain("--model");

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -634,3 +634,44 @@ describe("tmux resolveAgentModel — latest-within-class default", () => {
     );
   });
 });
+
+describe("agentCliCommand — passes --model + Fable remediation (task-13dee93b AC5/8/9)", () => {
+  test("claude-code agent passes the resolved model via --model, no remediation for non-Fable", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const cmd = agentCliCommand({ provider: "claude-code", model: "claude-opus-4-8", role: "coder", thinkingEffort: "high" });
+    expect(cmd).toContain("--model claude-opus-4-8");
+    expect(cmd).toContain("--effort"); // effort still mapped
+    // Mutation guard: a non-Fable model carries NO remediation wrapper.
+    expect(cmd).not.toContain("claude-fable unavailable");
+    expect(cmd).not.toContain("||");
+  });
+
+  test("a claude-fable coder appends the nonzero-exit remediation naming coder_class + claude-opus", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const cmd = agentCliCommand({ provider: "claude-code", model: "claude-fable-5", role: "coder" });
+    expect(cmd).toContain("--model claude-fable-5");
+    expect(cmd).toContain("claude-fable unavailable");
+    expect(cmd).toContain("coder_class");
+    expect(cmd).toContain("claude-opus");
+  });
+
+  test("a claude-fable reviewer names reviewer_class, not coder_class", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const cmd = agentCliCommand({ provider: "claude-code", model: "claude-fable-5", role: "reviewer" });
+    expect(cmd).toContain("reviewer_class");
+    expect(cmd).not.toContain("coder_class");
+  });
+
+  test("no --model is emitted when model is absent", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    expect(agentCliCommand({ provider: "claude-code" })).not.toContain("--model");
+  });
+
+  test("codex agent is unaffected (no --model, no remediation)", async () => {
+    const { agentCliCommand } = await import("./tmux-adapter.ts");
+    const cmd = agentCliCommand({ provider: "codex", model: "gpt-5.5", thinkingEffort: "high" });
+    expect(cmd).toContain("codex --yolo");
+    expect(cmd).not.toContain("--model");
+    expect(cmd).not.toContain("claude-fable unavailable");
+  });
+});

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -37,6 +37,7 @@ import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/defer
 import { isoNow, nowEpoch } from "../orchestration/util.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
 import { parseOrchestrationAdapterArgs, providerDefaultModel } from "./t3code.ts";
+import { isFableModel } from "../orchestration/model-defaults.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -276,6 +277,7 @@ export function startTmuxAgentSessionsForOrchestratedSlot(
   peerSyncDir: string,
   taskId: string | undefined,
   startTtydEnabled: boolean,
+  orchCfg?: Record<string, unknown>,
 ): Record<string, number> {
   const ttydPids: Record<string, number> = {};
   for (let i = 0; i < agents.length; i++) {
@@ -283,8 +285,9 @@ export function startTmuxAgentSessionsForOrchestratedSlot(
     createTmuxAgentSession(slot, agent.name, agent.worktreePath, taskId);
     const role = agentPortRole(agent, i);
     if (startTtydEnabled) ttydPids[agent.name] = startTtyd(slot, agent.name, role, taskId);
-    // Boot persistent interactive agent CLI in the session
-    bootAgentCli(slot, agent, peerSyncDir, "setup", taskId);
+    // Boot persistent interactive agent CLI in the session (orchCfg lets the
+    // Fable-remediation guard recognise a config-bumped Fable model id).
+    bootAgentCli(slot, agent, peerSyncDir, "setup", taskId, orchCfg);
   }
   return ttydPids;
 }
@@ -384,6 +387,7 @@ function bootAgentCli(
   peerSyncDir: string,
   _phaseToken: string,
   taskId?: string,
+  orchCfg?: Record<string, unknown>,
 ): void {
   const target = tmuxTarget(slot, agent.name, taskId);
 
@@ -397,7 +401,7 @@ function bootAgentCli(
   tmuxSendCommand(target, envCmd);
 
   // Boot the CLI (runs persistently in the pane)
-  tmuxSendCommand(target, agentCliCommand(agent));
+  tmuxSendCommand(target, agentCliCommand(agent, orchCfg));
 }
 
 // ---------------------------------------------------------------------------
@@ -496,13 +500,22 @@ export function captureLastMessageHash(target: string, lines: number = 50): stri
  * class, a pane-visible remediation is appended that fires on a nonzero exit
  * (e.g. Fable unreachable on the active plan), naming the role's config key and
  * `claude-opus` — AC9's actionable hard error for the fire-and-forget tmux launch.
+ *
+ * The Fable check uses {@link isFableModel} against `orchCfg`, so it stays correct
+ * when `model_classes.claude-fable` is config-bumped to a future Fable ID (not just
+ * the seeded `claude-fable-5`). When `orchCfg` is absent, isFableModel falls back to
+ * the canonical literal — the launch still passes `--model`, only the remediation
+ * text depends on recognising the Fable class.
  */
-export function agentCliCommand(agent: {
-  provider: string;
-  model?: string;
-  role?: "coder" | "reviewer";
-  thinkingEffort?: string;
-}): string {
+export function agentCliCommand(
+  agent: {
+    provider: string;
+    model?: string;
+    role?: "coder" | "reviewer";
+    thinkingEffort?: string;
+  },
+  orchCfg?: Record<string, unknown>,
+): string {
   const effortRaw = agent.thinkingEffort?.trim();
   if (agent.provider === "claude-code") {
     let base = "claude --dangerously-skip-permissions";
@@ -512,7 +525,7 @@ export function agentCliCommand(agent: {
       const level = normaliseEffortLevel(effortRaw);
       base += ` --effort ${claudeEffort(level)}`;
     }
-    if (model === "claude-fable-5") {
+    if (model && isFableModel(model, orchCfg)) {
       // AC9: leave the config-key remediation visible in the pane if the Fable
       // CLI exits nonzero (e.g. model unavailable). No silent fallback.
       const roleKey = `${agent.role ?? "coder"}_class`;
@@ -662,7 +675,7 @@ async function start(ctx: AdapterContext): Promise<string> {
 
   // --- tmux-specific setup: create sessions + ttyd + boot agent CLIs ---
   const ttydPids = startTmuxAgentSessionsForOrchestratedSlot(
-    ctx.slot, agents, setup.peerSyncDir, taskId, ctx.startTtyd !== false,
+    ctx.slot, agents, setup.peerSyncDir, taskId, ctx.startTtyd !== false, orchCfg,
   );
 
   // --- Build orchestration state (no t3code threadIds) ---

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -380,7 +380,7 @@ function killTtydForSlot(slot: number): void {
  */
 function bootAgentCli(
   slot: number,
-  agent: { name: string; provider: string; thinkingEffort?: string },
+  agent: { name: string; provider: string; model?: string; role?: "coder" | "reviewer"; thinkingEffort?: string },
   peerSyncDir: string,
   _phaseToken: string,
   taskId?: string,
@@ -489,14 +489,38 @@ export function captureLastMessageHash(target: string, lines: number = 50): stri
  * Get the CLI launch command for an agent. If the agent has a thinkingEffort
  * set, it is translated through the unified ladder and passed as the
  * provider-specific flag (claude: --effort; codex: -c model_reasoning_effort).
+ *
+ * task-13dee93b: for `claude-code` agents the resolved `model` is now passed via
+ * `--model` (previously the model was display/state-only under tmux, so the class
+ * selection — incl. claude-fable — had no effect). When the model is the Fable
+ * class, a pane-visible remediation is appended that fires on a nonzero exit
+ * (e.g. Fable unreachable on the active plan), naming the role's config key and
+ * `claude-opus` — AC9's actionable hard error for the fire-and-forget tmux launch.
  */
-export function agentCliCommand(agent: { provider: string; thinkingEffort?: string }): string {
+export function agentCliCommand(agent: {
+  provider: string;
+  model?: string;
+  role?: "coder" | "reviewer";
+  thinkingEffort?: string;
+}): string {
   const effortRaw = agent.thinkingEffort?.trim();
   if (agent.provider === "claude-code") {
-    const base = "claude --dangerously-skip-permissions";
-    if (!effortRaw) return base;
-    const level = normaliseEffortLevel(effortRaw);
-    return `${base} --effort ${claudeEffort(level)}`;
+    let base = "claude --dangerously-skip-permissions";
+    const model = agent.model?.trim();
+    if (model) base += ` --model ${model}`;
+    if (effortRaw) {
+      const level = normaliseEffortLevel(effortRaw);
+      base += ` --effort ${claudeEffort(level)}`;
+    }
+    if (model === "claude-fable-5") {
+      // AC9: leave the config-key remediation visible in the pane if the Fable
+      // CLI exits nonzero (e.g. model unavailable). No silent fallback.
+      const roleKey = `${agent.role ?? "coder"}_class`;
+      base +=
+        ` || printf >&2 'ludics: claude-fable unavailable — ` +
+        `set mag.orchestration.%s: claude-opus in config.yaml and restart\\n' '${roleKey}'`;
+    }
+    return base;
   }
   const base = "codex --yolo -c check_for_update_on_startup=false";
   if (!effortRaw) return base;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -214,6 +214,63 @@ describe("writeOrchestrationDefaults", () => {
     expect(parsed.mag.orchestration.default_coder).toBeNull();
   });
 
+  // task-13dee93b: per-role high-end class persistence + idempotent fable seed.
+  test("persists coder_class/reviewer_class and round-trips them (AC4); fable selection seeds model_classes", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const YAML = (await import("yaml")).default;
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(
+      configPath,
+      "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_mode: pair\n",
+    );
+    writeOrchestrationDefaults({
+      coder: "claude-code",
+      reviewer: "codex",
+      coderClass: "claude-fable",
+      reviewerClass: "claude-opus",
+    });
+    const raw = readFileSync(configPath, "utf-8");
+    // Round-trip via the YAML parser so a silent serialization omission shows up.
+    const parsed = YAML.parse(raw) as { mag: { orchestration: Record<string, unknown> } };
+    const orch = parsed.mag.orchestration;
+    expect(orch.coder_class).toBe("claude-fable");
+    expect(orch.reviewer_class).toBe("claude-opus");
+    // Positive backfill: a fable selection seeds a resolvable model_classes entry.
+    expect((orch.model_classes as Record<string, unknown>)["claude-fable"]).toBe("claude-fable-5");
+  });
+
+  test("negative control: an opus-only write does NOT add model_classes and leaves existing values intact", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const YAML = (await import("yaml")).default;
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(
+      configPath,
+      "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    default_mode: pair\n    model_classes:\n      claude-opus: pinned-opus\n",
+    );
+    writeOrchestrationDefaults({ coder: "claude-code", reviewer: "codex", coderClass: "claude-opus" });
+    const parsed = YAML.parse(readFileSync(configPath, "utf-8")) as { mag: { orchestration: Record<string, unknown> } };
+    const mc = parsed.mag.orchestration.model_classes as Record<string, unknown>;
+    expect(parsed.mag.orchestration.coder_class).toBe("claude-opus");
+    expect("claude-fable" in mc).toBe(false); // no fable seed for an opus selection
+    expect(mc["claude-opus"]).toBe("pinned-opus"); // existing value untouched
+  });
+
+  test("omitting class fields leaves any existing class keys untouched", async () => {
+    const { readFileSync } = await import("fs");
+    const { writeOrchestrationDefaults } = await import("./config.ts");
+    const YAML = (await import("yaml")).default;
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(
+      configPath,
+      "state_repo: owner/ludics-state\nstate_path: harness\nmag:\n  orchestration:\n    coder_class: claude-fable\n",
+    );
+    writeOrchestrationDefaults({ coder: "claude-code", reviewer: "codex" });
+    const parsed = YAML.parse(readFileSync(configPath, "utf-8")) as { mag: { orchestration: Record<string, unknown> } };
+    expect(parsed.mag.orchestration.coder_class).toBe("claude-fable"); // untouched
+  });
+
   test("preserves adjacent comment + sibling default_mode verbatim", async () => {
     const { readFileSync } = await import("fs");
     const { writeOrchestrationDefaults } = await import("./config.ts");

--- a/src/config.ts
+++ b/src/config.ts
@@ -653,6 +653,8 @@ export function milestoneKey(
 export function writeOrchestrationDefaults(state: {
   coder: Provider | null;
   reviewer: Provider | null;
+  coderClass?: "claude-opus" | "claude-fable";
+  reviewerClass?: "claude-opus" | "claude-fable";
 }): void {
   const configPath = resolveConfigPath();
   if (!existsSync(configPath)) {
@@ -662,6 +664,24 @@ export function writeOrchestrationDefaults(state: {
   const doc = YAML.parseDocument(text);
   doc.setIn(["mag", "orchestration", "default_coder"], state.coder);
   doc.setIn(["mag", "orchestration", "default_reviewer"], state.reviewer);
+  // task-13dee93b: persist the per-role high-end class when provided; absent
+  // fields leave the existing config key untouched.
+  let seedFable = false;
+  if (state.coderClass !== undefined) {
+    doc.setIn(["mag", "orchestration", "coder_class"], state.coderClass);
+    if (state.coderClass === "claude-fable") seedFable = true;
+  }
+  if (state.reviewerClass !== undefined) {
+    doc.setIn(["mag", "orchestration", "reviewer_class"], state.reviewerClass);
+    if (state.reviewerClass === "claude-fable") seedFable = true;
+  }
+  // Idempotent backfill: a claude-fable selection requires a resolvable
+  // model_classes.claude-fable, or the session would throw "…is required" at
+  // launch. Seed the canonical value only when the key is absent — never
+  // overwrite a user's existing value.
+  if (seedFable && doc.getIn(["mag", "orchestration", "model_classes", "claude-fable"]) === undefined) {
+    doc.setIn(["mag", "orchestration", "model_classes", "claude-fable"], "claude-fable-5");
+  }
   atomicWriteFileSync(configPath, doc.toString());
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -281,6 +281,22 @@ export async function loadConfig(): Promise<LudicsFullConfig> {
 }
 
 /**
+ * Return the parsed `mag.orchestration` config block (or undefined when absent
+ * or config loading fails). Neutral, exported home for the orchestration record
+ * so non-adapter modules (e.g. `transport-t3code.ts`) can resolve it without
+ * importing an adapter's private `loadConfigOrchestration` helper (task-13dee93b).
+ */
+export function loadOrchestrationConfig(): Record<string, unknown> | undefined {
+  try {
+    const cfg = loadConfigSync();
+    const mag = cfg.mag as Record<string, unknown> | undefined;
+    return mag?.orchestration as Record<string, unknown> | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Return the global orchestration adapter mode.
  * Defaults to "t3code" when the key is absent for backward compatibility.
  */

--- a/src/dashboard-server.ts
+++ b/src/dashboard-server.ts
@@ -834,10 +834,20 @@ export function buildHandlers(deps: DashboardHandlerDeps): (req: Request) => Pro
         );
       }
       try {
-        writeOrchestrationDefaults({ coder: result.coder, reviewer: result.reviewer });
+        writeOrchestrationDefaults({
+          coder: result.coder,
+          reviewer: result.reviewer,
+          coderClass: result.coderClass,
+          reviewerClass: result.reviewerClass,
+        });
         lastGenerated = 0; // force regeneration on next data request
         return new Response(
-          JSON.stringify({ coder: result.coder, reviewer: result.reviewer }),
+          JSON.stringify({
+            coder: result.coder,
+            reviewer: result.reviewer,
+            coderClass: result.coderClass,
+            reviewerClass: result.reviewerClass,
+          }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         );
       } catch (e) {

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -1624,6 +1624,8 @@ describe("generateOrchestrationDefaults — task-b43bd578", () => {
     expect(generateOrchestrationDefaults()).toEqual({
       coder: "claude-code",
       reviewer: "codex",
+      coderClass: "claude-opus",
+      reviewerClass: "claude-opus",
     });
   });
 
@@ -1633,6 +1635,8 @@ describe("generateOrchestrationDefaults — task-b43bd578", () => {
     expect(generateOrchestrationDefaults()).toEqual({
       coder: "codex",
       reviewer: "claude-code",
+      coderClass: "claude-opus",
+      reviewerClass: "claude-opus",
     });
   });
 
@@ -1642,6 +1646,8 @@ describe("generateOrchestrationDefaults — task-b43bd578", () => {
     expect(generateOrchestrationDefaults()).toEqual({
       coder: null,
       reviewer: "codex",
+      coderClass: "claude-opus",
+      reviewerClass: "claude-opus",
     });
   });
 
@@ -1653,12 +1659,32 @@ describe("generateOrchestrationDefaults — task-b43bd578", () => {
       const { generateOrchestrationDefaults } = await import("./dashboard.ts");
       const result = generateOrchestrationDefaults();
       calls = spy.mock.calls;
-      expect(result).toEqual({ coder: "claude-code", reviewer: "codex" });
+      expect(result).toEqual({ coder: "claude-code", reviewer: "codex", coderClass: "claude-opus", reviewerClass: "claude-opus" });
     } finally {
       spy.mockRestore();
     }
     const matched = calls.some((c) => String(c[0]).includes("cursor"));
     expect(matched).toBe(true);
+  });
+
+  // task-13dee93b AC4: the effective per-role high-end class is exposed for the
+  // dashboard sub-select and survives reload.
+  test("configured coder_class/reviewer_class are reflected; default is claude-opus", async () => {
+    writeConfigWithMag(
+      "mag:\n  orchestration:\n    coder_class: claude-fable\n    reviewer_class: claude-opus\n",
+    );
+    const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+    const r = generateOrchestrationDefaults();
+    expect(r.coderClass).toBe("claude-fable");
+    expect(r.reviewerClass).toBe("claude-opus");
+  });
+
+  test("absent class keys default to claude-opus (mutation guard vs reading a wrong key)", async () => {
+    writeConfigWithMag("mag:\n  orchestration:\n    default_coder: codex\n");
+    const { generateOrchestrationDefaults } = await import("./dashboard.ts");
+    const r = generateOrchestrationDefaults();
+    expect(r.coderClass).toBe("claude-opus");
+    expect(r.reviewerClass).toBe("claude-opus");
   });
 });
 
@@ -1674,7 +1700,7 @@ describe("dashboardGenerate writes orchestration-defaults.json — task-b43bd578
     const outFile = join(harnessDir(), "dashboard", "data", "orchestration-defaults.json");
     expect(existsSync(outFile)).toBe(true);
     const parsed = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
-    expect(parsed).toEqual({ coder: "codex", reviewer: "claude-code" });
+    expect(parsed).toEqual({ coder: "codex", reviewer: "claude-code", coderClass: "claude-opus", reviewerClass: "claude-opus" });
   });
 
   test("regenerates after writeOrchestrationDefaults (POST-then-regenerate path)", async () => {
@@ -1684,13 +1710,13 @@ describe("dashboardGenerate writes orchestration-defaults.json — task-b43bd578
     dashboardGenerate();
     const outFile = join(harnessDir(), "dashboard", "data", "orchestration-defaults.json");
     const before = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
-    expect(before).toEqual({ coder: "claude-code", reviewer: "codex" });
+    expect(before).toEqual({ coder: "claude-code", reviewer: "codex", coderClass: "claude-opus", reviewerClass: "claude-opus" });
 
     const { writeOrchestrationDefaults } = await import("./config.ts");
     writeOrchestrationDefaults({ coder: "codex", reviewer: "claude-code" });
     dashboardGenerate();
     const after = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>;
-    expect(after).toEqual({ coder: "codex", reviewer: "claude-code" });
+    expect(after).toEqual({ coder: "codex", reviewer: "claude-code", coderClass: "claude-opus", reviewerClass: "claude-opus" });
   });
 });
 
@@ -1727,6 +1753,38 @@ describe("dashboard HTTP /api/orchestration-defaults — task-b43bd578", () => {
     const raw = readFileSync(process.env.LUDICS_CONFIG!, "utf-8");
     expect(raw).toMatch(/default_coder:\s*codex/);
     expect(raw).toMatch(/default_reviewer:\s*claude-code/);
+  });
+
+  test("POST with coderClass: claude-fable persists the key, seeds model_classes, and echoes it (AC4)", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "claude-code", reviewer: "codex", coderClass: "claude-fable", reviewerClass: "claude-opus" }),
+    }));
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as { coderClass: string; reviewerClass: string };
+    expect(body.coderClass).toBe("claude-fable");
+    expect(body.reviewerClass).toBe("claude-opus");
+    const raw = readFileSync(process.env.LUDICS_CONFIG!, "utf-8");
+    expect(raw).toMatch(/coder_class:\s*claude-fable/);
+    expect(raw).toMatch(/reviewer_class:\s*claude-opus/);
+    // Idempotent backfill: a fable selection seeds a resolvable model entry.
+    expect(raw).toMatch(/claude-fable:\s*claude-fable-5/);
+  });
+
+  test("POST with an invalid coderClass → 400", async () => {
+    seedConfig();
+    const handler = await makeHandler();
+    const resp = await handler(new Request("http://x/api/orchestration-defaults", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ coder: "claude-code", reviewer: "codex", coderClass: "claude-sonnet" }),
+    }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toMatch(/coderClass/);
   });
 
   test("missing 'coder' key → 400 + JSON error", async () => {
@@ -1798,7 +1856,7 @@ describe("dashboard HTTP /api/orchestration-defaults — task-b43bd578", () => {
     const { dashboardGenerate } = await import("./dashboard.ts");
     dashboardGenerate();
     const out = JSON.parse(readFileSync(join(harnessDir(), "dashboard", "data", "orchestration-defaults.json"), "utf-8"));
-    expect(out).toEqual({ coder: null, reviewer: "codex" });
+    expect(out).toEqual({ coder: null, reviewer: "codex", coderClass: "claude-opus", reviewerClass: "claude-opus" });
   });
 
   test("GET to /api/orchestration-defaults → 405", async () => {
@@ -1842,7 +1900,7 @@ describe("dashboard HTTP /api/orchestration-defaults — task-b43bd578", () => {
     const dataReq = new Request("http://x/data/orchestration-defaults.json");
     const dataResp = await handler(dataReq);
     expect(dataResp.status).toBe(200);
-    const dataBody = await dataResp.json() as { coder: string; reviewer: string };
-    expect(dataBody).toEqual({ coder: "codex", reviewer: "claude-code" });
+    const dataBody = await dataResp.json() as { coder: string; reviewer: string; coderClass: string; reviewerClass: string };
+    expect(dataBody).toEqual({ coder: "codex", reviewer: "claude-code", coderClass: "claude-opus", reviewerClass: "claude-opus" });
   });
 });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -21,7 +21,7 @@ import { ludicsSelfCommand } from "./orchestration/util.ts";
 import { startDashboardServer } from "./dashboard-server.ts";
 import { clusterIsController, heartbeatIsFresh, clusterCurrentMachineName } from "./cluster.ts";
 import { getIntentForDashboard } from "./cluster-http.ts";
-import { effectiveDefaultsFromConfig } from "./orchestration-defaults.ts";
+import { effectiveDefaultsFromConfig, highEndClassesFromConfig } from "./orchestration-defaults.ts";
 
 function readSlotIntentForDashboard(slotNum: number): { action: string } | null {
   return getIntentForDashboard(slotNum);
@@ -845,14 +845,23 @@ function generateAdapter(): Record<string, unknown> {
 //   - key present and null → null (preserves explicit user "none")
 //   - key present + valid  → the configured value
 
-export function generateOrchestrationDefaults(): { coder: string | null; reviewer: string | null } {
+export function generateOrchestrationDefaults(): {
+  coder: string | null;
+  reviewer: string | null;
+  coderClass: string;
+  reviewerClass: string;
+} {
+  // task-13dee93b: also expose the effective per-role high-end class so the
+  // dashboard sub-select renders the persisted choice (survives reload, AC4).
   try {
     const config = loadConfigSync();
     const mag = config.mag as Record<string, unknown> | undefined;
     const orch = mag?.orchestration as Record<string, unknown> | undefined;
-    return effectiveDefaultsFromConfig(orch);
+    const classes = highEndClassesFromConfig(orch);
+    return { ...effectiveDefaultsFromConfig(orch), coderClass: classes.coder, reviewerClass: classes.reviewer };
   } catch {
-    return effectiveDefaultsFromConfig(undefined);
+    const classes = highEndClassesFromConfig(undefined);
+    return { ...effectiveDefaultsFromConfig(undefined), coderClass: classes.coder, reviewerClass: classes.reviewer };
   }
 }
 

--- a/src/orchestration-defaults.test.ts
+++ b/src/orchestration-defaults.test.ts
@@ -7,6 +7,8 @@ import {
   EFFECTIVE_DEFAULTS,
   PROVIDERS,
   effectiveDefaultsFromConfig,
+  highEndClassesFromConfig,
+  isHighEndClass,
   isProvider,
   validatePayload,
 } from "./orchestration-defaults.ts";
@@ -93,6 +95,60 @@ describe("validatePayload", () => {
     expect(validatePayload(null).ok).toBe(false);
     expect(validatePayload([]).ok).toBe(false);
     expect(validatePayload("string").ok).toBe(false);
+  });
+
+  // task-13dee93b AC4 — optional per-role high-end class fields.
+  test("accepts valid coderClass/reviewerClass and returns them", () => {
+    const r = validatePayload({
+      coder: "claude-code",
+      reviewer: "codex",
+      coderClass: "claude-fable",
+      reviewerClass: "claude-opus",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.coderClass).toBe("claude-fable");
+      expect(r.reviewerClass).toBe("claude-opus");
+    }
+  });
+
+  test("omitting class fields leaves them undefined (server preserves existing)", () => {
+    const r = validatePayload({ coder: "claude-code", reviewer: "codex" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.coderClass).toBeUndefined();
+      expect(r.reviewerClass).toBeUndefined();
+    }
+  });
+
+  test("rejects an invalid class value (e.g. claude-sonnet or a number)", () => {
+    const r1 = validatePayload({ coder: "claude-code", reviewer: "codex", coderClass: "claude-sonnet" });
+    expect(r1.ok).toBe(false);
+    if (!r1.ok) expect(r1.error).toMatch(/coderClass/);
+    const r2 = validatePayload({ coder: "claude-code", reviewer: "codex", reviewerClass: 5 });
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.error).toMatch(/reviewerClass/);
+  });
+});
+
+describe("isHighEndClass / highEndClassesFromConfig (task-13dee93b)", () => {
+  test("isHighEndClass accepts only opus + fable", () => {
+    expect(isHighEndClass("claude-opus")).toBe(true);
+    expect(isHighEndClass("claude-fable")).toBe(true);
+    expect(isHighEndClass("claude-sonnet")).toBe(false);
+    expect(isHighEndClass("codex")).toBe(false);
+    expect(isHighEndClass(123)).toBe(false);
+  });
+
+  test("highEndClassesFromConfig reads per-role keys, defaulting to claude-opus", () => {
+    expect(highEndClassesFromConfig({ coder_class: "claude-fable", reviewer_class: "claude-opus" })).toEqual({
+      coder: "claude-fable",
+      reviewer: "claude-opus",
+    });
+    // Absent / undefined config → both default to claude-opus.
+    expect(highEndClassesFromConfig(undefined)).toEqual({ coder: "claude-opus", reviewer: "claude-opus" });
+    // Unknown value → forgiving default (not a throw).
+    expect(highEndClassesFromConfig({ coder_class: "bogus" }).coder).toBe("claude-opus");
   });
 });
 

--- a/src/orchestration-defaults.ts
+++ b/src/orchestration-defaults.ts
@@ -12,8 +12,34 @@
 // the literal fallback. Honouring null at auto-fill is deferred to the
 // N≥3 provider-extension task.
 
+import {
+  HIGH_END_CLAUDE_CLASSES,
+  normalizeHighEndClass,
+  type HighEndClass,
+} from "./orchestration/model-defaults.ts";
+
 export const PROVIDERS = ["claude-code", "codex"] as const;
 export type Provider = (typeof PROVIDERS)[number];
+
+/** True for a valid per-role high-end Claude class (`claude-opus` | `claude-fable`).
+ *  Used by the dashboard POST validator (task-13dee93b AC4). */
+export function isHighEndClass(x: unknown): x is HighEndClass {
+  return typeof x === "string" && (HIGH_END_CLAUDE_CLASSES as readonly string[]).includes(x);
+}
+
+/**
+ * Resolve the effective per-role high-end class from a parsed `mag.orchestration`
+ * block, for the dashboard role-switcher's initial state (task-13dee93b AC4).
+ * Forgiving: missing/invalid → `claude-opus` (default), via normalizeHighEndClass.
+ */
+export function highEndClassesFromConfig(
+  orch: Record<string, unknown> | undefined | null,
+): { coder: HighEndClass; reviewer: HighEndClass } {
+  return {
+    coder: normalizeHighEndClass(orch?.coder_class),
+    reviewer: normalizeHighEndClass(orch?.reviewer_class),
+  };
+}
 
 export const ROLES = ["coder", "reviewer", "none"] as const;
 export type Role = (typeof ROLES)[number];
@@ -68,7 +94,13 @@ function resolveRole(
 }
 
 export type ValidatePayloadResult =
-  | { ok: true; coder: Provider | null; reviewer: Provider | null }
+  | {
+      ok: true;
+      coder: Provider | null;
+      reviewer: Provider | null;
+      coderClass?: HighEndClass;
+      reviewerClass?: HighEndClass;
+    }
   | { ok: false; error: string };
 
 /**
@@ -94,9 +126,27 @@ export function validatePayload(body: unknown): ValidatePayloadResult {
   if (coder !== null && reviewer !== null && coder === reviewer) {
     return { ok: false, error: "'coder' and 'reviewer' must differ when both non-null" };
   }
+  // task-13dee93b: optional per-role high-end class. Absent → omitted (server
+  // leaves the existing config key untouched); present-but-invalid → reject.
+  let coderClass: HighEndClass | undefined;
+  let reviewerClass: HighEndClass | undefined;
+  if ("coderClass" in obj) {
+    if (!isHighEndClass(obj.coderClass)) {
+      return { ok: false, error: `invalid 'coderClass' value: ${JSON.stringify(obj.coderClass)}` };
+    }
+    coderClass = obj.coderClass;
+  }
+  if ("reviewerClass" in obj) {
+    if (!isHighEndClass(obj.reviewerClass)) {
+      return { ok: false, error: `invalid 'reviewerClass' value: ${JSON.stringify(obj.reviewerClass)}` };
+    }
+    reviewerClass = obj.reviewerClass;
+  }
   return {
     ok: true,
     coder: coder as Provider | null,
     reviewer: reviewer as Provider | null,
+    coderClass,
+    reviewerClass,
   };
 }

--- a/src/orchestration/model-defaults.test.ts
+++ b/src/orchestration/model-defaults.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   TRACKED_MODEL_CLASSES,
+  HIGH_END_CLAUDE_CLASSES,
   classForProvider,
+  dispatchWithFableContext,
+  fableUnavailableMessage,
+  isFableModel,
+  normalizeHighEndClass,
   resolveModelClass,
+  type HighEndClass,
   type ModelClass,
 } from "./model-defaults.ts";
 
@@ -11,6 +17,7 @@ const FULL_TABLE: Record<string, string> = {
   codex: "gpt-5.5",
   "claude-opus": "claude-opus-4-8",
   "claude-sonnet": "claude-sonnet-4-6",
+  "claude-fable": "claude-fable-5",
 };
 
 describe("resolveModelClass — returns the configured value", () => {
@@ -18,6 +25,12 @@ describe("resolveModelClass — returns the configured value", () => {
     expect(resolveModelClass(FULL_TABLE, "codex")).toBe("gpt-5.5");
     expect(resolveModelClass(FULL_TABLE, "claude-opus")).toBe("claude-opus-4-8");
     expect(resolveModelClass(FULL_TABLE, "claude-sonnet")).toBe("claude-sonnet-4-6");
+    // task-13dee93b: claude-fable is a tracked class resolving to claude-fable-5 (AC1).
+    expect(resolveModelClass(FULL_TABLE, "claude-fable")).toBe("claude-fable-5");
+  });
+
+  test("claude-fable is enumerated in TRACKED_MODEL_CLASSES (AC1)", () => {
+    expect(TRACKED_MODEL_CLASSES).toContain("claude-fable");
   });
 
   test("trims surrounding whitespace from a configured value", () => {
@@ -92,5 +105,102 @@ describe("classForProvider", () => {
 
   test("unknown provider falls to claude-sonnet (non-codex default)", () => {
     expect(classForProvider("whatever")).toBe<ModelClass>("claude-sonnet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task-13dee93b — per-role high-end class + Fable-unavailable handling
+// ---------------------------------------------------------------------------
+
+describe("normalizeHighEndClass (AC3 — forgiving, default claude-opus)", () => {
+  test("HIGH_END_CLAUDE_CLASSES is exactly opus + fable", () => {
+    expect([...HIGH_END_CLAUDE_CLASSES]).toEqual(["claude-opus", "claude-fable"]);
+  });
+
+  test("claude-fable selects fable; claude-opus / absent / blank → claude-opus", () => {
+    expect(normalizeHighEndClass("claude-fable")).toBe<HighEndClass>("claude-fable");
+    expect(normalizeHighEndClass(" claude-fable ")).toBe<HighEndClass>("claude-fable");
+    expect(normalizeHighEndClass("claude-opus")).toBe<HighEndClass>("claude-opus");
+    expect(normalizeHighEndClass(undefined)).toBe<HighEndClass>("claude-opus");
+    expect(normalizeHighEndClass("")).toBe<HighEndClass>("claude-opus");
+  });
+
+  test("unrecognised / non-string values fall back to claude-opus without throwing", () => {
+    // Harness: the value is a recognisably-wrong string / wrong type — the AC's
+    // forgiving branch must default it, NOT throw (throws are reserved for unset
+    // tracked classes in resolveModelClass).
+    expect(normalizeHighEndClass("claude-sonnet")).toBe<HighEndClass>("claude-opus");
+    expect(normalizeHighEndClass("gpt-5")).toBe<HighEndClass>("claude-opus");
+    expect(normalizeHighEndClass(123)).toBe<HighEndClass>("claude-opus");
+    expect(normalizeHighEndClass(null)).toBe<HighEndClass>("claude-opus");
+  });
+});
+
+describe("isFableModel", () => {
+  const orchCfg = { model_classes: FULL_TABLE };
+
+  test("true for the resolved fable model and the canonical literal (even without orchCfg)", () => {
+    expect(isFableModel("claude-fable-5", orchCfg)).toBe(true);
+    expect(isFableModel("claude-fable-5")).toBe(true); // literal fallback, no orchCfg
+  });
+
+  test("matches a config-overridden fable model string", () => {
+    expect(isFableModel("fable-next", { model_classes: { "claude-fable": "fable-next" } })).toBe(true);
+  });
+
+  test("false for opus / sonnet / codex / blank", () => {
+    expect(isFableModel("claude-opus-4-8", orchCfg)).toBe(false);
+    expect(isFableModel("claude-sonnet-4-6", orchCfg)).toBe(false);
+    expect(isFableModel("gpt-5.5", orchCfg)).toBe(false);
+    expect(isFableModel("", orchCfg)).toBe(false);
+  });
+});
+
+describe("fableUnavailableMessage (AC9 — names the config key + claude-opus)", () => {
+  test("names the role-specific key and claude-opus", () => {
+    const m = fableUnavailableMessage("claude-fable-5", "coder");
+    expect(m).toContain("mag.orchestration.coder_class");
+    expect(m).toContain("claude-opus");
+    expect(m).toContain("claude-fable-5");
+    expect(fableUnavailableMessage("claude-fable-5", "reviewer")).toContain(
+      "mag.orchestration.reviewer_class",
+    );
+  });
+
+  test("names BOTH keys when the role is unknown", () => {
+    const m = fableUnavailableMessage("claude-fable-5");
+    expect(m).toContain("mag.orchestration.coder_class");
+    expect(m).toContain("mag.orchestration.reviewer_class");
+  });
+});
+
+describe("dispatchWithFableContext (AC9 — annotate Fable failures, no relabel/fallback)", () => {
+  const orchCfg = { model_classes: FULL_TABLE };
+
+  test("rethrows an annotated error when a Fable dispatch fails", async () => {
+    // Harness: the dispatched model IS the fable class AND fn rejects — the only
+    // state in which the AC9 annotation must fire.
+    const p = dispatchWithFableContext(
+      () => Promise.reject(new Error("model claude-fable-5 not available")),
+      "claude-fable-5",
+      "coder",
+      orchCfg,
+    );
+    await expect(p).rejects.toThrow(/mag\.orchestration\.coder_class/);
+    await expect(p).rejects.toThrow(/claude-opus/);
+    // Original error text is preserved, not discarded.
+    await expect(p).rejects.toThrow(/not available/);
+  });
+
+  test("passes a NON-Fable failure through unchanged (mutation guard — no relabel)", async () => {
+    // Harness: same rejecting fn, but the model is Opus — the annotation branch
+    // must NOT fire; deleting the isFableModel guard would relabel this and fail.
+    const original = new Error("transient socket hangup");
+    const p = dispatchWithFableContext(() => Promise.reject(original), "claude-opus-4-8", "coder", orchCfg);
+    await expect(p).rejects.toBe(original);
+  });
+
+  test("returns the value on success", async () => {
+    expect(await dispatchWithFableContext(() => Promise.resolve(42), "claude-fable-5", "coder", orchCfg)).toBe(42);
   });
 });

--- a/src/orchestration/model-defaults.ts
+++ b/src/orchestration/model-defaults.ts
@@ -12,10 +12,19 @@
 // code change — see templates/config.reference.yaml for the documented table.
 
 /** The model classes resolved from `mag.orchestration.model_classes`. Provider
- *  is NOT class: `claude-code` resolves to `claude-opus` (medium/large coder)
- *  or `claude-sonnet` (tiny/small coder + the generic claude default). */
-export const TRACKED_MODEL_CLASSES = ["codex", "claude-opus", "claude-sonnet"] as const;
+ *  is NOT class: `claude-code` resolves to its high-end class (`claude-opus` by
+ *  default, or `claude-fable` when selected per role) for medium/large effort, or
+ *  `claude-sonnet` (tiny/small coder + the generic claude default). `claude-fable`
+ *  is a *selectable high-end model class* (task-13dee93b), NOT a new provider —
+ *  it runs on the same `claude-code` provider / `claudeAgent` runner as Opus. */
+export const TRACKED_MODEL_CLASSES = ["codex", "claude-opus", "claude-sonnet", "claude-fable"] as const;
 export type ModelClass = (typeof TRACKED_MODEL_CLASSES)[number];
+
+/** The two Claude classes a user may pick as a role's high-end (medium/large
+ *  effort) model. A strict subset of {@link TRACKED_MODEL_CLASSES}; the default
+ *  is `claude-opus` (preserves pre-task-13dee93b behaviour). */
+export const HIGH_END_CLAUDE_CLASSES = ["claude-opus", "claude-fable"] as const;
+export type HighEndClass = (typeof HIGH_END_CLAUDE_CLASSES)[number];
 
 /**
  * Resolve the latest-within-class model for `cls` from the
@@ -51,4 +60,99 @@ export function resolveModelClass(
  */
 export function classForProvider(provider: string): ModelClass {
   return provider === "codex" ? "codex" : "claude-sonnet";
+}
+
+// ---------------------------------------------------------------------------
+// Per-role high-end class selection + Fable-unavailable handling (task-13dee93b)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a per-role high-end class config value (`mag.orchestration.coder_class`
+ * / `reviewer_class`) into a {@link HighEndClass}. FORGIVING by contract (AC3 of
+ * task-13dee93b): missing / blank / non-string / unrecognised values resolve to
+ * `claude-opus` (preserving today's behaviour), warning on a recognisably-wrong
+ * non-empty string. This deliberately does NOT throw — the hard throw is reserved
+ * for an unset tracked class in `resolveModelClass`.
+ */
+export function normalizeHighEndClass(value: unknown): HighEndClass {
+  if (typeof value === "string") {
+    const v = value.trim();
+    if (v === "claude-fable") return "claude-fable";
+    if (v === "claude-opus" || v === "") return "claude-opus";
+    console.error(
+      `ludics: orchestration: ignoring unknown high-end class ${JSON.stringify(value)}; ` +
+        `expected "claude-opus" or "claude-fable" — falling back to claude-opus.`,
+    );
+    return "claude-opus";
+  }
+  if (value != null) {
+    console.error(
+      `ludics: orchestration: ignoring non-string high-end class ${JSON.stringify(value)}; ` +
+        `falling back to claude-opus.`,
+    );
+  }
+  return "claude-opus";
+}
+
+/**
+ * True when `model` is the Fable class model. Compares against the resolved
+ * `model_classes.claude-fable` from `orchCfg` (robust to a config override) and
+ * always also matches the canonical literal `claude-fable-5` — so it stays
+ * correct at launch boundaries that lack an `orchCfg` (e.g. when config loading
+ * returns undefined). Never throws.
+ *
+ * @param orchCfg the parsed `mag.orchestration` block (reads `.model_classes`).
+ */
+export function isFableModel(model: string, orchCfg?: Record<string, unknown>): boolean {
+  const m = (model ?? "").trim();
+  if (!m) return false;
+  if (m === "claude-fable-5") return true;
+  try {
+    const table = orchCfg?.model_classes as Record<string, unknown> | undefined;
+    return resolveModelClass(table, "claude-fable") === m;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the actionable hard-error message shown when a `claude-fable` session
+ * fails to launch / first-message (AC9 of task-13dee93b). Names the failing
+ * model AND the exact config key to edit, instructing the user to switch to
+ * `claude-opus`. When `role` is unknown, both role keys are named.
+ */
+export function fableUnavailableMessage(model: string, role?: "coder" | "reviewer"): string {
+  const key = role
+    ? `mag.orchestration.${role}_class`
+    : `mag.orchestration.coder_class / mag.orchestration.reviewer_class`;
+  return (
+    `claude-fable (${model}) failed to launch — it may be unavailable on the active ` +
+    `plan (Fable is promo-gated to 2026-06-22 and is not guaranteed on subscription ` +
+    `plans). There is no silent fallback. To proceed, set ${key} to claude-opus in ` +
+    `config.yaml and retry.`
+  );
+}
+
+/**
+ * Run an awaited launch/first-message dispatch, and — ONLY when the dispatched
+ * model is the Fable class — rethrow a failure annotated with the actionable
+ * {@link fableUnavailableMessage} (preserving the original error text). Non-Fable
+ * failures pass through completely unchanged (never relabeled). No silent
+ * fallback: the original failure is never swallowed.
+ */
+export async function dispatchWithFableContext<T>(
+  fn: () => Promise<T>,
+  model: string,
+  role: "coder" | "reviewer" | undefined,
+  orchCfg?: Record<string, unknown>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (isFableModel(model, orchCfg)) {
+      const orig = e instanceof Error ? e.message : String(e);
+      throw new Error(`${fableUnavailableMessage(model, role)}\n(original error: ${orig})`);
+    }
+    throw e;
+  }
 }

--- a/src/orchestration/transport-t3code.test.ts
+++ b/src/orchestration/transport-t3code.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test, spyOn } from "bun:test";
+import { T3CodeTransport } from "./transport-t3code.ts";
+import { T3CodeClient } from "../t3code/client.ts";
+import * as t3server from "../t3code/server.ts";
+import type { T3CodeServerRecord } from "../t3code/types.ts";
+import type { AgentConfig, OrchestrationState } from "./state.ts";
+
+// task-13dee93b AC9: T3CodeTransport.sendTurn wraps the first-turn dispatch
+// (thread.turn.start) in dispatchWithFableContext, so a launch/first-message
+// failure of a claude-fable session is rethrown with the actionable config-key
+// remediation, while a non-Fable failure passes through unchanged.
+
+const RECORD: T3CodeServerRecord = {
+  pid: 1, port: 1234, host: "127.0.0.1",
+  webUrl: "http://127.0.0.1:1234", wsUrl: "ws://127.0.0.1:1234", authToken: "t",
+  stateDir: "/tmp/t3", startedAt: "2026-06-12T00:00:00Z", command: ["t3"],
+};
+
+function makeState(agentName: string): OrchestrationState {
+  return { threadIds: { [agentName]: "thread-1" } } as unknown as OrchestrationState;
+}
+
+function makeAgent(model: string, role: "coder" | "reviewer"): AgentConfig {
+  return { name: role, provider: "claude-code", role, model, branch: "b", worktreePath: "/tmp/wt" } as AgentConfig;
+}
+
+describe("T3CodeTransport.sendTurn — Fable-unavailable hard error (AC9)", () => {
+  afterEach(() => {
+    // spyOn auto-tracks; explicit restore via mock registry not needed per-call,
+    // but we re-spy fresh in each test below.
+  });
+
+  test("a Fable first-turn dispatch failure rethrows naming reviewer_class + claude-opus", async () => {
+    const recSpy = spyOn(t3server, "readServerRecord").mockReturnValue(RECORD);
+    const closeSpy = spyOn(T3CodeClient.prototype, "close").mockImplementation(() => {});
+    const dispatchSpy = spyOn(T3CodeClient.prototype, "dispatchCommand").mockImplementation(() =>
+      Promise.reject(new Error("ws: model claude-fable-5 rejected")),
+    );
+    try {
+      const t = new T3CodeTransport();
+      const p = t.sendTurn(makeState("reviewer"), makeAgent("claude-fable-5", "reviewer"), "go");
+      await expect(p).rejects.toThrow(/mag\.orchestration\.reviewer_class/);
+      await expect(p).rejects.toThrow(/claude-opus/);
+      await expect(p).rejects.toThrow(/claude-fable-5 rejected/); // original preserved
+    } finally {
+      recSpy.mockRestore();
+      closeSpy.mockRestore();
+      dispatchSpy.mockRestore();
+    }
+  });
+
+  test("a non-Fable first-turn dispatch failure is NOT relabeled (mutation guard)", async () => {
+    const recSpy = spyOn(t3server, "readServerRecord").mockReturnValue(RECORD);
+    const closeSpy = spyOn(T3CodeClient.prototype, "close").mockImplementation(() => {});
+    const dispatchSpy = spyOn(T3CodeClient.prototype, "dispatchCommand").mockImplementation(() =>
+      Promise.reject(new Error("ws disconnected")),
+    );
+    try {
+      const t = new T3CodeTransport();
+      const p = t.sendTurn(makeState("coder"), makeAgent("claude-opus-4-8", "coder"), "go");
+      await expect(p).rejects.toThrow(/ws disconnected/);
+      await expect(p).rejects.not.toThrow(/mag\.orchestration/);
+    } finally {
+      recSpy.mockRestore();
+      closeSpy.mockRestore();
+      dispatchSpy.mockRestore();
+    }
+  });
+});

--- a/src/orchestration/transport-t3code.ts
+++ b/src/orchestration/transport-t3code.ts
@@ -2,7 +2,7 @@
 // Extracted from runner.ts to allow pluggable transport backends.
 
 import { T3CodeClient } from "../t3code/client.ts";
-import { readServerRecord } from "../t3code/server.ts";
+import * as t3server from "../t3code/server.ts";
 import { toWireProvider } from "../t3code/types.ts";
 import type { T3CodeServerRecord, T3Snapshot } from "../t3code/types.ts";
 import { emitEvent } from "../events.ts";
@@ -12,6 +12,8 @@ import type { OrchestrationTransport } from "./transport.ts";
 import type { AgentConfig, AgentTurnLifecycle, OrchestrationState } from "./state.ts";
 import { isoNow, makeId } from "./util.ts";
 import { claudeEffort, codexEffort, normaliseEffortLevel } from "./effort.ts";
+import { dispatchWithFableContext } from "./model-defaults.ts";
+import { loadOrchestrationConfig } from "../config.ts";
 
 async function withClient<T>(
   record: T3CodeServerRecord,
@@ -102,29 +104,38 @@ export class T3CodeTransport implements OrchestrationTransport {
     message: string,
   ): Promise<string> {
     const threadId = state.threadIds[agent.name];
-    const record = readServerRecord();
+    const record = t3server.readServerRecord();
     if (!record || !threadId) throw new Error(`no t3code thread for agent ${agent.name}`);
 
     const modelSelection = buildModelSelection(agent);
     const commandId = makeId("cmd");
 
-    await withClient(record, async (client) => {
-      await client.dispatchCommand({
-        type: "thread.turn.start",
-        commandId,
-        threadId,
-        message: {
-          messageId: makeId("msg"),
-          role: "user",
-          text: message,
-          attachments: [],
-        },
-        modelSelection,
-        runtimeMode: "full-access",
-        interactionMode: "default",
-        createdAt: isoNow(),
-      });
-    });
+    // task-13dee93b AC9: a claude-fable first-turn dispatch that fails (model
+    // unreachable) is rethrown with the actionable config-key remediation naming
+    // this agent's role; non-Fable failures pass through unchanged. No fallback.
+    await dispatchWithFableContext(
+      () =>
+        withClient(record, async (client) => {
+          await client.dispatchCommand({
+            type: "thread.turn.start",
+            commandId,
+            threadId,
+            message: {
+              messageId: makeId("msg"),
+              role: "user",
+              text: message,
+              attachments: [],
+            },
+            modelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: isoNow(),
+          });
+        }),
+      agent.model,
+      agent.role,
+      loadOrchestrationConfig(),
+    );
 
     return commandId;
   }
@@ -134,7 +145,7 @@ export class T3CodeTransport implements OrchestrationTransport {
   }
 
   async refreshAgentTransportState(state: OrchestrationState): Promise<void> {
-    const record = readServerRecord();
+    const record = t3server.readServerRecord();
     const snapshot = await fetchSnapshot(record);
 
     for (const agent of state.agents) {
@@ -224,7 +235,7 @@ export class T3CodeTransport implements OrchestrationTransport {
     agent: AgentConfig,
   ): Promise<void> {
     const threadId = state.threadIds[agent.name];
-    const record = readServerRecord();
+    const record = t3server.readServerRecord();
     if (record && threadId) {
       await withClient(record, async (client) => {
         try {
@@ -242,7 +253,7 @@ export class T3CodeTransport implements OrchestrationTransport {
   }
 
   async subscribeEvents(callback: () => void): Promise<(() => void) | null> {
-    const record = readServerRecord();
+    const record = t3server.readServerRecord();
     if (!record) return null;
 
     try {

--- a/src/orchestration/transport-tmux.ts
+++ b/src/orchestration/transport-tmux.ts
@@ -11,6 +11,7 @@ import {
 } from "../adapters/tmux-adapter.ts";
 import { tmuxCapture } from "../adapters/tmux.ts";
 import { substantiveDiff } from "./runner.ts";
+import { loadOrchestrationConfig } from "../config.ts";
 
 // Re-export for backwards compatibility (used by tests)
 export { ttydPort };
@@ -45,7 +46,7 @@ export class TmuxTransport implements OrchestrationTransport {
     // Check if the agent CLI is already running in the pane (persistent session).
     // If not, reboot it — this handles crash recovery and first-turn-after-resume.
     if (!isAgentAlive(state.slot, agent.name, state.taskId)) {
-      tmuxSendCommand(target, agentCliCommand(agent));
+      tmuxSendCommand(target, agentCliCommand(agent, loadOrchestrationConfig()));
       // Wait for the CLI to boot, then verify it's alive before pasting.
       // Codex can take longer to start than Claude Code.
       for (let wait = 0; wait < 15; wait++) {

--- a/src/slots/duo-expand.test.ts
+++ b/src/slots/duo-expand.test.ts
@@ -65,4 +65,14 @@ describe("expandDuoSlots — no stray positional leak", () => {
       }
     }
   });
+
+  // task-13dee93b: the reviewer high-end suffix (e.g. claude-fable-5) must be
+  // preserved and swapped onto slot B's coder, mirroring the coder suffix.
+  test("--reviewer provider:model suffix swaps onto slot B coder", () => {
+    const result = expandDuoSlots(1, 2, "--coder claude-code:claude-opus-4-8 --reviewer claude-code:claude-fable-5");
+    expect(result.slotA.args).toContain("--reviewer claude-code:claude-fable-5");
+    // Roles swap: the reviewer's resolved model becomes slot B's coder model.
+    expect(result.slotB.args).toContain("--coder claude-code:claude-fable-5");
+    expect(result.slotB.args).toContain("--reviewer claude-code:claude-opus-4-8");
+  });
 });

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, readFileSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
-import { globalAdapter, harnessDir, slotsCount, stateRepoDir, resolveProjectPath, t3codeIntegrationEnabled } from "../config.ts";
+import { globalAdapter, harnessDir, loadOrchestrationConfig, slotsCount, stateRepoDir, resolveProjectPath, t3codeIntegrationEnabled } from "../config.ts";
 import { atomicWriteFileSync } from "../json.ts";
 import { mergeAdapterState, addNoteToSlotData } from "./markdown.ts";
 import { readSlotJson, writeSlotJson, readAllSlotJson, emptySlotData, slotJsonDir, slotDataToMarkdown, normalizeTaskId } from "./json.ts";
@@ -1334,7 +1334,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
         `LUDICS_PEER_SYNC_DIR="${orchState.peerSyncDir}"`,
       ].join(" ");
       tmuxSendCommand(session, envCmd);
-      tmuxSendCommand(session, agentCliCommand(agent));
+      tmuxSendCommand(session, agentCliCommand(agent, loadOrchestrationConfig()));
     };
 
     for (let i = 0; i < orchState.agents.length; i++) {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1327,7 +1327,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
     const newTtydPids: Record<string, number> = { ...(tmuxState?.ttydPids ?? {}) };
     const taskId = orchState.taskId;
 
-    const bootCliInSession = (session: string, agent: { name: string; provider: string; thinkingEffort?: string }) => {
+    const bootCliInSession = (session: string, agent: { name: string; provider: string; model?: string; role?: "coder" | "reviewer"; thinkingEffort?: string }) => {
       const envCmd = [
         `export LUDICS_SLOT=${slotNum}`,
         `LUDICS_AGENT=${agent.name}`,

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -118,6 +118,15 @@ mag:
     default_reviewer: codex      # Default reviewer provider for auto-selected sessions: codex | claude-code
     coder_model: ""              # Model ID for the coder agent (e.g. claude-opus-4-8); empty = provider default
     reviewer_model: ""           # Model ID for the reviewer agent; empty = provider default
+    # High-end Claude model class per role, for medium/large effort claude-code
+    # sessions only (task-13dee93b): claude-opus (default) | claude-fable.
+    # Selecting claude-fable runs claude-fable-5 (the tier above Opus) on
+    # medium/large sessions for that role; tiny/small + pilot/solo stay on Sonnet,
+    # and Codex / explicit model overrides are unaffected. Fable is promo-gated to
+    # 2026-06-22 and may be absent on a subscription plan; if a claude-fable session
+    # fails to launch, set the key back to claude-opus (there is no silent fallback).
+    coder_class: claude-opus     # High-end Claude class for the coder: claude-opus | claude-fable
+    reviewer_class: claude-opus  # High-end Claude class for the reviewer: claude-opus | claude-fable
     coder_effort: "high"         # Effort level for the coder: low | medium | high | xhigh | max; default: high
     reviewer_effort: "high"      # Effort level for the reviewer: low | medium | high | xhigh | max; default: high
     # Latest-within-class default models — the SINGLE SOURCE OF TRUTH for the
@@ -126,12 +135,15 @@ mag:
     # change. A missing/blank tracked class FAILS LOUDLY at session start,
     # before any worktree/session is created (resolveModelClass in
     # src/orchestration/model-defaults.ts). Provider is not class: a
-    # claude-code coder resolves to claude-opus for medium/large effort and
-    # claude-sonnet otherwise; codex coder/reviewer resolve to the codex class.
+    # claude-code coder resolves to its high-end class (claude-opus by default, or
+    # claude-fable when coder_class/reviewer_class selects it) for medium/large
+    # effort and claude-sonnet otherwise; codex coder/reviewer resolve to the codex
+    # class. claude-fable is a selectable high-end CLASS, not a provider.
     model_classes:
       codex: gpt-5.5                    # latest GPT-5 (codex coder/reviewer default)
-      claude-opus: claude-opus-4-8      # latest Opus 4 (medium/large claude-code coder)
+      claude-opus: claude-opus-4-8      # latest Opus 4 (default high-end claude-code class)
       claude-sonnet: claude-sonnet-4-6  # latest Sonnet 4 (tiny/small coder + claude-code default)
+      claude-fable: claude-fable-5      # latest Fable 5 (opt-in high-end class; promo-gated to 2026-06-22)
     # Unified ladder — same rung means same relative budget across providers.
     # Per-provider CLI/wire mapping:
     #   unified  | claude-code --effort | codex model_reasoning_effort

--- a/templates/dashboard/nav.js
+++ b/templates/dashboard/nav.js
@@ -83,6 +83,10 @@
             }).then(function (data) {
                 if (!data) return;
                 var initialState = mod.fromWireBody(data);
+                var initialClasses = {
+                    coder: (data && data.coderClass) || 'claude-opus',
+                    reviewer: (data && data.reviewerClass) || 'claude-opus',
+                };
                 var roleSwitcher = mod.createRoleSwitcherElement(initialState, function (newState) {
                     return fetch('/api/orchestration-defaults', {
                         method: 'POST',
@@ -95,7 +99,7 @@
                         }
                         return resp.json();
                     });
-                });
+                }, initialClasses);
                 statusBar.insertBefore(roleSwitcher, switcher);
             });
         }).catch(function (e) {

--- a/templates/dashboard/role-switcher.d.ts
+++ b/templates/dashboard/role-switcher.d.ts
@@ -7,10 +7,21 @@ export const ROLES: ReadonlyArray<"coder" | "reviewer">;
 
 export type RoleSwitcherRole = "coder" | "reviewer" | "none";
 export type RoleSwitcherState = Record<string, RoleSwitcherRole>;
+export type HighEndClass = "claude-opus" | "claude-fable";
 export interface RoleSwitcherWireBody {
   coder: string | null;
   reviewer: string | null;
+  // task-13dee93b: per-role high-end Claude class, carried alongside provider
+  // state in the same POST body.
+  coderClass?: HighEndClass;
+  reviewerClass?: HighEndClass;
 }
+export interface RoleSwitcherClasses {
+  coder?: HighEndClass;
+  reviewer?: HighEndClass;
+}
+
+export const HIGH_END_CLASSES: ReadonlyArray<HighEndClass>;
 
 export function applyRoleChange(
   state: RoleSwitcherState,
@@ -18,9 +29,17 @@ export function applyRoleChange(
   role: RoleSwitcherRole,
 ): RoleSwitcherState;
 
+export function roleHeldByClaudeCode(role: "coder" | "reviewer", state: RoleSwitcherState): boolean;
+
+export function toWireBody(
+  state: RoleSwitcherState,
+  classState?: RoleSwitcherClasses,
+): RoleSwitcherWireBody;
+
 export function createRoleSwitcherElement(
   initialState: RoleSwitcherState,
   onSubmit: (newState: RoleSwitcherWireBody) => Promise<unknown>,
+  initialClasses?: RoleSwitcherClasses,
 ): HTMLElement;
 
 export function fromWireBody(body: RoleSwitcherWireBody): RoleSwitcherState;

--- a/templates/dashboard/role-switcher.js
+++ b/templates/dashboard/role-switcher.js
@@ -13,6 +13,34 @@ export const PROVIDERS = ["claude-code", "codex"];
 export const ROLES = ["coder", "reviewer"];
 const ROLE_PREFIX = { coder: "C", reviewer: "R" };
 
+// task-13dee93b: per-role high-end Claude class sub-select. NOT a provider —
+// PROVIDERS stays exactly [claude-code, codex] (AC7). The class choice is only
+// meaningful for a claude-code-held role.
+export const HIGH_END_CLASSES = ["claude-opus", "claude-fable"];
+const DEFAULT_HIGH_END_CLASS = "claude-opus";
+
+/** A role's class sub-select is only enabled when claude-code holds that role
+ *  (a model class is meaningless for codex / an unheld role). Pure — exported so
+ *  the enable/disable rule is tested without a DOM. */
+export function roleHeldByClaudeCode(role, state) {
+  return !!state && state["claude-code"] === role;
+}
+
+/** Build the POST wire body from the provider role-state + the per-role class
+ *  state. Maps internal `none` → `null` for providers and always carries the two
+ *  class fields (so the persisted choice round-trips). Exported for testing. */
+export function toWireBody(state, classState) {
+  const out = { coder: null, reviewer: null };
+  for (const p of PROVIDERS) {
+    if (state[p] === "coder") out.coder = p;
+    else if (state[p] === "reviewer") out.reviewer = p;
+  }
+  const cs = classState || {};
+  out.coderClass = HIGH_END_CLASSES.includes(cs.coder) ? cs.coder : DEFAULT_HIGH_END_CLASS;
+  out.reviewerClass = HIGH_END_CLASSES.includes(cs.reviewer) ? cs.reviewer : DEFAULT_HIGH_END_CLASS;
+  return out;
+}
+
 /**
  * Pure constraint-propagation cascade.
  *
@@ -72,12 +100,20 @@ export function applyRoleChange(state, provider, role) {
  * Returns the constructed element. Pure DOM construction — no document
  * mutation outside the returned subtree.
  */
-export function createRoleSwitcherElement(initialState, onSubmit) {
+export function createRoleSwitcherElement(initialState, onSubmit, initialClasses) {
   let state = { ...initialState };
+  // Per-role high-end class, tracked separately from the provider role-state so
+  // the value is preserved even while a role is held by codex/none (AC4 reload).
+  const ic = initialClasses || {};
+  const classState = {
+    coder: HIGH_END_CLASSES.includes(ic.coder) ? ic.coder : DEFAULT_HIGH_END_CLASS,
+    reviewer: HIGH_END_CLASSES.includes(ic.reviewer) ? ic.reviewer : DEFAULT_HIGH_END_CLASS,
+  };
   const root = document.createElement("div");
   root.className = "role-switcher";
 
-  const selects = {}; // role -> <select>
+  const selects = {}; // role -> provider <select>
+  const classSelects = {}; // role -> class <select>
 
   function holderOf(role, st) {
     for (const p of PROVIDERS) {
@@ -90,6 +126,12 @@ export function createRoleSwitcherElement(initialState, onSubmit) {
     for (const r of ROLES) {
       const sel = selects[r];
       if (sel) sel.value = holderOf(r, state);
+      const csel = classSelects[r];
+      if (csel) {
+        csel.value = classState[r];
+        // The class sub-select is only relevant for a claude-code-held role.
+        csel.disabled = !roleHeldByClaudeCode(r, state);
+      }
     }
   }
 
@@ -114,12 +156,54 @@ export function createRoleSwitcherElement(initialState, onSubmit) {
     sel.addEventListener("change", () => handleChange(role, sel.value));
     selects[role] = sel;
     root.appendChild(sel);
+
+    // High-end class sub-select (Opus/Fable) for this role.
+    const csel = document.createElement("select");
+    csel.className = "class-select";
+    csel.dataset.role = role;
+    csel.setAttribute("aria-label", `${role === "coder" ? "Coder" : "Reviewer"} high-end class`);
+    for (const cls of HIGH_END_CLASSES) {
+      const opt = document.createElement("option");
+      opt.value = cls;
+      opt.textContent = cls === "claude-fable" ? "Fable" : "Opus";
+      csel.appendChild(opt);
+    }
+    csel.addEventListener("change", () => handleClassChange(role, csel.value));
+    classSelects[role] = csel;
+    root.appendChild(csel);
   }
 
   const sequencer = createInFlightSequencer();
 
+  async function submit(prevState, prevClasses) {
+    syncSelects();
+    root.removeAttribute("title");
+    const myId = sequencer.begin();
+    try {
+      const confirmed = await onSubmit(toWireBody(state, classState));
+      // Drop stale responses: if a newer change started after this one,
+      // its response (or its failure) is authoritative — not ours.
+      if (!sequencer.isLatest(myId)) return;
+      if (confirmed && typeof confirmed === "object") {
+        state = fromWireBody(confirmed);
+        if (HIGH_END_CLASSES.includes(confirmed.coderClass)) classState.coder = confirmed.coderClass;
+        if (HIGH_END_CLASSES.includes(confirmed.reviewerClass)) classState.reviewer = confirmed.reviewerClass;
+        syncSelects();
+      }
+    } catch (err) {
+      if (!sequencer.isLatest(myId)) return;
+      // Pessimistic rollback: server rejected or network failed.
+      state = prevState;
+      classState.coder = prevClasses.coder;
+      classState.reviewer = prevClasses.reviewer;
+      syncSelects();
+      root.setAttribute("title", `Failed to save: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   async function handleChange(role, chosenProvider) {
     const prev = state;
+    const prevClasses = { ...classState };
     let next;
     if (chosenProvider === "") {
       const holder = holderOf(role, prev);
@@ -129,25 +213,15 @@ export function createRoleSwitcherElement(initialState, onSubmit) {
       next = applyRoleChange(prev, chosenProvider, role);
     }
     state = next;
-    syncSelects();
-    root.removeAttribute("title");
-    const myId = sequencer.begin();
-    try {
-      const confirmed = await onSubmit(toWireBody(next));
-      // Drop stale responses: if a newer change started after this one,
-      // its response (or its failure) is authoritative — not ours.
-      if (!sequencer.isLatest(myId)) return;
-      if (confirmed && typeof confirmed === "object") {
-        state = fromWireBody(confirmed);
-        syncSelects();
-      }
-    } catch (err) {
-      if (!sequencer.isLatest(myId)) return;
-      // Pessimistic rollback: server rejected or network failed.
-      state = prev;
-      syncSelects();
-      root.setAttribute("title", `Failed to save: ${err instanceof Error ? err.message : String(err)}`);
-    }
+    await submit(prev, prevClasses);
+  }
+
+  async function handleClassChange(role, chosenClass) {
+    if (!HIGH_END_CLASSES.includes(chosenClass)) return;
+    const prev = state;
+    const prevClasses = { ...classState };
+    classState[role] = chosenClass;
+    await submit(prev, prevClasses);
   }
 
   syncSelects();
@@ -172,16 +246,6 @@ export function createInFlightSequencer() {
       return id === latest;
     },
   };
-}
-
-/** Map internal `none` ↔ wire-body `null`. */
-function toWireBody(state) {
-  const out = { coder: null, reviewer: null };
-  for (const p of PROVIDERS) {
-    if (state[p] === "coder") out.coder = p;
-    else if (state[p] === "reviewer") out.reviewer = p;
-  }
-  return out;
 }
 
 export function fromWireBody(body) {

--- a/templates/dashboard/role-switcher.test.ts
+++ b/templates/dashboard/role-switcher.test.ts
@@ -2,9 +2,9 @@
 // AC 14 names this transformation and pins its behaviour independently
 // of the DOM.
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { applyRoleChange, createInFlightSequencer, fromWireBody, HIGH_END_CLASSES, PROVIDERS, ROLES, roleHeldByClaudeCode, toWireBody } from "./role-switcher.js";
+import { applyRoleChange, createInFlightSequencer, createRoleSwitcherElement, fromWireBody, HIGH_END_CLASSES, PROVIDERS, ROLES, roleHeldByClaudeCode, toWireBody } from "./role-switcher.js";
 
 describe("PROVIDERS (browser-side copy)", () => {
   test("lists exactly claude-code and codex (in this order)", () => {
@@ -167,11 +167,11 @@ describe("fromWireBody — null ↔ none mapping", () => {
 });
 
 // ---------------------------------------------------------------------------
-// createRoleSwitcherElement source-level pins (AC 1, AC 3).
-// Bun's test runtime has no DOM and we don't want to add a polyfill dep
-// just for this test. The live HTTP smoke probe (AC 19) exercises the DOM
-// construction end-to-end against a real browser-like fetcher; here we pin
-// the source-level invariants that the DOM constructor must encode.
+// createRoleSwitcherElement (AC 1, AC 3). Bun's test runtime has no DOM; rather
+// than a polyfill dep, a minimal hand-rolled `document` stub (below, in the
+// task-13dee93b class sub-select describe) drives the DOM constructor directly.
+// The live HTTP smoke probe (AC 19) exercises construction end-to-end against a
+// real browser-like fetcher.
 //
 // AC 12 (pre-redesign) pinned a "Defaults for new sessions" label. That label
 // was removed in the per-role-select redesign; the assertion was dropped
@@ -318,5 +318,89 @@ describe("toWireBody — carries provider state + class fields", () => {
       reviewerClass: "claude-opus",
     });
     expect(toWireBody(state, { coder: "bogus" }).coderClass).toBe("claude-opus");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task-13dee93b AC4 — DOM-level test of the class sub-select interaction.
+// Bun has no DOM; a minimal hand-rolled `document` stub records change
+// listeners so we can drive the sub-select end-to-end. This enforces the GUI
+// invariant: a user can pick Opus/Fable from the role-switcher and have that
+// choice submitted (a future edit removing the sub-select or disconnecting its
+// change handler would fail here, not silently pass the pure-helper tests).
+// ---------------------------------------------------------------------------
+
+function makeFakeEl(tagName: string): any {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    tagName,
+    className: "",
+    dataset: {} as Record<string, string>,
+    children: [] as any[],
+    value: "",
+    disabled: false,
+    textContent: "",
+    _attrs: {} as Record<string, string>,
+    appendChild(c: any) { this.children.push(c); return c; },
+    setAttribute(k: string, v: string) { this._attrs[k] = v; },
+    removeAttribute(k: string) { delete this._attrs[k]; },
+    getAttribute(k: string) { return this._attrs[k]; },
+    addEventListener(t: string, cb: () => void) { (listeners[t] ||= []).push(cb); },
+    dispatch(t: string) { (listeners[t] || []).forEach((cb) => cb()); },
+  };
+}
+
+function findChild(root: any, className: string, role: string): any {
+  return root.children.find((c: any) => c.className === className && c.dataset.role === role);
+}
+
+describe("createRoleSwitcherElement — class sub-select DOM interaction (AC4)", () => {
+  let prevDoc: unknown;
+  beforeEach(() => {
+    prevDoc = (globalThis as any).document;
+    (globalThis as any).document = { createElement: (tag: string) => makeFakeEl(tag) };
+  });
+  afterEach(() => {
+    (globalThis as any).document = prevDoc;
+  });
+
+  test("coder class-select is enabled + set to the initial class; codex-held reviewer's is disabled", () => {
+    const root = createRoleSwitcherElement(
+      { "claude-code": "coder", "codex": "reviewer" },
+      () => Promise.resolve({}),
+      { coder: "claude-opus" },
+    );
+    const coderClassSel = findChild(root, "class-select", "coder");
+    const reviewerClassSel = findChild(root, "class-select", "reviewer");
+    expect(coderClassSel).toBeTruthy();
+    expect(coderClassSel.disabled).toBe(false); // claude-code holds coder
+    expect(coderClassSel.value).toBe("claude-opus");
+    // reviewer is held by codex → its class sub-select is disabled (meaningless).
+    expect(reviewerClassSel.disabled).toBe(true);
+  });
+
+  test("changing the coder class-select to claude-fable submits coderClass with the provider state", async () => {
+    let captured: any = null;
+    const onSubmit = (body: any) => { captured = body; return Promise.resolve(body); };
+    const root = createRoleSwitcherElement(
+      { "claude-code": "coder", "codex": "reviewer" },
+      onSubmit,
+      { coder: "claude-opus", reviewer: "claude-opus" },
+    );
+    const coderClassSel = findChild(root, "class-select", "coder");
+
+    // User picks Fable and the select fires `change`.
+    coderClassSel.value = "claude-fable";
+    coderClassSel.dispatch("change");
+    // onSubmit is invoked synchronously inside the handler (before its await),
+    // but await a tick for robustness against future refactors.
+    await Promise.resolve();
+
+    expect(captured).not.toBeNull();
+    expect(captured.coderClass).toBe("claude-fable"); // the GUI choice was submitted
+    // The existing provider role-state rides along in the same POST body.
+    expect(captured.coder).toBe("claude-code");
+    expect(captured.reviewer).toBe("codex");
+    expect(captured.reviewerClass).toBe("claude-opus"); // untouched
   });
 });

--- a/templates/dashboard/role-switcher.test.ts
+++ b/templates/dashboard/role-switcher.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { applyRoleChange, createInFlightSequencer, fromWireBody, PROVIDERS, ROLES } from "./role-switcher.js";
+import { applyRoleChange, createInFlightSequencer, fromWireBody, HIGH_END_CLASSES, PROVIDERS, ROLES, roleHeldByClaudeCode, toWireBody } from "./role-switcher.js";
 
 describe("PROVIDERS (browser-side copy)", () => {
   test("lists exactly claude-code and codex (in this order)", () => {
@@ -269,5 +269,54 @@ describe("role-switcher.js source-level pins (AC 1, AC 3)", () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
     // Must obtain its myId BEFORE awaiting onSubmit.
     expect(source).toMatch(/const myId\s*=\s*sequencer\.begin\(\);\s*\n\s*try\s*\{/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// task-13dee93b — per-role high-end class sub-select (pure, DOM-independent).
+// ---------------------------------------------------------------------------
+
+describe("HIGH_END_CLASSES (browser-side copy)", () => {
+  test("is exactly opus + fable, and PROVIDERS is unchanged (AC7)", () => {
+    expect([...HIGH_END_CLASSES]).toEqual(["claude-opus", "claude-fable"]);
+    // The class choice must NOT have leaked into the provider universe.
+    expect([...PROVIDERS]).toEqual(["claude-code", "codex"]);
+  });
+});
+
+describe("roleHeldByClaudeCode — class sub-select enablement rule", () => {
+  test("true only when claude-code holds that role", () => {
+    const state = { "claude-code": "coder", "codex": "reviewer" };
+    expect(roleHeldByClaudeCode("coder", state)).toBe(true);
+    expect(roleHeldByClaudeCode("reviewer", state)).toBe(false); // codex holds reviewer
+  });
+
+  test("false when the role is held by codex or is vacant", () => {
+    expect(roleHeldByClaudeCode("coder", { "claude-code": "none", "codex": "coder" })).toBe(false);
+    expect(roleHeldByClaudeCode("reviewer", { "claude-code": "coder", "codex": "none" })).toBe(false);
+  });
+});
+
+describe("toWireBody — carries provider state + class fields", () => {
+  test("emits provider nulls + both class fields", () => {
+    const state = { "claude-code": "coder", "codex": "reviewer" };
+    const body = toWireBody(state, { coder: "claude-fable", reviewer: "claude-opus" });
+    expect(body).toEqual({
+      coder: "claude-code",
+      reviewer: "codex",
+      coderClass: "claude-fable",
+      reviewerClass: "claude-opus",
+    });
+  });
+
+  test("defaults absent/invalid class values to claude-opus (preserves the choice across reload)", () => {
+    const state = { "claude-code": "none", "codex": "none" };
+    expect(toWireBody(state, {})).toEqual({
+      coder: null,
+      reviewer: null,
+      coderClass: "claude-opus",
+      reviewerClass: "claude-opus",
+    });
+    expect(toWireBody(state, { coder: "bogus" }).coderClass).toBe("claude-opus");
   });
 });

--- a/templates/harness/config.yaml
+++ b/templates/harness/config.yaml
@@ -47,10 +47,13 @@ mag:
   # Orchestration default models — bump a value when a new minor ships (config
   # edit, not a code change). A missing/blank class fails loudly at session start.
   orchestration:
+    coder_class: claude-opus     # High-end Claude class for the coder: claude-opus | claude-fable
+    reviewer_class: claude-opus  # High-end Claude class for the reviewer: claude-opus | claude-fable
     model_classes:
       codex: gpt-5.5
       claude-opus: claude-opus-4-8
       claude-sonnet: claude-sonnet-4-6
+      claude-fable: claude-fable-5
 
   autonomy_level:
     elaborate_tasks: auto


### PR DESCRIPTION
## Summary

Lets a user choose **Claude Fable** (`claude-fable-5`, the tier above Opus) as the high-end model for an orchestration role (coder or reviewer), selectable from both the dashboard role-switcher GUI and the harness config — **without splitting the `claude-code` provider**. `claude-fable` is a new model *class* alongside `claude-opus`/`claude-sonnet`; `claude-code` stays the single Claude provider (no new `T3ProviderKind`/`AgentType`/`PROVIDERS` entry).

Task: `task-13dee93b`. Proposal: `docs/proposals/task-13dee93b.md`. Deadline tracks the Fable promo window (2026-06-22).

## What changed

- **Class plumbing** (`src/orchestration/model-defaults.ts`): `claude-fable` added to `TRACKED_MODEL_CLASSES`; `HighEndClass` + `normalizeHighEndClass` (forgiving, default `claude-opus`, never throws); `isFableModel`, `fableUnavailableMessage`, and `dispatchWithFableContext` (shared AC9 boundary wrapper).
- **Per-role selection** (`mag.orchestration.coder_class`/`reviewer_class`): `selectOrchestrationFlags` reads the literal keys and applies the high-end class to coder **and** reviewer for medium/large effort. Tiny/small + pilot/solo stay Sonnet; Codex and explicit model overrides unaffected.
- **tmux parity** (`agentCliCommand`): now passes `--model <resolved>` for `claude-code` agents (previously the model was display-only under tmux, so the class had no effect). Achieves t3code/tmux consistency.
- **AC9 fail-loud, no silent fallback**: a Fable-model launch/first-message failure is rethrown with the config-key remediation at the real boundaries — t3code `ensureThread` (`thread.create`) and `T3CodeTransport.sendTurn` (`thread.turn.start`) — plus a pane-visible remediation baked into the tmux launch command. The Fable recognition uses `isFableModel(model, orchCfg)` everywhere (incl. the tmux remediation guard), so it stays correct when `model_classes.claude-fable` is config-bumped to a future Fable id. Non-Fable failures pass through unchanged.
- **Config seeds**: `claude-fable` + `coder_class`/`reviewer_class` documented in `templates/config.reference.yaml` and `templates/harness/config.yaml`.
- **Dashboard**: `validatePayload` accepts/validates the class fields; `writeOrchestrationDefaults` persists them and idempotently seeds `model_classes.claude-fable` on a fable pick; `generateOrchestrationDefaults` exposes them; the role-switcher renders an Opus/Fable sub-select enabled only for a `claude-code`-held role (with a DOM-level interaction test).

## Notes for reviewers

- **No new provider** (AC7): `PROVIDERS` stays `["claude-code","codex"]` and its lockstep sync test is unchanged.
- **Behaviour changes** (AC-required, authorized by the proposal Code Pointers): tmux now passes `--model` for claude-code agents; a `claude-code` reviewer on medium/large now resolves the high-end class (Opus default) instead of Sonnet (default reviewer is `codex`, so only opt-in claude-code reviewers are affected).
- **Out-of-PR edit**: the live state-repo config (`~/self-improve/harness/config.yaml`) was seeded with `claude-fable` per AC2 — not in this diff.
- One adjacent `lint:test-isolation` pinned-count bump (19→20), directly caused by the new transport test.

## Testing

- Full `bun test`: **2976 pass, 0 fail** (8 commits, 25 files)
- `bun run typecheck`, `bun run build`, eslint, and lints (config-reference, state-migration, cli-readme, no-mock-module, no-nul-bytes, template-safety, test-isolation) all green
- Per-AC verification recorded in `.peer-sync/workflow-feedback-coder.md`

## Review fixes

- Codex P2 (config-bumped Fable id): the tmux remediation guard now uses `isFableModel(model, orchCfg)` instead of the hardcoded `claude-fable-5`, with `orchCfg` threaded through the launch/reboot/resume paths. (commit `4da421b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)