### PR TITLE
gh-ludics-578: test-health capability gating + routed remote execution

### DIFF
--- a/src/cluster.test.ts
+++ b/src/cluster.test.ts
@@ -7,6 +7,7 @@ import { join } from "path";
 import {
   clusterConfig,
   selectMachineForSlot,
+  selectOnlineCapableMachine,
   resolveController,
   clusterCurrentMachineName,
   heartbeatsDir,
@@ -174,5 +175,95 @@ slots:
   it("honors LUDICS_CLUSTER_MACHINE_NAME for current-machine resolution", () => {
     process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl";
     expect(clusterCurrentMachineName()).toBe("minipc-wsl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectOnlineCapableMachine — capability + online filter for test-health
+// routing (gh-ludics-578). Mirrors selectMachineForSlot's per-key filter +
+// heartbeatIsFresh gate but returns the full ClusterMachine for SSH routing.
+// ---------------------------------------------------------------------------
+
+describe("selectOnlineCapableMachine — capability + online gate", () => {
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  let TMP = "";
+
+  const CONFIG = `state_repo: test/state
+state_path: harness
+cluster:
+  transport: tailscale
+  machines:
+    - name: mac-studio
+      host: mac-studio.ts.net
+      role: leader
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+    - name: minipc-wsl
+      host: minipc-wsl.ts.net
+      role: worker
+      os: linux
+      gpu: nvidia
+`;
+
+  function writeHeartbeat(name: string, ageSeconds: number): void {
+    const dir = heartbeatsDir();
+    mkdirSync(dir, { recursive: true });
+    const epoch = Math.floor(Date.now() / 1000) - ageSeconds;
+    writeFileSync(join(dir, `${name}.json`), JSON.stringify({ node: name, epoch }));
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-cluster-capable-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_HARNESS_DIR = join(TMP, "harness");
+    const cfgPath = join(TMP, "config.yaml");
+    writeFileSync(cfgPath, CONFIG);
+    process.env.LUDICS_CONFIG = cfgPath;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it("returns the fresh-heartbeat nvidia worker for { gpu: nvidia }", () => {
+    writeHeartbeat("minipc-wsl", 10); // fresh
+    const m = selectOnlineCapableMachine({ gpu: "nvidia" });
+    expect(m?.name).toBe("minipc-wsl");
+    expect(m?.host).toBe("minipc-wsl.ts.net"); // routing needs .host
+  });
+
+  it("returns null when the only capable worker is offline (no heartbeat)", () => {
+    // Invariant: an offline capable worker is not routable. Mutation: dropping
+    // the heartbeatIsFresh filter would return minipc-wsl here.
+    const m = selectOnlineCapableMachine({ gpu: "nvidia" });
+    expect(m).toBeNull();
+  });
+
+  it("returns null when the only capable worker heartbeat is stale", () => {
+    writeHeartbeat("minipc-wsl", 1000); // > 900s default TTL
+    expect(selectOnlineCapableMachine({ gpu: "nvidia" })).toBeNull();
+  });
+
+  it("returns null when no machine has the required capability (gpu: amd)", () => {
+    writeHeartbeat("minipc-wsl", 10);
+    expect(selectOnlineCapableMachine({ gpu: "amd" })).toBeNull();
+  });
+
+  it("matches both os and gpu keys exactly when both present", () => {
+    writeHeartbeat("minipc-wsl", 10);
+    expect(selectOnlineCapableMachine({ os: "linux", gpu: "nvidia" })?.name).toBe("minipc-wsl");
+    // os mismatch (macos worker with nvidia does not exist) → null
+    expect(selectOnlineCapableMachine({ os: "macos", gpu: "nvidia" })).toBeNull();
+  });
+
+  it("returns null when the cluster is disabled (no config)", () => {
+    delete process.env.LUDICS_CONFIG;
+    expect(selectOnlineCapableMachine({ gpu: "nvidia" })).toBeNull();
   });
 });

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -400,6 +400,30 @@ export function selectMachineForSlot(
   return pool[0]?.name ?? current;
 }
 
+/**
+ * Capability + online filter shared with test-health routing (gh-ludics-578).
+ * Mirrors `selectMachineForSlot`'s per-key exact-equality requirement filter
+ * (above) plus its `heartbeatIsFresh` online gate, but returns the full
+ * `ClusterMachine` (routing needs `.host` for SSH) and *any* fresh-heartbeat
+ * capable machine — no load-balancing tiebreak is needed for a health probe.
+ *
+ * The current (requirement-unmet) host cannot pass the capability filter, so it
+ * is excluded by construction — no non-current special-casing is required.
+ * Returns null when the cluster is disabled, no machine is capable, or no
+ * capable machine is online. If `selectMachineForSlot`'s filter changes, mirror
+ * it here.
+ */
+export function selectOnlineCapableMachine(
+  reqs: { os?: string; gpu?: string },
+): ClusterMachine | null {
+  if (!clusterEnabled()) return null;
+  let eligible = clusterMachines();
+  if (reqs.os) eligible = eligible.filter((m) => m.os === reqs.os);
+  if (reqs.gpu) eligible = eligible.filter((m) => m.gpu === reqs.gpu);
+  const online = eligible.filter((m) => heartbeatIsFresh(m.name));
+  return online[0] ?? null;
+}
+
 // --- WSL2 / systemd-user persistence (AC 8) ---
 
 /**

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -566,6 +566,31 @@ describe("test-health capability gating (gh-ludics-578)", () => {
     expect(taskFiles()).toEqual([]);
   });
 
+  test("unmet + online worker but NO test_command and NO resolvable checkout → skip (must not auto-detect from controller cwd)", () => {
+    // Regression (PR #582 review): with no test_command and no checkout on the
+    // controller, resolveProjectPath returns "" and a naive detectTestCommand("")
+    // would probe the controller's process cwd — which here (the ludics repo) has
+    // bun.lock, yielding "bun test" and wrongly routing an unrelated command.
+    // Invariant: routing requires a command we can actually name; otherwise skip.
+    // Mutation: reverting to detectTestCommand(resolveProjectPath(...)) makes
+    // `fired` true (bun test routed) from the repo cwd.
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    writeHeartbeat("minipc-wsl", 10); // capable worker IS online
+
+    let fired = false;
+    _remoteTestExec.fn = (): RemoteRunResult => { fired = true; return { kind: "ran", ok: true, stdout: "", stderr: "", timedOut: false }; };
+
+    // No test_command, no path → unresolvable command.
+    const project = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" } } as const;
+    const result = checkProjectTestHealth(project, { force: true });
+
+    expect(result).toEqual({ skipped: true, reason: "requirements-unmet" });
+    expect(fired).toBe(false); // never routed a cwd-detected command
+    expect(existsSync(testHealthStatePath())).toBe(false);
+    expect(taskFiles()).toEqual([]);
+  });
+
   // --- AC2: unknown-capability host ---
 
   test("unknown host (name not in cluster): gated project skips, requirement-free runs", () => {

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,7 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { _runAllTestHealthDispatch, checkProjectTestHealth, detectTestCommand, runAllTestHealth, shouldRunTestHealth, testHealthStatePath } from "./health.ts";
+import { _remoteTestExec, _runAllTestHealthDispatch, checkProjectTestHealth, detectTestCommand, requirementsSatisfiedByCurrentHost, runAllTestHealth, shouldRunTestHealth, testHealthStatePath } from "./health.ts";
+import type { RemoteRunResult } from "./remote.ts";
+import { heartbeatsDir } from "./cluster.ts";
 import { tmpdir } from "os";
 import { _resetPostponedProjectsCache } from "./config.ts";
 import { captureConsoleError, withSyntheticHarness } from "./test-utils.ts";
@@ -388,5 +390,231 @@ describe("test-health t3code integration gate (gh-ludics-539)", () => {
     } finally {
       _runAllTestHealthDispatch.fn = original;
     }
+  });
+});
+
+describe("test-health capability gating (gh-ludics-578)", () => {
+  // Current host is pinned via LUDICS_CLUSTER_MACHINE_NAME against a scratch
+  // cluster config; routed remote execution is injected through the
+  // _remoteTestExec seam so no real SSH/network runs. tasksCreate's side effect
+  // (a markdown file under <harness>/tasks) is observed on disk: the no-task
+  // guarantee is "the tasks dir does not exist".
+  let TMP = "";
+  const ORIG = {
+    HOME: process.env.HOME,
+    CONFIG: process.env.LUDICS_CONFIG,
+    HARNESS: process.env.LUDICS_HARNESS_DIR,
+    MACHINE: process.env.LUDICS_CLUSTER_MACHINE_NAME,
+  };
+  const ORIGINAL_REMOTE = _remoteTestExec.fn;
+
+  // mac-studio = apple-silicon (the always-on leader Mag runs on); minipc-wsl =
+  // the sole nvidia worker (always_on: false). Mirrors the live config the
+  // proposal corrected.
+  const CLUSTER = `cluster:
+  transport: tailscale
+  machines:
+    - name: mac-studio
+      host: mac-studio.ts.net
+      role: leader
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+    - name: minipc-wsl
+      host: minipc-wsl.ts.net
+      role: worker
+      os: linux
+      gpu: nvidia
+`;
+
+  /** Write config.yaml. `cluster` defaults on; pass `{ cluster: "" }` to omit it
+   *  (cluster-disabled case). `projectsBlock` declares postponed/requirements
+   *  for projects the guards read from config (postponedProjectSet). */
+  function writeConfig(opts?: { cluster?: string; projectsBlock?: string }): void {
+    const cfgPath = join(TMP, "config.yaml");
+    const cluster = opts?.cluster ?? CLUSTER;
+    writeFileSync(cfgPath, `state_repo: test/state\nstate_path: harness\n${cluster}${opts?.projectsBlock ?? ""}`);
+    process.env.LUDICS_CONFIG = cfgPath;
+  }
+
+  function writeHeartbeat(name: string, ageSeconds: number): void {
+    const dir = heartbeatsDir();
+    mkdirSync(dir, { recursive: true });
+    const epoch = Math.floor(Date.now() / 1000) - ageSeconds;
+    writeFileSync(join(dir, `${name}.json`), JSON.stringify({ node: name, epoch }));
+  }
+
+  function taskFiles(): string[] {
+    const dir = join(TMP, "tasks");
+    return existsSync(dir) ? readdirSync(dir).filter((f) => f.endsWith(".md")) : [];
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-health-cap-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_HARNESS_DIR = TMP;
+    _resetPostponedProjectsCache();
+  });
+
+  afterEach(() => {
+    _remoteTestExec.fn = ORIGINAL_REMOTE;
+    if (ORIG.HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIG.HOME;
+    if (ORIG.CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIG.CONFIG;
+    if (ORIG.HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIG.HARNESS;
+    if (ORIG.MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIG.MACHINE;
+    _resetPostponedProjectsCache();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  // --- AC1: predicate ---
+
+  test("requirementsSatisfiedByCurrentHost: satisfied / unmet / host-unknown / no-reqs", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // apple-silicon / macos
+
+    // No requirements → always satisfied.
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p" }).status).toBe("satisfied");
+    // Met (apple-silicon on mac-studio).
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p", requirements: { gpu: "apple-silicon" } }).status).toBe("satisfied");
+    // Unmet (nvidia on apple-silicon host).
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p", requirements: { gpu: "nvidia" } }).status).toBe("unmet");
+    // Both keys: os matches, gpu mismatch → unmet (exact per-key equality).
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p", requirements: { os: "macos", gpu: "nvidia" } }).status).toBe("unmet");
+
+    // Host unknown (name not in cluster) → host-unknown for gated, satisfied for free.
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "ghost";
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p", requirements: { gpu: "nvidia" } }).status).toBe("host-unknown");
+    expect(requirementsSatisfiedByCurrentHost({ name: "p", repo: "x/p" }).status).toBe("satisfied");
+  });
+
+  // --- AC3: capability-met runs unchanged ---
+
+  test("capability-met project is NOT skipped for requirements-unmet (falls through)", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    // ocaml-metal-shaped: gpu apple-silicon, met on mac-studio. No checkout on
+    // disk → falls through to path-not-found, NOT requirements-unmet.
+    const project = { name: "ocaml-metal", repo: "ex/metal", requirements: { gpu: "apple-silicon" } } as const;
+    const result = checkProjectTestHealth(project);
+    expect(result.reason).not.toBe("requirements-unmet");
+    expect(result.reason).toBe("path-not-found");
+  });
+
+  // --- AC4: routed remote execution ---
+
+  test("unmet + online capable worker → routes; a real remote failure files a fix-task", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // incapable (apple-silicon)
+    writeHeartbeat("minipc-wsl", 10); // fresh nvidia worker
+
+    const calls: Array<{ host: string; cmd: string; cwd: string }> = [];
+    _remoteTestExec.fn = (machine, cmd, opts): RemoteRunResult => {
+      calls.push({ host: machine.host, cmd, cwd: opts.cwd });
+      return { kind: "ran", ok: false, stdout: "3 tests failed", stderr: "", timedOut: false };
+    };
+
+    const project = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" }, test_command: "dune runtest", path: "~/ocaml-cudajit" } as const;
+    const result = checkProjectTestHealth(project, { force: true });
+
+    // Routed to the nvidia worker with the project's command + remote checkout.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.host).toBe("minipc-wsl.ts.net");
+    expect(calls[0]!.cmd).toBe("dune runtest");
+    expect(calls[0]!.cwd).toBe("~/ocaml-cudajit");
+    // Same result shape as a local run; a genuine non-zero result files a task.
+    expect(result).toMatchObject({ skipped: false, passed: false });
+    expect(existsSync(testHealthStatePath())).toBe(true); // state persisted
+    expect(taskFiles()).toHaveLength(1); // fix-task filed
+  });
+
+  // --- AC5: routing degrades to skip-not-fail ---
+
+  test("unmet + transport/connectivity failure → skip, NO state, NO fix-task", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    writeHeartbeat("minipc-wsl", 10);
+
+    let fired = false;
+    _remoteTestExec.fn = (): RemoteRunResult => {
+      fired = true;
+      return { kind: "transport-error", detail: "ssh: connect to host minipc-wsl.ts.net: Connection refused" };
+    };
+
+    const project = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" }, test_command: "dune runtest" } as const;
+    const result = checkProjectTestHealth(project, { force: true });
+
+    expect(fired).toBe(true); // routing was attempted (distinguishes from no-worker skip)
+    expect(result).toEqual({ skipped: true, reason: "requirements-unmet" });
+    expect(existsSync(testHealthStatePath())).toBe(false); // no state mutation
+    expect(taskFiles()).toEqual([]); // no fix-task
+  });
+
+  test("unmet + NO online worker → skip requirements-unmet; remote exec never attempted (AC5/AC6: cudajit on mac-studio)", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    // No heartbeat for minipc-wsl → offline → not routable.
+
+    let fired = false;
+    _remoteTestExec.fn = (): RemoteRunResult => { fired = true; return { kind: "transport-error", detail: "" }; };
+
+    const project = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" }, test_command: "dune runtest" } as const;
+    const result = checkProjectTestHealth(project, { force: true });
+
+    expect(result).toEqual({ skipped: true, reason: "requirements-unmet" });
+    expect(fired).toBe(false); // short-circuits at worker selection — never runs/fails locally
+    expect(existsSync(testHealthStatePath())).toBe(false);
+    expect(taskFiles()).toEqual([]);
+  });
+
+  // --- AC2: unknown-capability host ---
+
+  test("unknown host (name not in cluster): gated project skips, requirement-free runs", () => {
+    writeConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "ghost"; // not a configured machine
+
+    const gated = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" }, test_command: "dune runtest" } as const;
+    expect(checkProjectTestHealth(gated, { force: true })).toEqual({ skipped: true, reason: "requirements-unmet" });
+    expect(taskFiles()).toEqual([]);
+
+    // Negative control for AC2: a requirement-free project must NOT be skipped
+    // for requirements-unmet on the same unknown host (falls through).
+    const free = { name: "ludics", repo: "ex/ludics" } as const;
+    expect(checkProjectTestHealth(free, { force: true }).reason).not.toBe("requirements-unmet");
+  });
+
+  test("cluster disabled: gated project skips requirements-unmet", () => {
+    writeConfig({ cluster: "" }); // no cluster block → clusterEnabled() false
+    const gated = { name: "ocaml-cudajit", repo: "ex/cudajit", requirements: { gpu: "nvidia" }, test_command: "dune runtest" } as const;
+    expect(checkProjectTestHealth(gated, { force: true })).toEqual({ skipped: true, reason: "requirements-unmet" });
+  });
+
+  // --- AC7: precedence ---
+
+  test("postponed wins over requirements-unmet (ocaml-hipjit: postponed + gpu:amd)", () => {
+    // postponedProjectSet reads config.projects[].postponed, so the project must
+    // be declared postponed in config (not just on the literal).
+    writeConfig({
+      projectsBlock: "projects:\n  - name: ocaml-hipjit\n    repo: ex/hipjit\n    postponed: true\n    requirements:\n      gpu: amd\n",
+    });
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // would be unmet for gpu:amd
+    _resetPostponedProjectsCache();
+
+    const project = { name: "ocaml-hipjit", repo: "ex/hipjit", postponed: true, requirements: { gpu: "amd" }, test_command: "false" } as const;
+    const result = checkProjectTestHealth(project, { force: true });
+    expect(result).toEqual({ skipped: true, reason: "postponed" }); // NOT requirements-unmet
+  });
+
+  // --- AC8: batch-loop visible skip line ---
+
+  test("runAllTestHealth emits '[test-health] <name>: skipped (requirements-unmet)'", () => {
+    writeConfig({
+      projectsBlock: "projects:\n  - name: ocaml-cudajit\n    repo: ex/cudajit\n    test_command: dune runtest\n    requirements:\n      gpu: nvidia\n",
+    });
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    // minipc-wsl offline → unmet + no worker → requirements-unmet skip.
+
+    const { lines } = captureConsoleError(() => runAllTestHealth({ project: "ocaml-cudajit", force: true }));
+    expect(lines.some((l) => l.includes("[test-health] ocaml-cudajit: skipped (requirements-unmet)"))).toBe(true);
+    expect(taskFiles()).toEqual([]);
   });
 });

--- a/src/health.ts
+++ b/src/health.ts
@@ -203,7 +203,13 @@ function routeOrSkipRequirementsUnmet(
   const worker = selectOnlineCapableMachine(check.reqs);
   if (!worker) return SKIP; // no eligible/online worker (AC5)
 
-  const testCmd = (project.test_command?.trim() || null) ?? detectTestCommand(resolveProjectPath(project.name));
+  // Resolve the command WITHOUT probing the controller's process cwd: when the
+  // project has no `test_command` AND no checkout resolvable on the controller,
+  // `resolveProjectPath` returns "" and `detectTestCommand("")` would probe files
+  // in the current working directory (e.g. the ludics repo's own bun.lock),
+  // wrongly routing an unrelated command. Only auto-detect against a real path.
+  const localPath = resolveProjectPath(project.name); // "" or an existing path
+  const testCmd = project.test_command?.trim() || (localPath ? detectTestCommand(localPath) : null);
   if (!testCmd) return SKIP; // cannot route a command we can't name (synchronous remote detection isn't possible)
 
   // Respect the same nightly rate-limit gate as the local path, so routing does

--- a/src/health.ts
+++ b/src/health.ts
@@ -4,6 +4,8 @@ import { join } from "path";
 import { type ProjectConfig, loadConfigSync, harnessDir, resolveProjectPath, postponedProjectSet, t3codeIntegrationEnabled } from "./config.ts";
 import { tasksCreate } from "./tasks/index.ts";
 import { safeSyncOutput } from "./spawn.ts";
+import { clusterCurrentMachine, selectOnlineCapableMachine } from "./cluster.ts";
+import { runRemoteCommand } from "./remote.ts";
 
 // --- Types ---
 
@@ -100,6 +102,129 @@ export function projectRequiresT3code(project: ProjectConfig): boolean {
     || project.name.toLowerCase() === "t3code-ludics";
 }
 
+// --- Capability gating (gh-ludics-578) ---
+
+/** Result of evaluating a project's `requirements` against the current host.
+ *  - `satisfied`: no requirements, or the current host meets every present key.
+ *  - `unmet`: the current host is known but lacks a required capability.
+ *  - `host-unknown`: capabilities are unprovable (cluster disabled or the host
+ *    doesn't resolve to a `cluster.machines` entry). */
+export type RequirementsCheck =
+  | { status: "satisfied" }
+  | { status: "unmet"; reqs: { os?: string; gpu?: string } }
+  | { status: "host-unknown"; reqs: { os?: string; gpu?: string } };
+
+/**
+ * Evaluate `project.requirements` against the current host, mirroring
+ * `selectMachineForSlot`'s per-key exact-equality semantics projected onto the
+ * current machine: for each *present* requirement key (`os`, `gpu`), the host
+ * satisfies it iff `currentMachine[key] === reqs[key]`. A project with no
+ * requirements (or an empty requirements object) is always satisfied — even on
+ * an unknown host (so this gate never disables test-health for requirement-free
+ * projects on standalone deployments).
+ */
+export function requirementsSatisfiedByCurrentHost(project: ProjectConfig): RequirementsCheck {
+  const reqs = project.requirements;
+  const hasReqs = !!(reqs && (reqs.os || reqs.gpu));
+  if (!hasReqs) return { status: "satisfied" };
+  const current = clusterCurrentMachine(); // undefined when cluster disabled OR host unresolved
+  if (!current) return { status: "host-unknown", reqs: reqs! };
+  const ok = (!reqs!.os || current.os === reqs!.os)
+    && (!reqs!.gpu || current.gpu === reqs!.gpu);
+  return ok ? { status: "satisfied" } : { status: "unmet", reqs: reqs! };
+}
+
+// Test seam: routed remote execution dispatches through this holder so tests can
+// inject a synthetic result (no real SSH/network). Mirrors the
+// _runAllTestHealthDispatch pattern below.
+/** @internal exported for tests only */
+export const _remoteTestExec: { fn: typeof runRemoteCommand } = { fn: runRemoteCommand };
+
+/** Best-effort project checkout path on a *remote* worker. Uses the project's
+ *  configured `path` literally (a leading `~` is left for the remote shell to
+ *  expand — NOT against the controller's HOME), else the `~/<repoTail>`
+ *  convention. No local `existsSync` — the path lives on the worker. */
+function remoteProjectPath(project: ProjectConfig): string {
+  if (project.path) return String(project.path);
+  const repoTail = String(project.repo ?? "").split("/").pop() ?? "";
+  return `~/${repoTail}`;
+}
+
+/** Shared post-run finalization for an *actually-executed* suite (local or
+ *  remote): extract failure text, persist `mag/test-health.json`, and file a
+ *  fix-task on a real non-zero result. Guarantees AC4's "same result shape as a
+ *  local run" by being the single code path both runs flow through. */
+function finalizeExecutedRun(
+  project: ProjectConfig,
+  run: { ok: boolean; stdout: string; stderr: string; timedOut: boolean },
+  duration: number,
+): TestHealthResult {
+  const passed = run.ok;
+  let failures: string | undefined;
+  if (!passed) {
+    const source = run.stderr.trim().length >= 20 ? run.stderr : (run.stdout || run.stderr);
+    failures = source.slice(-500);
+    if (run.timedOut) {
+      failures = `timeout after 300s\n${failures}`;
+    }
+  }
+
+  const state = loadTestHealthState();
+  state[project.name] = { lastRun: new Date().toISOString(), passed, ...(failures ? { failures } : {}) };
+  saveTestHealthState(state);
+
+  if (!passed) {
+    tasksCreate(`Fix broken test suite: ${project.name}`, project.name, "A");
+  }
+
+  return { skipped: false, passed, duration, failures };
+}
+
+/**
+ * Handle a project whose current host does NOT satisfy its requirements
+ * (AC4/AC5). `host-unknown` skips directly (capabilities unprovable). For a
+ * known-but-incapable host, route the suite to a capability-matched, online
+ * worker; degrade to a `requirements-unmet` skip — with NO state mutation and NO
+ * fix-task — whenever routing can't complete for a capability/connectivity
+ * reason. Only an actually-executed remote suite with a real non-zero result
+ * files a fix-task.
+ */
+function routeOrSkipRequirementsUnmet(
+  project: ProjectConfig,
+  check: Extract<RequirementsCheck, { status: "unmet" | "host-unknown" }>,
+  options?: { force?: boolean },
+): TestHealthResult {
+  const SKIP: TestHealthResult = { skipped: true, reason: "requirements-unmet" };
+
+  // Unprovable capabilities (cluster off / host unresolved): skip, do not route.
+  if (check.status === "host-unknown") return SKIP;
+
+  // Known-but-incapable host: route to a fresh-heartbeat capable worker, if any.
+  const worker = selectOnlineCapableMachine(check.reqs);
+  if (!worker) return SKIP; // no eligible/online worker (AC5)
+
+  const testCmd = (project.test_command?.trim() || null) ?? detectTestCommand(resolveProjectPath(project.name));
+  if (!testCmd) return SKIP; // cannot route a command we can't name (synchronous remote detection isn't possible)
+
+  // Respect the same nightly rate-limit gate as the local path, so routing does
+  // not SSH the worker and run the full suite on every keepalive tick.
+  const config = loadConfigSync();
+  const state = loadTestHealthState();
+  if (!options?.force && !shouldRunTestHealth(project.name, state, config)) {
+    return { skipped: true, reason: "rate-limited" };
+  }
+
+  const start = Date.now();
+  const result = _remoteTestExec.fn(worker, testCmd, { cwd: remoteProjectPath(project), timeout: 300_000 });
+  const duration = Date.now() - start;
+
+  // Transport/connectivity failure: the suite never ran → skip-not-fail (AC5).
+  if (result.kind === "transport-error") return SKIP;
+
+  // The suite actually executed remotely: map exactly like a local run (AC4).
+  return finalizeExecutedRun(project, result, duration);
+}
+
 export function checkProjectTestHealth(
   project: ProjectConfig,
   options?: { force?: boolean },
@@ -112,6 +237,15 @@ export function checkProjectTestHealth(
   // 300s timeout run, no test-health.json entry, no fix-task.
   if (projectRequiresT3code(project) && !t3codeIntegrationEnabled()) {
     return { skipped: true, reason: "t3code-integration-paused" };
+  }
+  // gh-ludics-578: capability gate — after postponed/t3code (AC7 precedence),
+  // before path resolution / command detection / execution. A host that can't
+  // satisfy the project's requirements routes to a capable worker or skips
+  // `requirements-unmet` (never runs-and-fails locally / files a false-positive
+  // fix-task). Cheap (host-only); no path cost to avoid.
+  const capability = requirementsSatisfiedByCurrentHost(project);
+  if (capability.status !== "satisfied") {
+    return routeOrSkipRequirementsUnmet(project, capability, options);
   }
   const projectPath = resolveProjectPath(project.name);
   if (!existsSync(projectPath)) return { skipped: true, reason: "path-not-found" };
@@ -128,25 +262,8 @@ export function checkProjectTestHealth(
   const start = Date.now();
   const proc = safeSyncOutput(["sh", "-c", testCmd], { cwd: projectPath, timeout: 300_000, trim: false });
   const duration = Date.now() - start;
-  const passed = proc.ok;
 
-  let failures: string | undefined;
-  if (!passed) {
-    const source = proc.stderr.trim().length >= 20 ? proc.stderr : (proc.stdout || proc.stderr);
-    failures = source.slice(-500);
-    if (proc.timedOut) {
-      failures = `timeout after 300s\n${failures}`;
-    }
-  }
-
-  state[project.name] = { lastRun: new Date().toISOString(), passed, ...(failures ? { failures } : {}) };
-  saveTestHealthState(state);
-
-  if (!passed) {
-    tasksCreate(`Fix broken test suite: ${project.name}`, project.name, "A");
-  }
-
-  return { skipped: false, passed, duration, failures };
+  return finalizeExecutedRun(project, proc, duration);
 }
 
 // --- Batch ---

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -1,0 +1,51 @@
+// Remote-exec classification tests (gh-ludics-578).
+//
+// classifyRemoteResult is the AC5 "skip-on-connectivity-failure" guarantee: it
+// decides whether a routed test-health run actually executed the suite (→ may
+// file a fix-task) or hit a transport failure (→ must degrade to skip-not-fail,
+// never a false-positive task). The invariant under test: ssh/transport failures
+// (exit 255, spawn/timeout exit -1, or timedOut) classify as `transport-error`,
+// while a remote command that genuinely ran classifies as `ran` carrying its
+// real pass/fail.
+
+import { describe, test, expect } from "bun:test";
+import { classifyRemoteResult } from "./remote.ts";
+import type { SyncResult } from "./spawn.ts";
+
+function syncResult(over: Partial<SyncResult>): SyncResult {
+  return { ok: false, exitCode: 1, stdout: "", stderr: "", timedOut: false, ...over };
+}
+
+describe("classifyRemoteResult", () => {
+  test("ssh exit 255 (connection/auth failure) → transport-error", () => {
+    const r = classifyRemoteResult(syncResult({ ok: false, exitCode: 255, stderr: "ssh: connect to host: Connection refused" }));
+    expect(r.kind).toBe("transport-error");
+  });
+
+  test("exit -1 (spawn/ENOENT or local timeout) → transport-error", () => {
+    const r = classifyRemoteResult(syncResult({ ok: false, exitCode: -1, stderr: "spawn ssh ENOENT" }));
+    expect(r.kind).toBe("transport-error");
+  });
+
+  test("timedOut (run never completed) → transport-error, even with exitCode -1", () => {
+    const r = classifyRemoteResult(syncResult({ ok: false, exitCode: -1, timedOut: true }));
+    expect(r.kind).toBe("transport-error");
+  });
+
+  test("exit 1 (remote command actually ran and failed) → ran with ok:false", () => {
+    // The mutation guard for AC5: a real non-zero TEST result must NOT be
+    // swallowed as transport — it is the only thing that may file a fix-task.
+    const r = classifyRemoteResult(syncResult({ ok: false, exitCode: 1, stdout: "FAILED 3 tests" }));
+    expect(r.kind).toBe("ran");
+    if (r.kind === "ran") {
+      expect(r.ok).toBe(false);
+      expect(r.stdout).toBe("FAILED 3 tests");
+    }
+  });
+
+  test("exit 0 (remote suite passed) → ran with ok:true", () => {
+    const r = classifyRemoteResult(syncResult({ ok: true, exitCode: 0, stdout: "ok" }));
+    expect(r.kind).toBe("ran");
+    if (r.kind === "ran") expect(r.ok).toBe(true);
+  });
+});

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -9,7 +9,7 @@
 // real pass/fail.
 
 import { describe, test, expect } from "bun:test";
-import { classifyRemoteResult } from "./remote.ts";
+import { buildRemoteScript, classifyRemoteResult } from "./remote.ts";
 import type { SyncResult } from "./spawn.ts";
 
 function syncResult(over: Partial<SyncResult>): SyncResult {
@@ -47,5 +47,23 @@ describe("classifyRemoteResult", () => {
     const r = classifyRemoteResult(syncResult({ ok: true, exitCode: 0, stdout: "ok" }));
     expect(r.kind).toBe("ran");
     if (r.kind === "ran") expect(r.ok).toBe(true);
+  });
+});
+
+describe("buildRemoteScript", () => {
+  test("cd-failure is forced to the SSH transport sentinel (exit 255), not a test exit", () => {
+    // Invariant for skip-not-fail: a missing/invalid remote checkout must NOT
+    // reach the test command as a normal non-255 shell failure (which
+    // classifyRemoteResult would treat as `ran`/ok:false → a false fix-task).
+    // `|| exit 255` maps the cd failure onto ssh's transport sentinel, which the
+    // classifier above routes to transport-error → skip. Mutation: dropping the
+    // `|| exit 255` (back to `cd X && cmd`) makes a missing-checkout `cd` exit 1.
+    expect(buildRemoteScript("~/ocaml-cudajit", "dune runtest")).toBe("cd ~/ocaml-cudajit || exit 255; dune runtest");
+  });
+
+  test("classifying a forced cd-failure (exit 255) yields a transport-error skip", () => {
+    // End-to-end of the two-step chain: buildRemoteScript emits `|| exit 255`, a
+    // failed cd produces exit 255, classifyRemoteResult → transport-error.
+    expect(classifyRemoteResult(syncResult({ ok: false, exitCode: 255, stderr: "bash: cd: ~/missing: No such file or directory" })).kind).toBe("transport-error");
   });
 });

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,6 +1,7 @@
-// Remote utilities — machine identity checks
+// Remote utilities — machine identity checks + synchronous remote command exec
 
-import { clusterCurrentMachineName } from "./cluster.ts";
+import { clusterCurrentMachineName, type ClusterMachine } from "./cluster.ts";
+import { safeSyncOutput, type SyncResult } from "./spawn.ts";
 
 /**
  * Check if the given machine name refers to a remote machine (not this one).
@@ -13,4 +14,58 @@ export function isRemoteMachine(machineName: string): boolean {
   const currentName = clusterCurrentMachineName();
   if (!currentName) return true; // can't determine our identity — treat as remote (fail closed)
   return machineName !== currentName;
+}
+
+// --- Synchronous remote command execution (gh-ludics-578, Option A) ---
+
+/** Outcome of a remote command attempt.
+ *  - `ran`: ssh connected and the remote command produced a real exit status
+ *    (the suite actually executed) — `ok` reflects the test command's success.
+ *  - `transport-error`: ssh/connectivity failure — the suite never ran. The
+ *    caller MUST degrade to skip-not-fail, never to a fix-task. */
+export type RemoteRunResult =
+  | { kind: "ran"; ok: boolean; stdout: string; stderr: string; timedOut: boolean }
+  | { kind: "transport-error"; detail: string };
+
+/**
+ * Classify a raw ssh `SyncResult` into ran-vs-transport-error.
+ *
+ * ssh exit 255 = connection/auth/transport failure; `exitCode === -1` =
+ * spawn/ENOENT or a local timeout (`safeSyncOutput` maps a killed process to
+ * `-1` + `timedOut`); `timedOut` = the attempt never completed. All three are
+ * transport failures → skip-not-fail. A remote *test* command that actually ran
+ * and failed exits 1..254 → `ran` with `ok: false` → the caller files a fix-task.
+ *
+ * Conservative split (AC5): a remote timeout is treated as transport, NOT a
+ * suite failure, so a hung/unreachable worker can never produce a false-positive
+ * "Fix broken test suite" task.
+ */
+export function classifyRemoteResult(r: SyncResult): RemoteRunResult {
+  if (r.exitCode === 255 || r.exitCode === -1 || r.timedOut) {
+    return { kind: "transport-error", detail: r.stderr.slice(-300) || `ssh exit ${r.exitCode}` };
+  }
+  return { kind: "ran", ok: r.ok, stdout: r.stdout, stderr: r.stderr, timedOut: r.timedOut };
+}
+
+/**
+ * Run `cmd` in `cwd` on `machine` over SSH, synchronously, returning a
+ * classified result. `BatchMode=yes` fails fast on auth instead of prompting;
+ * `ConnectTimeout` bounds the connect attempt for a nightly probe.
+ *
+ * Remote env parity (e.g. `eval $(opam env)`) relies on the worker's login-shell
+ * profile sourcing on the SSH command channel; deeper hardening is out of scope.
+ * The `ssh` token in `scripts/lint-template-safety.ts`'s blocklist is
+ * template-markdown-only (that lint never scans `src/`).
+ */
+export function runRemoteCommand(
+  machine: ClusterMachine,
+  cmd: string,
+  opts: { cwd: string; timeout?: number },
+): RemoteRunResult {
+  const remoteScript = `cd ${opts.cwd} && ${cmd}`;
+  const res = safeSyncOutput(
+    ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", machine.host, remoteScript],
+    { timeout: opts.timeout, trim: false },
+  );
+  return classifyRemoteResult(res);
 }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -48,9 +48,25 @@ export function classifyRemoteResult(r: SyncResult): RemoteRunResult {
 }
 
 /**
+ * Build the remote shell script: change into the checkout, then run the command.
+ *
+ * The `|| exit 255` is load-bearing for the skip-not-fail invariant: a missing or
+ * invalid remote checkout makes `cd` fail *before the suite runs*, which is a
+ * setup/connectivity failure, NOT a test failure. Without the guard the failed
+ * `cd` would exit with the shell's normal non-zero status (e.g. 1), ssh would
+ * relay it, and `classifyRemoteResult` would mark it `ran`/`ok:false` → a
+ * false-positive fix-task. Forcing the exit to ssh's transport sentinel (255)
+ * routes a setup failure through the transport-error branch → skip.
+ */
+export function buildRemoteScript(cwd: string, cmd: string): string {
+  return `cd ${cwd} || exit 255; ${cmd}`;
+}
+
+/**
  * Run `cmd` in `cwd` on `machine` over SSH, synchronously, returning a
  * classified result. `BatchMode=yes` fails fast on auth instead of prompting;
- * `ConnectTimeout` bounds the connect attempt for a nightly probe.
+ * `ConnectTimeout` bounds the connect attempt for a nightly probe. A missing
+ * remote checkout is mapped to a transport-error skip via `buildRemoteScript`.
  *
  * Remote env parity (e.g. `eval $(opam env)`) relies on the worker's login-shell
  * profile sourcing on the SSH command channel; deeper hardening is out of scope.
@@ -62,9 +78,8 @@ export function runRemoteCommand(
   cmd: string,
   opts: { cwd: string; timeout?: number },
 ): RemoteRunResult {
-  const remoteScript = `cd ${opts.cwd} && ${cmd}`;
   const res = safeSyncOutput(
-    ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", machine.host, remoteScript],
+    ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", machine.host, buildRemoteScript(opts.cwd, cmd)],
     { timeout: opts.timeout, trim: false },
   );
   return classifyRemoteResult(res);


### PR DESCRIPTION
Closes #578. Makes the test-health pre-hook **capability-aware** so a project that structurally cannot build/run on the current host no longer flags red and auto-files a false-positive "Fix broken test suite" task (the `task-3124de24` / ocaml-cudajit case this blocks).

## Behavior

`checkProjectTestHealth` now consults `project.requirements` against the current host (`cluster.machines`) **after** the `postponed` / `t3code-integration-paused` guards and **before** path resolution:

- **Satisfied** (or no requirements) → runs locally, unchanged.
- **Host-unknown** (cluster disabled or host unresolved) → skip `requirements-unmet` (Q2 → b).
- **Unmet** → route the suite to a capability-matched, **fresh-heartbeat** worker over SSH; a real remote non-zero result files a fix-task with the *same result shape as a local run*. No eligible/online worker, or a transport/connectivity failure, degrades to a `requirements-unmet` skip with **no state mutation and no fix-task**. Routing respects the same nightly rate-limit gate as the local path.

The absolute invariant: a suite that did not actually run, or ran on an incapable/unreachable host for capability/connectivity reasons, **never** files a fix-task. Only an actually-executed suite with a real non-zero result does.

## Implementation (Option A — synchronous SSH)

Per the proposal's recommended Option A (the open question A-vs-B was carried into the proposal; A fits the synchronous caller and reuses the federation's passwordless SSH):

- `src/cluster.ts` — `selectOnlineCapableMachine(reqs)`: mirrors `selectMachineForSlot`'s per-key exact-equality filter + `heartbeatIsFresh` gate, returns the full `ClusterMachine` for routing.
- `src/remote.ts` — `runRemoteCommand` (`safeSyncOutput(["ssh", …])`) + pure `classifyRemoteResult` splitting transport-error (ssh 255 / spawn-or-timeout -1 / timedOut) from a real ran result.
- `src/health.ts` — `requirementsSatisfiedByCurrentHost` predicate (satisfied/unmet/host-unknown), the gate, the route-or-skip branch, and a shared `finalizeExecutedRun` so local and remote runs are identical by construction. Batch loop uses its existing generic skip branch → `[test-health] <name>: skipped (requirements-unmet)`.

## Tests

+20 tests (full suite 3114 → 3137, 0 fail): predicate four-way, capability-met falls through, unmet+online-worker routes (+ real-failure files a task), transport-error skips with no side effects, no-online-worker skips without any run (cudajit/mac-studio, AC6), unknown-host skips while requirement-free runs, cluster-disabled skips, postponed precedence, batch visible line, and a dedicated `classifyRemoteResult` connectivity-classification unit (`src/remote.test.ts`). `typecheck`, `build`, and all 18 CI lint steps pass.

## Note for reviewer

Implements routing as **Option A** (synchronous SSH) — the proposal recommends A and writes AC4–AC6 for it, but the A-vs-B mechanism was a carried open question. If B (async intent model) is mandated, AC4–AC6 and `src/remote.ts` routing change shape.
## Review fixes (Codex P2, commit 464200c)

- **Remote setup failures are skips:** a missing/invalid remote checkout makes `cd` fail before the suite runs; `buildRemoteScript` now forces it to ssh exit 255 (`cd … || exit 255; cmd`) → transport-error skip, never a fix-task.
- **No detection from the controller cwd:** auto-detect only against a resolved existing local path, so `detectTestCommand("")` can no longer probe the ludics repo's own `bun.lock` and route an unrelated command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)