### PR TITLE
fix(gh-ludics-580): worker dead-orchestrator resume uses controller-live slot state

### DIFF
--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { AdapterContext } from "./types.ts";
@@ -854,6 +854,31 @@ cluster:
     removeTmuxSlotState(4, harness);
     expect(existsSync(cachePath)).toBe(false);
     expect(readTmuxSlotState(4, harness)).toBeNull();
+  });
+
+  test("worker upgrade bridge: reads fall back to a legacy harness file when the cache is empty (gh-ludics-580 P1)", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker context
+    const { readTmuxSlotState, writeTmuxSlotState } = await import("./tmux-adapter.ts");
+
+    // In-flight slot started BEFORE the migration: state at the legacy harness
+    // path, nothing in the cache.
+    const harnessSlotPath = join(harness, "orchestration", "tmux-slot-7.json");
+    mkdirSync(join(harness, "orchestration"), { recursive: true });
+    writeFileSync(harnessSlotPath, JSON.stringify({ slot: 7, ttydPids: { coder: 7777 }, orchestration: { stateFile: "x", mode: "pair", pid: 4321 } }));
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "tmux", "slot-7.json"))).toBe(false);
+
+    // Invariant: legacy file is read (resume must not see "no state"). Without
+    // the fallback this is null.
+    const read = readTmuxSlotState(7, harness);
+    expect(read).not.toBeNull();
+    expect(read!.orchestration?.pid).toBe(4321);
+
+    // Next persist migrates forward to the cache, which shadows the (undeleted)
+    // legacy file; the worker did not mutate its git-tracked harness clone.
+    writeTmuxSlotState({ slot: 7, ttydPids: { coder: 8888 }, orchestration: { stateFile: "x", mode: "pair", pid: 9999 } } as unknown as Parameters<typeof writeTmuxSlotState>[0], harness);
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "tmux", "slot-7.json"))).toBe(true);
+    expect(readTmuxSlotState(7, harness)!.orchestration?.pid).toBe(9999);
+    expect(JSON.parse(readFileSync(harnessSlotPath, "utf-8")).orchestration.pid).toBe(4321);
   });
 
   test("controller: write/read uses harness tree, cache untouched, no leftover .tmp", async () => {

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -779,3 +779,96 @@ describe("agentCliCommand — passes --model + Fable remediation (task-13dee93b 
     expect(cmd).not.toContain("claude-fable unavailable");
   });
 });
+
+// gh-ludics-580 AC5 + AC9: per-slot tmux state must move to a non-harness
+// worker cache on a federation worker, while controller/standalone keeps using
+// the git-tracked harness tree (harnessDir/orchestration/tmux-slot-N.json).
+describe("readTmuxSlotState/writeTmuxSlotState/removeTmuxSlotState — worker-cache migration", () => {
+  let TMP: string;
+  let harness: string;
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(homeDir: string): string {
+    const cfg = join(homeDir, "config.yaml");
+    writeFileSync(cfg, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return cfg;
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "tmux-worker-cache-"));
+    process.env.HOME = TMP;
+    harness = join(TMP, "harness");
+    mkdirSync(harness, { recursive: true });
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+    try { rmSync(TMP, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("worker: write/read round-trip via $HOME/.ludics-orch-cache/tmux, harness untouched", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // → worker context
+    const { readTmuxSlotState, writeTmuxSlotState, removeTmuxSlotState } = await import("./tmux-adapter.ts");
+    const state = {
+      slot: 4,
+      ttydPids: { coder: 4242 },
+      orchestration: { stateFile: join(harness, "orchestration", "slot-4.json"), mode: "pair", pid: 9999 },
+    } as unknown as Parameters<typeof writeTmuxSlotState>[0];
+    writeTmuxSlotState(state, harness);
+
+    const round = readTmuxSlotState(4, harness);
+    expect(round).not.toBeNull();
+    expect(round!.slot).toBe(4);
+    expect(round!.ttydPids.coder).toBe(4242);
+    expect(round!.orchestration?.pid).toBe(9999);
+
+    const cachePath = join(TMP, ".ludics-orch-cache", "tmux", "slot-4.json");
+    expect(existsSync(cachePath)).toBe(true);
+    expect(existsSync(join(harness, "orchestration", "tmux-slot-4.json"))).toBe(false);
+
+    removeTmuxSlotState(4, harness);
+    expect(existsSync(cachePath)).toBe(false);
+    expect(readTmuxSlotState(4, harness)).toBeNull();
+  });
+
+  test("controller: write/read uses harness tree, cache untouched, no leftover .tmp", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // role leader → controller
+    const { readTmuxSlotState, writeTmuxSlotState, removeTmuxSlotState } = await import("./tmux-adapter.ts");
+    const state = { slot: 2, ttydPids: { coder: 1 } } as unknown as Parameters<typeof writeTmuxSlotState>[0];
+    writeTmuxSlotState(state, harness);
+
+    const harnessPath = join(harness, "orchestration", "tmux-slot-2.json");
+    expect(existsSync(harnessPath)).toBe(true);
+    expect(existsSync(`${harnessPath}.tmp`)).toBe(false);
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "tmux", "slot-2.json"))).toBe(false);
+    expect(readTmuxSlotState(2, harness)?.ttydPids.coder).toBe(1);
+
+    removeTmuxSlotState(2, harness);
+    expect(existsSync(harnessPath)).toBe(false);
+  });
+});

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -23,10 +23,12 @@ import {
   DEFAULT_SUBSTANTIVE_STALL_CONFIG,
   initAgentRuntimeState,
   parseSubstantiveStallOverrides,
+  isWorkerContext,
   persistState,
   readOrchestrationState,
   removeOrchestrationState,
   stateFilePath,
+  workerCacheDir,
   type AgentConfig,
   type OrchestrationState,
 } from "../orchestration/state.ts";
