### PR TITLE
fix(dashboard-ui): collapse per-role provider+class into one dropdown

### DIFF
--- a/templates/dashboard/role-switcher.d.ts
+++ b/templates/dashboard/role-switcher.d.ts
@@ -23,13 +23,17 @@ export interface RoleSwitcherClasses {
 
 export const HIGH_END_CLASSES: ReadonlyArray<HighEndClass>;
 
+// task-13dee93b: claude-code is surfaced in each role dropdown as its two
+// model classes directly (no separate sub-select).
+export const ROLE_OPTION_VALUES: ReadonlyArray<string>;
+
+export function providerForOptionValue(value: string): string;
+
 export function applyRoleChange(
   state: RoleSwitcherState,
   provider: string,
   role: RoleSwitcherRole,
 ): RoleSwitcherState;
-
-export function roleHeldByClaudeCode(role: "coder" | "reviewer", state: RoleSwitcherState): boolean;
 
 export function toWireBody(
   state: RoleSwitcherState,

--- a/templates/dashboard/role-switcher.js
+++ b/templates/dashboard/role-switcher.js
@@ -13,17 +13,26 @@ export const PROVIDERS = ["claude-code", "codex"];
 export const ROLES = ["coder", "reviewer"];
 const ROLE_PREFIX = { coder: "C", reviewer: "R" };
 
-// task-13dee93b: per-role high-end Claude class sub-select. NOT a provider —
-// PROVIDERS stays exactly [claude-code, codex] (AC7). The class choice is only
-// meaningful for a claude-code-held role.
+// task-13dee93b: per-role high-end Claude model class. NOT a provider —
+// PROVIDERS stays exactly [claude-code, codex] (AC7). claude-code is surfaced in
+// the role dropdown as these two classes directly (no separate sub-select), so
+// picking a class both assigns claude-code AND records the model class.
 export const HIGH_END_CLASSES = ["claude-opus", "claude-fable"];
 const DEFAULT_HIGH_END_CLASS = "claude-opus";
 
-/** A role's class sub-select is only enabled when claude-code holds that role
- *  (a model class is meaningless for codex / an unheld role). Pure — exported so
- *  the enable/disable rule is tested without a DOM. */
-export function roleHeldByClaudeCode(role, state) {
-  return !!state && state["claude-code"] === role;
+// The values offered in each role's single dropdown. claude-code expands into
+// its two model classes; every other provider appears as itself. PROVIDERS +
+// HIGH_END_CLASSES remain the semantic source of truth (AC7) — this is purely
+// the display expansion that lets one dropdown cover provider + class.
+export const ROLE_OPTION_VALUES = PROVIDERS.flatMap((p) =>
+  p === "claude-code" ? [...HIGH_END_CLASSES] : [p],
+);
+
+/** Map a dropdown value back to its underlying provider. Both high-end classes
+ *  resolve to claude-code; every other value is its own provider. Pure —
+ *  exported so the mapping is tested without a DOM. */
+export function providerForOptionValue(value) {
+  return HIGH_END_CLASSES.includes(value) ? "claude-code" : value;
 }
 
 /** Build the POST wire body from the provider role-state + the per-role class
@@ -86,9 +95,12 @@ export function applyRoleChange(state, provider, role) {
 /**
  * Construct a `.role-switcher` element with one `<select>` per role.
  *
- * Each select shows `<prefix>: <provider>` (e.g. "C: claude-code") or
- * `<prefix>: —` when no provider holds the role. The same cascade
- * `applyRoleChange` runs whether the user picks a provider (assign) or "—"
+ * Each select shows `<prefix>: <value>` where the value is the model class for
+ * a claude-code-held role (e.g. "C: claude-opus" / "C: claude-fable"), the
+ * provider for any other (e.g. "R: codex"), or `<prefix>: —` when no provider
+ * holds the role. Surfacing claude-code as its two model classes directly means
+ * the model choice needs no second dropdown (task-13dee93b). The same cascade
+ * `applyRoleChange` runs whether the user picks a value (assign) or "—"
  * (release) — the ≤1-coder / ≤1-reviewer invariant is preserved either way.
  *
  * `initialState` shape: { [provider]: "coder" | "reviewer" | "none" }
@@ -112,8 +124,7 @@ export function createRoleSwitcherElement(initialState, onSubmit, initialClasses
   const root = document.createElement("div");
   root.className = "role-switcher";
 
-  const selects = {}; // role -> provider <select>
-  const classSelects = {}; // role -> class <select>
+  const selects = {}; // role -> <select>
 
   function holderOf(role, st) {
     for (const p of PROVIDERS) {
@@ -122,16 +133,19 @@ export function createRoleSwitcherElement(initialState, onSubmit, initialClasses
     return "";
   }
 
+  // The dropdown value for a role encodes BOTH provider and (for claude-code)
+  // model class: claude-code → its class (opus/fable), another provider → that
+  // provider, unheld → "" (the em-dash option).
+  function optionValueFor(role) {
+    const holder = holderOf(role, state);
+    if (holder === "claude-code") return classState[role];
+    return holder; // codex → "codex"; unheld → ""
+  }
+
   function syncSelects() {
     for (const r of ROLES) {
       const sel = selects[r];
-      if (sel) sel.value = holderOf(r, state);
-      const csel = classSelects[r];
-      if (csel) {
-        csel.value = classState[r];
-        // The class sub-select is only relevant for a claude-code-held role.
-        csel.disabled = !roleHeldByClaudeCode(r, state);
-      }
+      if (sel) sel.value = optionValueFor(r);
     }
   }
 
@@ -147,30 +161,15 @@ export function createRoleSwitcherElement(initialState, onSubmit, initialClasses
     noneOpt.textContent = `${prefix}: —`;
     sel.appendChild(noneOpt);
 
-    for (const p of PROVIDERS) {
+    for (const v of ROLE_OPTION_VALUES) {
       const opt = document.createElement("option");
-      opt.value = p;
-      opt.textContent = `${prefix}: ${p}`;
+      opt.value = v;
+      opt.textContent = `${prefix}: ${v}`;
       sel.appendChild(opt);
     }
     sel.addEventListener("change", () => handleChange(role, sel.value));
     selects[role] = sel;
     root.appendChild(sel);
-
-    // High-end class sub-select (Opus/Fable) for this role.
-    const csel = document.createElement("select");
-    csel.className = "class-select";
-    csel.dataset.role = role;
-    csel.setAttribute("aria-label", `${role === "coder" ? "Coder" : "Reviewer"} high-end class`);
-    for (const cls of HIGH_END_CLASSES) {
-      const opt = document.createElement("option");
-      opt.value = cls;
-      opt.textContent = cls === "claude-fable" ? "Fable" : "Opus";
-      csel.appendChild(opt);
-    }
-    csel.addEventListener("change", () => handleClassChange(role, csel.value));
-    classSelects[role] = csel;
-    root.appendChild(csel);
   }
 
   const sequencer = createInFlightSequencer();
@@ -201,26 +200,21 @@ export function createRoleSwitcherElement(initialState, onSubmit, initialClasses
     }
   }
 
-  async function handleChange(role, chosenProvider) {
+  async function handleChange(role, chosenValue) {
     const prev = state;
     const prevClasses = { ...classState };
     let next;
-    if (chosenProvider === "") {
+    if (chosenValue === "") {
       const holder = holderOf(role, prev);
       if (!holder) return; // no-op release
       next = applyRoleChange(prev, holder, "none");
     } else {
-      next = applyRoleChange(prev, chosenProvider, role);
+      // A high-end class value both assigns claude-code to the role AND records
+      // which model class that role should use; a plain provider just assigns.
+      if (HIGH_END_CLASSES.includes(chosenValue)) classState[role] = chosenValue;
+      next = applyRoleChange(prev, providerForOptionValue(chosenValue), role);
     }
     state = next;
-    await submit(prev, prevClasses);
-  }
-
-  async function handleClassChange(role, chosenClass) {
-    if (!HIGH_END_CLASSES.includes(chosenClass)) return;
-    const prev = state;
-    const prevClasses = { ...classState };
-    classState[role] = chosenClass;
     await submit(prev, prevClasses);
   }
 

--- a/templates/dashboard/role-switcher.test.ts
+++ b/templates/dashboard/role-switcher.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { applyRoleChange, createInFlightSequencer, createRoleSwitcherElement, fromWireBody, HIGH_END_CLASSES, PROVIDERS, ROLES, roleHeldByClaudeCode, toWireBody } from "./role-switcher.js";
+import { applyRoleChange, createInFlightSequencer, createRoleSwitcherElement, fromWireBody, HIGH_END_CLASSES, PROVIDERS, providerForOptionValue, ROLE_OPTION_VALUES, ROLES, toWireBody } from "./role-switcher.js";
 
 describe("PROVIDERS (browser-side copy)", () => {
   test("lists exactly claude-code and codex (in this order)", () => {
@@ -247,8 +247,10 @@ describe("role-switcher.js source-level pins (AC 1, AC 3)", () => {
   });
 
   test("AC 3 (post-redesign): one <select> per role, classed .role-select, with C:/R: prefixes", () => {
-    // Two selects, one per role, each with three options (— + two providers).
+    // One select per role; each lists — plus ROLE_OPTION_VALUES
+    // (claude-opus, claude-fable, codex). No separate class sub-select.
     expect(source).toMatch(/document\.createElement\("select"\)/);
+    expect(source).not.toContain('"class-select"');
     expect(source).toMatch(/sel\.className\s*=\s*"role-select"/);
     // C: / R: prefixes are the user-visible mnemonic for which dropdown is which.
     expect(source).toContain('coder: "C"');
@@ -284,16 +286,17 @@ describe("HIGH_END_CLASSES (browser-side copy)", () => {
   });
 });
 
-describe("roleHeldByClaudeCode — class sub-select enablement rule", () => {
-  test("true only when claude-code holds that role", () => {
-    const state = { "claude-code": "coder", "codex": "reviewer" };
-    expect(roleHeldByClaudeCode("coder", state)).toBe(true);
-    expect(roleHeldByClaudeCode("reviewer", state)).toBe(false); // codex holds reviewer
+describe("ROLE_OPTION_VALUES / providerForOptionValue — single-dropdown expansion", () => {
+  test("claude-code expands into its two classes; codex stays as itself (AC7)", () => {
+    expect([...ROLE_OPTION_VALUES]).toEqual(["claude-opus", "claude-fable", "codex"]);
+    // The class expansion must NOT have leaked into the provider universe.
+    expect([...PROVIDERS]).toEqual(["claude-code", "codex"]);
   });
 
-  test("false when the role is held by codex or is vacant", () => {
-    expect(roleHeldByClaudeCode("coder", { "claude-code": "none", "codex": "coder" })).toBe(false);
-    expect(roleHeldByClaudeCode("reviewer", { "claude-code": "coder", "codex": "none" })).toBe(false);
+  test("both high-end classes map back to claude-code; other values map to themselves", () => {
+    expect(providerForOptionValue("claude-opus")).toBe("claude-code");
+    expect(providerForOptionValue("claude-fable")).toBe("claude-code");
+    expect(providerForOptionValue("codex")).toBe("codex");
   });
 });
 
@@ -322,12 +325,13 @@ describe("toWireBody — carries provider state + class fields", () => {
 });
 
 // ---------------------------------------------------------------------------
-// task-13dee93b AC4 — DOM-level test of the class sub-select interaction.
+// task-13dee93b AC4 — DOM-level test of the single per-role dropdown.
 // Bun has no DOM; a minimal hand-rolled `document` stub records change
-// listeners so we can drive the sub-select end-to-end. This enforces the GUI
-// invariant: a user can pick Opus/Fable from the role-switcher and have that
-// choice submitted (a future edit removing the sub-select or disconnecting its
-// change handler would fail here, not silently pass the pure-helper tests).
+// listeners so we can drive the select end-to-end. This enforces the GUI
+// invariant: a user picks Opus/Fable (or codex) from ONE dropdown per role and
+// has that choice submitted as provider + class — no separate sub-select. A
+// future edit reintroducing a second dropdown or disconnecting the change
+// handler would fail here, not silently pass the pure-helper tests.
 // ---------------------------------------------------------------------------
 
 function makeFakeEl(tagName: string): any {
@@ -354,7 +358,7 @@ function findChild(root: any, className: string, role: string): any {
   return root.children.find((c: any) => c.className === className && c.dataset.role === role);
 }
 
-describe("createRoleSwitcherElement — class sub-select DOM interaction (AC4)", () => {
+describe("createRoleSwitcherElement — single per-role dropdown DOM interaction (AC4)", () => {
   let prevDoc: unknown;
   beforeEach(() => {
     prevDoc = (globalThis as any).document;
@@ -364,22 +368,33 @@ describe("createRoleSwitcherElement — class sub-select DOM interaction (AC4)",
     (globalThis as any).document = prevDoc;
   });
 
-  test("coder class-select is enabled + set to the initial class; codex-held reviewer's is disabled", () => {
+  test("exactly one .role-select per role and no .class-select; values reflect class/provider", () => {
     const root = createRoleSwitcherElement(
       { "claude-code": "coder", "codex": "reviewer" },
       () => Promise.resolve({}),
-      { coder: "claude-opus" },
+      { coder: "claude-fable", reviewer: "claude-opus" },
     );
-    const coderClassSel = findChild(root, "class-select", "coder");
-    const reviewerClassSel = findChild(root, "class-select", "reviewer");
-    expect(coderClassSel).toBeTruthy();
-    expect(coderClassSel.disabled).toBe(false); // claude-code holds coder
-    expect(coderClassSel.value).toBe("claude-opus");
-    // reviewer is held by codex → its class sub-select is disabled (meaningless).
-    expect(reviewerClassSel.disabled).toBe(true);
+    const roleSelects = root.children.filter((c: any) => c.className === "role-select");
+    expect(roleSelects.length).toBe(2);
+    // The eliminated sub-select must be gone — this is the whole point of the fix.
+    expect(root.children.some((c: any) => c.className === "class-select")).toBe(false);
+    // claude-code-held coder shows its model class directly in the one dropdown.
+    expect(findChild(root, "role-select", "coder").value).toBe("claude-fable");
+    // codex-held reviewer shows the provider.
+    expect(findChild(root, "role-select", "reviewer").value).toBe("codex");
   });
 
-  test("changing the coder class-select to claude-fable submits coderClass with the provider state", async () => {
+  test("the dropdown lists — / claude-opus / claude-fable / codex", () => {
+    const root = createRoleSwitcherElement(
+      { "claude-code": "coder", "codex": "none" },
+      () => Promise.resolve({}),
+      {},
+    );
+    const coderSel = findChild(root, "role-select", "coder");
+    expect(coderSel.children.map((o: any) => o.value)).toEqual(["", "claude-opus", "claude-fable", "codex"]);
+  });
+
+  test("picking claude-fable submits coder=claude-code + coderClass=claude-fable (no second dropdown)", async () => {
     let captured: any = null;
     const onSubmit = (body: any) => { captured = body; return Promise.resolve(body); };
     const root = createRoleSwitcherElement(
@@ -387,20 +402,39 @@ describe("createRoleSwitcherElement — class sub-select DOM interaction (AC4)",
       onSubmit,
       { coder: "claude-opus", reviewer: "claude-opus" },
     );
-    const coderClassSel = findChild(root, "class-select", "coder");
+    const coderSel = findChild(root, "role-select", "coder");
 
-    // User picks Fable and the select fires `change`.
-    coderClassSel.value = "claude-fable";
-    coderClassSel.dispatch("change");
+    // User picks Fable from the single dropdown and it fires `change`.
+    coderSel.value = "claude-fable";
+    coderSel.dispatch("change");
     // onSubmit is invoked synchronously inside the handler (before its await),
     // but await a tick for robustness against future refactors.
     await Promise.resolve();
 
     expect(captured).not.toBeNull();
-    expect(captured.coderClass).toBe("claude-fable"); // the GUI choice was submitted
-    // The existing provider role-state rides along in the same POST body.
     expect(captured.coder).toBe("claude-code");
+    expect(captured.coderClass).toBe("claude-fable"); // the GUI choice was submitted
+    // The reviewer's provider + class ride along untouched in the same POST body.
     expect(captured.reviewer).toBe("codex");
-    expect(captured.reviewerClass).toBe("claude-opus"); // untouched
+    expect(captured.reviewerClass).toBe("claude-opus");
+  });
+
+  test("picking codex for the coder cascades claude-code to reviewer (swap)", async () => {
+    let captured: any = null;
+    const onSubmit = (body: any) => { captured = body; return Promise.resolve(body); };
+    const root = createRoleSwitcherElement(
+      { "claude-code": "coder", "codex": "reviewer" },
+      onSubmit,
+      { coder: "claude-fable", reviewer: "claude-opus" },
+    );
+    const coderSel = findChild(root, "role-select", "coder");
+
+    coderSel.value = "codex";
+    coderSel.dispatch("change");
+    await Promise.resolve();
+
+    // The ≤1-coder / ≤1-reviewer cascade still runs on the underlying provider.
+    expect(captured.coder).toBe("codex");
+    expect(captured.reviewer).toBe("claude-code");
   });
 });


### PR DESCRIPTION
## Problem

task-13dee93b (PR #563) shipped the per-role high-end model class as a **second** dropdown beside the provider select. Result: **four** selects crowding the status bar, and the class sub-select had **no `.class-select` CSS rule** so it rendered with raw browser styling (the "badly styled" complaint).

The original intent (task-13dee93b elaboration Q1) was to split the `claude-code` option into `claude-opus` / `claude-fable` **in the existing dropdown** — avoiding the extra control entirely.

## Fix

Collapse each role to **one** `.role-select`. `claude-code` is surfaced as its two model classes directly:

```
C: —   C: claude-opus   C: claude-fable   C: codex
```

Picking a class both assigns `claude-code` to the role **and** records the model class. Selecting `codex` runs the same ≤1-coder/≤1-reviewer cascade as before.

## Blast radius — UI only

The **wire protocol, server, config, and validation are unchanged**: `toWireBody` still emits `{coder, reviewer, coderClass, reviewerClass}`, and `src/` (config persistence, `validatePayload`, `dashboard-server`) is untouched. The collapse lives entirely in the dashboard display layer.

- New pure helpers `ROLE_OPTION_VALUES` / `providerForOptionValue` map the single dropdown value back to provider + class. Both exported + unit-tested without a DOM.
- Removed `roleHeldByClaudeCode` — it backed the sub-select's enable/disable rule, which no longer exists.
- `PROVIDERS` stays `[claude-code, codex]` (AC7); the class expansion is display-only.

## Tests

- DOM-interaction block rewritten: asserts exactly one `.role-select` per role, **no `.class-select`**, the option list `— / claude-opus / claude-fable / codex`, and that picking Fable/codex submits the correct wire body and runs the cascade.
- `roleHeldByClaudeCode` describe replaced with `ROLE_OPTION_VALUES` / `providerForOptionValue` pins.
- Full affected suite green: `role-switcher`, `nav`, `orchestration-defaults`, `config`, `dashboard`, `dashboard-server` (231 pass). Build + typecheck + template-safety + test-isolation clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)