### PR TITLE
Orchestration survives a tmux-server restart: recover vanished sessions + fix slot resume sibling write (gh-ludics-559)

### DIFF
--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -122,6 +122,48 @@ function removeTmuxSlotState(slot: number, harnessDir: string): void {
   }
 }
 
+/**
+ * Canonical post-`startOrchestrationProcess` sibling-state write, shared by the
+ * fresh-`start` path, `slotResume` (gh-ludics-559 defect B), and the runner's
+ * vanished-session recovery (gh-ludics-559 defect A).
+ *
+ * When `existing` is null/absent (post-tmux-server-restart, post-`stop`), the
+ * full `TmuxSlotState` is reconstructed exactly as `start()` does, so the
+ * runner's sibling-state self-guard is satisfied. When `existing` is provided,
+ * it is patched in place — `ttydPids` refreshed and `orchestration.pid` set —
+ * while unmanaged fields (notably `ttydRestartCounts`) are preserved.
+ */
+export function writeTmuxOrchestrationSiblingState(opts: {
+  slot: number;
+  harnessDir: string;
+  mode: OrchestrationState["mode"];
+  pid: number;
+  ttydPids: Record<string, number>;
+  existing?: TmuxSlotState | null;
+}): void {
+  const { slot, harnessDir, mode, pid, ttydPids, existing } = opts;
+  if (existing) {
+    writeTmuxSlotState(
+      {
+        ...existing,
+        slot,
+        ttydPids,
+        orchestration: {
+          stateFile: existing.orchestration?.stateFile ?? stateFilePath(slot, harnessDir),
+          mode: existing.orchestration?.mode ?? mode,
+          pid,
+        },
+      },
+      harnessDir,
+    );
+    return;
+  }
+  writeTmuxSlotState(
+    { slot, ttydPids, orchestration: { stateFile: stateFilePath(slot, harnessDir), mode, pid } },
+    harnessDir,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Naming / port helpers
 // ---------------------------------------------------------------------------

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -2045,7 +2045,7 @@ describe("detectAndRecoverVanishedTmuxSessions", () => {
 
     try {
       const res = await detectAndRecoverVanishedTmuxSessions(state);
-      expect(res).toBe("ok");
+      expect(res).toBe("recovered");
       // Invariant: exactly one slot-scoped recreate (not per-agent racing).
       expect(recreateSpy).toHaveBeenCalledTimes(1);
       expect(recreateSpy.mock.calls[0]![0]).toBe(slot);
@@ -2160,6 +2160,57 @@ describe("detectAndRecoverVanishedTmuxSessions", () => {
       recreateSpy.mockRestore();
       emitSpy.mockRestore();
       notifySpy.mockRestore();
+    }
+  });
+
+  test("after recovery the runner re-enters enterPhase to re-prompt the recreated CLIs (Codex PR #569 — no stall until timeout)", async () => {
+    // Codex flagged: clearing phaseDispatched inside pollUntilDone is insufficient
+    // — enterPhase only runs in the OUTER runOrchestration loop, so without a
+    // re-dispatch signal the freshly-booted CLIs sit idle (null lifecycles) until
+    // the phase deadline. Invariant: a successful recovery re-dispatches the
+    // current phase, i.e. transport.sendTurn is called again (initial dispatch +
+    // post-recovery re-dispatch). Mutation: if recovery returned "ok" instead of
+    // "redispatch" (or runOrchestration didn't `continue`), sendTurn fires only
+    // once. Harness: session vanished on the first detection then present after
+    // recreate; loop terminated deterministically by forcing allAgentsDone once
+    // the re-dispatch has happened.
+    const slot = 36;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+    process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "0";
+    const state = makeState({ slot, backend: "tmux", phase: "work", harnessDir: harness, phaseDispatched: false }, peerSyncDir);
+
+    let recreated = false;
+    let sendTurns = 0;
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession").mockImplementation(() => recreated);
+    const recreateSpy = spyOn(tmuxAdapter, "startTmuxAgentSessionsForOrchestratedSlot")
+      .mockImplementation(() => { recreated = true; return { coder: 1, reviewer: 2 }; });
+    const emitSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    // Terminate the loop once the re-dispatch has occurred: allAgentsDone true
+    // after sendTurns>=2 → pollUntilDone returns normally → evaluateTransition
+    // forces "done" → outer while exits.
+    const allDoneSpy = spyOn(phases, "allAgentsDone").mockImplementation(() => sendTurns >= 2);
+    const transitionSpy = spyOn(phases, "evaluateTransition").mockReturnValue("done");
+
+    const recordingTransport: OrchestrationTransport = {
+      async sendTurn() { sendTurns++; return "cmd-redispatch"; },
+      async sendEnter() {},
+      async refreshAgentTransportState() {},
+      async interruptAgent() {},
+    };
+
+    try {
+      await runOrchestration(state, recordingTransport);
+      // One recreate; sendTurn fired for the initial dispatch AND the
+      // post-recovery re-dispatch (≥2). Single-dispatch would mean the stall bug.
+      expect(recreateSpy).toHaveBeenCalledTimes(1);
+      expect(sendTurns).toBeGreaterThanOrEqual(2);
+    } finally {
+      hasSessionSpy.mockRestore();
+      recreateSpy.mockRestore();
+      emitSpy.mockRestore();
+      allDoneSpy.mockRestore();
+      transitionSpy.mockRestore();
     }
   });
 

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -4,8 +4,10 @@ import { join } from "path";
 import { isAgentDone } from "./phases.ts";
 import * as phases from "./phases.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
-import { ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests } from "./runner.ts";
+import { detectAndNudgeSettledNoSignal, detectAndRecoverVanishedTmuxSessions, ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests, __resetVanishedRecoveryStateForTests } from "./runner.ts";
 import * as tmuxAdapter from "../adapters/tmux-adapter.ts";
+import * as tmux from "../adapters/tmux.ts";
+import * as notify from "../notify.ts";
 import * as t3codeServer from "../t3code/server.ts";
 import * as orchUtil from "./util.ts";
 import * as wfr from "./wrong-filename-recovery.ts";
@@ -23,6 +25,7 @@ import {
   makePeerSyncDir,
   makeSnapshot,
   makeMockTransport,
+  noopTransport,
 } from "./runner.test-helpers.ts";
 
 setDefaultTimeout(20_000);
@@ -1966,6 +1969,271 @@ describe("ensureTtydAlive — flap suppression", () => {
       expect(types.filter((t) => t === "ttyd_restarted").length).toBe(1);
     } finally {
       matchSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vanished-session detection & recovery (gh-ludics-559 defect A)
+// ---------------------------------------------------------------------------
+
+describe("detectAndRecoverVanishedTmuxSessions", () => {
+  let origHarnessDir: string | undefined;
+  let origRetryMax: string | undefined;
+  let origStartupGrace: string | undefined;
+
+  beforeEach(() => {
+    origHarnessDir = process.env.LUDICS_HARNESS_DIR;
+    origRetryMax = process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX;
+    origStartupGrace = process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+    __resetVanishedRecoveryStateForTests();
+  });
+
+  afterEach(() => {
+    if (origHarnessDir !== undefined) process.env.LUDICS_HARNESS_DIR = origHarnessDir;
+    else delete process.env.LUDICS_HARNESS_DIR;
+    if (origRetryMax !== undefined) process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX = origRetryMax;
+    else delete process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX;
+    if (origStartupGrace !== undefined) process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = origStartupGrace;
+    else delete process.env.LUDICS_RUNNER_STARTUP_GRACE_MS;
+    __resetVanishedRecoveryStateForTests();
+  });
+
+  // Mirror of escalation.test.ts seedHarness: sibling tmux-slot file (pid == our
+  // own so the self-guard passes) + a slot json so liveness can flip.
+  function seedHarness(slot: number): { harness: string; peerSyncDir: string } {
+    const tmpDir = makeTmpDir();
+    const harness = join(tmpDir, "harness");
+    const peerSyncDir = join(tmpDir, "peer-sync");
+    mkdirSync(join(harness, "orchestration"), { recursive: true });
+    mkdirSync(join(harness, "slots"), { recursive: true });
+    mkdirSync(join(peerSyncDir, "plans"), { recursive: true });
+    mkdirSync(join(peerSyncDir, "reviews"), { recursive: true });
+    writeFileSync(
+      join(harness, "orchestration", `tmux-slot-${slot}.json`),
+      JSON.stringify({ slot, orchestration: { pid: process.pid, stateFile: "x", mode: "pair" }, ttydPids: {} }),
+    );
+    writeFileSync(
+      join(harness, "slots", `slot-${slot}.json`),
+      JSON.stringify({
+        slot, process: "test-process", task: "feat", mode: "tmux", session: null,
+        path: null, started: null, adapterArgs: null, machine: null,
+        sessionStarted: null, liveness: null, terminals: "", runtime: "", git: "",
+      }, null, 2),
+    );
+    return { harness, peerSyncDir };
+  }
+
+  function eventTypes(spy: ReturnType<typeof spyOn>): string[] {
+    return spy.mock.calls.map((c: unknown[]) => (c[0] as { event_type?: string }).event_type ?? "");
+  }
+
+  test("vanished participating session triggers exactly one slot-scoped recreate, rewrites sibling, resumes in order (AC6/AC7/AC8/AC10)", async () => {
+    const slot = 31;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    const state = makeState({ slot, backend: "tmux", phase: "work", harnessDir: harness }, peerSyncDir);
+    // Pre-set in-flight bookkeeping that orderly-resume must clear.
+    state.agentStates.coder!.turnLifecycle = makeLifecycle({ state: "running", observedTurnId: "turn-x" });
+    state.phaseDispatched = true;
+    const origPhase = state.phase;
+    const origRound = state.round;
+
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession").mockImplementation(() => false);
+    const recreateSpy = spyOn(tmuxAdapter, "startTmuxAgentSessionsForOrchestratedSlot")
+      .mockImplementation(() => ({ coder: 4242, reviewer: 4243 }));
+    const emitSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+
+    try {
+      const res = await detectAndRecoverVanishedTmuxSessions(state);
+      expect(res).toBe("ok");
+      // Invariant: exactly one slot-scoped recreate (not per-agent racing).
+      expect(recreateSpy).toHaveBeenCalledTimes(1);
+      expect(recreateSpy.mock.calls[0]![0]).toBe(slot);
+
+      // Invariant: sibling file rewritten with our pid + fresh ttyd pids, so
+      // stop/clear can still track the slot. Without the rewrite, the recovered
+      // slot would be untrackable (the original incident's orphan-ttyd problem).
+      const sib = tmuxAdapter.readTmuxSlotState(slot, harness);
+      expect(sib!.orchestration?.pid).toBe(process.pid);
+      expect(sib!.ttydPids).toEqual({ coder: 4242, reviewer: 4243 });
+
+      // Invariant (AC8): orderly resume — current-turn bookkeeping cleared,
+      // phase/round NOT rewound (no replay of prior phases).
+      expect(state.phaseDispatched).toBe(false);
+      expect(state.agentStates.coder!.turnLifecycle).toBeNull();
+      expect(state.agentStates.reviewer!.turnLifecycle).toBeNull();
+      expect(state.phase).toBe(origPhase);
+      expect(state.round).toBe(origRound);
+
+      // Invariant (AC10): recovery is observable in the event log.
+      const types = eventTypes(emitSpy);
+      expect(types).toContain("tmux_sessions_vanished");
+      expect(types).toContain("tmux_sessions_recovered");
+    } finally {
+      hasSessionSpy.mockRestore();
+      recreateSpy.mockRestore();
+      emitSpy.mockRestore();
+    }
+  });
+
+  test("missing NON-participating session does not trigger recovery (AC6 participant-scoping)", async () => {
+    // Harness condition: phase "review" → only the reviewer participates
+    // (agentParticipatesInPhase). The coder session is missing but the coder is
+    // a non-participant, and the reviewer session is present. A vacuous
+    // all-agents check (state.agents.some) would mis-fire here; the participant
+    // filter must not. Mutation: drop the participant filter → recreate fires.
+    const slot = 32;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    const state = makeState({ slot, backend: "tmux", phase: "review", harnessDir: harness }, peerSyncDir);
+    const coderSession = tmuxAdapter.tmuxSessionName(slot, "coder", state.taskId);
+
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession")
+      .mockImplementation((name: string) => name !== coderSession); // coder gone, reviewer present
+    const recreateSpy = spyOn(tmuxAdapter, "startTmuxAgentSessionsForOrchestratedSlot")
+      .mockImplementation(() => ({}));
+
+    try {
+      const res = await detectAndRecoverVanishedTmuxSessions(state);
+      expect(res).toBe("ok");
+      expect(recreateSpy).not.toHaveBeenCalled();
+    } finally {
+      hasSessionSpy.mockRestore();
+      recreateSpy.mockRestore();
+    }
+  });
+
+  test("all participating sessions present → no recovery (a dead CLI in a live session is not a vanish) (AC6)", async () => {
+    const slot = 33;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    const state = makeState({ slot, backend: "tmux", phase: "work", harnessDir: harness }, peerSyncDir);
+
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession").mockImplementation(() => true);
+    const recreateSpy = spyOn(tmuxAdapter, "startTmuxAgentSessionsForOrchestratedSlot")
+      .mockImplementation(() => ({}));
+
+    try {
+      const res = await detectAndRecoverVanishedTmuxSessions(state);
+      expect(res).toBe("ok");
+      expect(recreateSpy).not.toHaveBeenCalled();
+    } finally {
+      hasSessionSpy.mockRestore();
+      recreateSpy.mockRestore();
+    }
+  });
+
+  test("retry budget exhaustion escalates (priority-5 notify + escalation_requested + liveness flip) and halts (AC9/AC10)", async () => {
+    const slot = 34;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+    process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX = "1";
+    const state = makeState({ slot, backend: "tmux", phase: "work", harnessDir: harness }, peerSyncDir);
+
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession").mockImplementation(() => false);
+    // Recreate keeps failing (server wedged present-but-unresponsive).
+    const recreateSpy = spyOn(tmuxAdapter, "startTmuxAgentSessionsForOrchestratedSlot")
+      .mockImplementation(() => { throw new Error("tmux server unresponsive"); });
+    const emitSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+
+    try {
+      // Attempt 1: under budget → counted, recreate attempted (throws) → "ok".
+      const r1 = await detectAndRecoverVanishedTmuxSessions(state);
+      expect(r1).toBe("ok");
+      // Attempt 2: budget (1) reached → escalate + halt, no further recreate.
+      const r2 = await detectAndRecoverVanishedTmuxSessions(state);
+      expect(r2).toBe("halt");
+
+      // Invariant (AC9): bounded — recreate attempted at most maxRetries times.
+      expect(recreateSpy).toHaveBeenCalledTimes(1);
+
+      // Invariant (AC10): reuses the escalation machinery — failure precursor
+      // AND escalation_requested, priority-5 notify, slot liveness escalated.
+      const types = eventTypes(emitSpy);
+      expect(types).toContain("tmux_sessions_recovery_failed");
+      expect(types).toContain("escalation_requested");
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect((notifySpy.mock.calls[0] as unknown[])[1]).toBe(5);
+      const slotData = JSON.parse(readFileSync(join(harness, "slots", `slot-${slot}.json`), "utf-8"));
+      expect(slotData.liveness).toBe("escalated");
+    } finally {
+      hasSessionSpy.mockRestore();
+      recreateSpy.mockRestore();
+      emitSpy.mockRestore();
+      notifySpy.mockRestore();
+    }
+  });
+
+  test("vanished check runs BEFORE settled-no-signal: a vanished session is never nudged as settled (AC5/AC12d)", async () => {
+    // Positive control (non-vacuity): the primed coder genuinely trips the
+    // settled-no-signal detector when it runs.
+    const pcDir = makeTmpDir();
+    mkdirSync(join(pcDir, "plans"), { recursive: true });
+    mkdirSync(join(pcDir, "reviews"), { recursive: true });
+    const primed = makeState({ phase: "work" }, pcDir);
+    primed.agentStates.coder!.status = "done";
+    primed.agentStates.coder!.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-settled",
+      turnStartedAt: new Date(Date.now() - 400_000).toISOString(), // > 300s threshold
+    });
+    await detectAndNudgeSettledNoSignal(primed, noopTransport);
+    expect(primed.agentStates.coder!.turnLifecycle!.settledNoSignalDetectedAt).not.toBeNull();
+
+    // Negative (ordering): same prime, but the session vanished and the retry
+    // budget is 0 → the poll loop halts AT the vanished check, before reaching
+    // detectAndNudgeSettledNoSignal. The settled-no-signal event (whose only
+    // emitter is downstream of the halt) must therefore never appear. Mutation:
+    // moving the vanished check after the settled detector lets tick 1 emit it.
+    const slot = 35;
+    const { harness, peerSyncDir } = seedHarness(slot);
+    process.env.LUDICS_HARNESS_DIR = harness;
+    process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX = "0";
+    process.env.LUDICS_RUNNER_STARTUP_GRACE_MS = "0";
+    const state = makeState({
+      slot,
+      backend: "tmux",
+      phase: "work",
+      harnessDir: harness,
+      // Skip re-entry into enterPhase's dispatch loop while still exercising the
+      // real pollUntilDone path (same trick as escalation.test.ts).
+      phaseDispatched: true,
+      currentPhaseToken: "phase-existing",
+    }, peerSyncDir);
+    state.agentStates.coder!.status = "done";
+    state.agentStates.coder!.turnLifecycle = makeLifecycle({
+      state: "running",
+      observedTurnId: "turn-settled",
+      turnStartedAt: new Date(Date.now() - 400_000).toISOString(),
+    });
+
+    let sendTurnCalls = 0;
+    const recordingTransport: OrchestrationTransport = {
+      async sendTurn() { sendTurnCalls++; return "cmd-vanished-order"; },
+      async sendEnter() {},
+      async refreshAgentTransportState() {},
+      async interruptAgent() {},
+    };
+
+    const hasSessionSpy = spyOn(tmux, "tmuxHasSession").mockImplementation(() => false);
+    const emitSpy = spyOn(events, "emitEvent").mockImplementation(() => {});
+    const notifySpy = spyOn(notify, "notifyOutgoing").mockImplementation(() => {});
+
+    try {
+      await runOrchestration(state, recordingTransport);
+      const types = eventTypes(emitSpy);
+      // Ordering invariant: vanished session never aged into settled-no-signal.
+      expect(types).not.toContain("orchestration_settled_no_signal_detected");
+      expect(types).not.toContain("orchestration_settled_no_signal_nudge_sent");
+      // And recovery escalation did run (budget 0 → immediate give-up).
+      expect(types).toContain("escalation_requested");
+      // No prompt was pasted into the (dead) target.
+      expect(sendTurnCalls).toBe(0);
+      // Phase not advanced (orderly halt).
+      expect(state.phase).toBe("work");
+    } finally {
+      hasSessionSpy.mockRestore();
+      emitSpy.mockRestore();
+      notifySpy.mockRestore();
     }
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1171,8 +1171,10 @@ export function __resetVanishedRecoveryStateForTests(): void {
  *
  * Returns "halt" only when recovery has given up (budget exhausted): the caller
  * must `return` from the poll loop immediately, mirroring `checkEscalationHalt`.
- * Returns "ok" otherwise (healthy, recovered this tick, or recreate failed but
- * the budget is not yet spent).
+ * Returns "recovered" when sessions were recreated this tick — the caller must
+ * re-enter `enterPhase` (re-prompt the fresh CLIs for the current phase) rather
+ * than keep polling null lifecycles. Returns "ok" otherwise (healthy, or recreate
+ * failed but the budget is not yet spent — the next tick re-detects).
  *
  * Detection is participant-scoped (AC6): a missing session for a NON-participating
  * agent does not trigger recovery. A dead agent CLI inside a still-live session

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -20,7 +20,7 @@ import {
 import { isoNow, makeId, nowEpoch, sleepMs } from "./util.ts";
 import { fetchNewPrCommentCount, getPrVerification, hasCodexPostedComment, hasCodexSubmittedReview, isPrMerged, isPrUrl, postCodexReviewComment, postPrDriftComment, prUrlBelongsToRepo, repoSlugFromPrUrl, validateAndFixPrFile, type PrVerification } from "./github.ts";
 import { updateFrontmatterField, addFrontmatterField, appendToSection } from "../tasks/markdown.ts";
-import { findProjectConfig, globalAdapter, harnessDir as defaultHarnessDir, ludicsRoot } from "../config.ts";
+import { findProjectConfig, globalAdapter, harnessDir as defaultHarnessDir, loadOrchestrationConfig, ludicsRoot } from "../config.ts";
 import { taskFilePath } from "./paths.ts";
 import { notifyAgents, notifyOutgoing } from "../notify.ts";
 import { readSlotJson, writeSlotJson } from "../slots/json.ts";
@@ -29,7 +29,8 @@ import { setSlotLivenessOnData } from "../slots/index.ts";
 import { clusterRole } from "../cluster.ts";
 import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
-import { agentPortRole, readTmuxSlotState, startTtyd, ttydLogPath, ttydMatchesSession, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentPortRole, readTmuxSlotState, startTmuxAgentSessionsForOrchestratedSlot, startTtyd, tmuxSessionName, ttydLogPath, ttydMatchesSession, writeTmuxOrchestrationSiblingState, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { tmuxHasSession } from "../adapters/tmux.ts";
 import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts";
 import { recoverWrongFilename } from "./wrong-filename-recovery.ts";
 
@@ -1130,6 +1131,164 @@ export async function ensureTtydAlive(state: OrchestrationState): Promise<void> 
   if (changed) writeTmuxSlotState(tmuxState, dir);
 }
 
+// ---------------------------------------------------------------------------
+// Vanished-session detection & recovery (gh-ludics-559 defect A)
+//
+// When the tmux *server* dies (an opaque wedge, not a reboot/OOM/signal) the
+// orchestration runner process survives but every `sN_<role>_<task>` agent
+// session vanishes at once. Without this check the runner keeps driving dead
+// panes: `tmuxCapture` returns null on a missing session, the pane hash stops
+// advancing, and `detectAndNudgeSettledNoSignal` nudges a corpse forever.
+//
+// This polled check runs BEFORE the settled/hung detectors so a vanished
+// session is never misclassified as settled-no-signal. It is slot-scoped: per
+// the precipitating incident the server takes every session at once, so a
+// single recreate of all slot sessions avoids racing per-agent recoveries.
+// ---------------------------------------------------------------------------
+
+/** Small linear-backoff base between vanished-session recreate attempts. */
+const VANISHED_BACKOFF_MS = 500;
+
+/** Per-incident recreate-attempt counters, keyed by harnessDir:slot:taskId.
+ *  Module-level (not persisted) so it survives across poll ticks without
+ *  changing OrchestrationState's JSON shape; reset on healthy detection and on
+ *  successful recovery. */
+const vanishedRecoveryAttempts = new Map<string, number>();
+
+function vanishedKey(state: OrchestrationState): string {
+  return `${state.harnessDir ?? defaultHarnessDir()}:${state.slot}:${state.taskId}`;
+}
+
+/** Test-only: clear the module-scoped vanished-recovery attempt counters so
+ *  unit tests can drive consecutive detection calls deterministically. */
+export function __resetVanishedRecoveryStateForTests(): void {
+  vanishedRecoveryAttempts.clear();
+}
+
+/**
+ * Detect a slot-level vanished tmux session and recover it, or escalate-and-halt
+ * once a bounded retry budget is exhausted.
+ *
+ * Returns "halt" only when recovery has given up (budget exhausted): the caller
+ * must `return` from the poll loop immediately, mirroring `checkEscalationHalt`.
+ * Returns "ok" otherwise (healthy, recovered this tick, or recreate failed but
+ * the budget is not yet spent).
+ *
+ * Detection is participant-scoped (AC6): a missing session for a NON-participating
+ * agent does not trigger recovery. A dead agent CLI inside a still-live session
+ * is NOT a vanished session — that remains the existing isAgentAlive/sendTurn
+ * reboot path. Recovery recreates ALL slot sessions and continues the loop from
+ * the persisted phase/turn (orderly resume, AC8): no phase rewind, no replay.
+ */
+export async function detectAndRecoverVanishedTmuxSessions(
+  state: OrchestrationState,
+): Promise<"ok" | "halt"> {
+  if (state.backend !== "tmux") return "ok";
+
+  const key = vanishedKey(state);
+  const participants = state.agents.filter((a) => agentParticipatesInPhase(state, a));
+  const anyMissing = participants.some((a) => {
+    try {
+      return !tmuxHasSession(tmuxSessionName(state.slot, a.name, state.taskId));
+    } catch {
+      // Server present-but-unresponsive (wedge window): treat as missing so the
+      // bounded-retry budget converges to escalation rather than nudging.
+      return true;
+    }
+  });
+  if (!anyMissing) {
+    vanishedRecoveryAttempts.delete(key);
+    return "ok";
+  }
+
+  const maxRetries = Number(process.env.LUDICS_RUNNER_VANISHED_RETRY_MAX ?? "2");
+  const priorAttempts = vanishedRecoveryAttempts.get(key) ?? 0;
+
+  // Budget exhausted — escalate via the shared escalation machinery and halt.
+  if (priorAttempts >= maxRetries) {
+    const reason = `vanished tmux sessions: retry budget exhausted after ${maxRetries} attempt(s) — tmux server may be wedged present-but-unresponsive`;
+    escalateSlot(state, {
+      reason,
+      title: `slot ${state.slot} vanished-session escalation`,
+      message: `Slot ${state.slot} task ${state.taskId} at phase ${state.phase}: ${reason}`,
+      failedEvent: "tmux_sessions_recovery_failed",
+    });
+    vanishedRecoveryAttempts.delete(key);
+    return "halt";
+  }
+
+  const attempt = priorAttempts + 1;
+  vanishedRecoveryAttempts.set(key, attempt); // count before recreate can throw
+  await sleepMs(VANISHED_BACKOFF_MS * attempt);
+
+  emitEvent({
+    event_type: "tmux_sessions_vanished",
+    source: "orchestration",
+    scope: "slot",
+    slot: state.slot,
+    task: state.taskId,
+    phase: state.phase,
+    attempt,
+    max_attempts: maxRetries,
+    message: `slot ${state.slot}: tmux session(s) vanished — recreating (attempt ${attempt}/${maxRetries})`,
+  });
+
+  const dir = state.harnessDir ?? defaultHarnessDir();
+  try {
+    // Recreate ALL slot sessions (kills any stale session, recreates it,
+    // restarts ttyd — which pkills the role port, so no duplicate ttyds — and
+    // boots the agent CLI fresh per agent).
+    const ttydPids = startTmuxAgentSessionsForOrchestratedSlot(
+      state.slot,
+      state.agents,
+      state.peerSyncDir,
+      state.taskId,
+      /* startTtydEnabled */ true,
+      loadOrchestrationConfig(),
+    );
+
+    // Rewrite the sibling file so stop/clear can still track the slot, and so
+    // this runner re-asserts ownership (orchestration.pid === our pid).
+    writeTmuxOrchestrationSiblingState({
+      slot: state.slot,
+      harnessDir: dir,
+      mode: state.mode,
+      pid: process.pid,
+      ttydPids,
+      existing: readTmuxSlotState(state.slot, dir),
+    });
+
+    // Orderly resume (AC8): re-prompt only the CURRENT phase to the freshly
+    // booted CLIs — clear in-flight turn bookkeeping, exactly as slotResume
+    // does, WITHOUT rewinding state.phase/round or replaying prior phases.
+    for (const name of Object.keys(state.agentStates)) {
+      state.agentStates[name]!.turnLifecycle = null;
+    }
+    state.phaseDispatched = false;
+    persistState(state, dir);
+
+    emitEvent({
+      event_type: "tmux_sessions_recovered",
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.taskId,
+      phase: state.phase,
+      attempt,
+      message: `slot ${state.slot}: sessions recreated; resuming phase ${state.phase}`,
+    });
+    vanishedRecoveryAttempts.delete(key);
+    return "ok";
+  } catch (err) {
+    // Recreate failed (server still wedged). The attempt is already counted; the
+    // next tick re-detects and converges toward the escalation branch above.
+    console.error(
+      `ludics: slot ${state.slot}: vanished-session recreate failed (attempt ${attempt}/${maxRetries}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return "ok";
+  }
+}
+
 function markActiveAgents(state: OrchestrationState): void {
   for (const agent of state.agents) {
     if (!agentParticipatesInPhase(state, agent)) continue;
@@ -2005,7 +2164,7 @@ export async function runWrongFilenameRecovery(
   }
 }
 
-async function pollUntilDone(state: OrchestrationState, transport: OrchestrationTransport): Promise<void> {
+async function pollUntilDone(state: OrchestrationState, transport: OrchestrationTransport): Promise<"halt" | void> {
   const timeout = state.config.timeouts[state.phase] ?? 600;
   const deadline = state.phaseStartedAt + timeout;
   const interval = state.config.pollInterval * 1000;
@@ -2046,6 +2205,15 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       // event + priority-5 notification, and flip slot liveness without any
       // intervening phase-advance work (nudge, auto-commit, verification gate).
       if (checkEscalationHalt(state)) return;
+
+      // Vanished-session detection & recovery (gh-ludics-559 defect A). MUST run
+      // before the settled/hung detectors: a tmux session that vanished (opaque
+      // tmux-server wedge) otherwise reads as a static, settled pane and gets
+      // nudged forever. Recreates the slot (bounded retries) and resumes from
+      // the persisted phase; on "halt" the retry budget is spent and the runner
+      // has escalated — propagate the halt so runOrchestration returns without
+      // any phase-advance work (the escalation already flipped slot liveness).
+      if (await detectAndRecoverVanishedTmuxSessions(state) === "halt") return "halt";
 
       // Detect settled-no-signal agents (static terminal, read loop open) and
       // send Enter / "Continue." / re-dispatch / force-settle.
@@ -2438,11 +2606,20 @@ export function handleEscalation(state: OrchestrationState): void {
     ? `Slot ${state.slot} agent ${raisers[0]!.name} escalated on task ${state.taskId} at phase ${state.phase}: ${reasonFor(raisers[0]!.name).reason}`
     : `Slot ${state.slot} agents escalated on task ${state.taskId} at phase ${state.phase} — ${parts.join(" | ")}`;
   const title = `slot ${state.slot} escalation`;
+  notifyAndFlipEscalated(state, message, title);
+}
+
+/**
+ * Shared escalation tail: priority-5 `ludics notify outgoing` + flip slot
+ * liveness to "escalated" + persist. Used by both `handleEscalation`
+ * (agent-initiated) and `escalateSlot` (runtime-infrastructure give-up). notify
+ * is best-effort; the runner still halts if the notification pipe is broken —
+ * the event log is the authoritative record.
+ */
+function notifyAndFlipEscalated(state: OrchestrationState, message: string, title: string): void {
   try {
     notifyOutgoing(message, 5, title);
   } catch (err) {
-    // notify is best-effort; still halt the runner even if the notification
-    // pipe is broken. The event log is the authoritative record.
     console.error(`ludics: notifyOutgoing failed for slot ${state.slot} escalation: ${err instanceof Error ? err.message : String(err)}`);
   }
 
@@ -2455,6 +2632,44 @@ export function handleEscalation(state: OrchestrationState): void {
   }
 
   persistState(state, state.harnessDir ?? defaultHarnessDir());
+}
+
+/**
+ * Runtime-infrastructure escalation: a halt condition with no agent-authored
+ * escalate status (e.g. vanished tmux sessions that cannot be recreated). Reuses
+ * the existing `escalation_requested` event + priority-5 notify machinery (AC10
+ * — not a parallel notify), optionally preceded by a failure precursor event.
+ */
+export function escalateSlot(state: OrchestrationState, opts: {
+  reason: string;
+  title: string;
+  message: string;
+  failedEvent?: string;
+}): void {
+  if (opts.failedEvent) {
+    emitEvent({
+      event_type: opts.failedEvent,
+      source: "orchestration",
+      scope: "slot",
+      slot: state.slot,
+      task: state.taskId,
+      phase: state.phase,
+      reason: opts.reason,
+      message: opts.message,
+    });
+  }
+  emitEvent({
+    event_type: "escalation_requested",
+    source: "orchestration",
+    scope: "slot",
+    slot: state.slot,
+    task: state.taskId,
+    phase: state.phase,
+    reason: opts.reason,
+    reason_provided: true,
+    message: opts.message,
+  });
+  notifyAndFlipEscalated(state, opts.message, opts.title);
 }
 
 /**
@@ -2620,7 +2835,13 @@ export async function runOrchestration(
     await enterPhase(state, transport);
     persistState(state, state.harnessDir ?? defaultHarnessDir());
 
-    await pollUntilDone(state, transport);
+    const pollOutcome = await pollUntilDone(state, transport);
+
+    // Vanished-session give-up halt (gh-ludics-559 defect A). The recovery path
+    // already escalated (priority-5 notify + slot liveness flip + events) and
+    // signalled halt; return without phase-advance work, leaving the non-"done"
+    // phase intact so `ludics slot N resume` can recover the slot.
+    if (pollOutcome === "halt") return;
 
     // Escalation halt — checked before any phase-advance work so we don't
     // auto-commit, verify, or transition while the human is being flagged in.

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1182,7 +1182,7 @@ export function __resetVanishedRecoveryStateForTests(): void {
  */
 export async function detectAndRecoverVanishedTmuxSessions(
   state: OrchestrationState,
-): Promise<"ok" | "halt"> {
+): Promise<"ok" | "halt" | "recovered"> {
   if (state.backend !== "tmux") return "ok";
 
   const key = vanishedKey(state);
@@ -1278,7 +1278,7 @@ export async function detectAndRecoverVanishedTmuxSessions(
       message: `slot ${state.slot}: sessions recreated; resuming phase ${state.phase}`,
     });
     vanishedRecoveryAttempts.delete(key);
-    return "ok";
+    return "recovered";
   } catch (err) {
     // Recreate failed (server still wedged). The attempt is already counted; the
     // next tick re-detects and converges toward the escalation branch above.
@@ -2164,7 +2164,7 @@ export async function runWrongFilenameRecovery(
   }
 }
 
-async function pollUntilDone(state: OrchestrationState, transport: OrchestrationTransport): Promise<"halt" | void> {
+async function pollUntilDone(state: OrchestrationState, transport: OrchestrationTransport): Promise<"halt" | "redispatch" | void> {
   const timeout = state.config.timeouts[state.phase] ?? 600;
   const deadline = state.phaseStartedAt + timeout;
   const interval = state.config.pollInterval * 1000;
@@ -2213,7 +2213,16 @@ async function pollUntilDone(state: OrchestrationState, transport: Orchestration
       // the persisted phase; on "halt" the retry budget is spent and the runner
       // has escalated — propagate the halt so runOrchestration returns without
       // any phase-advance work (the escalation already flipped slot liveness).
-      if (await detectAndRecoverVanishedTmuxSessions(state) === "halt") return "halt";
+      // On "recovered" the sessions were recreated and the loop's current-turn
+      // bookkeeping was cleared (phaseDispatched=false); signal runOrchestration
+      // to re-enter enterPhase so the freshly-booted CLIs are re-prompted for the
+      // current phase immediately, rather than polling null lifecycles until the
+      // phase deadline (gh-ludics-559 — Codex review of PR #569).
+      {
+        const vanished = await detectAndRecoverVanishedTmuxSessions(state);
+        if (vanished === "halt") return "halt";
+        if (vanished === "recovered") return "redispatch";
+      }
 
       // Detect settled-no-signal agents (static terminal, read loop open) and
       // send Enter / "Continue." / re-dispatch / force-settle.
@@ -2836,6 +2845,13 @@ export async function runOrchestration(
     persistState(state, state.harnessDir ?? defaultHarnessDir());
 
     const pollOutcome = await pollUntilDone(state, transport);
+
+    // Vanished-session recovery re-dispatch (gh-ludics-559 defect A). The
+    // recovery path recreated the slot's sessions and cleared phaseDispatched;
+    // re-enter the loop so enterPhase re-prompts the freshly-booted CLIs for the
+    // CURRENT phase (phase/round unchanged → no replay). Without this `continue`
+    // the runner would poll null lifecycles until the phase deadline.
+    if (pollOutcome === "redispatch") continue;
 
     // Vanished-session give-up halt (gh-ludics-559 defect A). The recovery path
     // already escalated (priority-5 notify + slot liveness flip + events) and

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -7,7 +7,7 @@ import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
 import * as spawnMod from "../spawn.ts";
 import { hasStash, writeStash } from "./preempt.ts";
-import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, type OrchestrationState } from "../orchestration/state.ts";
+import { persistState, defaultOrchestrationConfig, initAgentRuntimeState, readOrchestrationState, stateFilePath, type OrchestrationState } from "../orchestration/state.ts";
 import { tmuxKillSession, tmuxHasSession } from "../adapters/tmux.ts";
 import { existsSync } from "fs";
 import { getIntentForDashboard, clearIntent } from "../cluster-http.ts";
@@ -1552,6 +1552,145 @@ describe("slotResume — escalated slot handling (task-4cd94043)", () => {
       // escalated-liveness acceptance branch, the resume would have thrown
       // earlier and this assertion would never run.
       expect(readSlotJson(1, harness).liveness).toBeNull();
+      expect(startSpy).toHaveBeenCalled();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  test("slotResume writes tmux-slot-N.json when absent, with live runner pid (gh-ludics-559 defect B)", async () => {
+    // Invariant (AC1/AC2): post-tmux-server-restart, `tmux-slot-N.json` is gone.
+    // After resume the sibling file MUST exist with orchestration.pid === the
+    // pid startOrchestrationProcess returned, plus a full reconstructed shape
+    // (mode + stateFile). Harness condition: NO tmux-slot-1.json is written
+    // before resume — that absence is exactly the bug's trigger. Without the
+    // unconditional write this assertion fails (file stays null → the runner
+    // would exit on the sibling-state grace timeout).
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const orchDir = join(harness, "orchestration");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(orchDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-absent-sibling", "Resume writes absent sibling");
+
+    void slotAssign(1, "task-absent-sibling", "tmux", "", "", "--pair --coder claude --reviewer claude");
+
+    const orchState: OrchestrationState = {
+      slot: 1,
+      taskId: "task-absent-sibling",
+      mode: "pair",
+      phase: "review",
+      round: 2,
+      mergeRound: 0,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "sonnet", branch: "test-coder", worktreePath: "/tmp/wt-coder" },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "sonnet", branch: "test-reviewer", worktreePath: "/tmp/wt-reviewer" },
+      ],
+      agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+      config: defaultOrchestrationConfig({}),
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+      startedAt: new Date().toISOString(),
+      projectDir: "/tmp/fake-project",
+      rootWorktree: "/tmp/fake-root",
+      peerSyncDir: "/tmp/fake-peersync",
+      threadIds: {},
+      backend: "tmux",
+      slotTitle: "test",
+    };
+    persistState(orchState, harness);
+
+    // Sanity: the sibling file is genuinely absent before resume (the bug state).
+    expect(tmuxAdapterMod.readTmuxSlotState(1, harness)).toBeNull();
+
+    const orchProcess = await import("../orchestration/process.ts");
+    const startSpy = spyOn(orchProcess, "startOrchestrationProcess")
+      .mockImplementation(async () => 99_998);
+
+    createdTmuxSessions.push(
+      "s1_coder_task-absent-sibling", "s1_reviewer_task-absent-sibling",
+    );
+    try {
+      await slotResume(1, { startTtyd: false });
+      const sibling = tmuxAdapterMod.readTmuxSlotState(1, harness);
+      expect(sibling).not.toBeNull();
+      expect(sibling!.orchestration?.pid).toBe(99_998);
+      expect(sibling!.orchestration?.mode).toBe("pair");
+      expect(sibling!.orchestration?.stateFile).toBe(stateFilePath(1, harness));
+      expect(typeof sibling!.ttydPids).toBe("object");
+      expect(startSpy).toHaveBeenCalled();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  test("slotResume preserves unmanaged tmux-slot-N.json fields when present (gh-ludics-559 defect B / AC3)", async () => {
+    // Invariant (AC3): when the sibling file already exists, resume patches it in
+    // place — refreshing ttydPids and orchestration.pid — WITHOUT discarding
+    // fields it does not own. ttydRestartCounts is the canary. Harness
+    // condition: pre-write a sibling file carrying a non-trivial
+    // ttydRestartCounts BEFORE resume; if the patch path clobbered the file
+    // (e.g. by reconstructing instead of spreading), the counter would vanish.
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    const orchDir = join(harness, "orchestration");
+    mkdirSync(tasksDir, { recursive: true });
+    mkdirSync(orchDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-present-sibling", "Resume preserves present sibling");
+
+    void slotAssign(1, "task-present-sibling", "tmux", "", "", "--pair --coder claude --reviewer claude");
+
+    const orchState: OrchestrationState = {
+      slot: 1,
+      taskId: "task-present-sibling",
+      mode: "pair",
+      phase: "review",
+      round: 2,
+      mergeRound: 0,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "sonnet", branch: "test-coder", worktreePath: "/tmp/wt-coder" },
+        { name: "reviewer", provider: "claude-code", role: "reviewer", model: "sonnet", branch: "test-reviewer", worktreePath: "/tmp/wt-reviewer" },
+      ],
+      agentStates: initAgentRuntimeState(["coder", "reviewer"]),
+      config: defaultOrchestrationConfig({}),
+      phaseStartedAt: Math.floor(Date.now() / 1000),
+      startedAt: new Date().toISOString(),
+      projectDir: "/tmp/fake-project",
+      rootWorktree: "/tmp/fake-root",
+      peerSyncDir: "/tmp/fake-peersync",
+      threadIds: {},
+      backend: "tmux",
+      slotTitle: "test",
+    };
+    persistState(orchState, harness);
+
+    // Pre-existing sibling file carrying an unmanaged field.
+    tmuxAdapterMod.writeTmuxSlotState({
+      slot: 1,
+      ttydPids: { coder: 111, reviewer: 222 },
+      ttydRestartCounts: { coder: { count: 3, firstRestartAt: 100, lastRestartAt: 200 } },
+      orchestration: { stateFile: stateFilePath(1, harness), mode: "pair", pid: 12_345 },
+    }, harness);
+
+    const orchProcess = await import("../orchestration/process.ts");
+    const startSpy = spyOn(orchProcess, "startOrchestrationProcess")
+      .mockImplementation(async () => 77_777);
+
+    createdTmuxSessions.push(
+      "s1_coder_task-present-sibling", "s1_reviewer_task-present-sibling",
+    );
+    try {
+      await slotResume(1, { startTtyd: false });
+      const sibling = tmuxAdapterMod.readTmuxSlotState(1, harness);
+      expect(sibling).not.toBeNull();
+      // pid refreshed to the new runner pid
+      expect(sibling!.orchestration?.pid).toBe(77_777);
+      // unmanaged field survives the patch
+      expect(sibling!.ttydRestartCounts?.coder?.count).toBe(3);
+      expect(sibling!.ttydRestartCounts?.coder?.firstRestartAt).toBe(100);
       expect(startSpy).toHaveBeenCalled();
     } finally {
       startSpy.mockRestore();

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -19,7 +19,7 @@ import { hasStash, readStash, writeStash, removeStash } from "./preempt.ts";
 import { expandDuoSlots } from "./duo-expand.ts";
 import type { PreemptStash } from "./preempt.ts";
 import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts";
-import { agentCliCommand, isAgentAlive, readTmuxSlotState, startTtyd, tmuxSessionName, ttydPort, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
+import { agentCliCommand, isAgentAlive, readTmuxSlotState, startTtyd, tmuxSessionName, ttydPort, writeTmuxOrchestrationSiblingState, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { tmuxHasSession, tmuxNewSession, tmuxSendCommand, tmuxSendKeys } from "../adapters/tmux.ts";
 import { selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError } from "../adapters/t3code.ts";
 import { readOrchestrationState, persistState, removeOrchestrationState } from "../orchestration/state.ts";
@@ -1347,6 +1347,12 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
     }
   }
 
+  // Collected during the tmux reconciliation loop below; hoisted to function
+  // scope so the post-`startOrchestrationProcess` sibling-state write can
+  // reconstruct the full TmuxSlotState even when the file was absent at resume
+  // start (gh-ludics-559 defect B).
+  let newTtydPids: Record<string, number> = {};
+
   // --- tmux-specific: verify/recreate tmux session, windows, ttyd, agent CLIs ---
   if (ctx.mode === "tmux") {
     const tmuxState = readTmuxSlotState(slotNum, ctx.harnessDir);
@@ -1363,7 +1369,7 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
       }
     }
 
-    const newTtydPids: Record<string, number> = { ...(tmuxState?.ttydPids ?? {}) };
+    newTtydPids = { ...(tmuxState?.ttydPids ?? {}) };
     const taskId = orchState.taskId;
 
     const bootCliInSession = (session: string, agent: { name: string; provider: string; model?: string; role?: "coder" | "reviewer"; thinkingEffort?: string }) => {
@@ -1476,13 +1482,22 @@ export async function slotResume(slotNum: number, { startTtyd: shouldStartTtyd =
       orchestration: { ...slotState.orchestration, pid: newPid },
     }, ctx.harnessDir);
   } else if (ctx.mode === "tmux") {
+    // Unconditional sibling-state write (gh-ludics-559 defect B). When
+    // `tmux-slot-N.json` is absent (post-tmux-server-restart, post-`stop`), the
+    // helper reconstructs the full TmuxSlotState mirroring `start()`; when it is
+    // present, the helper patches in place, preserving unmanaged fields such as
+    // `ttydRestartCounts`. Previously this write was guarded by `if (tmuxState)`
+    // and silently no-op'd on a missing file, so the runner exited on the
+    // sibling-state self-guard grace timeout.
     const tmuxState = readTmuxSlotState(slotNum, ctx.harnessDir);
-    if (tmuxState) {
-      writeTmuxSlotState({
-        ...tmuxState,
-        orchestration: { ...tmuxState.orchestration!, pid: newPid },
-      }, ctx.harnessDir);
-    }
+    writeTmuxOrchestrationSiblingState({
+      slot: slotNum,
+      harnessDir: ctx.harnessDir,
+      mode: orchState.mode,
+      pid: newPid,
+      ttydPids: newTtydPids,
+      existing: tmuxState,
+    });
   }
 
   // Clear interrupted liveness and stamp session-active marker


### PR DESCRIPTION
Fixes #559.

When the tmux **server** dies (an opaque wedge, not a reboot/OOM/signal) the ludics daemons and orchestration runner processes survive, but every `sN_<role>_<task>` agent session vanishes at once. Two independent defects made this unrecoverable; both are fixed here.

## Defect B — `slot resume` never wrote `tmux-slot-N.json` when absent

`slotResume`'s tmux branch guarded both sibling-state writes behind `if (tmuxState)`. Post-tmux-server-restart (or post-`stop`, which removes the file) `readTmuxSlotState` returns null, both writes were skipped, and the runner it spawned exited on the 5000ms sibling-state self-guard grace.

- New shared `writeTmuxOrchestrationSiblingState` helper in `src/adapters/tmux-adapter.ts`: reconstructs the full `TmuxSlotState` when the file is absent (mirroring `start()`), or patches in place when present — preserving unmanaged fields like `ttydRestartCounts`.
- `slotResume`'s post-`startOrchestrationProcess` write is now unconditional via the helper; `newTtydPids` is hoisted to function scope so the reconstruction carries the reconciled ttyd pids.

## Defect A — runner had no "vanished session" detection

A dead session reads as static (`tmuxCapture` returns null → pane hash stops advancing), so the runner nudged a corpse via `detectAndNudgeSettledNoSignal` forever.

- New `detectAndRecoverVanishedTmuxSessions`, called in `pollUntilDone` **before** the settled/hung detectors (tmux-only). Detection is **participant-scoped** (`agentParticipatesInPhase`): if any participating agent's session is missing the whole slot is treated as vanished. A dead CLI inside a live session is **not** a vanish (stays with the existing `isAgentAlive`/`sendTurn` reboot path).
- Recovery recreates all slot sessions via `startTmuxAgentSessionsForOrchestratedSlot` (`startTtyd` already pkills the role port → no duplicate ttyds), rewrites `tmux-slot-N.json` with the runner's own pid, and **resumes in order** — clearing only current-turn bookkeeping (`turnLifecycle`/`phaseDispatched`), never rewinding `phase`/`round`.
- **Re-dispatch after recovery:** recovery returns `"recovered"` → `pollUntilDone` returns `"redispatch"` → `runOrchestration` `continue`s into `enterPhase`, re-prompting the freshly-booted CLIs for the current phase immediately (rather than polling null lifecycles until the phase deadline).
- **Bounded retry** (`LUDICS_RUNNER_VANISHED_RETRY_MAX`, default 2) with linear backoff; on exhaustion the runner **escalates** via the existing machinery (new `escalateSlot`, factored from `handleEscalation`: emits `escalation_requested` + priority-5 `notifyOutgoing` + flips slot liveness to `escalated`) and **halts**. `pollUntilDone` returns a `"halt"` outcome that `runOrchestration` honors.
- Events: `tmux_sessions_vanished` / `tmux_sessions_recovered` / `tmux_sessions_recovery_failed`.

## Tests

- **Defect B** (`src/slots/index.test.ts`): absent-file resume → file exists with `orchestration.pid` == live runner pid + full shape; present-file → `ttydRestartCounts` preserved and pid refreshed.
- **Defect A** (`src/orchestration/runner.lifecycle.test.ts`): single slot-scoped recreate + orderly resume; non-participant session ignored; all-present no-op; budget exhaustion escalates + halts; re-dispatch after recovery (`sendTurn` fires again, no stall); and an ordering test (positive control + `runOrchestration` with budget 0) proving the vanished check runs before settled-no-signal.

## Validation

- `bun test`: 3022 pass / 2 fail — the 2 failures are pre-existing skill-lint *live corpus* tests (`lint-skill-shell`, `lint-skill-cli-refs`), unrelated to this change (recorded as the round baseline). +8 new tests, no new failures.
- `bun run typecheck`, `bun run lint`, `lint:state-migration` (✅ no persisted-shape change — env knob + module-level retry map), `lint:cli-readme`, `lint:no-nul-bytes`, `lint:test-isolation` all green.

## Review feedback addressed

- **Codex P2 (recovery stalled until phase deadline):** fixed in `f3163a1` — the in-loop recovery now re-enters `enterPhase` via the `"redispatch"` outcome so the recreated CLIs are re-prompted immediately (regression-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)