### PR TITLE
slot-ttyd: stop mid-session ttyd deaths (re-init coherence) + dual-stack bind (task-1373e911)

### DIFF
--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -448,6 +448,21 @@ describe("ttydMatchesSession — exact session-identity match (task-1373e911)", 
     mockPs("ttyd --writable -6 --port 76810 tmux attach -t s1_coder_task-abc");
     expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(false);
   });
+
+  test("target with WHITESPACE (custom agent name) still matches its own session → true", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession, tmuxTarget } = await import("./tmux-adapter.ts");
+    // slotSessionName does not sanitize the agent name, so a quoted custom
+    // agent name with a space yields a target with a space. `ps -o command=`
+    // flattens argv with spaces, so the OLD whitespace-split matcher truncated
+    // the target to its first word ("s1_my") and spuriously failed — restarting
+    // a HEALTHY ttyd on every tick (flap). Codex P2. The target is the final
+    // argv element, so we compare the slice after the last ` -t ` exactly.
+    const target = tmuxTarget(1, "my agent", "task-abc"); // -> "s1_my agent_task-abc"
+    expect(target).toContain(" "); // sanity: the harness condition (a space) holds
+    mockPs(`ttyd --writable -6 --port 7681 tmux attach -t ${target}`);
+    expect(ttydMatchesSession(4321, 1, "coder", "my agent", "task-abc")).toBe(true);
+  });
 });
 
 describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", () => {

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -395,7 +395,7 @@ describe("ttydMatchesSession — exact session-identity match (task-1373e911)", 
   // (safeSyncOutput) and must match the EXACT `--port`/`-t` tokens, not a
   // substring. We spy safeSyncOutput on the spawn module so no real `ps` runs.
   let spawnMod: typeof import("../spawn.ts");
-  let psSpy: ReturnType<typeof spyOn> | undefined;
+  let psSpy: ReturnType<typeof spyOn>;
 
   function mockPs(line: string): void {
     psSpy = spyOn(spawnMod, "safeSyncOutput").mockImplementation(
@@ -404,7 +404,7 @@ describe("ttydMatchesSession — exact session-identity match (task-1373e911)", 
   }
 
   afterEach(() => {
-    psSpy?.mockRestore();
+    psSpy.mockRestore();
   });
 
   test("alive ttyd attached to the expected slot/agent target → true", async () => {

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -334,6 +334,10 @@ describe("buildTtydSpawnArgs — bash wrapper appends to per-agent log file", ()
     // (>>) preserves cause-of-death history across restarts.
     expect(cmd).toContain("exec ttyd");
     expect(cmd).toContain("--writable");
+    // Dual-stack bind: `-6` must sit between `ttyd` and `--port` so ttyd serves
+    // both A and AAAA for the advertised MagicDNS host. Mutation: dropping `-6`
+    // fails this assertion (IPv6-preferring clients would hit a dead family).
+    expect(cmd).toContain("--writable -6 --port");
     const expectedLog = mod.ttydLogPath(3, "coder");
     expect(cmd).toContain(`>>'${expectedLog}'`);
     expect(cmd).toContain("2>&1");
@@ -383,6 +387,66 @@ describe("buildTtydSpawnArgs — bash wrapper appends to per-agent log file", ()
       else process.env.HOME = savedHome;
       rmSync(tmpRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe("ttydMatchesSession — exact session-identity match (task-1373e911)", () => {
+  // The matcher reads the live ttyd argv via `ps -p <pid> -o command=`
+  // (safeSyncOutput) and must match the EXACT `--port`/`-t` tokens, not a
+  // substring. We spy safeSyncOutput on the spawn module so no real `ps` runs.
+  let spawnMod: typeof import("../spawn.ts");
+  let psSpy: ReturnType<typeof spyOn> | undefined;
+
+  function mockPs(line: string): void {
+    psSpy = spyOn(spawnMod, "safeSyncOutput").mockImplementation(
+      () => ({ ok: line !== "", exitCode: line === "" ? 1 : 0, stdout: line, stderr: "", timedOut: false }),
+    );
+  }
+
+  afterEach(() => {
+    psSpy?.mockRestore();
+  });
+
+  test("alive ttyd attached to the expected slot/agent target → true", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession } = await import("./tmux-adapter.ts");
+    // Slot 1 coder port = 7681, target = s1_coder_task-abc.
+    mockPs("ttyd --writable -6 --port 7681 tmux attach -t s1_coder_task-abc");
+    expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(true);
+  });
+
+  test("alive ttyd attached to a DIFFERENT target → false", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession } = await import("./tmux-adapter.ts");
+    mockPs("ttyd --writable -6 --port 7681 tmux attach -t s1_coder_task-other");
+    expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(false);
+  });
+
+  test("empty/failed ps output → true (safe default, never churn on transient ps failure)", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession } = await import("./tmux-adapter.ts");
+    mockPs("");
+    expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(true);
+  });
+
+  test("prefix target is REJECTED: expected s1_coder_task-abc vs actual s1_coder_task-abcdef → false", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession } = await import("./tmux-adapter.ts");
+    // Invariant: exact adjacent-token equality on `-t <target>`. Mutation:
+    // reverting the matcher to `cmd.includes(target)` makes this WRONGLY return
+    // true — a wrong-session ttyd would be treated as healthy and never
+    // restarted, defeating the optional wrong-session hardening (AC5).
+    mockPs("ttyd --writable -6 --port 7681 tmux attach -t s1_coder_task-abcdef");
+    expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(false);
+  });
+
+  test("prefix port is REJECTED: expected --port 7681 vs actual --port 76810 → false", async () => {
+    spawnMod = await import("../spawn.ts");
+    const { ttydMatchesSession } = await import("./tmux-adapter.ts");
+    // Token equality also guards the port (substring `includes("7681")` would
+    // match "76810"). Target matches; only the port differs.
+    mockPs("ttyd --writable -6 --port 76810 tmux attach -t s1_coder_task-abc");
+    expect(ttydMatchesSession(4321, 1, "coder", "coder", "task-abc")).toBe(false);
   });
 });
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -377,17 +377,24 @@ export function startTtyd(slot: number, agentName: string, role: "coder" | "revi
  *
  * Reads the process command line via `ps -p <pid> -o command=`. After the
  * `exec ttyd …` replaces bash (see buildTtydSpawnArgs), that command line is
- * the ttyd argv itself, e.g.
+ * the ttyd argv itself, with the tmux target as the FINAL argument (the
+ * `>>log 2>&1` redirection is consumed by the shell and is not in argv):
  *   `ttyd --writable -6 --port 7681 tmux attach -t s1_coder_task-abc`
  *
- * Matches the EXACT adjacent tokens `--port <port>` and `-t <target>` by
- * splitting on whitespace and comparing token equality — NOT substring
- * `includes`. A substring match would false-positive when the expected target
- * is a prefix of a stale one (expected `s1_coder_task-abc` vs actual
- * `s1_coder_task-abcdef`) or a port is a prefix of another (`7681` vs `76810`),
- * making `ensureTtydAlive` treat a wrong-session ttyd as healthy. Tmux session
- * names contain no whitespace (slotSessionName) and buildTtydSpawnArgs emits the
- * space-separated `--port N` / `-t NAME` forms, so token splitting is exact.
+ * Two match conditions, both exact (NOT substring `includes`, which would
+ * false-positive when the expected target/port is a prefix of a stale one —
+ * `s1_coder_task-abc` vs `s1_coder_task-abcdef`, or `7681` vs `76810` — making
+ * `ensureTtydAlive` treat a wrong-session ttyd as healthy):
+ *  - **port**: the port is whitespace-free, so a whitespace-split token match
+ *    of `--port <port>` is exact.
+ *  - **target**: `slotSessionName` does NOT sanitize the agent name, so a
+ *    custom agent name containing whitespace yields a target with spaces. But
+ *    `ps -o command=` flattens argv (spaces between args), so whitespace-
+ *    splitting the line would truncate such a target to its first word and
+ *    spuriously fail — restarting a healthy ttyd on every tick (flap). Instead,
+ *    since the target is the LAST argv element, compare everything after the
+ *    final ` -t ` marker to the expected target exactly. End-of-string anchoring
+ *    preserves the prefix rejection while tolerating spaces inside the target.
  *
  * Empty / failed `ps` output → returns `true` (the safe default: never churn a
  * healthy ttyd on a transient ps failure).
@@ -402,11 +409,16 @@ export function ttydMatchesSession(
   const r = safeSyncOutput(["ps", "-p", String(pid), "-o", "command="]);
   const cmd = r.ok ? r.stdout.trim() : "";
   if (!cmd) return true;
-  const tokens = cmd.split(/\s+/);
   const expectedPort = String(ttydPort(slot, role));
   const expectedTarget = tmuxTarget(slot, agentName, taskId);
+  const tokens = cmd.split(/\s+/);
   const portOk = tokens.some((t, i) => t === "--port" && tokens[i + 1] === expectedPort);
-  const targetOk = tokens.some((t, i) => t === "-t" && tokens[i + 1] === expectedTarget);
+  // Target is the terminal argv element; match the slice after the last ` -t `
+  // exactly so a whitespace-bearing target round-trips and a prefix target is
+  // still rejected (end-of-string anchored).
+  const marker = " -t ";
+  const idx = cmd.lastIndexOf(marker);
+  const targetOk = idx >= 0 && cmd.slice(idx + marker.length) === expectedTarget;
   return portOk && targetOk;
 }
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -131,8 +131,10 @@ export function tmuxSessionName(slot: number, agentName: string, taskId?: string
   return slotSessionName(slot, agentName, taskId);
 }
 
-/** Target for tmux commands — just the session name (one window per session) */
-function tmuxTarget(slot: number, agentName: string, taskId?: string): string {
+/** Target for tmux commands — just the session name (one window per session).
+ *  Exported so `ensureTtydAlive`'s wrong-session check can match a live ttyd's
+ *  `tmux attach -t <target>` argv against the expected session identity. */
+export function tmuxTarget(slot: number, agentName: string, taskId?: string): string {
   return tmuxSessionName(slot, agentName, taskId);
 }
 
@@ -342,7 +344,12 @@ export function buildTtydSpawnArgs(
   const port = ttydPort(slot, role);
   const target = tmuxTarget(slot, agentName, taskId);
   const logFile = ttydLogPath(slot, agentName);
-  const cmd = `exec ttyd --writable --port ${port} tmux attach -t ${shellSingleQuote(target)} >>${shellSingleQuote(logFile)} 2>&1`;
+  // `-6` enables IPv6 so ttyd binds dual-stack (`::` with V6ONLY off → serves
+  // both A and AAAA). The dashboard advertises a MagicDNS host carrying both
+  // record families; without `-6` an IPv6-preferring client reaches a family
+  // ttyd never bound (connection-refused against a live session). IPv4
+  // localhost / Tailnet access is unaffected (still served).
+  const cmd = `exec ttyd --writable -6 --port ${port} tmux attach -t ${shellSingleQuote(target)} >>${shellSingleQuote(logFile)} 2>&1`;
   return setsidWrap(["bash", "-c", cmd]);
 }
 
@@ -363,6 +370,44 @@ export function startTtyd(slot: number, agentName: string, role: "coder" | "revi
     (proc as { unref: () => void }).unref();
   }
   return proc.pid;
+}
+
+/**
+ * True iff the live ttyd `pid` is attached to the expected slot/agent session.
+ *
+ * Reads the process command line via `ps -p <pid> -o command=`. After the
+ * `exec ttyd …` replaces bash (see buildTtydSpawnArgs), that command line is
+ * the ttyd argv itself, e.g.
+ *   `ttyd --writable -6 --port 7681 tmux attach -t s1_coder_task-abc`
+ *
+ * Matches the EXACT adjacent tokens `--port <port>` and `-t <target>` by
+ * splitting on whitespace and comparing token equality — NOT substring
+ * `includes`. A substring match would false-positive when the expected target
+ * is a prefix of a stale one (expected `s1_coder_task-abc` vs actual
+ * `s1_coder_task-abcdef`) or a port is a prefix of another (`7681` vs `76810`),
+ * making `ensureTtydAlive` treat a wrong-session ttyd as healthy. Tmux session
+ * names contain no whitespace (slotSessionName) and buildTtydSpawnArgs emits the
+ * space-separated `--port N` / `-t NAME` forms, so token splitting is exact.
+ *
+ * Empty / failed `ps` output → returns `true` (the safe default: never churn a
+ * healthy ttyd on a transient ps failure).
+ */
+export function ttydMatchesSession(
+  pid: number,
+  slot: number,
+  role: "coder" | "reviewer",
+  agentName: string,
+  taskId?: string,
+): boolean {
+  const r = safeSyncOutput(["ps", "-p", String(pid), "-o", "command="]);
+  const cmd = r.ok ? r.stdout.trim() : "";
+  if (!cmd) return true;
+  const tokens = cmd.split(/\s+/);
+  const expectedPort = String(ttydPort(slot, role));
+  const expectedTarget = tmuxTarget(slot, agentName, taskId);
+  const portOk = tokens.some((t, i) => t === "--port" && tokens[i + 1] === expectedPort);
+  const targetOk = tokens.some((t, i) => t === "-t" && tokens[i + 1] === expectedTarget);
+  return portOk && targetOk;
 }
 
 function killTtydForSlot(slot: number): void {

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -1922,4 +1922,50 @@ describe("ensureTtydAlive — flap suppression", () => {
     const expectedLog = tmuxAdapter.ttydLogPath(5, "coder");
     expect(String(payload.message)).toContain(expectedLog);
   });
+
+  // --- wrong-session hardening (task-1373e911) ---
+  // These cases set processAlive → TRUE (the rest of the suite mocks false) and
+  // spy ttydMatchesSession, isolating the alive-branch session-identity check.
+
+  test("alive ttyd attached to the CORRECT session → no startTtyd, no event (AC5 no-churn)", async () => {
+    seedSlot(1, { ttydPids: { coder: 12345 } });
+    const state = makeTmuxState(1);
+    processAliveSpy.mockImplementation(() => true);
+    const matchSpy = spyOn(tmuxAdapter, "ttydMatchesSession").mockImplementation(() => true);
+    startTtydSpy.mockClear();
+    emitSpy.mockClear();
+    try {
+      __resetTtydCheckGateForTests();
+      await ensureTtydAlive(state);
+      // Invariant: an alive, correctly-attached ttyd is left untouched.
+      // Mutation: dropping the `&& ttydMatchesSession(...)` term keeps the old
+      // `if (alive) continue` — still passes here, so the wrong-target test
+      // below is the discriminating case.
+      expect(startTtydSpy.mock.calls.length).toBe(0);
+      expect(emitSpy.mock.calls.length).toBe(0);
+    } finally {
+      matchSpy.mockRestore();
+    }
+  });
+
+  test("alive ttyd attached to the WRONG session → restart + one ttyd_restarted event", async () => {
+    seedSlot(2, { ttydPids: { coder: 12345 } });
+    const state = makeTmuxState(2);
+    processAliveSpy.mockImplementation(() => true);
+    const matchSpy = spyOn(tmuxAdapter, "ttydMatchesSession").mockImplementation(() => false);
+    startTtydSpy.mockClear();
+    emitSpy.mockClear();
+    try {
+      __resetTtydCheckGateForTests();
+      await ensureTtydAlive(state);
+      // Invariant: alive-but-wrong-session is treated as needing restart.
+      // Mutation: removing the `&& ttydMatchesSession(...)` term makes the
+      // alive ttyd `continue` here → 0 startTtyd calls, 0 events — caught.
+      expect(startTtydSpy.mock.calls.length).toBe(1);
+      const types = eventTypes();
+      expect(types.filter((t) => t === "ttyd_restarted").length).toBe(1);
+    } finally {
+      matchSpy.mockRestore();
+    }
+  });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -29,7 +29,7 @@ import { setSlotLivenessOnData } from "../slots/index.ts";
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
-import { agentPortRole, readTmuxSlotState, startTtyd, ttydLogPath, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentPortRole, readTmuxSlotState, startTtyd, ttydLogPath, ttydMatchesSession, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts";
 import { recoverWrongFilename } from "./wrong-filename-recovery.ts";
 
@@ -1047,11 +1047,17 @@ export async function ensureTtydAlive(state: OrchestrationState): Promise<void> 
     // further events, no respawn, no liveness churn while suppressed.
     if (prev?.backoffUntil === TTYD_GIVE_UP_SENTINEL) continue;
 
+    const role = agentPortRole(agent, i);
     const pid = tmuxState.ttydPids[agent.name];
     const alive = pid ? processAlive(pid) : false;
-    if (alive) continue;
-
-    const role = agentPortRole(agent, i);
+    // Optional wrong-session hardening (task-1373e911): a ttyd whose pid is
+    // alive but attached to the WRONG tmux target (a stale session left by an
+    // upstream re-init) is treated as needing restart, so the ensure converges
+    // on session identity rather than mere pid-liveness. startTtyd's pkill
+    // clears the stale-session ttyd before respawn. ttydMatchesSession returns
+    // true on a transient `ps` failure, so a correctly-attached ttyd is never
+    // churned.
+    if (alive && ttydMatchesSession(pid!, state.slot, role, agent.name, state.taskId)) continue;
 
     // Window-reset path: no record, or quiet > 5 min since the LAST
     // restart (not the first — that would misclassify an active flap

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -1710,17 +1710,10 @@ describe("slotResume — ttyd re-init persists fresh pid on session recreate (ta
   // ttyd and persist the FRESH pid (not the stale seeded pid). Proves the helper
   // is wired into the resume path, not vacuous.
   const createdTmuxSessions: string[] = [];
-  let startTtydSpy: ReturnType<typeof spyOn>;
-  let startOrchSpy: ReturnType<typeof spyOn> | undefined;
   const FRESH_PID = 515151;
   const STALE_PID = 909090;
 
-  beforeEach(() => {
-    startTtydSpy = spyOn(tmuxAdapterMod, "startTtyd").mockImplementation(() => FRESH_PID);
-  });
   afterEach(() => {
-    startTtydSpy.mockRestore();
-    startOrchSpy?.mockRestore();
     for (const session of createdTmuxSessions) {
       try { if (tmuxHasSession(session)) tmuxKillSession(session); } catch { /* ignore */ }
     }
@@ -1728,6 +1721,7 @@ describe("slotResume — ttyd re-init persists fresh pid on session recreate (ta
   });
 
   test("recreated session persists the fresh startTtyd pid, not the stale seeded pid", async () => {
+    const startTtydSpy = spyOn(tmuxAdapterMod, "startTtyd").mockImplementation(() => FRESH_PID);
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");
     const orchDir = join(harness, "orchestration");
@@ -1771,19 +1765,24 @@ describe("slotResume — ttyd re-init persists fresh pid on session recreate (ta
 
     // Stub the expensive runner spawn so resume reaches the ttyd-pid write.
     const orchProcess = await import("../orchestration/process.ts");
-    startOrchSpy = spyOn(orchProcess, "startOrchestrationProcess").mockImplementation(async () => 99_997);
+    const startOrchSpy = spyOn(orchProcess, "startOrchestrationProcess").mockImplementation(async () => 99_997);
 
     createdTmuxSessions.push("s1_coder_task-ttyd-recreate");
 
-    await slotResume(1, { startTtyd: true });
+    try {
+      await slotResume(1, { startTtyd: true });
 
-    // Invariant: the recreate branch restarted ttyd in the SAME operation as
-    // the session recreation and persisted the live pid. Mutation: the old
-    // "skip startTtyd when portInUse" leaves ttydPids.coder == STALE_PID.
-    expect(startTtydSpy).toHaveBeenCalled();
-    const persisted = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
-    expect(persisted.ttydPids.coder).toBe(FRESH_PID);
-    expect(persisted.ttydPids.coder).not.toBe(STALE_PID);
+      // Invariant: the recreate branch restarted ttyd in the SAME operation as
+      // the session recreation and persisted the live pid. Mutation: the old
+      // "skip startTtyd when portInUse" leaves ttydPids.coder == STALE_PID.
+      expect(startTtydSpy).toHaveBeenCalled();
+      const persisted = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
+      expect(persisted.ttydPids.coder).toBe(FRESH_PID);
+      expect(persisted.ttydPids.coder).not.toBe(STALE_PID);
+    } finally {
+      startTtydSpy.mockRestore();
+      startOrchSpy.mockRestore();
+    }
   });
 });
 

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid } from "./index.ts";
+import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
+import * as t3codeServerMod from "../t3code/server.ts";
 import { hasStash, writeStash } from "./preempt.ts";
 import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, type OrchestrationState } from "../orchestration/state.ts";
 import { tmuxKillSession, tmuxHasSession } from "../adapters/tmux.ts";
@@ -1640,6 +1642,148 @@ describe("slotResume — escalated slot handling (task-4cd94043)", () => {
       startSpy.mockRestore();
       logSpy.mockRestore();
     }
+  });
+});
+
+describe("reinitTtydPid — re-init coherence (task-1373e911)", () => {
+  // Observes the pid returned at the persisted seam — the value slotResume
+  // assigns to newTtydPids[agent] and writes into tmux-slot-N.json. startTtyd
+  // is spied so no real ttyd/bash spawns; processAlive is spied so the
+  // prior-pid liveness branch is deterministic.
+  let startTtydSpy: ReturnType<typeof spyOn>;
+  let processAliveSpy: ReturnType<typeof spyOn>;
+  const FRESH_PID = 424242;
+
+  beforeEach(() => {
+    startTtydSpy = spyOn(tmuxAdapterMod, "startTtyd").mockImplementation(() => FRESH_PID);
+    processAliveSpy = spyOn(t3codeServerMod, "processAlive").mockImplementation(() => true);
+  });
+  afterEach(() => {
+    startTtydSpy.mockRestore();
+    processAliveSpy.mockRestore();
+  });
+
+  const base = { slot: 1, agentName: "coder", role: "coder" as const, taskId: "task-abc" };
+
+  test("recreated session + port in use → restart unconditionally (orphan replaced), returns fresh pid [AC2-(a)]", () => {
+    // Invariant: a recreated session means the port listener is an orphan
+    // attached to the destroyed session — it MUST be replaced. Mutation:
+    // reverting to the old "skip when portInUse" returns the stale prior pid
+    // (7000) and calls startTtyd 0 times — both assertions catch it.
+    const pid = reinitTtydPid({ ...base, sessionRecreated: true, portInUse: true, priorPid: 7000 });
+    expect(pid).toBe(FRESH_PID);
+    expect(startTtydSpy.mock.calls.length).toBe(1);
+  });
+
+  test("intact session + port in use + live prior pid → preserve prior pid, no startTtyd [AC3/AC4]", () => {
+    const pid = reinitTtydPid({ ...base, sessionRecreated: false, portInUse: true, priorPid: 7000 });
+    expect(pid).toBe(7000);
+    expect(startTtydSpy.mock.calls.length).toBe(0);
+  });
+
+  test("intact session + free port → start ttyd, returns fresh pid", () => {
+    const pid = reinitTtydPid({ ...base, sessionRecreated: false, portInUse: false, priorPid: 7000 });
+    expect(pid).toBe(FRESH_PID);
+    expect(startTtydSpy.mock.calls.length).toBe(1);
+  });
+
+  test("intact session + port in use + NO prior pid → restart (never persist undefined) [AC4 negative]", () => {
+    // The bug AC4 forbids: persisting undefined/garbage for a busy port. With
+    // no tracked pid we restart to record a real pid.
+    const pid = reinitTtydPid({ ...base, sessionRecreated: false, portInUse: true, priorPid: undefined });
+    expect(pid).toBe(FRESH_PID);
+    expect(startTtydSpy.mock.calls.length).toBe(1);
+    expect(pid).not.toBeUndefined();
+  });
+
+  test("intact session + port in use + DEAD prior pid → restart (don't preserve a stale tracked pid)", () => {
+    processAliveSpy.mockImplementation(() => false);
+    const pid = reinitTtydPid({ ...base, sessionRecreated: false, portInUse: true, priorPid: 7000 });
+    expect(pid).toBe(FRESH_PID);
+    expect(startTtydSpy.mock.calls.length).toBe(1);
+  });
+});
+
+describe("slotResume — ttyd re-init persists fresh pid on session recreate (task-1373e911)", () => {
+  // Behavioural end-to-end: drive slotResume with startTtyd enabled. The agent
+  // tmux session does not exist → recreate branch → reinitTtydPid must restart
+  // ttyd and persist the FRESH pid (not the stale seeded pid). Proves the helper
+  // is wired into the resume path, not vacuous.
+  const createdTmuxSessions: string[] = [];
+  let startTtydSpy: ReturnType<typeof spyOn>;
+  let startOrchSpy: ReturnType<typeof spyOn> | undefined;
+  const FRESH_PID = 515151;
+  const STALE_PID = 909090;
+
+  beforeEach(() => {
+    startTtydSpy = spyOn(tmuxAdapterMod, "startTtyd").mockImplementation(() => FRESH_PID);
+  });
+  afterEach(() => {
+    startTtydSpy.mockRestore();
+    startOrchSpy?.mockRestore();
+    for (const session of createdTmuxSessions) {
+      try { if (tmuxHasSession(session)) tmuxKillSession(session); } catch { /* ignore */ }
+    }
+    createdTmuxSessions.length = 0;
+  });
+
+  test("recreated session persists the fresh startTtyd pid, not the stale seeded pid", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const orchDir = join(harness, "orchestration");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(orchDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-ttyd-recreate", "Recreate ttyd coherence");
+
+    void slotAssign(1, "task-ttyd-recreate", "tmux", "", "", "--pair --coder claude --reviewer claude");
+
+    // Seed tmux slot state with a STALE ttyd pid for the coder. The recreate
+    // branch must overwrite it with the fresh startTtyd pid.
+    writeFileSync(
+      join(orchDir, "tmux-slot-1.json"),
+      JSON.stringify({ slot: 1, ttydPids: { coder: STALE_PID }, orchestration: { stateFile: "orch-1.json", mode: "pair" } }),
+    );
+
+    const orchState: OrchestrationState = {
+      slot: 1,
+      taskId: "task-ttyd-recreate",
+      mode: "pair",
+      phase: "work",
+      round: 1,
+      mergeRound: 0,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "sonnet", branch: "test-coder", worktreePath: "/tmp/wt-coder" },
+      ],
+      agentStates: initAgentRuntimeState(["coder"]),
+      config: defaultOrchestrationConfig({}),
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+      startedAt: new Date().toISOString(),
+      projectDir: "/tmp/fake-project",
+      rootWorktree: "/tmp/fake-root",
+      peerSyncDir: "/tmp/fake-peersync",
+      threadIds: {},
+      backend: "tmux",
+      slotTitle: "test",
+    };
+    persistState(orchState, harness);
+
+    // Stub the expensive runner spawn so resume reaches the ttyd-pid write.
+    const orchProcess = await import("../orchestration/process.ts");
+    startOrchSpy = spyOn(orchProcess, "startOrchestrationProcess").mockImplementation(async () => 99_997);
+
+    createdTmuxSessions.push("s1_coder_task-ttyd-recreate");
+
+    await slotResume(1, { startTtyd: true });
+
+    // Invariant: the recreate branch restarted ttyd in the SAME operation as
+    // the session recreation and persisted the live pid. Mutation: the old
+    // "skip startTtyd when portInUse" leaves ttydPids.coder == STALE_PID.
+    expect(startTtydSpy).toHaveBeenCalled();
+    const persisted = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
+    expect(persisted.ttydPids.coder).toBe(FRESH_PID);
+    expect(persisted.ttydPids.coder).not.toBe(STALE_PID);
   });
 });
 

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid } from "./index.ts";
 import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
