### PR TITLE
Display milestone on task detail and task list pages

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -641,7 +641,8 @@ projects:
 
   test("milestone is surfaced on tasks-tree node for milestone-enabled project", async () => {
     writeConfigWithMilestones(TMP);
-    writeTask("task-ms-enabled", "milestonedproject", "v1.0");
+    // Use mixed-case project name to exercise case-insensitive matching.
+    writeTask("task-ms-enabled", "MilestonedProject", "v1.0");
 
     const { dashboardGenerate } = await import("./dashboard.ts");
     silenceConsoleError(() => dashboardGenerate());

--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -601,6 +601,86 @@ describe("tasks-tree link renders task.html", () => {
   });
 });
 
+describe("tasks-tree milestone gating", () => {
+  function writeConfigWithMilestones(homeDir: string): void {
+    const configPath = process.env.LUDICS_CONFIG!;
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: milestonedproject
+    milestones: true
+  - name: plainproject
+`);
+  }
+
+  function writeTask(id: string, project: string, milestone: string | null, extra = ""): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const milestoneLine = milestone !== null ? `milestone: ${milestone}\n` : "";
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${id}"\nstatus: ready\npriority: B\nproject: ${project}\ncreated: "2026-04-10"\n${milestoneLine}${extra}---\n\n# ${id}\n`,
+    );
+  }
+
+  function collectTaskNodes(nodes: unknown[]): Record<string, unknown>[] {
+    const out: Record<string, unknown>[] = [];
+    const walk = (arr: unknown[]): void => {
+      for (const n of arr) {
+        if (!n || typeof n !== "object") continue;
+        const node = n as Record<string, unknown>;
+        if (node.kind === "task") out.push(node);
+        if (Array.isArray(node.children)) walk(node.children as unknown[]);
+      }
+    };
+    walk(nodes);
+    return out;
+  }
+
+  test("milestone is surfaced on tasks-tree node for milestone-enabled project", async () => {
+    writeConfigWithMilestones(TMP);
+    writeTask("task-ms-enabled", "milestonedproject", "v1.0");
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    silenceConsoleError(() => dashboardGenerate());
+
+    const tree = JSON.parse(readFileSync(join(harnessDir(), "dashboard", "data", "tasks-tree.json"), "utf-8")) as unknown[];
+    const tasks = collectTaskNodes(tree);
+    const task = tasks.find((t) => t.id === "task-ms-enabled");
+    expect(task).toBeDefined();
+    expect(task!.milestone).toBe("v1.0");
+  });
+
+  test("stray milestone is suppressed (null) for non-milestone-enabled project", async () => {
+    writeConfigWithMilestones(TMP);
+    writeTask("task-ms-stray", "plainproject", "v1.0");
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    silenceConsoleError(() => dashboardGenerate());
+
+    const tree = JSON.parse(readFileSync(join(harnessDir(), "dashboard", "data", "tasks-tree.json"), "utf-8")) as unknown[];
+    const tasks = collectTaskNodes(tree);
+    const task = tasks.find((t) => t.id === "task-ms-stray");
+    expect(task).toBeDefined();
+    expect(task!.milestone).toBeNull();
+  });
+
+  test("milestone-projects.json lists only projects with milestones enabled", async () => {
+    writeConfigWithMilestones(TMP);
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    silenceConsoleError(() => dashboardGenerate());
+
+    const projectsFile = join(harnessDir(), "dashboard", "data", "milestone-projects.json");
+    expect(existsSync(projectsFile)).toBe(true);
+    const projects = JSON.parse(readFileSync(projectsFile, "utf-8")) as string[];
+    expect(projects).toContain("milestonedproject");
+    expect(projects).not.toContain("plainproject");
+  });
+});
+
 describe("taskLink / proposalLink round-trip", () => {
   const ids = ["plain", "task&x", "task#x", "task?x", "task+x", "task with space", "tâsk-ünîcödé"];
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -665,7 +665,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
         retroLink,
         priority: task.priority,
         status: task.status,
-        milestone: milestonesEnabled.has(task.project) ? task.milestone : null,
+        milestone: milestonesEnabled.has(task.project.toLowerCase()) ? task.milestone : null,
         hasProposal: hasActiveProposal,
         highlighted,
         mtime: task.mtime,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -378,6 +378,7 @@ interface TasksTreeNode {
   retroLink: string | null;
   priority: string | null;
   status: string | null;
+  milestone: string | null;
   hasProposal: boolean;
   highlighted: boolean;
   mtime: string | null;
@@ -607,6 +608,8 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
     return a.id.localeCompare(b.id);
   }
 
+  const milestonesEnabled = milestonesEnabledProjects();
+
   function buildTaskNode(
     taskId: string,
     path: Set<string>,
@@ -622,6 +625,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
         retroLink: null,
         priority: null,
         status: null,
+        milestone: null,
         hasProposal: false,
         highlighted: false,
         mtime: null,
@@ -661,6 +665,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
         retroLink,
         priority: task.priority,
         status: task.status,
+        milestone: milestonesEnabled.has(task.project) ? task.milestone : null,
         hasProposal: hasActiveProposal,
         highlighted,
         mtime: task.mtime,
@@ -701,6 +706,7 @@ function generateTasksTree(tasks: DashboardTask[]): TasksTreeNode[] {
       retroLink: null,
       priority: null,
       status: null,
+      milestone: null,
       hasProposal: false,
       highlighted: childResults.some((child) => child.subtreeHasActiveProposal),
       mtime: null,
@@ -1176,6 +1182,9 @@ export function dashboardGenerate(): void {
 
   writeFileSync(join(dataDir, "tasks-tree.json"), JSON.stringify(generateTasksTree(tasks), null, 2));
   console.error("  tasks-tree.json");
+
+  writeFileSync(join(dataDir, "milestone-projects.json"), JSON.stringify([...milestonesEnabledProjects()], null, 2));
+  console.error("  milestone-projects.json");
 
   writeFileSync(join(dataDir, "notifications.json"), JSON.stringify(generateNotifications(), null, 2));
   console.error("  notifications.json");

--- a/templates/dashboard/task.html
+++ b/templates/dashboard/task.html
@@ -127,7 +127,7 @@
             if (meta.status) parts.push(`<span class="task-badge">${escapeHtml(String(meta.status))}</span>`);
             if (meta.priority) parts.push(`<span class="task-badge">P${escapeHtml(String(meta.priority))}</span>`);
             if (meta.project) parts.push(`<span class="task-badge">${escapeHtml(String(meta.project))}</span>`);
-            if (meta.milestone && Array.isArray(milestoneProjects) && milestoneProjects.includes(meta.project)) {
+            if (meta.milestone && Array.isArray(milestoneProjects) && milestoneProjects.includes(meta.project.toLowerCase())) {
                 parts.push(`<span class="task-badge">${escapeHtml(String(meta.milestone))}</span>`);
             }
             container.innerHTML = parts.join(' ');

--- a/templates/dashboard/task.html
+++ b/templates/dashboard/task.html
@@ -53,6 +53,7 @@
     <script>
         const params = new URLSearchParams(window.location.search);
         const taskId = params.get('task') || '';
+        let milestoneProjects = null;
 
         if (taskId) {
             document.title = `ludics Task: ${taskId}`;
@@ -60,9 +61,19 @@
             if (taskIdEl) taskIdEl.textContent = taskId;
         }
 
-        document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', async () => {
+            await fetchMilestoneProjects();
             fetchTask();
         });
+
+        async function fetchMilestoneProjects() {
+            try {
+                const resp = await fetch('data/milestone-projects.json');
+                milestoneProjects = resp.ok ? await resp.json() : [];
+            } catch {
+                milestoneProjects = [];
+            }
+        }
 
         // Strip leading YAML frontmatter (between two --- fences) and return
         // { frontmatter: string, body: string }. If there is no frontmatter, the
@@ -116,6 +127,9 @@
             if (meta.status) parts.push(`<span class="task-badge">${escapeHtml(String(meta.status))}</span>`);
             if (meta.priority) parts.push(`<span class="task-badge">P${escapeHtml(String(meta.priority))}</span>`);
             if (meta.project) parts.push(`<span class="task-badge">${escapeHtml(String(meta.project))}</span>`);
+            if (meta.milestone && Array.isArray(milestoneProjects) && milestoneProjects.includes(meta.project)) {
+                parts.push(`<span class="task-badge">${escapeHtml(String(meta.milestone))}</span>`);
+            }
             container.innerHTML = parts.join(' ');
         }
 

--- a/templates/dashboard/task.test.ts
+++ b/templates/dashboard/task.test.ts
@@ -185,9 +185,9 @@ describe("task.html template", () => {
     expect(template).toContain("milestoneProjects");
   });
 
-  test("renders milestone badge gated by milestoneProjects", () => {
+  test("renders milestone badge gated by milestoneProjects with case-insensitive project check", () => {
     expect(template).toContain("meta.milestone");
-    expect(template).toContain("milestoneProjects.includes(meta.project)");
+    expect(template).toContain("milestoneProjects.includes(meta.project.toLowerCase())");
   });
 });
 

--- a/templates/dashboard/task.test.ts
+++ b/templates/dashboard/task.test.ts
@@ -179,6 +179,42 @@ describe("task.html template", () => {
   test("sets the document title to include the task ID", () => {
     expect(template).toContain("ludics Task: ${taskId}");
   });
+
+  test("fetches data/milestone-projects.json for project gating", () => {
+    expect(template).toContain("data/milestone-projects.json");
+    expect(template).toContain("milestoneProjects");
+  });
+
+  test("renders milestone badge gated by milestoneProjects", () => {
+    expect(template).toContain("meta.milestone");
+    expect(template).toContain("milestoneProjects.includes(meta.project)");
+  });
+});
+
+describe("parseFrontmatter milestone field", () => {
+  test("extracts milestone as a plain value", () => {
+    const yaml = "id: task-1\nstatus: ready\nmilestone: v1.0";
+    const meta = parseFrontmatter(yaml);
+    expect(meta.milestone).toBe("v1.0");
+  });
+
+  test("strips surrounding double-quotes from milestone value", () => {
+    const yaml = 'milestone: "v0.7.1"';
+    const meta = parseFrontmatter(yaml);
+    expect(meta.milestone).toBe("v0.7.1");
+  });
+
+  test("strips surrounding single-quotes from milestone value", () => {
+    const yaml = "milestone: 'v0.7.1'";
+    const meta = parseFrontmatter(yaml);
+    expect(meta.milestone).toBe("v0.7.1");
+  });
+
+  test("null milestone value is parsed as null", () => {
+    const yaml = "milestone: null";
+    const meta = parseFrontmatter(yaml);
+    expect(meta.milestone).toBeNull();
+  });
 });
 
 describe("dashboard.js task links", () => {

--- a/templates/dashboard/tasks.html
+++ b/templates/dashboard/tasks.html
@@ -233,6 +233,13 @@
                     row.appendChild(proposal);
                 }
 
+                if (node.milestone) {
+                    const milestoneBadge = document.createElement('span');
+                    milestoneBadge.className = 'task-badge';
+                    milestoneBadge.textContent = node.milestone;
+                    row.appendChild(milestoneBadge);
+                }
+
                 body.appendChild(row);
             }
 


### PR DESCRIPTION
## Summary

- Adds `milestone: string | null` to `TasksTreeNode` in `src/dashboard.ts`, gated by `milestonesEnabledProjects()` in `buildTaskNode()` (set computed once per tree); emits `data/milestone-projects.json` listing opted-in project names.
- `tasks.html` `renderNode()` appends a `task-badge` milestone chip when `node.milestone` is non-null.
- `task.html` fetches `data/milestone-projects.json` on load and renders a milestone `task-badge` in `renderBadges()` when both `meta.milestone` is present and the task's project is in the enabled list.
- Stray/legacy milestone values on non-opted-in projects are suppressed at the emitter (server-side null), so the browser never sees them.
- Project names are compared case-insensitively (`.toLowerCase()`) on both the server-side emitter and the client-side gate, since `milestonesEnabledProjects()` stores lowercase names but frontmatter values are case-preserved.

## Commits

- `b7c3108` feat: display milestone on task detail and task list pages
- `f2b496e` fix: normalize project name to lowercase for milestone gating

## Test plan

- [ ] `bun test src/dashboard.test.ts` — 3 new tests: milestone on opted-in project (mixed-case name), null for stray milestone on non-opted-in project, `milestone-projects.json` contents
- [ ] `bun test templates/dashboard/task.test.ts` — 2 template-assertion tests + 4 `parseFrontmatter` milestone tests (plain, quoted ×2, null)
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)