### PR TITLE
feat(health-check): outbound-staging-ff finding diagnostic — auth vs downtime

### DIFF
--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -164,6 +164,20 @@ This skill is invoked when:
    - Build stable issue key: `outbound-staging-ff-stale:<project>`
      (delta-tracked against `mag/health-last.json` so the same staleness
      counts as `ongoing` after the first detection, not `new`).
+   - **Annotate each finding** by invoking the diagnostic subcommand:
+     ```bash
+     annotation=$(ludics mag outbound-cause-remedy "$project" 2>/dev/null || echo '{"kind":"unknown"}')
+     kind=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('kind','unknown'))")
+     if [ "$kind" = "auth" ]; then
+       cause=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('cause',''))")
+       remedy=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('remedy',''))")
+       finding_text="$finding_text — cause: $cause; remedy: $remedy"
+     elif [ "$kind" = "no-attempts" ]; then
+       remedy=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('remedy',''))")
+       finding_text="$finding_text — $remedy"
+     fi
+     ```
+     When `kind` is `unknown`, leave the finding text unchanged.
    - **No notification**: `git push` auth failure does NOT raise a
      `ludics notify outgoing` from the push function or from this
      check. This stable-key entry is the only surfacing path for

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,6 +175,8 @@ Commands:
                                Reset task(s) to deferred and queue revision (comma-separated ids)
   mag auto-start-evaluate <id> <high|low> [rationale]
                                Evaluate auto-start decision and update task status
+  mag outbound-cause-remedy <project>
+                               Classify outbound sentinel staleness (auth/no-attempts/unknown) as JSON
   mag completed <proposal>     Mark a proposal completed (without .md extension)
   mag feedback-digest          Queue a feedback digest run
   mag sync-learnings           Queue a learnings-consolidation run

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -53,6 +53,7 @@ import {
 } from "./adapters/tmux.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { ludicsSelfCommand } from "./orchestration/util.ts";
+import { classifyOutboundStaleness } from "./staging-event-meta.ts";
 
 const MAG_SESSION_NAME = process.env.LUDICS_MAG_SESSION ?? "ludics-mag";
 const MAG_DEFAULT_PORT = process.env.LUDICS_MAG_PORT ?? "7679";
@@ -4425,6 +4426,22 @@ const magSubcommands: ReadonlyMap<string, MagSubHandler> = new Map<string, MagSu
       }
     }
     console.log(JSON.stringify(result));
