### PR TITLE
fix(triggers): seed an initial trigger on recurring systemd timers

### DIFF
--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -12,11 +12,33 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readFileSync } from "fs";
-import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, shouldRunTeardown, isUnitDisabledInPrintOutput, plistEnvXml, magKeepaliveServiceBody } from "./triggers.ts";
+import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, shouldRunTeardown, isUnitDisabledInPrintOutput, plistEnvXml, magKeepaliveServiceBody, systemdIntervalTimerBody } from "./triggers.ts";
 import type { ClusterMachine } from "./cluster.ts";
 
 const CONTROLLER_ONLY = ["dashboard", "ntfy-subscribe", "morning", "health", "sync", "watch"] as const;
 const WORKER_RELEVANT = ["mag", "cluster", "startup", "sessions", "sessions-sweep", "t3code-cleanup"] as const;
+
+describe("systemdIntervalTimerBody — recurring timers seed an initial trigger", () => {
+  // Regression: a timer with only OnUnitActiveSec (relative to the service's last
+  // activation) never schedules a first run when the action is invoked directly
+  // (e.g. `cluster tick` during init), so the worker heartbeat went stale and the
+  // node dropped out of routing. The body must carry BOTH an activation-relative
+  // initial trigger (OnActiveSec) and the recurrence (OnUnitActiveSec).
+  const body = systemdIntervalTimerBody("cluster", "cluster heartbeat", "300");
+
+  test("includes an OnActiveSec initial trigger", () => {
+    expect(body).toContain("OnActiveSec=300s");
+  });
+  test("includes the OnUnitActiveSec recurrence", () => {
+    expect(body).toContain("OnUnitActiveSec=300s");
+  });
+  test("OnActiveSec is ordered before OnUnitActiveSec (initial trigger seeds the cycle)", () => {
+    expect(body.indexOf("OnActiveSec=")).toBeLessThan(body.indexOf("OnUnitActiveSec="));
+  });
+  test("binds the right service unit", () => {
+    expect(body).toContain("Unit=ludics-cluster.service");
+  });
+});
 
 describe("triggerAllowedForRole — worker excludes controller-only units (AC 7)", () => {
   // One assertion per named member: a single representative would let a

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -537,6 +537,21 @@ function installSimpleTrigger(
   console.log(`Installed ${platform} trigger: ${logMessage}`);
 }
 
+/**
+ * Body of a recurring systemd interval timer.
+ *
+ * `OnActiveSec` seeds an initial trigger relative to *timer activation* (boot or
+ * the `daemon-reload` that `ludics init` performs). Without it, `OnUnitActiveSec`
+ * alone — which is relative to the triggered *service's* last activation — never
+ * schedules a first run when the action is invoked directly (e.g. `cluster tick`
+ * during init rather than via the service), so the timer silently never fires.
+ * That regression left worker `ludics-cluster.timer` publishing one heartbeat at
+ * init and then never again, so the node went stale and dropped out of routing.
+ */
+export function systemdIntervalTimerBody(name: string, description: string, interval: string): string {
+  return `[Unit]\nDescription=ludics ${description} timer\n\n[Timer]\nOnActiveSec=${interval}s\nOnUnitActiveSec=${interval}s\nUnit=ludics-${name}.service\n\n[Install]\nWantedBy=timers.target\n`;
+}
+
 function installIntervalTrigger(name: string, description: string, defaultInterval: number): void {
   if (triggerGet(name, "enabled") !== "true") return;
   const bin = binPath();
@@ -557,7 +572,7 @@ function installIntervalTrigger(name: string, description: string, defaultInterv
     installPlist(label, content);
   } else {
     writeSystemdUnit(`ludics-${name}.service`, `[Unit]\nDescription=ludics ${description}\n\n[Service]\nType=oneshot\nExecStart=${bin} ${action}\n`);
-    writeSystemdUnit(`ludics-${name}.timer`, `[Unit]\nDescription=ludics ${description} timer\n\n[Timer]\nOnUnitActiveSec=${interval}s\nUnit=ludics-${name}.service\n\n[Install]\nWantedBy=timers.target\n`);
+    writeSystemdUnit(`ludics-${name}.timer`, systemdIntervalTimerBody(name, description, interval));
     enableSystemdUnit(`ludics-${name}.timer`);
   }
 
@@ -668,7 +683,9 @@ function triggersInstallLinux(): void {
       timerSection = `[Timer]\n${onCalendarLines}\nPersistent=true\nUnit=ludics-health.service`;
     } else {
       const interval = triggerGet("health", "interval") || "14400";
-      timerSection = `[Timer]\nOnUnitActiveSec=${interval}s\nUnit=ludics-health.service`;
+      // OnActiveSec seeds the initial trigger (same reason as the generic timer
+      // above) — OnUnitActiveSec alone never schedules a first run.
+      timerSection = `[Timer]\nOnActiveSec=${interval}s\nOnUnitActiveSec=${interval}s\nUnit=ludics-health.service`;
     }
 
     writeSystemdUnit("ludics-health.timer", `[Unit]\nDescription=ludics health check timer\n\n${timerSection}\n\n[Install]\nWantedBy=timers.target\n`);


### PR DESCRIPTION
## Problem

A freshly-onboarded systemd worker (minipc-wsl, the first real remote worker) published **one** cluster heartbeat at `ludics init` and then **never again**. `systemctl --user list-timers` showed `ludics-cluster.timer` with no `NEXT` elapse despite being `active (waiting)`. After the 900s heartbeat timeout the node went stale, so `selectMachineForSlot` returned `null` for `gpu: nvidia` tasks and the node silently dropped out of routing.

## Root cause

The generic interval-timer body (`installIntervalTrigger`, used for `cluster`) and the health interval timer were generated with **only** `OnUnitActiveSec=<interval>s`. `OnUnitActiveSec` is relative to the triggered **service's** last activation. When the action is invoked **directly** rather than via the service — `cluster tick` runs inline during `init`, not through `ludics-cluster.service` — the service is never activated by the timer, so `OnUnitActiveSec` has no reference point and the timer never schedules a first run.

`ludics-mag.timer` avoided this only because it *also* carries `OnBootSec=60`.

## Fix

Add `OnActiveSec=<interval>s` (relative to **timer activation** — boot or the `daemon-reload` `init` performs) alongside `OnUnitActiveSec`, so every recurring timer gets a guaranteed first trigger that then seeds the recurrence. Applied to:
- the generic interval-timer body (extracted as the pure, tested `systemdIntervalTimerBody()`), covering `cluster` et al.;
- the health interval timer's `else` branch (the `OnCalendar` branch was already fine).

## Verification

- `bun test src/triggers.test.ts` -> **45 pass** (adds 4 regression assertions on the timer body: presence + ordering of `OnActiveSec` / `OnUnitActiveSec`, correct `Unit=`).
- Live on minipc-wsl: applying the equivalent unit change flipped `ludics-cluster.timer` from no-`NEXT` to a recurring `NEXT` (`14:07:26`, then every 5m); the controller now sees the worker stay `online`, and `selectMachineForSlot({requirements:{gpu:"nvidia"}})` -> `minipc-wsl`.

Surfaced by operational onboarding of the minipc-wsl worker (harness task-7eab5162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)