### PR TITLE
fix(cluster): don't disable leader duties on transient identity miss; pin machine name in plist env

### DIFF
--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -11,7 +11,8 @@ import { describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits } from "./triggers.ts";
+import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, plistEnvXml } from "./triggers.ts";
+import type { ClusterMachine } from "./cluster.ts";
 
 const CONTROLLER_ONLY = ["dashboard", "ntfy-subscribe", "morning", "health", "sync", "watch"] as const;
 const WORKER_RELEVANT = ["mag", "cluster", "startup", "sessions", "sessions-sweep", "t3code-cleanup"] as const;
@@ -124,5 +125,52 @@ describe("removeControllerTriggerUnits — removes stale controller units, keeps
       expect(existsSync(join(agentsDir, "com.ludics.dashboard.plist"))).toBe(false);
       expect(existsSync(join(agentsDir, "com.ludics.mag.plist"))).toBe(true);
     } finally { teardown(); }
+  });
+});
+
+// The destructive teardown loop above must NOT run on a transient identity miss.
+// `triggersInstall` gates it on shouldTeardownControllerUnits(clusterCurrentMachine()):
+// only an *identified non-leader* tears down. Unknown identity (Tailscale down +
+// hostname mismatch — exactly the leader-at-home failure mode) must be left alone,
+// or the leader disables its own dashboard/briefing units on a flaky resolve.
+describe("shouldTeardownControllerUnits — only confidently-identified workers tear down", () => {
+  const machine = (role: string): ClusterMachine => ({
+    name: "n", host: "n.ts.net", os: "macos", role, always_on: true, gpu: "",
+  });
+
+  test("unknown identity (undefined) → false (the leader-safety fix)", () => {
+    // Mutation guard: reverting to `clusterRole() === "worker"` would make an
+    // unidentified leader tear down its own controller units — this stays false.
+    expect(shouldTeardownControllerUnits(undefined)).toBe(false);
+  });
+
+  test("identified worker → true", () => {
+    expect(shouldTeardownControllerUnits(machine("worker"))).toBe(true);
+  });
+
+  test("identified console (non-leader) → true", () => {
+    expect(shouldTeardownControllerUnits(machine("console"))).toBe(true);
+  });
+
+  test("identified leader → false", () => {
+    expect(shouldTeardownControllerUnits(machine("leader"))).toBe(false);
+  });
+});
+
+// KeepAlive jobs re-resolve cluster identity on every relaunch; baking the
+// install-time machine name into the plist env keeps the dashboard serving even
+// while Tailscale is reconnecting (the override is honored by clusterCurrentMachine).
+describe("plistEnvXml — bakes LUDICS_CLUSTER_MACHINE_NAME when resolvable", () => {
+  test("includes the override key/value when a name is given", () => {
+    const xml = plistEnvXml("mac-studio");
+    expect(xml).toContain("<key>LUDICS_CLUSTER_MACHINE_NAME</key>");
+    expect(xml).toContain("<string>mac-studio</string>");
+    expect(xml).toContain("<key>PATH</key>"); // PATH still present
+  });
+
+  test("omits the override entirely when name is null (no empty/garbage env)", () => {
+    const xml = plistEnvXml(null);
+    expect(xml).not.toContain("LUDICS_CLUSTER_MACHINE_NAME");
+    expect(xml).toContain("<key>PATH</key>");
   });
 });

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -4,7 +4,7 @@ import { existsSync, writeFileSync, mkdirSync, readdirSync, unlinkSync } from "f
 import { join } from "path";
 import { loadConfigSync, ludicsRoot } from "./config.ts";
 import { safeSyncOutput } from "./spawn.ts";