+  }],
+  ["outbound-cause-remedy", (args) => {
+    const project = args[0];
+    if (!project) throw new Error("project name required");
+    const eventsFile = join(harnessDir(), "journal", "events.jsonl");
+    const sentinelPath = join(harnessDir(), "mag", `last-outbound-fast-forward-${project}.epoch`);
+    let sinceEpoch = 0;
+    if (existsSync(sentinelPath)) {
+      try {
+        sinceEpoch = Math.floor(statSync(sentinelPath).mtimeMs / 1000);
+      } catch {
+        sinceEpoch = 0;
+      }
+    }
+    const classification = classifyOutboundStaleness(eventsFile, project, sinceEpoch);
+    console.log(JSON.stringify(classification));
   }],
   ["draft-proposal", (args) => {
     const taskId = args[0];

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -4,7 +4,10 @@ import { join } from "path";
 import { tmpdir } from "os";
 import {
   OUTBOUND_EVENT_CAUSE_REMEDY,
+  NO_ATTEMPTS_REMEDY,
   latestOutboundCauseRemedy,
+  outboundActivitySince,
+  classifyOutboundStaleness,
 } from "./staging-event-meta.ts";
 
 function tmpEvents(lines: Record<string, unknown>[]): string {
@@ -113,5 +116,127 @@ describe("latestOutboundCauseRemedy", () => {
 
   test("missing file → null (best-effort, never throws)", () => {
     expect(latestOutboundCauseRemedy(join(tmpdir(), "does-not-exist-xyz", "events.jsonl"), "ocannl")).toBeNull();
+  });
+});
+
+describe("outboundActivitySince", () => {
+  test("returns true when a staging_outbound_* event for the project is in-window", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 500, message: "ocannl: pushed" },
+    ]);
+    expect(outboundActivitySince(file, "ocannl", 400)).toBe(true);
+  });
+
+  test("returns false when the only matching event predates sinceEpoch", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 100, message: "ocannl: pushed" },
+    ]);
+    expect(outboundActivitySince(file, "ocannl", 200)).toBe(false);
+  });
+
+  test("returns false for events belonging to a different project", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "other", epoch: 500, message: "other: pushed" },
+    ]);
+    expect(outboundActivitySince(file, "ocannl", 0)).toBe(false);
+  });
+
+  test("returns false for non-staging_outbound_ events", () => {
+    const file = tmpEvents([
+      { event_type: "some_other_event", project: "ocannl", epoch: 500, message: "ocannl: x" },
+    ]);
+    expect(outboundActivitySince(file, "ocannl", 0)).toBe(false);
+  });
+
+  test("returns false for missing file (best-effort)", () => {
+    expect(outboundActivitySince(join(tmpdir(), "does-not-exist-xyz", "events.jsonl"), "ocannl", 0)).toBe(false);
+  });
+
+  test("matches events at exactly sinceEpoch boundary", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_error", project: "ocannl", epoch: 300, message: "ocannl: err" },
+    ]);
+    expect(outboundActivitySince(file, "ocannl", 300)).toBe(true);
+    expect(outboundActivitySince(file, "ocannl", 301)).toBe(false);
+  });
+});
+
+describe("classifyOutboundStaleness", () => {
+  test("auth branch: workflow-scope failure in window → { kind: 'auth', cause, remedy }", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 500, message: "ocannl: x" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("auth");
+    if (result.kind === "auth") {
+      expect(result.cause).toBe(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!.cause);
+      expect(result.remedy).toBe(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_workflow_scope_missing!.remedy);
+    }
+  });
+
+  test("auth branch: credentials failure in window → { kind: 'auth', cause, remedy }", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_credentials_missing", project: "ocannl", epoch: 500, message: "ocannl: x" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("auth");
+    if (result.kind === "auth") {
+      expect(result.cause).toBe(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!.cause);
+      expect(result.remedy).toBe(OUTBOUND_EVENT_CAUSE_REMEDY.staging_outbound_credentials_missing!.remedy);
+    }
+  });
+
+  test("boundary: obsolete pre-sinceEpoch auth failure does NOT produce auth", () => {
+    // Auth event exists but predates the sentinel boundary — must be dropped.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 100, message: "ocannl: x" },
+    ]);
+    // sinceEpoch 200 > epoch 100 → event is obsolete
+    const result = classifyOutboundStaleness(file, "ocannl", 200);
+    expect(result.kind).not.toBe("auth");
+  });
+
+  test("no-attempts branch: empty/missing events file → { kind: 'no-attempts', remedy }", () => {
+    const file = tmpEvents([]);
+    const result = classifyOutboundStaleness(file, "ocannl", 0);
+    expect(result.kind).toBe("no-attempts");
+    if (result.kind === "no-attempts") {
+      expect(result.remedy).toBe(NO_ATTEMPTS_REMEDY);
+    }
+  });
+
+  test("no-attempts branch: only pre-sinceEpoch activity → { kind: 'no-attempts' }", () => {
+    // Tick ran before the sentinel, but nothing since — downtime diagnosis.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 100, message: "ocannl: pushed" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 200);
+    expect(result.kind).toBe("no-attempts");
+  });
+
+  test("unknown branch: non-auth outbound activity in window → { kind: 'unknown' }", () => {
+    // Tick ran (non-auth outcome like fast_forward or error) — conservative, no annotation.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 500, message: "ocannl: pushed" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("unknown");
+  });
+
+  test("unknown branch: staging_outbound_local_behind in window → { kind: 'unknown' }", () => {
+    const file = tmpEvents([
+      { event_type: "staging_outbound_local_behind", project: "ocannl", epoch: 500, message: "ocannl: behind" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("unknown");
+  });
+
+  test("missing file with positive sinceEpoch → no-attempts (never throws)", () => {
+    const result = classifyOutboundStaleness(
+      join(tmpdir(), "does-not-exist-xyz", "events.jsonl"),
+      "ocannl",
+      1000,
+    );
+    expect(result.kind).toBe("no-attempts");
   });
 });

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -11,6 +11,11 @@
 import { existsSync, readFileSync } from "fs";
 import { isPlainObject } from "./json.ts";
 
+// Shared prefix that all outbound staging→upstream event types carry.
+// Used by `outboundActivitySince` to detect any push-tick activity without
+// enumerating every outcome type.
+const OUTBOUND_EVENT_PREFIX = "staging_outbound_";
+
 export interface OutboundCauseRemedy {
   cause: string;
   remedy: string;
@@ -33,6 +38,22 @@ export const OUTBOUND_EVENT_CAUSE_REMEDY: Record<string, OutboundCauseRemedy> = 
     remedy: "refresh the push credentials (gh auth login / update the stored token)",
   },
 };
