### PR TITLE
docs(arch): fix CLI inventory drift — 2 stale + 4 missing commands

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -171,7 +171,7 @@ When a proposal is ready, ludics evaluates whether to automatically launch a cod
 4. If no slot available → defer
 5. Otherwise → auto-start
 
-Exposed via `ludics auto-start-evaluate <taskId> [high|low] [rationale...]`.
+Exposed via `ludics mag auto-start-evaluate <id> <high|low> [rationale]`.
 
 **Deferred launch** (task `status: deferred`):
 
@@ -179,7 +179,7 @@ When auto-start defers to the user, the task gets `status: deferred`. The dashbo
 
 **Project health test monitoring** (`src/health.ts`, ~166 lines):
 
-Projects can have an optional `test_command` (auto-detected from build system files). Tests run during night window `[0, 6)` or every 24h. Results stored in `mag/test-health.json`. On test failure, a priority-A fix task is auto-filed with content-fingerprint dedup. CLI: `ludics health run-tests [--project=NAME] [--force]`.
+Projects can have an optional `test_command` (auto-detected from build system files). Tests run during night window `[0, 6)` or every 24h. Results stored in `mag/test-health.json`. On test failure, a priority-A fix task is auto-filed with content-fingerprint dedup. (No user-facing CLI entry point; invoked internally by the night-window scheduler.)
 
 **How automation invokes Mag:**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1134,6 +1134,12 @@ ludics t3code [status]         # Show t3code server status
 ludics t3code start            # Start t3code server
 ludics t3code stop             # Stop t3code server
 
+# tmux inspection
+ludics tmux status             # Show tmux session state, windows, and ttyd processes
+ludics tmux list-panes         # Show all panes with process state
+ludics tmux attach <slot> [agent]  # Attach to a slot's agent tmux window
+ludics tmux capture <slot> [agent] # Capture pane content for debugging
+
 # Events
 ludics events [--type X] [--task Y] [--scope S] [--source R] [--since T] [--limit N]
 
@@ -1156,7 +1162,7 @@ ludics mag queue pop all       # Atomic dequeue of all requests
 ludics mag queue promote <id>  # Move pending request to head of queue
 ludics mag queue cancel <id>   # Remove pending request (prints the JSON line)
 ludics mag context             # Pre-compute briefing context file
-ludics auto-start-evaluate <id> [confidence] [rationale...]  # Evaluate auto-start decision
+ludics mag auto-start-evaluate <id> <high|low> [rationale]  # Evaluate auto-start decision
 
 # Session discovery
 ludics sessions [--json]       # Discover and classify all agent sessions
@@ -1192,13 +1198,16 @@ ludics cluster heartbeat       # Publish heartbeat only
 ludics cluster ping <machine>  # Ping another cluster machine
 ludics cluster doctor          # Check worker onboarding state (exit 1 on failure)
 
-# Health monitoring
-ludics health run-tests [--project=NAME] [--force]  # Run project test suites
+# Queue control
+ludics queue hold              # Suppress automatic slot assignments
+ludics queue resume            # Re-enable automatic slot assignments
+ludics queue status            # Show whether queue is held or active
 
 # Network
 ludics network status          # Show network configuration
 
 # Setup & diagnostics
+ludics config proposals-path <project>  # Print resolved proposals directory path for a project
 ludics init [--no-hooks] [--no-dashboard] [--no-triggers]
 ludics stop [pause|uninstall]  # Stop scheduled trigger activity
 ludics triggers install        # Install launchd/systemd triggers
@@ -1209,6 +1218,7 @@ ludics doctor                  # Check system health and dependencies
 ludics status                  # Overview of slots + tasks
 ludics briefing                # Morning briefing (invokes Mag)
 ludics quote                   # Print a random quote
+ludics help                    # Show this message
 ```
 
 ## Design Principles


### PR DESCRIPTION
## Summary

- **Stale entry 1**: `auto-start-evaluate` was documented top-level with a stale `[confidence]` arg in both the CLI inventory block and prose (line 174). Corrected to `ludics mag auto-start-evaluate <id> <high|low> [rationale]` in both locations.
- **Stale entry 2**: `health run-tests` had no CLI entry point in `src/index.ts`. Removed the `# Health monitoring` inventory section and the inline prose CLI reference (line 182); replaced prose with a note that invocation is internal-only.
- **4 missing commands added**: `# tmux inspection` group (status, list-panes, attach, capture), `# Queue control` group (hold, resume, status), `config proposals-path <project>` and `help` in `# Setup & diagnostics` — all matching `USAGE` phrasing from `src/index.ts`.

Change is doc-only (`docs/ARCHITECTURE.md` only). No CI lint, scripts, or code changed.

## Test plan

- [x] `grep -vF "mag " docs/ARCHITECTURE.md | grep "auto-start-evaluate"` → empty (no stale top-level form anywhere in the file)
- [x] `grep -c "health run-tests\|# Health monitoring" docs/ARCHITECTURE.md` → `0`
- [x] `grep -nE "^  (config|help|queue|tmux) " src/index.ts` → 4 matches, each has a corresponding line in the inventory
- [x] `git diff main...HEAD --name-only` → only `docs/ARCHITECTURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)