### PR TITLE
feat(lint:test-isolation): direction-aware pin-mismatch diagnostic

### DIFF
--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -14,6 +14,7 @@ import {
   runCli,
   RULE_3_TARGETS,
   formatWarningCountHeuristic,
+  formatPinMismatch,
 } from "./lint-test-isolation.ts";
 
 // ---------------------------------------------------------------------------
@@ -843,6 +844,52 @@ describe("runCli", () => {
 });
 
 // ---------------------------------------------------------------------------
+// formatPinMismatch — unit coverage for the direction-aware diagnostic
+// ---------------------------------------------------------------------------
+
+describe("formatPinMismatch", () => {
+  test("UP: names cause, remedy, and all offending files", () => {
+    const msg = formatPinMismatch(21, 20, [
+      { rule: "rule-3", severity: "warning", file: "src/foo.test.ts", message: "imports src/config.ts" },
+      { rule: "rule-3", severity: "warning", file: "src/bar.test.ts", message: "imports src/events.ts" },
+    ]);
+    expect(msg).toContain("rose 20 → 21");
+    expect(msg).toContain("transitively imports a flagged module");
+    expect(msg).toContain("withSyntheticHarness(beforeEach, afterEach)");
+    expect(msg).toContain("src/foo.test.ts");
+    expect(msg).toContain("src/bar.test.ts");
+    expect(msg).not.toContain("fell");
+    expect(msg).not.toContain("lowering");
+  });
+
+  test("UP: deduplicates repeated files in rule-3 issues", () => {
+    const msg = formatPinMismatch(21, 20, [
+      { rule: "rule-3", severity: "warning", file: "src/dup.test.ts", message: "imports src/config.ts" },
+      { rule: "rule-3", severity: "warning", file: "src/dup.test.ts", message: "imports src/events.ts" },
+    ]);
+    // "src/dup.test.ts" appears only once in the file list
+    const occurrences = (msg.match(/src\/dup\.test\.ts/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test("UP: works with no rule-3 issues supplied (omitted)", () => {
+    const msg = formatPinMismatch(22, 20);
+    expect(msg).toContain("rose 20 → 22");
+    expect(msg).toContain("withSyntheticHarness");
+    expect(msg).not.toContain("Offending");
+  });
+
+  test("DOWN: recommends lowering pin, does NOT suggest synthetic-harness wrap", () => {
+    const msg = formatPinMismatch(18, 20);
+    expect(msg).toContain("fell 20 → 18");
+    expect(msg).toContain("update the pin to 18");
+    expect(msg).toContain("legitimate lowering");
+    expect(msg).not.toContain("withSyntheticHarness");
+    expect(msg).not.toContain("transitively imports");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Integration — drive the real CLI against the real repo
 // ---------------------------------------------------------------------------
 
@@ -864,7 +911,13 @@ describe("integration", () => {
     // trips rule-3 despite needing no real harness.
     const expectedWarningCount = 20;
     if (result.warningCount !== expectedWarningCount) {
-      throw new Error(formatWarningCountHeuristic(result.warningCount));
+      throw new Error(
+        formatPinMismatch(
+          result.warningCount,
+          expectedWarningCount,
+          result.issues.filter((i) => i.rule === "rule-3"),
+        ),
+      );
     }
     expect(result.warningCount).toBe(expectedWarningCount);
   });

--- a/scripts/lint-test-isolation.ts
+++ b/scripts/lint-test-isolation.ts
@@ -67,6 +67,44 @@ export function formatWarningCountHeuristic(warningCount: number): string {
   return `(${warningCount} warnings — to silence a new test: wrap with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts (preferred — actually isolates the harness env), OR bump the pinned count in scripts/lint-test-isolation.test.ts (only for pure-unit tests with no harness needs).`;
 }
 
+/**
+ * Direction-aware diagnostic for a pin mismatch in the integration test.
+ * UP branch: names the cause (transitive import of a flagged module), the
+ * remedy (withSyntheticHarness wrap), and every offending rule-3 file.
+ * DOWN branch: explains the count fell and recommends lowering the pin.
+ * Never called on the CLI success-summary path — that path keeps using
+ * formatWarningCountHeuristic (no pin context available there).
+ */
+export function formatPinMismatch(
+  observed: number,
+  expected: number,
+  rule3Issues?: LintIssue[],
+): string {
+  if (observed > expected) {
+    const files = rule3Issues
+      ? [...new Set(rule3Issues.map((i) => i.file))]
+      : [];
+    const fileList =
+      files.length > 0
+        ? `\nOffending file(s) tripping rule-3:\n${files.map((f) => `  - ${f}`).join("\n")}`
+        : "";
+    return (
+      `warning count rose ${expected} → ${observed}. ` +
+      `A new *.test.ts likely transitively imports a flagged module ` +
+      `(src/config.ts, src/events.ts, src/slots/json.ts, or src/adapters/base.ts). ` +
+      `Wrap its describe with withSyntheticHarness(beforeEach, afterEach) from src/test-utils.ts ` +
+      `to keep the pin; bump the pin only for a genuine pure-unit file.` +
+      fileList
+    );
+  } else {
+    return (
+      `warning count fell ${expected} → ${observed}. ` +
+      `A test was removed or isolated — this is a legitimate lowering: ` +
+      `update the pin to ${observed}.`
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Issue shape
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `formatPinMismatch(observed, expected, rule3Issues?)` to `scripts/lint-test-isolation.ts`: when the integration pin mismatches, the **UP** branch explains the cause (transitive import of a flagged module such as `src/config.ts`), lists all offending rule-3 files by name, and recommends `withSyntheticHarness(beforeEach, afterEach)` to keep the pin; the **DOWN** branch recommends lowering the pin and omits the harness-wrap advice.
- The integration test's throw site now passes `result.issues.filter(i => i.rule === "rule-3")` into the new builder.
- The CLI success-summary path (`formatWarningCountHeuristic`) is byte-for-byte unchanged — existing pinned-string assertions pass without modification.
- 4 new unit tests cover UP with files, UP with dedup, UP without files, and DOWN (including absence-of-harness-wrap assertion on DOWN).

## Test plan

- [x] `bun test scripts/lint-test-isolation.test.ts` — 55 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint:test-isolation` — 20 warnings, exit 0, CLI summary unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)