@@ -82,6 +84,14 @@ function tmuxSlotPath(slot: number, harnessDir: string): string {
   return join(harnessDir, "orchestration", `tmux-slot-${slot}.json`);
 }
 
+// gh-ludics-580: on a federation worker, per-slot tmux state must NOT live in
+// the git-tracked harness tree. Mirror readOrchestrationState: redirect to a
+// non-harness cache under workerCacheDir(), disambiguated by the `tmux/`
+// subdirectory.
+function tmuxWorkerCachePath(slot: number): string {
+  return join(workerCacheDir(), "tmux", `slot-${slot}.json`);
+}
+
 // Per-slot per-agent ttyd log path. Mirrors src/mag.ts's HOME/Library/Logs
 // preference with a /tmp fallback for non-macOS hosts so newsyslog rotates
 // the macOS path for free.
@@ -93,7 +103,7 @@ export function ttydLogPath(slot: number, agentName: string): string {
 }
 
 function readTmuxSlotState(slot: number, harnessDir: string): TmuxSlotState | null {
-  const path = tmuxSlotPath(slot, harnessDir);
+  const path = isWorkerContext() ? tmuxWorkerCachePath(slot) : tmuxSlotPath(slot, harnessDir);
   if (!existsSync(path)) return null;
   try {
     // Read-boundary for TmuxSlotState. Optional persisted fields stay sparse:
@@ -107,6 +117,12 @@ function readTmuxSlotState(slot: number, harnessDir: string): TmuxSlotState | nu
 }
 
 function writeTmuxSlotState(state: TmuxSlotState, harnessDir: string): void {
+  if (isWorkerContext()) {
+    const dir = join(workerCacheDir(), "tmux");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeJsonFile(tmuxWorkerCachePath(state.slot), state);
+    return;
+  }
   const path = tmuxSlotPath(state.slot, harnessDir);
   const dir = join(harnessDir, "orchestration");
   if (!existsSync(dir)) {
@@ -116,7 +132,7 @@ function writeTmuxSlotState(state: TmuxSlotState, harnessDir: string): void {
 }
 
 function removeTmuxSlotState(slot: number, harnessDir: string): void {
-  const path = tmuxSlotPath(slot, harnessDir);
+  const path = isWorkerContext() ? tmuxWorkerCachePath(slot) : tmuxSlotPath(slot, harnessDir);
   if (existsSync(path)) {
     try { unlinkSync(path); } catch { /* ignore */ }
   }

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -103,17 +103,30 @@ export function ttydLogPath(slot: number, agentName: string): string {
 }
 
 function readTmuxSlotState(slot: number, harnessDir: string): TmuxSlotState | null {
-  const path = isWorkerContext() ? tmuxWorkerCachePath(slot) : tmuxSlotPath(slot, harnessDir);
-  if (!existsSync(path)) return null;
-  try {
-    // Read-boundary for TmuxSlotState. Optional persisted fields stay sparse:
-    // ttydRestartCounts is preserved as-on-disk (undefined for legacy files,
-    // populated Record when present). New optional fields should land here so
-    // every reader sees the same normalized shape.
-    return JSON.parse(readFileSync(path, "utf-8")) as TmuxSlotState;
-  } catch {
-    return null;
+  // On a worker, prefer the non-harness cache but fall back to a legacy
+  // pre-migration harness file written by THIS worker before the cache existed
+  // (gh-ludics-580 upgrade bridge — mirrors readSlotState). Read-only: writes
+  // go to the cache, which then shadows the stale legacy file; the legacy file
+  // is not deleted (a worker must not dirty its git-tracked harness clone). A
+  // corrupt cache file returns null without falling through (preserves the
+  // existing "exists-but-corrupt → null" semantics); only an ABSENT cache
+  // falls back to the legacy path.
+  const candidates = isWorkerContext()
+    ? [tmuxWorkerCachePath(slot), tmuxSlotPath(slot, harnessDir)]
+    : [tmuxSlotPath(slot, harnessDir)];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      // Read-boundary for TmuxSlotState. Optional persisted fields stay sparse:
+      // ttydRestartCounts is preserved as-on-disk (undefined for legacy files,
+      // populated Record when present). New optional fields should land here so
+      // every reader sees the same normalized shape.
+      return JSON.parse(readFileSync(path, "utf-8")) as TmuxSlotState;
+    } catch {
+      return null;
+    }
   }
+  return null;
 }
 
 function writeTmuxSlotState(state: TmuxSlotState, harnessDir: string): void {

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick, maybeResumeDeadOrchestrators } from "./mag.ts";
+import { emptySlotData, writeSlotJson } from "./slots/json.ts";
+import type { SlotData } from "./slots/types.ts";
 import type { RunGit } from "./git-runner.ts";
 import type { LudicsFullConfig, ProjectConfig } from "./config.ts";
 
@@ -1601,5 +1603,182 @@ describe("runStagingOutboundPushTick", () => {
     });
     expect(results).toEqual([]);
     expect(calls).toHaveLength(0);
+  });
+});
+
+// gh-ludics-580: worker dead-orchestrator auto-resume must use controller-live
+// slot state (the `freshSlots` map), never the worker's stale local harness
+// clone. These tests exercise maybeResumeDeadOrchestrators on a federation
+// worker — a path that previously had zero coverage.
+describe("maybeResumeDeadOrchestrators — worker controller-live slot state (gh-ludics-580)", () => {
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  let TMP = "";
+
+  function harness(): string { return join(TMP, "harness"); }
+  function orchCacheDir(): string { return join(TMP, ".ludics-orch-cache"); }
+
+  // Config: start_sessions autonomy must be non-manual or the function
+  // early-returns (gh feedback: keepalive tests need autonomy auto), plus a
+  // two-machine cluster so worker/controller context resolves via
+  // LUDICS_CLUSTER_MACHINE_NAME.
+  function writeConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+mag:
+  autonomy_level:
+    start_sessions: auto
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  // Worker-cache writers (mirror the migrated read paths in worker context).
+  function writeWorkerOrchState(slot: number, taskId: string): void {
+    mkdirSync(orchCacheDir(), { recursive: true });
+    writeFileSync(join(orchCacheDir(), `slot-${slot}.json`), JSON.stringify({
+      slot, taskId, phase: "work", mode: "pair",
+    }));
+  }
+  function writeWorkerT3codeState(slot: number, pid: number): void {
+    const dir = join(orchCacheDir(), "t3code");
+    mkdirSync(dir, { recursive: true });
+    // threads: [] → slotResume's t3code branch throws "no persisted t3code
+    // state" *after* the machine gate — a deterministic, process-free failure
+    // that is NOT the remote-offline refusal.
+    writeFileSync(join(dir, `slot-${slot}.json`), JSON.stringify({
+      slot, threads: [], orchestration: { stateFile: "x", mode: "pair", pid },
+    }));
+  }
+  function freshSlot(slot: number, machine: string, taskId: string): SlotData {
+    return { ...emptySlotData(slot), process: "orch-runner", task: taskId, mode: "t3code", machine, path: join(TMP, "wt"), liveness: null };
+  }
+  // Observable seam: on a worker, emitEvent forwards to the controller over
+  // HTTP and writes no local journal, so we observe the resume decision via
+  // console.error — which fires locally for both the "detected dead
+  // orchestrator" detection log and the catch-path "failed to auto-resume" log
+  // (carrying the thrown message).
+  async function runCapturingErrors(fresh: Map<number, SlotData> | null): Promise<string> {
+    const logs: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    try {
+      await maybeResumeDeadOrchestrators(fresh);
+    } finally {
+      spy.mockRestore();
+    }
+    return logs.join("\n");
+  }
+
+  const DEAD_PID = 2147483647; // INT32_MAX — never a live process
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-mag-resume-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_CONFIG = writeConfig(TMP);
+    process.env.LUDICS_HARNESS_DIR = harness();
+    mkdirSync(harness(), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("AC1: worker resumes its own slot locally despite a stale local harness clone (no remote-offline refusal)", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker context
+
+    // Stale LOCAL harness slot — the bug's trigger: machine=mac-studio (a remote
+    // peer with no heartbeat). Without the override, readSlot reads THIS.
+    writeSlotJson(1, { ...emptySlotData(1), process: "orch-runner", task: "task-850e1b37", mode: "t3code", machine: "mac-studio" });
+
+    // Worker-cache state (fresh, what the runner wrote): orch state + dead t3code pid.
+    writeWorkerOrchState(1, "task-66a3bbff");
+    writeWorkerT3codeState(1, DEAD_PID);
+
+    // Controller-live state: this worker (minipc-wsl) owns slot 1, current task.
+    const freshSlots = new Map<number, SlotData>([[1, freshSlot(1, "minipc-wsl", "task-66a3bbff")]]);
+
+    const out = await runCapturingErrors(freshSlots);
+
+    // Harness condition: stale local machine=mac-studio + freshSlots machine=self.
+    // Invariant: the slot the worker legitimately owns reaches LOCAL execution.
+    // The override makes readSlot return machine=minipc-wsl (self), so resume
+    // passes the isRemoteMachine gate and fails only on the t3code state check —
+    // never the machine-identity refusal.
+    expect(out).toContain("detected dead orchestrator for slot 1"); // reached resume
+    expect(out).toContain("no persisted t3code state");             // failed LOCALLY, past the gate
+    // Mutation control: dropping the setWorkerSlotsOverride wrap makes readSlot
+    // return the stale machine=mac-studio → this assertion would FAIL with
+    // "assigned machine mac-studio is offline — cannot resume".
+    expect(out).not.toContain("is offline — cannot resume");
+  });
+
+  test("AC2: worker skips auto-resume when freshSlots is null — no local-clone fallback", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker context
+
+    // A LOCAL slot that WOULD look resumable (machine=self so it survives the
+    // remote-skip; dead orch in the worker cache). If the function fell back to
+    // readAllSlotJson, it would detect this and attempt resume.
+    writeSlotJson(1, { ...emptySlotData(1), process: "orch-runner", task: "task-66a3bbff", mode: "t3code", machine: "minipc-wsl" });
+    writeWorkerOrchState(1, "task-66a3bbff");
+    writeWorkerT3codeState(1, DEAD_PID);
+
+    const out = await runCapturingErrors(null);
+
+    // Harness condition: worker context + null freshSlots + a resumable local
+    // clone. Invariant: with no controller-live state, a worker never reads the
+    // local clone, so it never even detects the dead orchestrator. Mutation
+    // control: removing the `if (isWorkerNode()) return` guard makes
+    // readAllSlotJson find slot 1 → "detected dead orchestrator" would appear →
+    // this assertion would FAIL.
+    expect(out).not.toContain("detected dead orchestrator");
+  });
+
+  test("AC2 positive control: controller WITH null freshSlots still reaches the loop (skip is worker-only)", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller context
+
+    // On the controller the harness is authoritative; the local-clone fallback
+    // is legitimate. Same resumable local slot → resume IS attempted.
+    writeSlotJson(1, { ...emptySlotData(1), process: "orch-runner", task: "task-66a3bbff", mode: "t3code", machine: "leader-box" });
+    // On the controller, orch + t3code state live in the harness tree (not the
+    // worker cache), so write them there.
+    mkdirSync(join(harness(), "orchestration"), { recursive: true });
+    writeFileSync(join(harness(), "orchestration", "slot-1.json"), JSON.stringify({ slot: 1, taskId: "task-66a3bbff", phase: "work", mode: "pair" }));
+    mkdirSync(join(harness(), "t3code"), { recursive: true });
+    writeFileSync(join(harness(), "t3code", "slot-1.json"), JSON.stringify({ slot: 1, threads: [], orchestration: { stateFile: "x", mode: "pair", pid: DEAD_PID } }));
+
+    const out = await runCapturingErrors(null);
+
+    // Controller did NOT early-return: it reached slotResume (which fails on the
+    // t3code state check). isRemoteMachine("leader-box")=self → local, so the
+    // failure is the t3code-state one, not an offline refusal. This proves the
+    // null-freshSlots skip is gated on isWorkerNode(), not unconditional.
+    expect(out).toContain("detected dead orchestrator for slot 1");
+    expect(out).toContain("no persisted t3code state");
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3418,11 +3418,26 @@ export function orchPidForSlotMode(
   return undefined;
 }
 
-async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, SlotData> | null): Promise<void> {
+/** True on a federation worker (cluster identity resolves + not the controller). */
+function isWorkerNode(): boolean {
+  return !!clusterCurrentMachineName() && !clusterIsController();
+}
+
+export async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, SlotData> | null): Promise<void> {
   if (startSessionsAutonomy() === "manual") return;
 
-  // On worker: use in-memory slots from HTTP fetch; otherwise read from JSON files
-  const slots: Map<number, SlotData> = freshSlots ?? readAllSlotJson(slotsCount());
+  // gh-ludics-580: a worker must never trust its stale local harness clone.
+  // START (processSlotIntents) already uses controller-live `freshSlots`; the
+  // RESUME path must do the same. When `freshSlots` is null on a worker
+  // (controller unreachable), skip this tick rather than falling back to
+  // readAllSlotJson — the next keepalive retries once the controller is back.
+  let slots: Map<number, SlotData>;
+  if (freshSlots) {
+    slots = freshSlots;
+  } else {
+    if (isWorkerNode()) return; // no controller-live state — skip (Q2 → (a))
+    slots = readAllSlotJson(slotsCount()); // controller/standalone: harness is authoritative
+  }
   let resumed = 0;
 
   for (const [slotNum, data] of slots) {
@@ -3465,7 +3480,23 @@ async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, SlotData> |
       `(pid ${pid}, task ${taskId}, phase ${orchState.phase}) — auto-resuming`,
     );
     try {
-      await slotResume(slotNum);
+      // gh-ludics-580: on the worker path, set the controller-live slots
+      // override so readSlot inside slotResume returns the fresh machine/task
+      // (this worker) instead of the stale local harness clone — mirroring
+      // processSlotIntents. Without it, a slot the worker legitimately owns is
+      // refused "machine offline" against a stale assignment. Cleared per-slot
+      // in finally so it cannot leak across slots/ticks.
+      const applyOverride = !!freshSlots && isWorkerNode();
+      let setWorkerSlotsOverride: ((data: Map<number, SlotData> | null) => void) | null = null;
+      if (applyOverride) {
+        ({ setWorkerSlotsOverride } = await import("./slots/index.ts"));
+      }
+      try {
+        if (setWorkerSlotsOverride) setWorkerSlotsOverride(freshSlots ?? null);
+        await slotResume(slotNum);
+      } finally {
+        if (setWorkerSlotsOverride) setWorkerSlotsOverride(null);
+      }
       resumed += 1;
       emitEvent({
         event_type: "orchestration_auto_resume",

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -399,8 +399,10 @@ export function stateFilePath(slot: number, harnessDir: string = defaultHarnessD
   return join(orchestrationDir(harnessDir), `slot-${slot}.json`);
 }
 
-// Non-harness local cache for worker-side orchestration state
-function workerCacheDir(): string {
+// Non-harness local cache root for worker-side orchestration + adapter state.
+// Exported so the t3code/tmux per-slot state readers/writers can place their
+// own (disambiguated) cache files under the same root — see gh-ludics-580.
+export function workerCacheDir(): string {
   return join(process.env.HOME ?? "/tmp", ".ludics-orch-cache");
 }
 
@@ -408,7 +410,9 @@ function workerCacheFilePath(slot: number): string {
   return join(workerCacheDir(), `slot-${slot}.json`);
 }
 
-function isWorkerContext(): boolean {
+// Exported so adapters (t3code/server.ts, tmux-adapter.ts) share a single
+// worker-context detector instead of duplicating it (gh-ludics-580 AC6).
+export function isWorkerContext(): boolean {
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- circular-dep chain: cluster → events → journal → state
     const { clusterIsController, clusterCurrentMachineName } = require("../cluster.ts") as typeof import("../cluster.ts");

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride } from "./index.ts";
 import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
 import * as spawnMod from "../spawn.ts";
@@ -2901,5 +2901,93 @@ cluster:
 
     const data = readSlotJson(1, harness);
     expect(data.machine).toBe("explicit-node");
+  });
+});
+
+// gh-ludics-580 AC7: worker-resume routing. On a worker, the controller-live
+// slots override (set around slotResume by maybeResumeDeadOrchestrators) must
+// make readSlot return the worker's own machine, so a slot it legitimately owns
+// routes to LOCAL execution instead of being refused "machine offline" against
+// a stale local harness clone. This is the slotResume + setWorkerSlotsOverride
+// unit seam the integration test in mag.test.ts exercises end-to-end.
+describe("slotResume worker override routing (gh-ludics-580)", () => {
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(): void {
+    const cfgDir = join(TMP, ".config", "ludics");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.yaml"), `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: self-node
+      host: self-node.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+    - name: worker-a
+      host: worker-a.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    process.env.LUDICS_CONFIG = join(cfgDir, "config.yaml");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "self-node"; // this host = the worker
+  }
+
+  function staleLocal(slot: number): import("./types.ts").SlotData {
+    // The bug's trigger: local harness clone says a DIFFERENT, offline machine.
+    return { ...emptySlotData(slot), process: "orch-runner", task: "task-stale", mode: "t3code", machine: "worker-a" };
+  }
+  function controllerLive(slot: number): import("./types.ts").SlotData {
+    // Controller-live truth: this worker (self-node) owns the slot.
+    return { ...emptySlotData(slot), process: "orch-runner", task: "task-live", mode: "t3code", machine: "self-node" };
+  }
+
+  afterEach(() => {
+    setWorkerSlotsOverride(null); // never leak the override across tests
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+  });
+
+  test("control: WITHOUT the override, slotResume reads the stale local clone and refuses (machine offline)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(join(harness, "tasks"), { recursive: true });
+    writeClusterConfig();
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeSlotJson(1, staleLocal(1), harness); // machine=worker-a, no heartbeat → offline
+
+    await expect(slotResume(1)).rejects.toThrow("offline — cannot resume");
+  });
+
+  test("WITH the override, slotResume routes locally (no offline refusal) and fails only on the t3code-state check", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(join(harness, "tasks"), { recursive: true });
+    writeClusterConfig();
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeSlotJson(1, staleLocal(1), harness); // stale local would say worker-a/offline
+
+    // Controller-live override: slot 1 belongs to self-node (this worker).
+    setWorkerSlotsOverride(new Map([[1, controllerLive(1)]]));
+
+    // Invariant: readSlot returns self-node → isRemoteMachine(self-node)=false →
+    // LOCAL execution. Resume then fails only because no t3code slot state was
+    // persisted — NOT the machine-identity refusal. Mutation control: if the
+    // override were ignored (readSlot → stale worker-a), this would reject with
+    // "offline — cannot resume" and the assertions below would fail.
+    await expect(slotResume(1)).rejects.toThrow("no persisted t3code state");
+    await expect(slotResume(1)).rejects.not.toThrow("offline — cannot resume");
   });
 });

--- a/src/t3code/server.test.ts
+++ b/src/t3code/server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { commandLineMatchesServerRecord, processAlive, readServerRecord, readSlotState, removeSlotState, writeSlotState } from "./server.ts";
@@ -237,6 +237,31 @@ cluster:
     removeSlotState(4, harness);
     expect(existsSync(cachePath)).toBe(false);
     expect(readSlotState(4, harness)).toBeNull();
+  });
+
+  test("worker upgrade bridge: reads fall back to a legacy harness file when the cache is empty (gh-ludics-580 P1)", () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker context
+    // Simulate an in-flight slot started BEFORE the migration: state at the
+    // legacy harness path, nothing in the cache.
+    const harnessSlotPath = join(harness, "t3code", "slot-7.json");
+    mkdirSync(join(harness, "t3code"), { recursive: true });
+    const legacy = makeState(7);
+    writeFileSync(harnessSlotPath, JSON.stringify(legacy));
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "t3code", "slot-7.json"))).toBe(false);
+
+    // Invariant: the legacy file is read (resume must not treat the active slot
+    // as having no persisted state). Without the `?? legacy` fallback this is null.
+    const read = readSlotState(7, harness);
+    expect(read).not.toBeNull();
+    expect(read!.threads.map((t) => t.threadId)).toEqual(["thr-7"]);
+
+    // After the next persist, state migrates forward to the cache, which then
+    // shadows the (intentionally undeleted) legacy file.
+    writeSlotState({ ...makeState(7), threads: [{ ...legacy.threads[0], threadId: "thr-7-migrated" }] }, harness);
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "t3code", "slot-7.json"))).toBe(true);
+    expect(readSlotState(7, harness)!.threads.map((t) => t.threadId)).toEqual(["thr-7-migrated"]);
+    // Worker did NOT mutate its git-tracked harness clone on write.
+    expect(JSON.parse(readFileSync(harnessSlotPath, "utf-8")).threads[0].threadId).toBe("thr-7");
   });
 
   test("controller/standalone: write/read uses harness tree, cache untouched", () => {

--- a/src/t3code/server.test.ts
+++ b/src/t3code/server.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { commandLineMatchesServerRecord, processAlive, readServerRecord } from "./server.ts";
-import type { T3CodeServerRecord } from "./types.ts";
+import { commandLineMatchesServerRecord, processAlive, readServerRecord, readSlotState, removeSlotState, writeSlotState } from "./server.ts";
+import type { T3CodeServerRecord, T3CodeSlotState } from "./types.ts";
 
 function makeRecord(overrides: Partial<T3CodeServerRecord> = {}): T3CodeServerRecord {
   return {
@@ -146,5 +146,111 @@ describe("processAlive", () => {
     // processAlive catches it. Using a sentinel pid avoids the PID-reuse race
     // a freshly-exited spawnSync child would have on busy CI hosts.
     expect(processAlive(2147483647)).toBe(false);
+  });
+});
+
+// gh-ludics-580 AC4 + AC9: per-slot t3code state must move to a non-harness
+// worker cache on a federation worker, while controller/standalone keeps using
+// the git-tracked harness tree.
+describe("readSlotState/writeSlotState/removeSlotState — worker-cache migration", () => {
+  let TMP: string;
+  let harness: string;
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(homeDir: string): string {
+    const cfg = join(homeDir, "config.yaml");
+    writeFileSync(cfg, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return cfg;
+  }
+
+  function makeState(slot: number): T3CodeSlotState {
+    return {
+      slot,
+      threads: [{
+        threadId: `thr-${slot}`,
+        projectId: "proj-1",
+        worktreePath: `/tmp/wt-${slot}`,
+        title: "t",
+        model: "claude-opus-4-8",
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        createdAt: "2026-06-22T00:00:00Z",
+        updatedAt: "2026-06-22T00:00:00Z",
+      }],
+    } as T3CodeSlotState;
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "t3code-worker-cache-"));
+    process.env.HOME = TMP;
+    harness = join(TMP, "harness");
+    mkdirSync(harness, { recursive: true });
+    process.env.LUDICS_CONFIG = writeClusterConfig(TMP);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+    try { rmSync(TMP, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("worker: write/read round-trip via $HOME/.ludics-orch-cache/t3code, harness untouched", () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // → worker context
+    const state = makeState(4);
+    writeSlotState(state, harness);
+
+    // Round-trip fidelity: every key field survives serialize→deserialize.
+    const round = readSlotState(4, harness);
+    expect(round).not.toBeNull();
+    expect(round!.slot).toBe(4);
+    expect(round!.threads.map((t) => t.threadId)).toEqual(["thr-4"]);
+
+    // Bytes live in the non-harness cache…
+    const cachePath = join(TMP, ".ludics-orch-cache", "t3code", "slot-4.json");
+    expect(existsSync(cachePath)).toBe(true);
+    // …and NOT in the git-tracked harness tree.
+    expect(existsSync(join(harness, "t3code", "slot-4.json"))).toBe(false);
+
+    removeSlotState(4, harness);
+    expect(existsSync(cachePath)).toBe(false);
+    expect(readSlotState(4, harness)).toBeNull();
+  });
+
+  test("controller/standalone: write/read uses harness tree, cache untouched", () => {
+    // No LUDICS_CLUSTER_MACHINE_NAME and host won't match a configured machine →
+    // not a worker (isWorkerContext false). Use a self-leader to be explicit.
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // role leader → controller
+    const state = makeState(2);
+    writeSlotState(state, harness);
+
+    expect(existsSync(join(harness, "t3code", "slot-2.json"))).toBe(true);
+    expect(existsSync(join(TMP, ".ludics-orch-cache", "t3code", "slot-2.json"))).toBe(false);
+    expect(readSlotState(2, harness)?.threads.map((t) => t.threadId)).toEqual(["thr-2"]);
+
+    removeSlotState(2, harness);
+    expect(existsSync(join(harness, "t3code", "slot-2.json"))).toBe(false);
   });
 });

--- a/src/t3code/server.ts
+++ b/src/t3code/server.ts
@@ -106,7 +106,16 @@ export function readSlotState(
   harnessDir: string = defaultHarnessDir(),
 ): T3CodeSlotState | null {
   if (isWorkerContext()) {
-    return readJsonFile<T3CodeSlotState>(t3codeWorkerCachePath(slot));
+    // Prefer the non-harness cache, but fall back to a legacy pre-migration
+    // harness file written by THIS worker before the cache existed
+    // (gh-ludics-580 upgrade bridge): an in-flight slot upgraded across this
+    // change would otherwise read an empty cache and look like it has no
+    // persisted state. Read-only — writes go to the cache, so the next persist
+    // migrates state forward and the cache shadows the stale legacy file. The
+    // legacy file is intentionally not deleted here (a worker must not dirty
+    // its git-tracked harness clone).
+    return readJsonFile<T3CodeSlotState>(t3codeWorkerCachePath(slot))
+      ?? readJsonFile<T3CodeSlotState>(t3codeSlotPath(slot, harnessDir));
   }
   return readJsonFile<T3CodeSlotState>(t3codeSlotPath(slot, harnessDir));
 }

--- a/src/t3code/server.ts
+++ b/src/t3code/server.ts
@@ -20,6 +20,7 @@ function migrateStateDirIfNeeded(t3Dir: string): void {
   }
 }
 import { harnessDir as defaultHarnessDir } from "../config.ts";
+import { isWorkerContext, workerCacheDir } from "../orchestration/state.ts";
 import { networkHostname } from "../network.ts";
 import { T3CodeClient } from "./client.ts";
 import type { T3CodeServerRecord, T3CodeSlotState, T3Snapshot } from "./types.ts";
@@ -87,6 +88,15 @@ export function t3codeSlotPath(slot: number, harnessDir: string = defaultHarness
   return join(t3codeDir(harnessDir), `slot-${slot}.json`);
 }
 
+// gh-ludics-580: on a federation worker, per-slot t3code state must NOT live in
+// the git-tracked harness tree (it is worker-local runtime state, never the
+// controller's source of truth). Mirror readOrchestrationState: redirect to a
+// non-harness cache under workerCacheDir(). Disambiguated by the `t3code/`
+// subdirectory so it never collides with orch-state's `slot-N.json`.
+function t3codeWorkerCachePath(slot: number): string {
+  return join(workerCacheDir(), "t3code", `slot-${slot}.json`);
+}
+
 export function readServerRecord(harnessDir: string = defaultHarnessDir()): T3CodeServerRecord | null {
   return readJsonFile<T3CodeServerRecord>(t3codeServerPath(harnessDir));
 }
@@ -95,6 +105,9 @@ export function readSlotState(
   slot: number,
   harnessDir: string = defaultHarnessDir(),
 ): T3CodeSlotState | null {
+  if (isWorkerContext()) {
+    return readJsonFile<T3CodeSlotState>(t3codeWorkerCachePath(slot));
+  }
   return readJsonFile<T3CodeSlotState>(t3codeSlotPath(slot, harnessDir));
 }
 
@@ -102,11 +115,16 @@ export function writeSlotState(
   state: T3CodeSlotState,
   harnessDir: string = defaultHarnessDir(),
 ): void {
+  if (isWorkerContext()) {
+    mkdirSync(join(workerCacheDir(), "t3code"), { recursive: true });
+    writeJsonFile(t3codeWorkerCachePath(state.slot), state);
+    return;
+  }
   writeJsonFile(t3codeSlotPath(state.slot, harnessDir), state);
 }
 
 export function removeSlotState(slot: number, harnessDir: string = defaultHarnessDir()): void {
-  const path = t3codeSlotPath(slot, harnessDir);
+  const path = isWorkerContext() ? t3codeWorkerCachePath(slot) : t3codeSlotPath(slot, harnessDir);
   if (!existsSync(path)) return;
   unlinkSync(path);
 }


### PR DESCRIPTION
## Summary

Fixes #580. On a federation **worker**, the keepalive's dead-orchestrator auto-resume read the worker's **stale local harness slot clone** instead of the controller-live `freshSlots` the START path already uses. A stale `slot-N.json` still held an old assignment (`machine=mac-studio`), so resume computed `assignedMachine != self`, declared it "offline", and refused — looping `orchestration_auto_resume_failed` every keepalive tick (the slot-4 → minipc-wsl failure, 17:26–17:34Z).

### Core fix (`src/mag.ts`)
`maybeResumeDeadOrchestrators` now mirrors `processSlotIntents`:
- Wraps `slotResume(slotNum)` in `setWorkerSlotsOverride(freshSlots)`/`(null)` (try/finally), applied only on the worker path, so `readSlot` returns the controller-live machine (self) and the slot routes to **local** execution instead of the "machine offline" refusal.
- When `freshSlots` is null on a worker, **skips** the tick rather than falling back to `readAllSlotJson` (the stale clone); next tick retries once the controller is reachable. Controller/standalone keep the local-harness fallback (authoritative there).
- No worker-side `statePull` is introduced (federation v2: controller authoritative).

### Extended scope — worker-cache migration (`src/t3code/server.ts`, `src/adapters/tmux-adapter.ts`)
Per-slot t3code/tmux state was the same bug class as orch-state (already fixed). On a worker, `read/write/removeSlotState` and `read/write/removeTmuxSlotState` now redirect to a non-harness cache under `$HOME/.ludics-orch-cache/{t3code,tmux}/slot-N.json` (mirroring `readOrchestrationState`), so worker-local runtime state never lands in the git-tracked harness tree. Controller/standalone unchanged. `isWorkerContext`/`workerCacheDir` are exported from `orchestration/state.ts` as the shared detector + cache root.

**Upgrade bridge (review follow-up, `c99a2e2`)**: a worker upgraded with an in-flight slot has its state at the *old* harness path. `readSlotState`/`readTmuxSlotState` fall back to the legacy harness path when the worker cache entry is absent (read-only), so active legacy slots resume correctly. Writes stay cache-only; the next persist migrates state forward and the cache shadows the legacy file. The legacy file is intentionally not deleted — a worker must not dirty its git-tracked harness clone.

## Tests (path previously had **zero** coverage)
All new behaviour is regression-tested and mutation-verified:
- **AC1 worker-resume routing** (`mag.test.ts`, + a `slotResume`+`setWorkerSlotsOverride` unit seam in `slots/index.test.ts`): stale local machine vs controller-live self → resume reaches local execution, never the offline refusal. Mutating away the override flips the output to "is offline — cannot resume".
- **AC2 null-`freshSlots` skip** (`mag.test.ts`): worker emits no resume and never reads the local clone; controller positive-control still reaches the loop. Mutating away the guard makes the detection fire.
- **AC4/5/9 migration round-trips** (`t3code/server.test.ts`, `tmux-adapter.test.ts`): worker write→read via the cache with a negative assertion the harness tree is untouched; controller controls use the harness path.
- **Upgrade-bridge** (both adapter suites): legacy-only read returns the state, next write lands in the cache and shadows the (undeleted) legacy file. Mutation-verified.

## Validation
- `bun run typecheck`, `bun run build` — clean (no import cycle from the new `state.ts` import).
- Full `bun test`: **3125 pass, 0 fail** (+11 over the 3114 baseline).
- CI lints run locally: `lint:no-mock-module`, `lint:no-nul-bytes`, `lint:test-isolation`, `lint:contracts`, `lint:no-shadow-util`, `lint:test-spawn-coverage`, `lint:state-migration`, and `eslint` on changed files — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)