### PR TITLE
feat(task-cabf6402): emit staging_outbound_skipped_dirty + blocked-worktree classification

### DIFF
--- a/skills/ludics-health-check.md
+++ b/skills/ludics-health-check.md
@@ -175,6 +175,9 @@ This skill is invoked when:
      elif [ "$kind" = "no-attempts" ]; then
        remedy=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('remedy',''))")
        finding_text="$finding_text — $remedy"
+     elif [ "$kind" = "blocked-worktree" ]; then
+       remedy=$(echo "$annotation" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('remedy',''))")
+       finding_text="$finding_text — $remedy"
      fi
      ```
      When `kind` is `unknown`, leave the finding text unchanged.

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ Commands:
   mag auto-start-evaluate <id> <high|low> [rationale]
                                Evaluate auto-start decision and update task status
   mag outbound-cause-remedy <project>
-                               Classify outbound sentinel staleness (auth/no-attempts/unknown) as JSON
+                               Classify outbound sentinel staleness (auth/no-attempts/blocked-worktree/unknown) as JSON
   mag completed <proposal>     Mark a proposal completed (without .md extension)
   mag feedback-digest          Queue a feedback digest run
   mag sync-learnings           Queue a learnings-consolidation run

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -256,8 +256,24 @@ describe("classifyOutboundStaleness", () => {
     }
   });
 
-  test("blocked-worktree: dirty-skip + real activity (fast-forward) → unknown (negative control)", () => {
-    // Real push activity present alongside dirty-skip: not exclusively dirty-skip → unknown.
+  test("blocked-worktree: prior success AT sinceEpoch boundary + dirty-skip after → blocked-worktree (sentinel-epoch excluded)", () => {
+    // Real-world case: last tick succeeded at epoch 400 and touched the sentinel
+    // (sinceEpoch = 400). After that the worktree became dirty, so ticks at 401+
+    // all emitted dirty-skip events. The success event at epoch === sinceEpoch must
+    // NOT count as "real post-sentinel activity" — only events strictly after the
+    // boundary are in scope for the dirty-only check.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 400, message: "ocannl: pushed" },
+      { event_type: "staging_outbound_skipped_dirty", project: "ocannl", epoch: 401, message: "ocannl: skipped" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    // Without the > fix (old >=), the fast_forwarded event at epoch 400 is kept,
+    // isExclusivelyDirtySkipActivity returns false, result is "unknown".
+    expect(result.kind).toBe("blocked-worktree");
+  });
+
+  test("blocked-worktree: dirty-skip + real activity (fast-forward) after sentinel → unknown (negative control)", () => {
+    // Real push activity AFTER sinceEpoch alongside dirty-skip: not exclusively dirty-skip → unknown.
     const file = tmpEvents([
       { event_type: "staging_outbound_skipped_dirty", project: "ocannl", epoch: 500, message: "ocannl: skipped" },
       { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 510, message: "ocannl: pushed" },

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -250,6 +250,9 @@ describe("classifyOutboundStaleness", () => {
     expect(result.kind).toBe("blocked-worktree");
     if (result.kind === "blocked-worktree") {
       expect(result.remedy).toBe(BLOCKED_WORKTREE_REMEDY);
+      // Invariant: remedy must name the blocked ~/<repo> checkout so the
+      // operator knows what to clear. Fails if the placeholder is dropped.
+      expect(result.remedy).toContain("~/<repo>");
     }
   });
 

--- a/src/staging-event-meta.test.ts
+++ b/src/staging-event-meta.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import {
   OUTBOUND_EVENT_CAUSE_REMEDY,
   NO_ATTEMPTS_REMEDY,
+  BLOCKED_WORKTREE_REMEDY,
   latestOutboundCauseRemedy,
   outboundActivitySince,
   classifyOutboundStaleness,
@@ -238,5 +239,47 @@ describe("classifyOutboundStaleness", () => {
       1000,
     );
     expect(result.kind).toBe("no-attempts");
+  });
+
+  test("blocked-worktree: dirty-skip-only window → { kind: 'blocked-worktree', remedy }", () => {
+    // Only in-window activity is the dirty-skip event → tick ran, worktree blocked.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_skipped_dirty", project: "ocannl", epoch: 500, message: "ocannl: outbound skipped — /path worktree dirty" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("blocked-worktree");
+    if (result.kind === "blocked-worktree") {
+      expect(result.remedy).toBe(BLOCKED_WORKTREE_REMEDY);
+    }
+  });
+
+  test("blocked-worktree: dirty-skip + real activity (fast-forward) → unknown (negative control)", () => {
+    // Real push activity present alongside dirty-skip: not exclusively dirty-skip → unknown.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_skipped_dirty", project: "ocannl", epoch: 500, message: "ocannl: skipped" },
+      { event_type: "staging_outbound_fast_forwarded", project: "ocannl", epoch: 510, message: "ocannl: pushed" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("unknown");
+    expect(result.kind).not.toBe("blocked-worktree");
+  });
+
+  test("blocked-worktree: zero events → no-attempts (negative control)", () => {
+    // No activity at all → controller downtime, not dirty worktree.
+    const file = tmpEvents([]);
+    const result = classifyOutboundStaleness(file, "ocannl", 0);
+    expect(result.kind).toBe("no-attempts");
+    expect(result.kind).not.toBe("blocked-worktree");
+  });
+
+  test("blocked-worktree: dirty-skip + in-window auth failure → auth (auth takes precedence)", () => {
+    // Auth failure co-present with dirty-skip event: auth must win over blocked-worktree.
+    const file = tmpEvents([
+      { event_type: "staging_outbound_skipped_dirty", project: "ocannl", epoch: 500, message: "ocannl: skipped" },
+      { event_type: "staging_outbound_workflow_scope_missing", project: "ocannl", epoch: 510, message: "ocannl: x" },
+    ]);
+    const result = classifyOutboundStaleness(file, "ocannl", 400);
+    expect(result.kind).toBe("auth");
+    expect(result.kind).not.toBe("blocked-worktree");
   });
 });

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -225,7 +225,9 @@ function isExclusivelyDirtySkipActivity(
     const matches = structured === project || message.startsWith(`${project}:`);
     if (!matches) continue;
     const epoch = typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch) ? parsed.epoch : 0;
-    if (epoch < sinceEpoch) continue;
+    // Use strict > so the sentinel-creating event (success/error, epoch === sinceEpoch)
+    // is excluded. Only post-sentinel dirty-skip events count for blocked-worktree.
+    if (epoch <= sinceEpoch) continue;
     hasAny = true;
     if (type !== "staging_outbound_skipped_dirty") return false;
   }

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -49,10 +49,19 @@ export const OUTBOUND_EVENT_CAUSE_REMEDY: Record<string, OutboundCauseRemedy> = 
 export const NO_ATTEMPTS_REMEDY =
   "no outbound push attempts since <sentinel time> — the once-daily outbound tick is not running; verify the controller/keepalive is alive";
 
+/**
+ * Remedy string for the "blocked worktree" case: the tick ran but the staging
+ * worktree was dirty, so the push was skipped. Single-sourced here beside
+ * `NO_ATTEMPTS_REMEDY` / `OUTBOUND_EVENT_CAUSE_REMEDY` (task-cabf6402).
+ */
+export const BLOCKED_WORKTREE_REMEDY =
+  "the outbound tick is skipping because the staging worktree is dirty — commit, stash, or clean it so the push can run";
+
 /** Discriminated union returned by `classifyOutboundStaleness`. */
 export type OutboundStaleClassification =
   | { kind: "auth"; cause: string; remedy: string }
   | { kind: "no-attempts"; remedy: string }
+  | { kind: "blocked-worktree"; remedy: string }
   | { kind: "unknown" };
 
 /**
@@ -178,6 +187,52 @@ export function outboundActivitySince(
 }
 
 /**
+ * Return true when ALL in-window `staging_outbound_*` events for `project`
+ * are of type `staging_outbound_skipped_dirty` (and at least one exists).
+ * Used by `classifyOutboundStaleness` to distinguish a persistently dirty
+ * worktree (tick ran but was blocked) from a real push attempt or error.
+ * Best-effort: missing/empty/unparseable file → false.
+ */
+function isExclusivelyDirtySkipActivity(
+  eventsFile: string,
+  project: string,
+  sinceEpoch: number,
+): boolean {
+  let content: string;
+  try {
+    if (!existsSync(eventsFile)) return false;
+    content = readFileSync(eventsFile, "utf-8");
+  } catch {
+    return false;
+  }
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+
+  let hasAny = false;
+  for (const line of trimmed.split("\n")) {
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) continue;
+    const type = typeof parsed.event_type === "string" ? parsed.event_type : "";
+    if (!type.startsWith(OUTBOUND_EVENT_PREFIX)) continue;
+    const structured = typeof parsed.project === "string" ? parsed.project : null;
+    const message = typeof parsed.message === "string" ? parsed.message : "";
+    const matches = structured === project || message.startsWith(`${project}:`);
+    if (!matches) continue;
+    const epoch = typeof parsed.epoch === "number" && Number.isFinite(parsed.epoch) ? parsed.epoch : 0;
+    if (epoch < sinceEpoch) continue;
+    hasAny = true;
+    if (type !== "staging_outbound_skipped_dirty") return false;
+  }
+  return hasAny;
+}
+
+/**
  * Classify why the outbound staging→upstream sentinel is stale, given the
  * events file, project name, and the `sinceEpoch` boundary (floor of sentinel
  * mtime / 1000; pass 0 to scan the whole file when the sentinel is missing).
@@ -187,9 +242,12 @@ export function outboundActivitySince(
  *     event exists in the window (workflow-scope or credentials gap).
  *   - `{ kind: "no-attempts", remedy }` when no `staging_outbound_*` events
  *     exist for the project in the window — the tick never ran (downtime).
+ *   - `{ kind: "blocked-worktree", remedy }` when the only in-window activity
+ *     is `staging_outbound_skipped_dirty` — the tick ran but the staging
+ *     worktree was dirty; the operator should commit / stash / clean it.
  *   - `{ kind: "unknown" }` when outbound events exist but none are auth
- *     failures — the tick ran but produced a non-auth outcome; stay
- *     conservative, emit no annotation.
+ *     failures and not all are dirty-skip — stay conservative, emit no
+ *     annotation.
  *
  * Pure given (eventsFile contents, project, sinceEpoch): no harness paths
  * resolved here. The caller (`ludics mag outbound-cause-remedy`) resolves
@@ -207,6 +265,9 @@ export function classifyOutboundStaleness(
   const hasActivity = outboundActivitySince(eventsFile, project, sinceEpoch);
   if (!hasActivity) {
     return { kind: "no-attempts", remedy: NO_ATTEMPTS_REMEDY };
+  }
+  if (isExclusivelyDirtySkipActivity(eventsFile, project, sinceEpoch)) {
+    return { kind: "blocked-worktree", remedy: BLOCKED_WORKTREE_REMEDY };
   }
   return { kind: "unknown" };
 }

--- a/src/staging-event-meta.ts
+++ b/src/staging-event-meta.ts
@@ -55,7 +55,7 @@ export const NO_ATTEMPTS_REMEDY =
  * `NO_ATTEMPTS_REMEDY` / `OUTBOUND_EVENT_CAUSE_REMEDY` (task-cabf6402).
  */
 export const BLOCKED_WORKTREE_REMEDY =
-  "the outbound tick is skipping because the staging worktree is dirty — commit, stash, or clean it so the push can run";
+  "the outbound tick is skipping because `~/<repo>` has a dirty worktree — commit, stash, or clean `~/<repo>` so the push can run";
 
 /** Discriminated union returned by `classifyOutboundStaleness`. */
 export type OutboundStaleClassification =

--- a/src/staging-ff.test.ts
+++ b/src/staging-ff.test.ts
@@ -905,6 +905,32 @@ describe("syncUpstreamMainFromStaging", () => {
     expect(existsSync(join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch"))).toBe(false);
   });
 
+  test("dirty worktree: emits staging_outbound_skipped_dirty event for the project, sentinel NOT touched", () => {
+    const dir = mkdtempSync("/tmp/outbound-checkout-");
+    const sentinelDir = mkdtempSync("/tmp/outbound-sentinel-");
+    const events: Array<{ type: string; project: string; message: string }> = [];
+    const { run } = outboundFakeGit({
+      status: { stdout: " M file.ts\n" },
+    });
+    const res = syncUpstreamMainFromStaging(
+      [project("ocannl", dir)],
+      {
+        now: new Date(),
+        runGit: run,
+        sentinelDir,
+        emitEvent: (ev) => events.push({ type: ev.type, project: ev.project, message: ev.message }),
+      },
+    );
+    expect(res[0]!.outcome).toBe("skipped-dirty-worktree");
+    // AC 1: exactly one staging_outbound_skipped_dirty event emitted with structured project.
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe("staging_outbound_skipped_dirty");
+    expect(events[0]!.project).toBe("ocannl");
+    expect(events[0]!.message).toContain("ocannl");
+    // AC 2: sentinel still untouched after the event.
+    expect(existsSync(join(sentinelDir, "last-outbound-fast-forward-ocannl.epoch"))).toBe(false);
+  });
+
   test("throttled within 24h: outcome=throttled, zero git calls, independent of inbound sentinel", () => {
     const dir = mkdtempSync("/tmp/outbound-checkout-");
     const sentinelDir = mkdtempSync("/tmp/outbound-sentinel-");

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -361,6 +361,11 @@ export function syncUpstreamMainFromStaging(
 
     if (!worktreeClean(path, opts.runGit)) {
       out.push({ project, outcome: "skipped-dirty-worktree" });
+      opts.emitEvent?.({
+        type: "staging_outbound_skipped_dirty",
+        project,
+        message: `${project}: outbound skipped — ${path} worktree dirty`,
+      });
       // No sentinel touch — same policy as inbound (transient user state).
       continue;
     }


### PR DESCRIPTION
## Summary

- **Emission** (`src/staging-ff.ts`): `syncUpstreamMainFromStaging` now emits `staging_outbound_skipped_dirty` from the dirty-worktree skip branch via `opts.emitEvent?.`. The sentinel-untouched policy is preserved so the stale-sentinel health finding continues to fire.
- **Classification** (`src/staging-event-meta.ts`): `classifyOutboundStaleness` gains a new `{ kind: "blocked-worktree", remedy }` outcome. It fires when the only **post-sentinel** outbound events for the project are dirty-skip events — i.e. the tick ran but the staging checkout was blocked. Auth still takes precedence; mixed real activity → `unknown`; zero activity → `no-attempts`.
- **Sentinel-epoch fix**: `isExclusivelyDirtySkipActivity` used `epoch >= sinceEpoch`, keeping the sentinel-creating tick's success/error event (emitted at `epoch === sinceEpoch`). That event caused the dirty-only window to be classified as `unknown`. Fixed with `epoch > sinceEpoch` (strict boundary).
- **Remedy** (`BLOCKED_WORKTREE_REMEDY`): single-sourced in `staging-event-meta.ts` beside `NO_ATTEMPTS_REMEDY`; names `` `~/<repo>` `` twice so the operator knows what to clear.
- **Health-check skill** (`skills/ludics-health-check.md`): annotation block gains a `blocked-worktree` arm reading the remedy from CLI JSON.
- **USAGE** (`src/index.ts`): description updated to list the new kind.

## Test plan

- [ ] `bun test src/staging-ff.test.ts` — new test: dirty-skip branch emits exactly one `staging_outbound_skipped_dirty` event with structured project, sentinel untouched
- [ ] `bun test src/staging-event-meta.test.ts` — new tests: dirty-skip-only → `blocked-worktree` (remedy contains `~/<repo>`); sentinel-epoch regression (prior success at `sinceEpoch` + dirty-skip after → `blocked-worktree`, not `unknown`); dirty-skip + real post-sentinel activity → `unknown`; zero activity → `no-attempts`; dirty-skip + auth → `auth`
- [ ] `bun run typecheck`, `bun run lint`, `bun run lint:cli-readme`, `bun run lint:cli-subcommands` — clean
- [ ] Full `bun test` — 2999 pass, 2 pre-existing failures in `lint-skill-shell.test.ts` (confirmed on base branch)

Closes task-cabf6402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)