### PR TITLE
docs: prepare v1.0 release without t3code support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+## v1.0.0 — 2026-06-17
 
-Simplified upstream workflow: for projects declaring `upstream_repo`, orchestration now completes at staging-main PR merge, identical to the non-upstream flow.
+First stable release. ludics is feature-complete for everyday use: ephemeral slot management, flow-based task aggregation from GitHub and READMEs, the phase-driven multi-agent orchestration engine, Mag autonomous coordination, and multi-machine cluster coordination are all exercised in daily use through the `tmux` adapter.
+
+**t3code orchestration is not part of the v1.0 supported surface.** The `t3code` adapter and its CLI (`ludics t3code …`) remain in the tree and can still be enabled, but they ship as **experimental and unsupported** in this release: t3code has not reached the stability bar where it offers sufficient value over the `tmux` adapter. Every documented and supported orchestration workflow runs through `tmux`. t3code support may return in a future release as its stability improves.
+
+This release also simplifies the upstream workflow: for projects declaring `upstream_repo`, orchestration now completes at staging-main PR merge, identical to the non-upstream flow.
 
 ### Documentation / contracts
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ For the full list of options and their defaults, see [`templates/config.referenc
 state_repo: your-username/private-state
 state_path: harness
 
+adapter: tmux   # global orchestration adapter; required for v1 (defaults to the experimental t3code if omitted)
+
 projects:
   - name: my-app
     repo: your-username/my-app

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Inspired by Daniel Miessler's Personal AI Infrastructure, by Steve Yegge's Gas T
 - **Slots**: 6 ephemeral "CPUs" for active work, not memory or identity.
 - **Task index**: unified task list from GitHub issues and README TODOs.
 - **Flow engine**: priority/dependency-based views (ready, blocked, critical, impact).
-- **Adapters**: thin integrations with existing agent setups (tmux, t3code, claude.ai, manual).
+- **Adapters**: thin integrations with existing agent setups (tmux, claude.ai, manual; t3code is experimental).
 - **Notifications**: ntfy.sh integration — outgoing (strategic), incoming (from phone), agents (operational).
 - **Triggers**: launchd/systemd automation for briefings and syncs.
 
@@ -182,12 +182,12 @@ mag:
   enabled: true
 
 adapters:
-  t3code:
-    enabled: true
   tmux:
     enabled: true
   manual:
     enabled: true
+  t3code:
+    enabled: false   # experimental; unsupported in v1.0
 
 triggers:
   startup:
@@ -212,9 +212,9 @@ notifications:
 
 ### Adapter Args Layering
 
-For orchestrated work (the `t3code` or `tmux` adapter plus orchestration flags
-such as `--pair` / `--duo`), ludics builds final CLI args from multiple sources
-in this order:
+For orchestrated work (the `tmux` adapter plus orchestration flags such as
+`--pair` / `--duo`; the experimental `t3code` adapter follows the same rules),
+ludics builds final CLI args from multiple sources in this order:
 
 1. `adapters.<adapter>.default_args`
 2. `projects[].adapter_profiles.<adapter>`
@@ -223,11 +223,11 @@ in this order:
 
 Later layers are appended last, so they override earlier options in typical CLI parsing.
 
-#### 1) Global defaults for `t3code`
+#### 1) Global defaults for `tmux`
 
 ```yaml
 adapters:
-  t3code:
+  tmux:
     enabled: true
     default_args:
       - --clarify
@@ -236,7 +236,7 @@ adapters:
       - "5400"
 ```
 
-#### 2) Per-project profile for `t3code`
+#### 2) Per-project profile for `tmux`
 
 ```yaml
 projects:
@@ -244,7 +244,7 @@ projects:
     repo: your-username/my-app
     issues: true
     adapter_profiles:
-      t3code:
+      tmux:
         args:
           - --clarify
           - --pushback
@@ -381,7 +381,9 @@ ludics dashboard restart [port]   # Restart the dashboard server
 ludics dashboard install          # Install dashboard assets to state repo
 ```
 
-### t3code adapter
+### t3code adapter (experimental)
+
+> **Experimental — unsupported in v1.0.** The `t3code` adapter and these commands remain in the tree but are not part of the supported v1.0 surface. Use the `tmux` adapter for orchestrated work; t3code support may return in a future release as its stability improves.
 
 ```bash
 ludics t3code [status]                    # Show shared t3code server status
@@ -491,14 +493,15 @@ ludics help                    # Show help
 
 Adapters are thin integrations that translate external state into slot format:
 
-Only `tmux`, `t3code`, and `manual` are assignable via `-a` (see `slot <n> assign`).
+`tmux` and `manual` are the supported assignable adapters via `-a` (see `slot <n> assign`).
+`t3code` is also assignable but experimental and unsupported in v1.0.
 `claude-ai` and `chatgpt-com` stay registered for legacy bookmark-slot state reads.
 
 | Adapter | Description |
 |---------|-------------|
-| `t3code` | Multi-agent orchestration or single-thread coding via t3code |
-| `tmux` | Agent sessions (solo or orchestrated) managed in tmux |
+| `tmux` | Agent sessions (solo or orchestrated) managed in tmux — the primary, supported adapter |
 | `manual` | Track human work without an agent |
+| `t3code` | Multi-agent orchestration or single-thread coding via t3code — **experimental, unsupported in v1.0** |
 | `claude-ai` | Treats bookmarked claude.ai URLs as sessions (state reads only) |
 | `chatgpt-com` | Tracks ChatGPT browser sessions (state reads only) |
 


### PR DESCRIPTION
## What changed

Prepares the docs for a **v1.0.0 stable release** that ships without t3code support. This is a documentation reframe — the t3code adapter and CLI remain in the tree; they are simply no longer part of the supported surface.

### CHANGELOG.md
- Promoted `## Unreleased` → `## v1.0.0 — 2026-06-17` with a stable-release intro positioning the `tmux` adapter as the path that drives all daily-use workflows.
- Added a prominent note that **t3code orchestration is experimental and unsupported in v1.0** — it stays in the tree and can be enabled, but hasn't met the stability bar and may return in a future release. Existing upstream-workflow release notes are folded under v1.0.0.

### README.md
- Adapter list, Adapter Args intro, CLI Reference section, and adapters table now flag t3code as experimental/unsupported; `tmux` is described as the primary, supported adapter.
- Adapter Args layering examples and the example full config switched to `tmux`; t3code disabled (`enabled: false`) in the example config.

## Why

We never did iterative releases and are now feature-complete except for t3code integration, which isn't offering sufficient value. This cuts a clean v1.0 around the supported `tmux` path.

## Reviewer notes
- The `ludics t3code …` commands are **intentionally kept** in the README CLI Reference: `t3code` is still a top-level command in the `USAGE` constant (`src/index.ts`), and `lint:cli-readme` enforces parity between USAGE and the README CLI Reference. Removing them would fail the lint. `bun run lint:cli-readme` passes.
- Out of scope (left untouched): the "Multi-machine setup" section still describes seniority-based leader election, which v0.7.0 replaced with a static `role: leader` controller. Stale, but unrelated to this t3code/v1.0 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)