+
+/**
+ * Remedy string for the "no push attempts" case: the outbound sentinel is
+ * stale but there are zero `staging_outbound_*` events in the window, meaning
+ * the once-daily outbound tick never ran (controller/keepalive downtime) rather
+ * than an auth failure. Single-sourced here beside `OUTBOUND_EVENT_CAUSE_REMEDY`
+ * so all remedy strings live in one module (task-c4aedd6b).
+ */
+export const NO_ATTEMPTS_REMEDY =
+  "no outbound push attempts since <sentinel time> — the once-daily outbound tick is not running; verify the controller/keepalive is alive";
+
+/** Discriminated union returned by `classifyOutboundStaleness`. */
+export type OutboundStaleClassification =
+  | { kind: "auth"; cause: string; remedy: string }
+  | { kind: "no-attempts"; remedy: string }
+  | { kind: "unknown" };
 
 /**
  * Return the cause/remedy for the most recent outbound push-auth event for
@@ -109,4 +130,83 @@ export function latestOutboundCauseRemedy(
   }
   if (!best) return null;
   return OUTBOUND_EVENT_CAUSE_REMEDY[best.type] ?? null;
+}
+
+/**
+ * Return true when any `staging_outbound_*` event for `project` exists in the
+ * events file with `epoch >= sinceEpoch`. Used by `classifyOutboundStaleness`
+ * to distinguish "tick ran but produced no auth failure" from "tick never ran".
+ *
+ * Matches all `staging_outbound_` event types (not just auth failures) so new
+ * outcome types added to `src/staging-ff.ts` are covered automatically.
+ * Best-effort: missing/empty/unparseable file → false.
+ */
+export function outboundActivitySince(
+  eventsFile: string,
+  project: string,
+  sinceEpoch: number,
+): boolean {
+  let content: string;
+  try {
+    if (!existsSync(eventsFile)) return false;
+    content = readFileSync(eventsFile, "utf-8");
+  } catch {
+    return false;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+
+  for (const line of trimmed.split("\n")) {
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) continue;
+    const type = typeof parsed.event_type === "string" ? parsed.event_type : "";
+    if (!type.startsWith(OUTBOUND_EVENT_PREFIX)) continue;
+    const structured = typeof parsed.project === "string" ? parsed.project : null;
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    const matches = structured === project || message.startsWith(`${project}:`);
+    if (!matches) continue;
+    const epoch = typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch) ? parsed.epoch : 0;
+    if (epoch >= sinceEpoch) return true;
+  }
+  return false;
+}
+
+/**
+ * Classify why the outbound staging→upstream sentinel is stale, given the
+ * events file, project name, and the `sinceEpoch` boundary (floor of sentinel
+ * mtime / 1000; pass 0 to scan the whole file when the sentinel is missing).
+ *
+ * Returns:
+ *   - `{ kind: "auth", cause, remedy }` when a recent outbound auth failure
+ *     event exists in the window (workflow-scope or credentials gap).
+ *   - `{ kind: "no-attempts", remedy }` when no `staging_outbound_*` events
+ *     exist for the project in the window — the tick never ran (downtime).
+ *   - `{ kind: "unknown" }` when outbound events exist but none are auth
+ *     failures — the tick ran but produced a non-auth outcome; stay
+ *     conservative, emit no annotation.
+ *
+ * Pure given (eventsFile contents, project, sinceEpoch): no harness paths
+ * resolved here. The caller (`ludics mag outbound-cause-remedy`) resolves
+ * paths and computes sinceEpoch from the sentinel mtime.
+ */
+export function classifyOutboundStaleness(
+  eventsFile: string,
+  project: string,
+  sinceEpoch: number,
+): OutboundStaleClassification {
+  const auth = latestOutboundCauseRemedy(eventsFile, project, { sinceEpoch });
+  if (auth !== null) {
+    return { kind: "auth", cause: auth.cause, remedy: auth.remedy };
+  }
+  const hasActivity = outboundActivitySince(eventsFile, project, sinceEpoch);
+  if (!hasActivity) {
+    return { kind: "no-attempts", remedy: NO_ATTEMPTS_REMEDY };
+  }
+  return { kind: "unknown" };
 }


### PR DESCRIPTION
## Summary

- Adds `ludics mag outbound-cause-remedy <project>` JSON subcommand that classifies outbound sentinel staleness into `auth` / `no-attempts` / `unknown`
- `auth`: recent workflow-scope or credentials failure → appends `— cause: <cause>; remedy: <remedy>` (same wording as briefing-lag arm)
- `no-attempts`: stale sentinel + zero outbound push-tick events → appends downtime/keepalive guidance (the OCANNL incident case)
- `unknown`: outbound events exist but no auth failures → no annotation (conservative)
- All remedy strings single-sourced in `src/staging-event-meta.ts` beside `OUTBOUND_EVENT_CAUSE_REMEDY`; no cause/remedy prose added to the skill markdown (task-35e74651 AC4 preserved)

## Test plan

- [ ] `bun test src/staging-event-meta.test.ts` — 25 tests pass (includes all three classifier branches + pre-`sinceEpoch` boundary control + `outboundActivitySince` helpers)
- [ ] `bun run typecheck` — clean
- [ ] `bun scripts/lint-cli-subcommands.ts` — CLI parity holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)