-import { clusterRole } from "./cluster.ts";
+import { clusterRole, clusterCurrentMachine, clusterCurrentMachineName, type ClusterMachine } from "./cluster.ts";
 
 const KNOWN_LUDICS_TRIGGER_NAMES = [
   "startup",
@@ -48,6 +48,20 @@ export function triggerAllowedForRole(
 ): boolean {
   if (role === "worker") return !CONTROLLER_ONLY_TRIGGER_NAMES.has(name);
   return true;
+}
+
+/**
+ * Whether `triggersInstall` should actively tear down (disable + bootout + delete)
+ * controller-only units. ONLY true when this node is *confidently* identified as a
+ * non-leader machine. If identity is unknown — `clusterCurrentMachine()` returned
+ * undefined because Tailscale is down AND the system hostname matched no machine —
+ * we must NOT tear down: `clusterRole()` defaults such a host to "worker", and
+ * blindly trusting that default would let a transient identity miss on the *leader*
+ * itself disable its own dashboard/briefing/health units. Leaving controller units
+ * up on a misidentified node is recoverable; destroying the leader's duties is not.
+ */
+export function shouldTeardownControllerUnits(machine: ClusterMachine | undefined): boolean {
+  return machine !== undefined && machine.role !== "leader";
 }
 
 /**
@@ -164,12 +178,29 @@ const PLIST_HEADER = `<?xml version="1.0" encoding="UTF-8"?>
 const PLIST_FOOTER = `</dict>
 </plist>`;
 
-function plistEnv(): string {
+/**
+ * Render the launchd EnvironmentVariables dict. When `machineName` is non-null we
+ * bake it in as `LUDICS_CLUSTER_MACHINE_NAME` so long-running KeepAlive jobs (the
+ * dashboard especially) resolve their cluster identity from a fixed env var rather
+ * than re-running Tailscale/hostname detection on every relaunch — which fails
+ * transiently while Tailscale is reconnecting and would otherwise demote the leader
+ * to "worker" and skip serving. Pure for testability; `plistEnv()` supplies the
+ * runtime-resolved name. Extracted so the override is exercised without live state.
+ */
+export function plistEnvXml(machineName: string | null): string {
+  const path = `/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:${process.env.HOME}/.local/bin:${process.env.HOME}/.bun/bin`;
+  const override = machineName
+    ? `\n    <key>LUDICS_CLUSTER_MACHINE_NAME</key>\n    <string>${machineName}</string>`
+    : "";
   return `  <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:${process.env.HOME}/.local/bin:${process.env.HOME}/.bun/bin</string>
+    <string>${path}</string>${override}
   </dict>`;
+}
+
+function plistEnv(): string {
+  return plistEnvXml(clusterCurrentMachineName());
 }
 
 function plistArgs(bin: string, ...args: string[]): string {
@@ -880,8 +911,14 @@ export function triggersInstall(): void {
   // only *skip* controller units (they don't stop ones already running), so
   // without this an upgraded worker keeps a stale dashboard/briefing/health/etc.
   // unit alive — split-brain that the role gate is meant to prevent.
-  if (clusterRole() === "worker") {
+  const currentMachine = clusterCurrentMachine();
+  if (shouldTeardownControllerUnits(currentMachine)) {
     for (const name of CONTROLLER_ONLY_TRIGGER_NAMES) removeControllerTriggerUnits(name);
+  } else if (!currentMachine) {
+    console.error(
+      "ludics: triggers: this host is not in cluster.machines (Tailscale down + hostname mismatch?) — " +
+      "skipping controller-unit teardown to avoid destroying leader duties on a transient identity miss",
+    );
   }
 
   const platform = currentPlatform();


### PR DESCRIPTION
## Why

The always-on leader (mac-studio) lost its dashboard (port 7678) — not a crash. Root cause traced to two cluster-identity fragilities, both exposed when Tailscale was reinstalled/reconnecting:

1. **Destructive default on unknown identity.** `triggersInstall()` tore down (disable + bootout + `unlink`) every controller-only unit when `clusterRole() === "worker"`. But `clusterRole()` **defaults to `"worker"` when identity is unknown** (Tailscale down *and* system hostname matches no machine — the leader-at-home case). A single `triggers install`/`init` that coincided with a Tailscale reconnect disabled the leader's own dashboard/briefing/health units. (Explains the "surfaced hours after the reinstall" symptom — it was a later install run, not the reinstall itself.)
2. **Identity re-resolved on every relaunch.** `dashboardServe()` checks `clusterIsController()` at startup; under KeepAlive, a relaunch while Tailscale is reconnecting resolves to "worker" and the server silently skips serving (`dashboard serve skipped — not the cluster controller`).

## What

- **`shouldTeardownControllerUnits(machine)`** — new pure seam. Teardown fires only when the node is *confidently* identified as a non-leader. Unknown identity (`undefined`) → **no teardown** (logs a warning instead). Leaving controller units up on a misidentified node is recoverable; destroying the leader's duties is not.
- **`plistEnvXml(machineName)`** — bakes the install-time machine name into the launchd plist env as `LUDICS_CLUSTER_MACHINE_NAME` (already honored by `clusterCurrentMachine()`), so KeepAlive relaunches resolve identity from a fixed env var instead of live Tailscale/hostname state.

## Tests

`bun test src/triggers.test.ts` — 47 pass. New cases:
- `shouldTeardownControllerUnits`: undefined→false (the safety fix), worker→true, console→true, leader→false.
- `plistEnvXml`: override key/value present when name given; omitted entirely when null.

Build + lint clean.

## Notes / follow-ups
- Scope is the launchd (darwin) path where the outage occurred. The systemd worker units don't carry the env override yet — a symmetric `Environment=` line is a reasonable follow-up.
- Separate, unrelated bug found while investigating: harness `config.yaml` `triggers.federation.action: federation tick` is a dead command after the `federation`→`cluster` rename (should be `cluster tick`); fixed harness-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)