### PR TITLE
fix(remote-dispatch): resolve slot project path for the destination machine (gh-ludics-579)

### DIFF
--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -914,7 +914,13 @@ describe("integration", () => {
     // but src/cluster.test.ts gained real harness isolation (scratch
     // LUDICS_HARNESS_DIR / LUDICS_CLUSTER_MACHINE_NAME setup) and no longer trips,
     // REMOVING one — so the count is unchanged.
-    const expectedWarningCount = 20;
+    // 22 after gh-ludics-579: staging-ff.ts and briefing-lag.ts now VALUE-import
+    // `projectConfigPath` from src/config.ts (formerly `import type { ProjectConfig }`,
+    // erased at runtime), so src/staging-ff.test.ts and src/briefing-lag.test.ts
+    // newly trip rule-3 (transitive runtime config.ts import). Both are pure-unit —
+    // they exercise projectConfigPath on string `path` fixtures, which never touches
+    // config/cluster — so no real harness is needed; +2.
+    const expectedWarningCount = 22;
     if (result.warningCount !== expectedWarningCount) {
       throw new Error(
         formatPinMismatch(

--- a/src/briefing-lag.ts
+++ b/src/briefing-lag.ts
@@ -12,7 +12,7 @@
 
 import { existsSync, statSync } from "fs";
 import { join } from "path";
-import type { ProjectConfig } from "./config.ts";
+import { projectConfigPath, type ProjectConfig } from "./config.ts";
 import { detectDefaultBranches, expandHome, hasRemote, type RunGit } from "./git-runner.ts";
 import { latestOutboundCauseRemedy } from "./staging-event-meta.ts";
 
@@ -136,9 +136,10 @@ export function formatUpstreamLagSection(
   const blocks: string[] = [];
   for (const p of relevant) {
     const name = p.name || p.repo || "(unnamed)";
-    const path = p.path ? expandHome(String(p.path)) : null;
+    const cfgPath = projectConfigPath(p);
+    const path = cfgPath ? expandHome(cfgPath) : null;
     if (!path || !existsSync(path)) {
-      blocks.push(`### ${name}\n\n- checkout path not found (configured: ${p.path ?? "none"})\n`);
+      blocks.push(`### ${name}\n\n- checkout path not found (configured: ${cfgPath ?? "none"})\n`);
       continue;
     }
     if (!hasRemote(path, "upstream", opts.runGit)) {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -809,4 +809,26 @@ cluster:
     process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
     expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
   });
+
+  // gh-ludics-579 (review round 3): a present-but-blank map entry (YAML
+  // `minipc-wsl:` → null) is NOT a match — precedence continues to the OS key.
+  test("blank map entry is not a match — precedence falls through to the OS key", () => {
+    writeClusterConfig({ "minipc-wsl": "", linux: "~/ocaml-cudajit" });
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
+  });
+
+  // The reviewer's silent-wrong-root case: a map whose only candidate entry is
+  // blank must THROW (map-miss), not match "" and fall back to ~/<repoTail>.
+  // Mutation: a `!== undefined` (instead of non-empty-string) match returns ""
+  // → resolveProjectPath's `if (selected)` is falsy → returns "~/ocaml-cudajit",
+  // failing the .toThrow below.
+  test("map whose only matching entry is blank throws (no silent ~/<repoTail>)", () => {
+    writeClusterConfig({ "minipc-wsl": "" }); // present but blank, no OS key
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(() => resolveProjectPath("cudajit", "minipc-wsl")).toThrow(ProjectPathMapMissError);
+    // Direct unit form: empty-string and null entries are both non-matches.
+    expect(projectConfigPath({ name: "q", repo: "o/q", path: { "minipc-wsl": "" } }, "minipc-wsl")).toBeUndefined();
+    expect(projectConfigPath({ name: "q", repo: "o/q", path: { "minipc-wsl": null } } as unknown as ProjectConfig, "minipc-wsl")).toBeUndefined();
+  });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,6 +10,8 @@ import {
   resolveProjectPath,
   projectConfigPath,
   ProjectPathMapMissError,
+  findProjectConfigByName,
+  loadConfigSync,
   type ProjectConfig,
 } from "./config.ts";
 
@@ -729,5 +731,82 @@ ${pathBlock}cluster:
     expect(projectConfigPath({ name: "z", repo: "o/z", path: { linux: "~/l" } }, "minipc-wsl")).toBe("~/l"); // os key
     expect(projectConfigPath({ name: "w", repo: "o/w", path: { macos: "~/mac" } }, "minipc-wsl")).toBeUndefined(); // miss
     expect(projectConfigPath({ name: "n", repo: "o/n" })).toBeUndefined(); // no path
+  });
+
+  // gh-ludics-579 (review round 2): YAML produces `null` for a blank `path:`,
+  // and loadConfigSync() casts rather than validates. projectConfigPath must
+  // treat null / non-string / non-plain-object as "no path" (the former
+  // `if (p.path)` falsy semantics) instead of indexing into it and crashing.
+  test("projectConfigPath tolerates null / non-map runtime path values (no crash)", () => {
+    writeClusterConfig(undefined);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    // The exact reviewer-reported crash case: path === null must NOT throw.
+    expect(projectConfigPath({ name: "a", repo: "o/a", path: null } as unknown as ProjectConfig)).toBeUndefined();
+    expect(projectConfigPath({ name: "b", repo: "o/b", path: 42 } as unknown as ProjectConfig)).toBeUndefined();
+    expect(projectConfigPath({ name: "c", repo: "o/c", path: [] } as unknown as ProjectConfig)).toBeUndefined();
+  });
+
+  // Round-trip from YAML (the real external surface): a project with a blank
+  // `path:` loads as { path: null }; projectConfigPath returns undefined and
+  // resolveProjectPath falls through exactly like an absent path — no crash for
+  // best-effort consumers. Mutation: removing the isPlainObject guard makes
+  // projectConfigPath throw "null is not an object" here.
+  test("blank YAML path: round-trips as absent (null) without crashing consumers", () => {
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: blankpath
+    repo: owner/blankrepo
+    path:
+  - name: strpath
+    repo: owner/strrepo
+    path: ~/strrepo
+`);
+    const cfg = loadConfigSync();
+    const blank = findProjectConfigByName("blankpath", cfg)!;
+    const str = findProjectConfigByName("strpath", cfg)!;
+    // Sanity: blank path really parsed as a non-string falsy (null), not "".
+    expect(typeof blank.path === "string").toBe(false);
+    // Helper treats it as absent.
+    expect(projectConfigPath(blank)).toBeUndefined();
+    expect(projectConfigPath(str)).toBe("~/strrepo");
+    // resolveProjectPath: blank behaves like absent (local → "" since no dir
+    // exists; never throws). String path resolves through the normal branch.
+    expect(() => resolveProjectPath("blankpath")).not.toThrow();
+    expect(resolveProjectPath("blankpath")).toBe("");
+  });
+
+  // And a null path on a REMOTE dispatch returns the conventional ~/<repoTail>
+  // (unexpanded) rather than crashing or returning "".
+  test("null path on a remote destination yields conventional ~/<repoTail>", () => {
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: cudajit
+    repo: lukstafi/ocaml-cudajit
+    path:
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: mac-studio
+      host: mac-studio.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: nvidia
+`);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import {
   postponedProjectSet,
@@ -7,6 +7,10 @@ import {
   _resetPostponedProjectsCache,
   _resetPriorityProjectsCache,
   _peekPriorityProjectsCache,
+  resolveProjectPath,
+  projectConfigPath,
+  ProjectPathMapMissError,
+  type ProjectConfig,
 } from "./config.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-config");
@@ -609,5 +613,121 @@ projects:
 `);
     const proj = findProjectConfig("/nonexistent/ocannl-staging-task-71e28eb1-s1", loadConfigSync());
     expect(proj?.name).toBe("ocannl");
+  });
+});
+
+// gh-ludics-579: destination-aware project path resolution.
+describe("resolveProjectPath / projectConfigPath — destination-aware (gh-ludics-579)", () => {
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  /** Write a config with a 2-machine cluster (mac-studio/macos leader,
+   *  minipc-wsl/linux worker) and the given project `path` value. */
+  function writeClusterConfig(cudajitPath: string | Record<string, string> | undefined): void {
+    const pathBlock = cudajitPath === undefined
+      ? ""
+      : typeof cudajitPath === "string"
+        ? `    path: ${cudajitPath}\n`
+        : `    path:\n${Object.entries(cudajitPath).map(([k, v]) => `      ${k}: ${v}`).join("\n")}\n`;
+    writeFileSync(process.env.LUDICS_CONFIG!, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+projects:
+  - name: cudajit
+    repo: lukstafi/ocaml-cudajit
+${pathBlock}cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: mac-studio
+      host: mac-studio.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: nvidia
+`);
+  }
+
+  afterEach(() => {
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+  });
+
+  // AC1: controller (mac-studio) resolving for the remote worker ships the
+  // ~/-relative path UNEXPANDED — not /Users/... — so the worker can expand it
+  // against /home. The assertion that would fail if the controller pre-expanded
+  // against its own $HOME (the bug) is `.toBe("~/ocaml-cudajit")`.
+  test("remote dispatch ships the ~/-relative path unexpanded (AC1)", () => {
+    writeClusterConfig("~/ocaml-cudajit");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // we are the controller
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
+  });
+
+  // AC3: the remote branch must NOT existsSync-gate against the controller's
+  // disk. `~/ocaml-cudajit` does not exist under the test $HOME, yet it must
+  // still be returned. A reintroduced existsSync gate would fall through to the
+  // local fallbacks and NOT return the literal "~/ocaml-cudajit".
+  test("remote resolution skips the local existsSync gate (AC3)", () => {
+    writeClusterConfig("~/ocaml-cudajit");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    // Harness condition: HOME=TMP, and TMP/ocaml-cudajit does NOT exist.
+    expect(existsSync(join(process.env.HOME!, "ocaml-cudajit"))).toBe(false);
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
+  });
+
+  // Local resolution unchanged: expand ~/ against local $HOME and existsSync-gate.
+  test("local resolution still expands and existsSync-gates", () => {
+    writeClusterConfig("~/ocaml-cudajit");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    const dir = join(process.env.HOME!, "ocaml-cudajit");
+    mkdirSync(dir, { recursive: true });
+    // No machine arg → local; same node (mac-studio) → also local.
+    expect(resolveProjectPath("cudajit")).toBe(dir);
+    expect(resolveProjectPath("cudajit", "mac-studio")).toBe(dir);
+  });
+
+  // Map: machine-name key wins over OS key (precedence).
+  test("path map selects machine-name key over OS key", () => {
+    writeClusterConfig({ "minipc-wsl": "~/by-machine", linux: "~/by-os", macos: "~/mac" });
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/by-machine");
+  });
+
+  // Map: OS key resolves for any machine of that OS when no machine-name key.
+  test("path map falls back to OS key when no machine-name key", () => {
+    writeClusterConfig({ linux: "~/ocaml-cudajit", macos: "~/mac" });
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(resolveProjectPath("cudajit", "minipc-wsl")).toBe("~/ocaml-cudajit");
+  });
+
+  // Map-miss → hard error (NOT "" which would fall through to the wrong root).
+  test("path map with no matching machine/OS key throws ProjectPathMapMissError", () => {
+    writeClusterConfig({ macos: "~/mac-only" }); // no linux / minipc-wsl entry
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    expect(() => resolveProjectPath("cudajit", "minipc-wsl")).toThrow(ProjectPathMapMissError);
+    expect(() => resolveProjectPath("cudajit", "minipc-wsl")).toThrow(/no entry for machine/);
+  });
+
+  // projectConfigPath unit selection (string passthrough + undefined on miss).
+  test("projectConfigPath: string passthrough and map selection", () => {
+    writeClusterConfig(undefined);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    const strProj: ProjectConfig = { name: "x", repo: "o/x", path: "~/x" };
+    expect(projectConfigPath(strProj)).toBe("~/x");
+
+    const mapProj: ProjectConfig = {
+      name: "y", repo: "o/y",
+      path: { "minipc-wsl": "~/m", linux: "~/l", macos: "~/mac" },
+    };
+    expect(projectConfigPath(mapProj, "minipc-wsl")).toBe("~/m");     // machine key
+    expect(projectConfigPath({ name: "z", repo: "o/z", path: { linux: "~/l" } }, "minipc-wsl")).toBe("~/l"); // os key
+    expect(projectConfigPath({ name: "w", repo: "o/w", path: { macos: "~/mac" } }, "minipc-wsl")).toBeUndefined(); // miss
+    expect(projectConfigPath({ name: "n", repo: "o/n" })).toBeUndefined(); // no path
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -352,9 +352,16 @@ function currentOsId(): string {
  * branch touches cluster, so plain-string configs never do.
  */
 export function projectConfigPath(p: ProjectConfig, machine?: string): string | undefined {
-  const raw = p.path;
-  if (raw === undefined) return undefined;
+  const raw = p.path as unknown;
   if (typeof raw === "string") return raw;
+  // Tolerate runtime values the static type forbids but YAML produces: a blank
+  // `path:` parses to `null`, and loadConfigSync() casts parsed YAML rather than
+  // validating it. Treat null / non-string / non-plain-object as "no path" —
+  // matching the former `if (p.path)` falsy semantics — so best-effort consumers
+  // (findProjectConfig / init / staging-ff / briefing-lag) never crash indexing
+  // into a non-object. Only a genuine map reaches the selection below.
+  if (!isPlainObject(raw)) return undefined;
+  const map = raw as Record<string, string>;
   // Map form: resolve target machine name + OS.
   let targetName = machine;
   let targetOs: string | undefined;
@@ -365,8 +372,8 @@ export function projectConfigPath(p: ProjectConfig, machine?: string): string | 
     targetOs = machine ? cluster.clusterMachine(machine)?.os : cluster.clusterCurrentMachine()?.os;
   } catch { /* cluster unavailable — fall back to platform OS below */ }
   if (!targetOs) targetOs = machine ? undefined : currentOsId();
-  if (targetName && raw[targetName] !== undefined) return raw[targetName];
-  if (targetOs && raw[targetOs] !== undefined) return raw[targetOs];
+  if (targetName && map[targetName] !== undefined) return map[targetName];
+  if (targetOs && map[targetOs] !== undefined) return map[targetOs];
   return undefined;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -372,9 +372,17 @@ export function projectConfigPath(p: ProjectConfig, machine?: string): string | 
     targetOs = machine ? cluster.clusterMachine(machine)?.os : cluster.clusterCurrentMachine()?.os;
   } catch { /* cluster unavailable — fall back to platform OS below */ }
   if (!targetOs) targetOs = machine ? undefined : currentOsId();
-  if (targetName && map[targetName] !== undefined) return map[targetName];
-  if (targetOs && map[targetOs] !== undefined) return map[targetOs];
-  return undefined;
+  // Only a non-empty STRING entry counts as a match. A blank/non-string entry
+  // (YAML `linux:` parses to null) must NOT match — otherwise resolveProjectPath
+  // would skip the ProjectPathMapMissError and silently fall back to ~/<repoTail>,
+  // dispatching to the wrong root. Treat it as a miss so precedence continues to
+  // the OS key, and an all-blank map ultimately throws.
+  const pick = (key?: string): string | undefined => {
+    if (!key) return undefined;
+    const v = map[key];
+    return typeof v === "string" && v !== "" ? v : undefined;
+  };
+  return pick(targetName) ?? pick(targetOs);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,18 @@ export interface ProjectConfig {
    *  outbound when `outbound_sync_enabled` is true). PR creation targets `repo`
    *  (the working/staging fork). */
   upstream_repo?: string;
-  path?: string;
+  /**
+   * Local checkout path for the project. Either:
+   * - a plain string (back-compat; `~/`-relative is expanded against the
+   *   resolving machine's `$HOME`), or
+   * - a map keyed by cluster machine name (e.g. `mac-studio`) or OS identifier
+   *   (`macos` / `linux`, matching `cluster.machines[].os` — NOT `darwin`),
+   *   selected most-specific-first (machine name → OS). Use the map only when
+   *   the cluster spans genuinely divergent roots that the `~/`-relative
+   *   convention cannot bridge (e.g. macOS `/Users` vs Linux `/home`).
+   * Resolved via {@link projectConfigPath} / {@link resolveProjectPath}.
+   */
+  path?: string | Record<string, string>;
   issues?: boolean;
   priority?: boolean;
   /** When true, tasks from this project are excluded from the ready queue,
@@ -310,6 +321,56 @@ export function globalAdapter(): GlobalAdapterMode {
 }
 
 /**
+ * Thrown when a project's `path` is a machine/OS map but no entry matches the
+ * resolution target. A hard error (rather than an empty string) so a
+ * misconfigured map cannot silently fall through to the empty-path fallback
+ * chain (`makeAdapterContext` local re-resolve / `resolveProjectDir` →
+ * `process.cwd()`) and dispatch a slot against the wrong root.
+ */
+export class ProjectPathMapMissError extends Error {}
+
+/** Map `process.platform` to the config's OS vocabulary (`macos` / `linux`). */
+function currentOsId(): string {
+  return process.platform === "darwin" ? "macos" : "linux";
+}
+
+/**
+ * Select the configured checkout path string for a project, honoring the
+ * `string | Record<string,string>` schema. Returns the **unexpanded** string
+ * (a leading `~/` is left for the resolving machine to expand against its own
+ * `$HOME`).
+ *
+ * For a map, selects most-specific-first: machine name → that machine's OS →
+ * `undefined`. `machine` defaults to the local cluster machine name; the OS
+ * defaults to the local platform. Returns `undefined` when no `path` is
+ * configured or (for a map) no key matches — callers that are dispatch
+ * authorities translate the map-miss into a thrown {@link ProjectPathMapMissError};
+ * best-effort/display callers treat `undefined` as "no path".
+ *
+ * Cluster lookups are done via a lazy `require("./cluster.ts")` (cluster.ts
+ * imports this module, so a static import would create a cycle); only the map
+ * branch touches cluster, so plain-string configs never do.
+ */
+export function projectConfigPath(p: ProjectConfig, machine?: string): string | undefined {
+  const raw = p.path;
+  if (raw === undefined) return undefined;
+  if (typeof raw === "string") return raw;
+  // Map form: resolve target machine name + OS.
+  let targetName = machine;
+  let targetOs: string | undefined;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- cluster.ts imports config.ts; lazy require breaks the cycle
+    const cluster = require("./cluster.ts") as typeof import("./cluster.ts");
+    if (!targetName) targetName = cluster.clusterCurrentMachineName() ?? undefined;
+    targetOs = machine ? cluster.clusterMachine(machine)?.os : cluster.clusterCurrentMachine()?.os;
+  } catch { /* cluster unavailable — fall back to platform OS below */ }
+  if (!targetOs) targetOs = machine ? undefined : currentOsId();
+  if (targetName && raw[targetName] !== undefined) return raw[targetName];
+  if (targetOs && raw[targetOs] !== undefined) return raw[targetOs];
+  return undefined;
+}
+
+/**
  * Find the ProjectConfig entry matching a given project directory.
  * Match semantics, tried in order against each configured project's `path`:
  * - Exact match against the configured path (with `~/` expansion).
@@ -331,10 +392,14 @@ export function findProjectConfig(
   const cfg = config ?? loadConfigSync();
   const normalized = projectDir.replace(/\/+$/, "");
   return (cfg.projects ?? []).find((p) => {
-    if (p.path) {
-      const expanded = (String(p.path).startsWith("~/")
-        ? join(process.env.HOME ?? "~", String(p.path).slice(2))
-        : String(p.path)).replace(/\/+$/, "");
+    // Best-effort reverse lookup: a map-miss yields `undefined` and simply
+    // falls through to the name/repo-tail match below (no throw — this is not
+    // a dispatch authority).
+    const cfgPath = projectConfigPath(p);
+    if (cfgPath) {
+      const expanded = (cfgPath.startsWith("~/")
+        ? join(process.env.HOME ?? "~", cfgPath.slice(2))
+        : cfgPath).replace(/\/+$/, "");
       if (normalized === expanded || normalized.startsWith(expanded + "/")) return true;
       // Orchestration worktree sibling: same parent, basename prefixed with
       // the configured project's basename + "-". The "-" separator anchors
@@ -494,12 +559,41 @@ export function t3codeIntegrationEnabled(): boolean {
 }
 
 /**
- * Resolve the local checkout path for a project by name.
- * Checks the `path` field in config, then falls back to ~/name and ~/repos/name.
+ * Resolve the checkout path for a project by name.
+ *
+ * Local resolution (no `machine`, or `machine` == this node, or no cluster):
+ * checks the `path` field in config, then falls back to ~/name and ~/repos/name,
+ * existsSync-gating each candidate against the local disk.
+ *
+ * Remote resolution (controller resolving for a non-local destination
+ * `machine`): selects the destination's `path` (machine/OS map entry or the
+ * plain string) and returns it **unexpanded** — a leading `~/` is left for the
+ * worker to expand against its own `$HOME` — and **without** existsSync gating,
+ * since the controller cannot see the worker's disk (gh-ludics-579 AC3). The
+ * worker-side `createWorktrees` guard owns the actual checkout-existence check.
+ *
+ * @throws {ProjectPathMapMissError} when the matched project's `path` is a
+ *   machine/OS map with no entry for the resolution target — a hard error so a
+ *   misconfigured map cannot silently fall through to a wrong-root fallback.
  */
-export function resolveProjectPath(projectName: string): string {
+export function resolveProjectPath(projectName: string, machine?: string): string {
   const config = loadConfigSync();
   const projects = config.projects ?? [];
+
+  // A `machine` denotes a *remote* destination only when cluster is enabled and
+  // we can resolve the current node's name. Standalone / no-cluster / same-node
+  // → local resolution (the `machine` arg is a no-op), preserving every existing
+  // single-box and local caller's behaviour.
+  let isRemote = false;
+  if (machine) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- cluster.ts imports config.ts; lazy require breaks the cycle
+      const cluster = require("./cluster.ts") as typeof import("./cluster.ts");
+      const current = cluster.clusterCurrentMachineName();
+      isRemote = !!current && machine !== current;
+    } catch { isRemote = false; }
+  }
+
   for (const p of projects) {
     const name = String(p.name ?? "").toLowerCase();
     const repo = String(p.repo ?? "");
@@ -508,10 +602,28 @@ export function resolveProjectPath(projectName: string): string {
       name === projectName.toLowerCase()
       || repoTail.toLowerCase() === projectName.toLowerCase()
     ) {
-      if (p.path) {
-        const resolved = String(p.path).startsWith("~/")
-          ? join(process.env.HOME ?? "~", String(p.path).slice(2))
-          : String(p.path);
+      const selected = projectConfigPath(p, machine);
+      // Map present but no machine/OS key matched → loud config error rather
+      // than an empty path that would fall through to the wrong root.
+      if (selected === undefined && isPlainObject(p.path)) {
+        throw new ProjectPathMapMissError(
+          `project "${projectName}" has a path map with no entry for machine ` +
+          `"${machine ?? "<local>"}" or its OS — add a machine- or OS-keyed entry to projects[].path`,
+        );
+      }
+
+      if (isRemote) {
+        // Ship unexpanded, no existsSync (controller can't see the worker disk).
+        if (selected) return selected;
+        // No `path` configured → conventional ~/<repoTail> (worker expands).
+        return repoTail ? `~/${repoTail}` : (projectName ? `~/${projectName}` : "");
+      }
+
+      // Local resolution (unchanged semantics).
+      if (selected) {
+        const resolved = selected.startsWith("~/")
+          ? join(process.env.HOME ?? "~", selected.slice(2))
+          : selected;
         if (existsSync(resolved)) return resolved;
       }
       // repo is the working repo directly; try upstream_repo tail as fallback
@@ -532,7 +644,10 @@ export function resolveProjectPath(projectName: string): string {
       }
     }
   }
-  // Last resort: try ~/projectName
+  // No project config matched. For a remote destination, return the conventional
+  // ~/<projectName> unexpanded (no local existsSync — AC3).
+  if (isRemote) return projectName ? `~/${projectName}` : "";
+  // Last resort (local): try ~/projectName
   const home = process.env.HOME ?? "~";
   for (const candidate of [
     join(home, projectName),

--- a/src/init.ts
+++ b/src/init.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, readlinkSync, writeFileSync, mkdirSync, copyF
 import { join, dirname } from "path";
 import YAML from "yaml";
 import { safeSyncOutput } from "./spawn.ts";
-import { ludicsRoot, pointerConfigPath, loadConfigSync, slotsCount } from "./config.ts";
+import { ludicsRoot, pointerConfigPath, loadConfigSync, slotsCount, projectConfigPath } from "./config.ts";
 import { dashboardInstall, dashboardStop } from "./dashboard.ts";
 import { writeSlotJson, emptySlotData } from "./slots/json.ts";
 import { triggersInstall } from "./triggers.ts";
@@ -27,14 +27,15 @@ function validateProjectPaths(): void {
   for (const p of config.projects ?? []) {
     const repo = String(p.repo ?? "");
     const upstreamRepo = String(p.upstream_repo ?? "");
-    if (!upstreamRepo || upstreamRepo === repo || !p.path) continue;
+    const cfgPath = projectConfigPath(p);
+    if (!upstreamRepo || upstreamRepo === repo || !cfgPath) continue;
 
     const repoTail = repo.split("/").pop() ?? "";
     const upstreamTail = upstreamRepo.split("/").pop() ?? "";
     // When both repos share the same tail (e.g. lukstafi/ocannl vs ahrefs/ocannl),
     // path-tail comparison cannot distinguish them — skip the heuristic.
     if (repoTail === upstreamTail) continue;
-    const pathStr = String(p.path);
+    const pathStr = cfgPath;
     // Check if path ends with upstream repo tail — likely misconfigured
     const pathTail = pathStr.replace(/\/+$/, "").split("/").pop() ?? "";
     if (pathTail === upstreamTail) {

--- a/src/mag-remote-dispatch-path.test.ts
+++ b/src/mag-remote-dispatch-path.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { maybeFillEmptySlots } from "./mag.ts";
+import { heartbeatsDir } from "./cluster.ts";
+
+// gh-ludics-579: the controller must resolve a slot's project path FOR the
+// destination machine at dispatch (maybeFillEmptySlots) — shipping a
+// ~/-relative (or map-selected) path the worker expands against its own $HOME,
+// never the controller's locally-expanded absolute path. A map-miss throws and
+// assigns no slot rather than dispatching an empty/wrong path.
+
+let TMP = "";
+const ORIGINAL = {
+  HOME: process.env.HOME,
+  CONFIG: process.env.LUDICS_CONFIG,
+  HARNESS: process.env.LUDICS_HARNESS_DIR,
+  MACHINE: process.env.LUDICS_CLUSTER_MACHINE_NAME,
+};
+
+/** Write config.yaml: tmux orchestration (codex coder/reviewer → no model_classes
+ *  needed), autonomy auto, a 2-machine cluster (mac-studio/macos leader [us],
+ *  minipc-wsl/linux worker with nvidia gpu), and a cudajit project whose `path`
+ *  is the given value, requiring an nvidia gpu (routes to minipc-wsl). */
+function writeConfig(cudajitPath: string | Record<string, string>): void {
+  const pathBlock = typeof cudajitPath === "string"
+    ? `    path: ${cudajitPath}\n`
+    : `    path:\n${Object.entries(cudajitPath).map(([k, v]) => `      ${k}: ${v}`).join("\n")}\n`;
+  const configPath = join(TMP, "config.yaml");
+  writeFileSync(configPath, `state_repo: test/state
+state_path: harness
+adapter: tmux
+slots:
+  count: 2
+projects:
+  - name: cudajit
+    repo: lukstafi/ocaml-cudajit
+${pathBlock}    requirements:
+      gpu: nvidia
+mag:
+  autonomy_level:
+    start_sessions: auto
+  orchestration:
+    default_coder: codex
+    default_reviewer: codex
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: mac-studio
+      host: mac-studio.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: nvidia
+`);
+  process.env.LUDICS_CONFIG = configPath;
+}
+
+/** Publish a fresh heartbeat for `node` so selectMachineForSlot treats it as
+ *  online (required for requirement-routed assignment). */
+function writeFreshHeartbeat(node: string): void {
+  const dir = heartbeatsDir();
+  mkdirSync(dir, { recursive: true });
+  const epoch = Math.floor(Date.now() / 1000);
+  writeFileSync(join(dir, `${node}.json`), JSON.stringify({ node, role: "worker", epoch, mag_running: true }));
+}
+
+function writeReadyTask(): void {
+  const tasksDir = join(TMP, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(
+    join(tasksDir, "task-cudajit-remote.md"),
+    `---\nid: task-cudajit-remote\ntitle: CUDA remote\nproject: cudajit\n`
+      + `status: ready\npriority: B\neffort: medium\nelaborated: 2026-05-01\n`
+      + `proposal: docs/proposals/x.md\ndependencies:\n  blocks: []\n  blocked_by: []\n`
+      + `  relates_to: []\n  subtask_of: null\ncontext: cudajit\nuses_browser: false\n`
+      + `created: 2026-05-01\nsource: manual\n---\n# task-cudajit-remote\n`,
+  );
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-mag-remote-path-"));
+  process.env.HOME = TMP;
+  process.env.LUDICS_HARNESS_DIR = TMP;
+  mkdirSync(join(TMP, "slots"), { recursive: true });
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(ORIGINAL)) {
+    const key = k === "HOME" ? "HOME" : k === "CONFIG" ? "LUDICS_CONFIG" : k === "HARNESS" ? "LUDICS_HARNESS_DIR" : "LUDICS_CLUSTER_MACHINE_NAME";
+    if (v === undefined) delete process.env[key];
+    else process.env[key] = v;
+  }
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("maybeFillEmptySlots — destination-aware path resolution (gh-ludics-579)", () => {
+  // AC1: dispatching cudajit (controller mac-studio) to the nvidia worker
+  // minipc-wsl stores the UNEXPANDED ~/ocaml-cudajit on the slot — not the
+  // controller's /Users/... — so the worker expands it against /home. The
+  // assertion `slot.path === "~/ocaml-cudajit"` would fail under the bug
+  // (controller pre-expanding against its own $HOME) or if selectMachineForSlot
+  // ran after resolveProjectPath (machine unknown at resolve time).
+  test("remote assignment stores the ~/-relative path unexpanded (AC1)", async () => {
+    writeConfig("~/ocaml-cudajit");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    writeFreshHeartbeat("minipc-wsl");
+    writeReadyTask();
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await maybeFillEmptySlots();
+    } finally {
+      errSpy.mockRestore();
+    }
+    const slotFile = join(TMP, "slots", "slot-1.json");
+    expect(existsSync(slotFile)).toBe(true);
+    const slot = JSON.parse(readFileSync(slotFile, "utf-8")) as { path: string; machine: string; task: string };
+    expect(slot.machine).toBe("minipc-wsl");
+    expect(slot.task).toBe("task-cudajit-remote");
+    // The crux: path shipped unexpanded for the worker to resolve locally.
+    expect(slot.path).toBe("~/ocaml-cudajit");
+    expect(slot.path.startsWith("/Users/")).toBe(false);
+  });
+
+  // Map-miss (rev 2): a path map missing the worker's machine/OS key throws
+  // ProjectPathMapMissError at resolution; the dispatch catch logs and assigns
+  // NO slot — rather than returning "" which would silently fall through to the
+  // wrong root. Mutation: returning "" instead of throwing would write a slot
+  // file (assertion `not exist` fails).
+  test("path map missing the worker's machine/OS assigns no slot and logs the config error", async () => {
+    writeConfig({ macos: "~/ocaml-cudajit" }); // no linux / minipc-wsl entry
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    writeFreshHeartbeat("minipc-wsl");
+    writeReadyTask();
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    let calls: string[] = [];
+    try {
+      await maybeFillEmptySlots();
+      calls = errSpy.mock.calls.map((c) => String(c[0]));
+    } finally {
+      errSpy.mockRestore();
+    }
+    // No slot assigned.
+    expect(existsSync(join(TMP, "slots", "slot-1.json"))).toBe(false);
+    expect(readdirSync(join(TMP, "slots"))).toEqual([]);
+    // And the config error was surfaced (loud, retryable next tick).
+    expect(calls.some((l) => l.includes("no entry for machine"))).toBe(true);
+  });
+});

--- a/src/mag-remote-dispatch-path.test.ts
+++ b/src/mag-remote-dispatch-path.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { maybeFillEmptySlots } from "./mag.ts";
+import { maybeFillEmptySlots, launchSessionFromNotification } from "./mag.ts";
 import { heartbeatsDir } from "./cluster.ts";
 
 // gh-ludics-579: the controller must resolve a slot's project path FOR the
@@ -153,5 +153,72 @@ describe("maybeFillEmptySlots — destination-aware path resolution (gh-ludics-5
     expect(readdirSync(join(TMP, "slots"))).toEqual([]);
     // And the config error was surfaced (loud, retryable next tick).
     expect(calls.some((l) => l.includes("no entry for machine"))).toBe(true);
+  });
+});
+
+// gh-ludics-579 (review round 3): the notification/dashboard launch path
+// (launchSessionFromNotification) is a SECOND dispatch site with the same bug —
+// it must resolve the project path FOR the destination machine, after machine
+// selection, not via the controller-local resolveTaskProjectPath.
+describe("launchSessionFromNotification — destination-aware path (gh-ludics-579)", () => {
+  /** t3code-enabled config (launchSessionFromNotification hardcodes adapter t3code),
+   *  controller mac-studio + nvidia worker minipc-wsl, cudajit requires nvidia gpu. */
+  function writeLaunchConfig(): void {
+    const configPath = join(TMP, "config.yaml");
+    writeFileSync(configPath, `state_repo: test/state
+state_path: harness
+adapter: tmux
+slots:
+  count: 2
+projects:
+  - name: cudajit
+    repo: lukstafi/ocaml-cudajit
+    path: ~/ocaml-cudajit
+    requirements:
+      gpu: nvidia
+mag:
+  t3code_integration_enabled: true
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: mac-studio
+      host: mac-studio.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: nvidia
+`);
+    process.env.LUDICS_CONFIG = configPath;
+  }
+
+  // Invariant: the slot stamped for the remote worker carries the UNEXPANDED
+  // ~/ocaml-cudajit, not the controller's /Users/.... slotStart short-circuits
+  // to a recorded intent for a remote machine, so slotAssign's persisted path is
+  // observable. Fails under the bug (path resolved via resolveTaskProjectPath
+  // before machine selection → controller-local /Users/... or "").
+  test("notification launch to a remote worker stores the ~/-relative path unexpanded", async () => {
+    writeLaunchConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // controller
+    writeFreshHeartbeat("minipc-wsl");
+    writeReadyTask(); // task-cudajit-remote, project cudajit
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await launchSessionFromNotification("task-cudajit-remote");
+    } finally {
+      errSpy.mockRestore();
+    }
+    const slotFile = join(TMP, "slots", "slot-1.json");
+    expect(existsSync(slotFile)).toBe(true);
+    const slot = JSON.parse(readFileSync(slotFile, "utf-8")) as { path: string; machine: string };
+    expect(slot.machine).toBe("minipc-wsl");
+    expect(slot.path).toBe("~/ocaml-cudajit");
+    expect(slot.path.startsWith("/Users/")).toBe(false);
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -2,7 +2,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, renameSync, statSync, unlinkSync } from "fs";
 import { dirname, join } from "path";
-import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, effectivePriorityValue, milestonesEnabledProjects, resolveProjectPath, postponedProjectSet, findProjectConfigByName, t3codeIntegrationEnabled, type LudicsFullConfig } from "./config.ts";
+import { harnessDir, loadConfigSync, startSessionsAutonomy, slotsCount, effectivePriorityValue, milestonesEnabledProjects, resolveProjectPath, projectConfigPath, postponedProjectSet, findProjectConfigByName, t3codeIntegrationEnabled, ProjectPathMapMissError, type LudicsFullConfig } from "./config.ts";
 import { formatUpstreamLagSection } from "./briefing-lag.ts";
 import { defaultRunGit, type RunGit } from "./git-runner.ts";
 import { clearSentinel, readSentinelEpoch, sentinelExists, sentinelFresh, touchSentinel } from "./sentinel.ts";
@@ -2743,8 +2743,9 @@ export function computeTaskLastActivityEpoch(taskId: string): number | null {
       const projectName = String(fm.project ?? "");
       if (projectName) {
         const proj = findProjectConfigByName(projectName);
-        const projPath = proj?.path
-          ? (proj.path.startsWith("~/") ? join(process.env.HOME ?? "~", proj.path.slice(2)) : proj.path)
+        const projCfgPath = proj ? projectConfigPath(proj) : undefined;
+        const projPath = projCfgPath
+          ? (projCfgPath.startsWith("~/") ? join(process.env.HOME ?? "~", projCfgPath.slice(2)) : projCfgPath)
           : null;
         if (projPath && existsSync(projPath)) {
           const r = Bun.spawnSync(["git", "log", "-1", "--format=%ct", "HEAD"], { cwd: projPath });
@@ -3342,11 +3343,24 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
     const slotA = emptySlots[0]!;
     const slotB = emptySlots[1]!;
     const expansion = expandDuoSlots(slotA, slotB, autoArgs);
-    const projectPath = resolveProjectPath(task.project);
+    // Select the destination machine BEFORE resolving the path so the path is
+    // resolved for that machine (gh-ludics-579): a `~/`-relative or map-selected
+    // path is shipped for the worker to expand against its own $HOME, never the
+    // controller's locally-expanded absolute path.
     const machine = selectMachineForSlot({ project: task.project, effort: task.effort, requirements: task.requirements });
     if (machine === null) {
       console.error(`ludics: no machine meets requirements for ${task.id} — skipping`);
       return;
+    }
+    let projectPath: string;
+    try {
+      projectPath = resolveProjectPath(task.project, machine);
+    } catch (e) {
+      if (e instanceof ProjectPathMapMissError) {
+        console.error(`ludics: ${task.id}: ${e.message} — skipping`);
+        return;
+      }
+      throw e;
     }
 
     await slotAssign(slotA, task.id, autoAdapter, "", projectPath, expansion.slotA.args, machine);
@@ -3367,14 +3381,25 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
   } else {
     const slot = emptySlots[0]!;
 
-    // Resolve project path from config
-    const projectPath = resolveProjectPath(task.project);
-
-    // Select machine for slot assignment (cluster-aware)
+    // Select machine for slot assignment (cluster-aware) BEFORE resolving the
+    // path, so the path is resolved for the destination machine (gh-ludics-579).
     const machine = selectMachineForSlot({ project: task.project, effort: task.effort, requirements: task.requirements });
     if (machine === null) {
       console.error(`ludics: no machine meets requirements for ${task.id} — skipping`);
       return;
+    }
+
+    // Resolve project path from config FOR the destination machine. A map-miss
+    // throws ProjectPathMapMissError → skip (no slot assigned), retried next tick.
+    let projectPath: string;
+    try {
+      projectPath = resolveProjectPath(task.project, machine);
+    } catch (e) {
+      if (e instanceof ProjectPathMapMissError) {
+        console.error(`ludics: ${task.id}: ${e.message} — skipping`);
+        return;
+      }
+      throw e;
     }
 
     // Assign task to the empty slot using the auto-selected adapter, path, and flags

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -1475,7 +1475,8 @@ export function evaluateAutoStartDecisionPure(
 }
 
 
-async function launchSessionFromNotification(taskId: string, adapterArgs: string = ""): Promise<void> {
+/** @internal exported for tests (gh-ludics-579 notification-launch path resolution) */
+export async function launchSessionFromNotification(taskId: string, adapterArgs: string = ""): Promise<void> {
   const adapter = "t3code";
   const launchArgs = adapterArgs.trim();
   const selection = selectSlotForLaunch(taskId);
@@ -1508,17 +1509,21 @@ async function launchSessionFromNotification(taskId: string, adapterArgs: string
   }
 
   const slotNum = selection.taskSlot ?? selection.emptySlot!;
-  const path = selection.existingPath || resolveTaskProjectPath(taskId);
 
-  // Resolve merged requirements for machine selection
+  // gh-ludics-579: resolve the destination machine FIRST, then resolve the
+  // project path FOR that machine. Shipping a controller-local /Users/... path
+  // to a Linux worker is the worktree-ENOENT bug this task fixes (same class as
+  // the keepalive maybeFillEmptySlots dispatch).
   const taskFile = join(harnessDir(), "tasks", `${taskId}.md`);
   let launchMachine = "";
+  let launchProject = "";
   if (existsSync(taskFile)) {
     const taskContent = readFileSync(taskFile, "utf-8");
     try {
       const taskFm = parseTaskFrontmatter(taskContent);
       const cfgLaunch = loadConfigSync();
       const projectName = taskFm.project ?? "";
+      launchProject = projectName;
       const projectReqs = findProjectConfigByName(projectName, cfgLaunch)?.requirements;
       const launchReqs = mergeRequirements(taskFm.requirements, projectReqs);
       const machine = selectMachineForSlot({
@@ -1535,6 +1540,27 @@ async function launchSessionFromNotification(taskId: string, adapterArgs: string
       launchMachine = machine;
     } catch {
       // Malformed task file — proceed without requirements (graceful degradation)
+    }
+  }
+
+  // Resolve the project path FOR the destination machine (remote → ~/-relative,
+  // expanded by the worker). Prefer an existing slot path on a re-launch. A
+  // path-map miss surfaces a clear config error and aborts rather than
+  // dispatching to the wrong root.
+  let path = selection.existingPath;
+  if (!path) {
+    try {
+      path = launchProject
+        ? resolveProjectPath(launchProject, launchMachine)
+        : resolveTaskProjectPath(taskId);
+    } catch (e) {
+      if (e instanceof ProjectPathMapMissError) {
+        const msg = `Cannot launch ${taskId}: ${e.message}`;
+        notifyOutgoing(msg, 3, "ludics");
+        console.error(`ludics: ${msg}`);
+        return;
+      }
+      throw e;
     }
   }
 

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1802,3 +1802,45 @@ describe("createWorktrees refreshes main before forking", () => {
     cleanupWorktrees(repo, "feat", [{ name: "agent1" }], 7);
   });
 });
+
+// gh-ludics-579 AC2: fail loudly when the project checkout is absent on the
+// executing machine, BEFORE any git op (defaultMainBranch / git worktree add)
+// faults on the missing cwd with the misleading `posix_spawn 'git'` ENOENT.
+describe("createWorktrees missing-checkout guard (gh-ludics-579 AC2)", () => {
+  beforeEach(() => {
+    mkdirSync(TMP, { recursive: true });
+  });
+
+  // The omitted `mainBranch` arg is load-bearing: it exercises the path that
+  // previously evaluated `defaultMainBranch(projectDir)` as a default parameter
+  // (a git call) BEFORE the body. Reverting to that default-param form would
+  // make this throw the old git/cwd error instead of the explicit message.
+  test("throws explicit 'project checkout not found' for a nonexistent projectDir (no mainBranch arg)", () => {
+    const missing = join(TMP, "does-not-exist-repo");
+    expect(existsSync(missing)).toBe(false);
+    expect(() => createWorktrees(missing, "feat", [{ name: "agent1" }])).toThrow(
+      /project checkout not found on .* at /,
+    );
+    // And it must NOT surface the misleading spawn/cwd error.
+    expect(() => createWorktrees(missing, "feat", [{ name: "agent1" }])).not.toThrow(/posix_spawn/);
+  });
+
+  // Positive control: a REAL repo with the `mainBranch` arg omitted still
+  // resolves the default branch after the guard and creates the worktree.
+  test("real repo with omitted mainBranch resolves the default branch after the guard", () => {
+    if (!Bun.which("git")) return;
+    const repo = join(TMP, "real-repo");
+    mkdirSync(repo, { recursive: true });
+    run(["git", "init", "-b", "main"], repo);
+    run(["git", "config", "user.email", "test@example.com"], repo);
+    run(["git", "config", "user.name", "Test User"], repo);
+    writeFileSync(join(repo, "README.md"), "hello\n");
+    run(["git", "add", "README.md"], repo);
+    run(["git", "commit", "-m", "init"], repo);
+
+    const setup = createWorktrees(repo, "feat", [{ name: "agent1" }], undefined, 9);
+    expect(existsSync(setup.rootWorktree)).toBe(true);
+    expect(existsSync(setup.agentWorktrees.agent1!)).toBe(true);
+    cleanupWorktrees(repo, "feat", [{ name: "agent1" }], 9);
+  });
+});

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -526,16 +526,41 @@ export function createWorktrees(
   projectDir: string,
   taskId: string,
   agents: Array<{ name: string }>,
-  mainBranch: string = defaultMainBranch(projectDir),
+  // gh-ludics-579: NO `= defaultMainBranch(projectDir)` default — default
+  // parameter expressions evaluate before the body, and `defaultMainBranch`
+  // runs git against `projectDir`; with a missing checkout that would surface
+  // the misleading `posix_spawn 'git'` ENOENT *before* the guard below can
+  // throw the clear error. Resolve the branch only AFTER the guard.
+  mainBranch?: string,
   slot?: number,
   mode: "duo" | "pair" | "solo" | "pilot" = "duo",
 ): WorktreeSetup {
+  // gh-ludics-579 AC2: fail loudly with a clear, machine-attributed error when
+  // the project checkout is absent on the executing machine, BEFORE any git op
+  // (defaultMainBranch / refreshMainBranchFromRemote / git worktree add) faults
+  // on a non-existent cwd. Expand a leading `~/` against the local $HOME first
+  // (workers receive `~/`-relative paths the controller did not pre-expand).
+  if (projectDir.startsWith("~/")) projectDir = resolve(process.env.HOME ?? "~", projectDir.slice(2));
+  if (!existsSync(projectDir)) {
+    let machineLabel = "local";
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- avoid a top-level cluster import in this leaf module; only used on the error path
+      machineLabel = (require("../cluster.ts") as typeof import("../cluster.ts")).clusterCurrentMachineName() ?? "local";
+    } catch { /* cluster unavailable — keep "local" */ }
+    throw new Error(`project checkout not found on ${machineLabel} at ${projectDir}`);
+  }
+
+  // Resolve the main branch now that `projectDir` is known to exist (caller
+  // value wins; otherwise probe via git). Identical semantics to the former
+  // default parameter, just sequenced after the existence guard.
+  const resolvedMainBranch = mainBranch ?? defaultMainBranch(projectDir);
+
   // Refresh the project's main branch from origin so new worktrees fork from
   // current upstream rather than whatever the local checkout last pointed at.
   // Best-effort: any reason this can't proceed (no origin, wrong branch
   // checked out, dirty working tree, network failure, or local divergence) is
   // logged and skipped — see refreshMainBranchFromRemote for details.
-  refreshMainBranchFromRemote(projectDir, mainBranch);
+  refreshMainBranchFromRemote(projectDir, resolvedMainBranch);
 
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));
@@ -546,16 +571,16 @@ export function createWorktrees(
     root: orchBranchName(taskId, slot, "root"),
   };
   // Invariant (paired with scope (1) of `proposal-commit-on-main-and-worktree-resume`):
-  // every per-agent and root branch is forked from `mainBranch` (resolved by
-  // `defaultMainBranch(projectDir)` unless the caller passes a different
-  // value). In duo mode the coder and reviewer never share a branch, so the
-  // proposal commit reaches them only if it is already on `mainBranch` at
-  // the moment `addWorktree` runs — which is what the worker-skill edits in
+  // every per-agent and root branch is forked from `resolvedMainBranch`
+  // (the caller's `mainBranch` if supplied, else `defaultMainBranch(projectDir)`).
+  // In duo mode the coder and reviewer never share a branch, so the
+  // proposal commit reaches them only if it is already on `resolvedMainBranch`
+  // at the moment `addWorktree` runs — which is what the worker-skill edits in
   // `skills/ludics-{draft,revise}-proposal-worker.md` step "Commit and push"
-  // guarantee. Do not change the `mainBranch` argument here without also
+  // guarantee. Do not change the branch argument here without also
   // re-validating that the worker still commits the proposal on the same
   // branch.
-  addWorktree(projectDir, rootWorktree, branches.root, mainBranch);
+  addWorktree(projectDir, rootWorktree, branches.root, resolvedMainBranch);
 
   const agentWorktrees: Record<string, string> = {};
   if (mode === "pair" || mode === "solo" || mode === "pilot") {
@@ -567,13 +592,13 @@ export function createWorktrees(
     }
   } else {
     // Duo mode: each agent gets its own worktree and branch.
-    // Each per-agent branch is forked from `mainBranch` (see invariant
+    // Each per-agent branch is forked from `resolvedMainBranch` (see invariant
     // comment on the root `addWorktree` call above).
     for (const agent of agents) {
       const path = join(parentDir, `${stem}-${slugify(agent.name)}`);
       const branch = orchBranchName(taskId, slot, slugify(agent.name));
       branches[agent.name] = branch;
-      addWorktree(projectDir, path, branch, mainBranch);
+      addWorktree(projectDir, path, branch, resolvedMainBranch);
       agentWorktrees[agent.name] = path;
     }
   }

--- a/src/staging-ff.ts
+++ b/src/staging-ff.ts
@@ -19,7 +19,7 @@ import {
 import { parseLeftRightCount } from "./briefing-lag.ts";
 import { OUTBOUND_EVENT_CAUSE_REMEDY } from "./staging-event-meta.ts";
 import { sentinelFresh, touchSentinel } from "./sentinel.ts";
-import type { ProjectConfig } from "./config.ts";
+import { projectConfigPath, type ProjectConfig } from "./config.ts";
 
 export type FastForwardOutcome =
   | "throttled"
@@ -97,9 +97,10 @@ export function syncStagingMainWithUpstream(
       continue;
     }
 
-    const path = p.path ? expandHome(String(p.path)) : null;
+    const cfgPath = projectConfigPath(p);
+    const path = cfgPath ? expandHome(cfgPath) : null;
     if (!path || !existsSync(path)) {
-      out.push({ project, outcome: "skipped-no-path", detail: p.path ?? undefined });
+      out.push({ project, outcome: "skipped-no-path", detail: cfgPath ?? undefined });
       continue;
     }
     if (!hasRemote(path, "upstream", opts.runGit)) {
@@ -308,9 +309,10 @@ export function syncUpstreamMainFromStaging(
       continue;
     }
 
-    const path = p.path ? expandHome(String(p.path)) : null;
+    const cfgPath = projectConfigPath(p);
+    const path = cfgPath ? expandHome(cfgPath) : null;
     if (!path || !existsSync(path)) {
-      out.push({ project, outcome: "skipped-no-path", detail: p.path ?? undefined });
+      out.push({ project, outcome: "skipped-no-path", detail: cfgPath ?? undefined });
       continue;
     }
     if (!hasRemote(path, "upstream", opts.runGit)) {

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -31,7 +31,19 @@ projects:
                           # construction: client-side `git merge-base --is-ancestor` pre-check plus server-side
                           # non-ff rejection (no --force / --force-with-lease). Throttled via
                           # mag/last-outbound-fast-forward-<project>.epoch. Absent → off (legacy configs stay off).
-    path: ~/my-project    # Local checkout path (used for slot start, worktree creation)
+    path: ~/my-project    # Local checkout path (used for slot start, worktree creation).
+                          # A leading ~/ is expanded against the RESOLVING machine's $HOME — so a
+                          # ~/-relative string already bridges same-OS cluster machines. For
+                          # clusters with divergent roots (macOS /Users vs Linux /home) that ~/
+                          # cannot bridge, `path` may instead be a map keyed by cluster machine
+                          # name or OS identifier (`macos` / `linux` — matching cluster.machines[].os,
+                          # NOT `darwin`), selected most-specific-first (machine name → OS), e.g.:
+                          #   path:
+                          #     mac-studio: ~/ocaml-cudajit   # machine-specific wins
+                          #     linux: ~/ocaml-cudajit        # all linux machines
+                          #     macos: ~/ocaml-cudajit
+                          # The controller resolves `path` FOR the destination machine at dispatch
+                          # and ships it unexpanded; the worker expands ~/ against its own $HOME.
     issues: true          # Include GitHub issues as tasks
     priority: false       # Priority project: preempt slots when tasks arrive
     postponed: false      # When true, tasks from this project are excluded from the ready queue,


### PR DESCRIPTION
## Problem

The first live remote slot launch (controller **mac-studio**/macOS → worker **minipc-wsl**/Linux, the federation's sole CUDA host) failed deterministically every keepalive tick:

```
ludics: intent start slot 4: ENOENT: no such file or directory, posix_spawn 'git'
```

`posix_spawn 'git'` is a Bun mis-attribution — git is installed on the worker. The real ENOENT is on the spawn's **working directory**: the controller stamped its own locally-expanded checkout path (`/Users/lukstafi/ocaml-cudajit`) into the slot and shipped it verbatim, but on the Linux worker that project lives at `/home/lukstafi/ocaml-cudajit` and `/Users` does not exist, so `git worktree add` ran against a nonexistent `cwd`.

## Fix

The controller now resolves a slot's project path **for the destination machine** at dispatch; a guard fails loudly when a checkout is genuinely absent.

1. **`ProjectConfig.path: string | Record<string,string>`** — `path` may now be a map keyed by cluster machine name or OS identifier (`macos`/`linux`, matching `cluster.machines[].os`). Plain strings stay valid. `templates/config.reference.yaml` documents the map form (drift pair, `lint:config-reference` green).
2. **Destination-aware `resolveProjectPath(projectName, machine?)`** — a remote destination ships the selected path **unexpanded** (a leading `~/` is expanded by the worker against its own `$HOME` — both adapters' `normalizeWorkspacePath` already do this) and **skips the controller-side `existsSync`** gate. A map present but missing the machine/OS key (or whose matching entry is blank/non-string) **throws** `ProjectPathMapMissError` rather than returning `""` (which would fall through to a wrong-root fallback). `projectConfigPath()` tolerates `null`/non-map runtime values (blank YAML `path:`).
3. **Both dispatch sites resolve after machine selection** — keepalive `maybeFillEmptySlots` (single + duo) **and** the notification/dashboard `launchSessionFromNotification` flow select the destination machine **before** resolving the path; a map-miss is caught → logged/notified → no slot assigned.
4. **AC2 guard in `createWorktrees`** — fails with `project checkout not found on <machine> at <path>` before any git op. `mainBranch` is now optional so the `defaultMainBranch(projectDir)` git call no longer runs as a default-parameter expression *before* the guard.
5. **Data-shape sweep** — every `String(p.path)` / `p.path.startsWith` reader (`mag.ts`, `init.ts`, `staging-ff.ts`, `briefing-lag.ts`, `findProjectConfig`) routes through `projectConfigPath()`, so a map config never renders `"[object Object]"` and legacy/blank configs never crash.

Net: `ocaml-cudajit` dispatched to minipc-wsl now resolves to `/home/lukstafi/ocaml-cudajit` on the worker, from both the keepalive and notification launch paths.

## Scope

Path resolution only — sibling **gh-ludics-580** (stale-state resume / `setWorkerSlotsOverride`) is untouched. The notification-launch dispatch site (commit `7e6de47`) is a sibling of the proposal's `maybeFillEmptySlots` call-site audit, flagged by Codex review and fixed with the same resolver.

## Tests

Regression tests across `src/config.test.ts`, `src/orchestration/worktrees.test.ts`, and `src/mag-remote-dispatch-path.test.ts`: remote ships unexpanded (AC1), skips controller `existsSync` (AC3), map precedence + map-miss throw, blank/null entry tolerance and blank-entry-throws, null-path round-trip, both dispatch sites store the destination-resolved path, dispatch no-slot-on-miss, worktree missing-checkout guard with omitted `mainBranch`.

Full suite: **3131 pass / 0 fail**. `typecheck`, `build`, and `lint` (config-reference, cli-readme, no-nul-bytes, test-isolation) all green.

> ⚠️ The proposal file `docs/proposals/gh-ludics-579-remote-dispatch-path-resolution.md` referenced by the task is **absent** from every ref; this PR is anchored to the embedded resolved design + the GitHub-issue Acceptance list. **Live re-validation of task-7eab5162 AC4** (end-to-end remote launch on minipc-wsl) still needs an operator on the real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)