+import * as spawnMod from "../spawn.ts";
 import { hasStash, writeStash } from "./preempt.ts";
 import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, type OrchestrationState } from "../orchestration/state.ts";
 import { tmuxKillSession, tmuxHasSession } from "../adapters/tmux.ts";
@@ -1720,8 +1721,23 @@ describe("slotResume — ttyd re-init persists fresh pid on session recreate (ta
     createdTmuxSessions.length = 0;
   });
 
-  test("recreated session persists the fresh startTtyd pid, not the stale seeded pid", async () => {
+  test("recreated session + ttyd port ALREADY BUSY persists the fresh startTtyd pid, not the stale seeded pid", async () => {
     const startTtydSpy = spyOn(tmuxAdapterMod, "startTtyd").mockImplementation(() => FRESH_PID);
+    // Instantiate the actual failing condition: the slot-1 coder ttyd port
+    // (7681) is ALREADY occupied at re-init time (by the orphaned ttyd still
+    // attached to the destroyed session). Force the `lsof -i :7681` probe to
+    // report busy; delegate every other safeSyncOutput call (real tmux
+    // session create / set-option / send) to the real implementation so the
+    // recreate path runs normally. Without this, lsof returns not-busy and the
+    // OLD `if (!portInUse) startTtyd(...)` would have started ttyd anyway,
+    // making the fresh-pid assertion pass vacuously.
+    const realSafeSync = spawnMod.safeSyncOutput;
+    const safeSyncSpy = spyOn(spawnMod, "safeSyncOutput").mockImplementation((args, opts) => {
+      if (Array.isArray(args) && args.includes("-i") && args.includes(":7681")) {
+        return { ok: true, exitCode: 0, stdout: "ttyd 12345 user ...", stderr: "", timedOut: false };
+      }
+      return realSafeSync(args, opts);
+    });
     const harness = join(TMP, "ludics-state", "harness");
     const tasksDir = join(harness, "tasks");
     const orchDir = join(harness, "orchestration");
@@ -1772,14 +1788,26 @@ describe("slotResume — ttyd re-init persists fresh pid on session recreate (ta
     try {
       await slotResume(1, { startTtyd: true });
 
-      // Invariant: the recreate branch restarted ttyd in the SAME operation as
-      // the session recreation and persisted the live pid. Mutation: the old
-      // "skip startTtyd when portInUse" leaves ttydPids.coder == STALE_PID.
+      // Harness precondition actually fired: the lsof port-busy probe was hit
+      // (so portInUse=true was in play). Without this the test could silently
+      // regress to the not-busy path and the mutation below would no longer be
+      // caught.
+      const lsofProbed = safeSyncSpy.mock.calls.some(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("-i") && (c[0] as string[]).includes(":7681"),
+      );
+      expect(lsofProbed).toBe(true);
+
+      // Invariant: with the port ALREADY busy, the recreate branch still
+      // restarted ttyd in the SAME operation as the session recreation and
+      // persisted the live pid. Mutation: reverting the call site to the old
+      // `if (!portInUse) startTtyd(...)` skips the restart (port is busy) and
+      // leaves ttydPids.coder == STALE_PID — failing both assertions below.
       expect(startTtydSpy).toHaveBeenCalled();
       const persisted = JSON.parse(readFileSync(join(orchDir, "tmux-slot-1.json"), "utf-8"));
       expect(persisted.ttydPids.coder).toBe(FRESH_PID);
       expect(persisted.ttydPids.coder).not.toBe(STALE_PID);
     } finally {
+      safeSyncSpy.mockRestore();
       startTtydSpy.mockRestore();
       startOrchSpy.mockRestore();
     }

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1168,6 +1168,45 @@ function readLiveOrchestratorPid(slotNum: number, mode: string, harness: string)
 }
 
 /**
+ * Decide the ttyd pid to persist for an agent during slot re-init, bringing the
+ * ttyd into a consistent state in the SAME operation as the tmux-session
+ * decision (the root-cause fix for mid-session ttyd deaths — task-1373e911):
+ *
+ *  - `sessionRecreated` → any pre-existing ttyd is attached to the now-destroyed
+ *    session instance; restart it unconditionally. (startTtyd's `pkill -f
+ *    "ttyd.*--port ${port}"` clears the orphan and the fresh ttyd re-attaches
+ *    the new session.) Returns the fresh pid. Skipping the restart here because
+ *    the old ttyd still occupies the port is exactly the bug: that orphan dies
+ *    ~30-60s later and the runner flap logic eventually trips the give-up
+ *    sentinel (the observed connection-refused gap).
+ *  - `!sessionRecreated` & port free → (re)start; fresh pid.
+ *  - `!sessionRecreated` & port in use & a tracked prior pid is still alive →
+ *    preserve it (a healthy ttyd is still serving the intact session). Never
+ *    pkill a healthy ttyd here.
+ *  - `!sessionRecreated` & port in use & no/dead tracked pid → restart, so we
+ *    record a real pid instead of persisting `undefined`/a stale pid for a
+ *    process the next `ensureTtydAlive` tick would then have to chase.
+ *
+ * Exported as a test seam (mirrors `createTmuxAgentSession`): the decision is
+ * verified directly without driving the full resume against a live tmux.
+ */
+export function reinitTtydPid(opts: {
+  slot: number;
+  agentName: string;
+  role: "coder" | "reviewer";
+  taskId?: string;
+  sessionRecreated: boolean;
+  portInUse: boolean;
+  priorPid?: number;
+}): number {
+  const { slot, agentName, role, taskId, sessionRecreated, portInUse, priorPid } = opts;
+  if (sessionRecreated) return startTtyd(slot, agentName, role, taskId);
+  if (!portInUse) return startTtyd(slot, agentName, role, taskId);
+  if (priorPid !== undefined && processAlive(priorPid)) return priorPid;
+  return startTtyd(slot, agentName, role, taskId);
+}
+
+/**
  * Resume a crashed orchestrated session from persisted state.
  */
 export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd = true }: { startTtyd?: boolean } = {}): Promise<void> {
@@ -1376,10 +1415,24 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
           const lsofBin = process.platform === "darwin" ? "/usr/sbin/lsof" : "lsof";
           portInUse = safeSyncOutput([lsofBin, "-i", `:${port}`]).ok;
         } catch { /* lsof not available */ }
-        if (!portInUse) {
-          newTtydPids[agent.name] = startTtyd(slotNum, agent.name, role, taskId);
-          console.error(`ludics: re-started ttyd on port ${port} for ${agent.name}`);
-        }
+        // Bring the ttyd into a consistent state in the same operation as the
+        // session decision. On a recreate the port-in-use ttyd is an orphan
+        // attached to the destroyed session and MUST be replaced; the skip is
+        // valid only when the session was left intact and a healthy ttyd is
+        // still serving it (see reinitTtydPid).
+        newTtydPids[agent.name] = reinitTtydPid({
+          slot: slotNum,
+          agentName: agent.name,
+          role,
+          taskId,
+          sessionRecreated: !sessionExists,
+          portInUse,
+          priorPid: tmuxState?.ttydPids?.[agent.name],
+        });
+        console.error(
+          `ludics: ttyd for ${agent.name} on port ${port} reconciled ` +
+          `(recreated=${!sessionExists}, portInUse=${portInUse}, pid=${newTtydPids[agent.name]})`,
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Dashboard terminals for an active slot intermittently showed "failing to connect" while the tmux session was alive — root-caused to **`slotResume`'s tmux re-init recreating a tmux agent session while skipping the ttyd restart** because the old ttyd's port was still occupied.

### Root cause (AC1)

`slotResume`'s per-agent re-init loop gated the ttyd `(re)start` behind a single `lsof -i :${port}` port-in-use check applied to **both** the recreate (`!sessionExists`) branch and the intact branch. When the session was recreated, the occupied port belonged to the now-**orphaned** ttyd — still attached to the just-destroyed tmux target. The lsof skip left that orphan in place; its `tmux attach` client then exited ~30–60s later, ttyd died, and `ensureTtydAlive` faithfully respawned it. Repeated deaths eventually tripped the anti-flap **give-up sentinel** — the observed ~11m45s connection-refused gap against a live session.

`ensureTtydAlive` and the respawn/back-off/flap machinery were already correct; the fix is in the re-init, not the loop.

## Changes

1. **`slotResume` re-init coherence** (`src/slots/index.ts`) — extract `reinitTtydPid()`: on a recreate, restart ttyd unconditionally (its `pkill -f "ttyd.*--port ${port}"` clears the orphan, the fresh ttyd re-attaches the new session); keep the port-in-use skip only for the intact branch, and only when a tracked prior pid is still alive — otherwise restart so we never persist `undefined`/a stale pid for a busy port. (AC2, AC3, AC4)

2. **Dual-stack bind** (`src/adapters/tmux-adapter.ts`) — `buildTtydSpawnArgs` now passes `-6` so ttyd binds dual-stack (serves both A and AAAA). The dashboard advertises a MagicDNS host carrying both record families, so an IPv6-preferring client previously reached a family ttyd never bound. IPv4 localhost / Tailnet access is unchanged (additive). Chose option (a) over (b) because `ClusterMachine` has no IPv4 field — option (b) would need new config + resolution. (AC connectivity 6, 7)

3. **Wrong-session hardening** (`ensureTtydAlive` + `ttydMatchesSession`) — an alive ttyd attached to the **wrong** tmux target (stale session) is now treated as needing restart, so the ensure converges on session identity, not mere pid-liveness. `ttydMatchesSession` reads the live ttyd argv (`ps -p <pid> -o command=`) and matches the port as an exact whitespace-split token and the target as the slice after the final ` -t ` compared exactly (end-of-string anchored). This rejects prefix targets/ports (`s1_coder_task-abc` vs `…-abcdef`, `7681` vs `76810`) **and** round-trips a target containing whitespace — `ps` flattens argv, so a naive whitespace-split would truncate an unsanitized custom-agent target and churn a healthy ttyd (Codex P2, fixed in `6d648d8`). Empty/failed `ps` → treated as matching (never churn a healthy ttyd on a transient failure). (AC5)

## Tests

- `reinitTtydPid` decision matrix (5 cases at the persisted seam) + a behavioural `slotResume` test asserting `tmux-slot-1.json` `ttydPids[coder]` becomes the fresh `startTtyd` pid, not the stale seeded pid — with the `lsof` probe forced busy so the recreate-while-port-occupied condition is actually instantiated (mutation-verified) (`src/slots/index.test.ts`).
- `buildTtydSpawnArgs` asserts `--writable -6 --port`; `ttydMatchesSession` exact-match cases incl. prefix-target/prefix-port rejection and a **whitespace-bearing target** round-trip (mutation-verified) (`src/adapters/tmux-adapter.test.ts`).
- Two new cases extending the existing `ensureTtydAlive — flap suppression` matrix: alive+correct-target → no restart/no event; alive+wrong-target → one restart + one `ttyd_restarted` (`src/orchestration/runner.lifecycle.test.ts`).

`bun test` → 3014 pass / 2 fail (both pre-existing `scripts/lint-skill-shell.test.ts` baseline failures on `main`, unrelated to this PR). `bun run lint`, `typecheck`, `build` all clean.

Supersedes gh-ludics-145 (already closed as fixed — its `setsid` ask landed earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)