### PR TITLE
proposal: guarantee proposal reachable from fork ref (self-heal/block at slot-start)

### DIFF
--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { parseTaskFrontmatter } from "../tasks/markdown.ts";
-import { basename, resolve } from "path";
+import { basename, join, resolve } from "path";
 import {
   getGitBranch,
   getMainRepoFromWorktree,
@@ -1093,7 +1093,12 @@ async function startOrchestratedThreads(
     ),
   );
 
-  const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode);
+  // Read proposal path for the reachability guard (AC1–AC5).
+  const taskFilePath_ = join(ctx.harnessDir, "tasks", `${taskId}.md`);
+  const taskContent_ = existsSync(taskFilePath_) ? readFileSync(taskFilePath_, "utf-8") : null;
+  const proposalPath_ = taskContent_ ? (parseTaskFrontmatter(taskContent_).proposal ?? "") : "";
+
+  const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode, proposalPath_);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
 
   const agents: AgentConfig[] = orchestration.agents.map((agent, index) => ({

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -35,6 +35,7 @@ import {
 import { initPeerSync, writeAgentMarkerFiles } from "../orchestration/peer-sync.ts";
 import { claudeEffort, codexEffort, normaliseEffortLevel } from "../orchestration/effort.ts";
 import { createWorktrees, symlinkPeerSync } from "../orchestration/worktrees.ts";
+import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/deferred-cleanup.ts";
 import { isoNow, nowEpoch } from "../orchestration/util.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
@@ -771,7 +772,12 @@ async function start(ctx: AdapterContext): Promise<string> {
     ),
   );
 
-  const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode);
+  // Read proposal path for the reachability guard (AC1–AC5).
+  const taskFilePath_ = join(ctx.harnessDir, "tasks", `${taskId}.md`);
+  const taskContent_ = existsSync(taskFilePath_) ? readFileSync(taskFilePath_, "utf-8") : null;
+  const proposalPath_ = taskContent_ ? (parseTaskFrontmatter(taskContent_).proposal ?? "") : "";
+
+  const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode, proposalPath_);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
 
   const agents: AgentConfig[] = orchestration.agents.map((agent, index) => ({

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
-import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureProposalReachable, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, proposalReachableFromRef, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureProposalReachable, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, maybeGit, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, proposalReachableFromRef, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError, withSyntheticHarness } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -1973,6 +1973,43 @@ describe("AC6(iii): both-refs check — one ref missing triggers guard", () => {
     });
   });
 
+  test("only origin (not local): guard treats as not reachable → hard-fails when artifact absent", () => {
+    // AC1 mutation evidence: if we changed `&&` to `||` in the both-refs check,
+    // a `proposal_unreachable` event would never be emitted here — the guard would
+    // short-circuit on origin=true and silently return instead of throwing.
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/origin-only.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Origin-only Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+    run(["git", "push", "origin", "main"], repo);
+
+    // Reset local main back before the proposal commit so only origin has it.
+    // Hard reset also removes the tracked file from the working tree — no artifact on disk.
+    run(["git", "reset", "--hard", "HEAD~1"], repo);
+
+    // Precondition: local=false, origin=true
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(false);
+    expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(true);
+
+    withHarnessDir((harnessDir) => {
+      // Guard must NOT treat origin-only as "reachable" — it throws (AC3)
+      expect(() =>
+        ensureProposalReachable(repo, "task-iii-origin", proposalPath, "main", 1),
+      ).toThrow(/proposal.*task-iii-origin.*not reachable/i);
+
+      // proposal_unreachable event emitted (not short-circuited by origin-only)
+      const unreachable = readEvents(harnessDir).find(
+        (e) => e.event_type === "proposal_unreachable",
+      );
+      expect(unreachable).toBeDefined();
+      expect(unreachable!.proposal_path).toBe(proposalPath);
+    });
+  });
+
   test("both refs reachable: guard is a no-op (positive control)", () => {
     if (!Bun.which("git")) return;
     mkdirSync(TMP, { recursive: true });
@@ -2167,10 +2204,37 @@ describe("AC6(v): proposal-less no-op — guard emits nothing, fork proceeds unc
       expect(readEvents(harnessDir)).toHaveLength(0);
     });
   });
+
+  test("AC1: invalid proposal path (absolute) throws setup error rather than silently no-opping", () => {
+    // AC1 requires assertRepoRelativeProposalPath to gate invalid paths.
+    // Before this fix, absolute/home-relative/escaping paths silently returned.
+    // Now they fail setup so operator sees the misconfiguration.
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+
+    withHarnessDir((_harnessDir) => {
+      expect(() =>
+        ensureProposalReachable(repo, "task-bad-path", "/etc/passwd", "main", 1),
+      ).toThrow(/proposal path must be repo-relative/i);
+
+      expect(() =>
+        ensureProposalReachable(repo, "task-bad-path", "~/secrets.md", "main", 1),
+      ).toThrow(/proposal path must be repo-relative/i);
+
+      expect(() =>
+        ensureProposalReachable(repo, "task-bad-path", "../outside.md", "main", 1),
+      ).toThrow(/proposal path escapes project tree/i);
+    });
+  });
 });
 
 describe("AC4 resume tolerance: agent branch with proposal allows re-run without block", () => {
-  test("resume: root branch already has proposal → guard passes without self-heal", () => {
+  test("resume: main + origin no longer have proposal, root branch does → guard does not false-fail", () => {
+    // Mutation evidence: removing the root-branch arm from ensureProposalReachable
+    // (lines `if (branchRefExists(...) && proposalReachableFromRef(repo, rootBranch, ...)) return;`)
+    // would make this test throw instead of passing — since both main refs are reset to
+    // before the proposal commit, the only escape from the block path is that arm.
     if (!Bun.which("git")) return;
     mkdirSync(TMP, { recursive: true });
     const { repo } = setupOriginClone(TMP);
@@ -2182,31 +2246,38 @@ describe("AC4 resume tolerance: agent branch with proposal allows re-run without
     run(["git", "push", "origin", "main"], repo);
 
     withHarnessDir((harnessDir) => {
-      // First run: cold-start, creates worktrees (proposal reachable from both refs)
+      // Cold-start fork: proposal reachable from both refs → root branch created with proposal
       const setup = createWorktrees(
         repo, "task-resume", [{ name: "coder" }], "main", 1, "solo", proposalPath,
       );
       expect(existsSync(setup.rootWorktree)).toBe(true);
 
-      // Simulate: local main no longer has the proposal (e.g., it was rebased away),
-      // but the root orchestration branch still does (it was forked from main with it).
-      // We test ensureProposalReachable directly with the root branch already existing.
+      // Verify root branch has proposal in its tree
       const rootBranch = orchBranchName("task-resume", 1, "root");
       expect(proposalReachableFromRef(repo, rootBranch, proposalPath)).toBe(true);
 
-      // Guard with no refreshSkip: if both main refs had it this passes; verifying
-      // resume tolerance by testing the helper directly with a fabricated scenario
-      // where localReachable=false but rootBranch has it.
-      // (Directly test that the root-branch arm prevents a false-fail on resume.)
-      // We cannot easily un-commit from local main without affecting origin, so we
-      // test the invariant via proposalReachableFromRef directly:
-      expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true); // still true here
+      // Simulate "main has since moved" — reset local main and origin tracking ref
+      // to the init commit so neither main ref satisfies the both-refs check.
+      const initCommit = maybeGit(repo, ["rev-list", "--max-parents=0", "HEAD"]).trim();
+      run(["git", "update-ref", "refs/heads/main", initCommit], repo);
+      run(["git", "update-ref", "refs/remotes/origin/main", initCommit], repo);
+      // Remove the artifact from disk too (so self-heal cannot rescue)
+      rmSync(join(repo, proposalPath));
 
-      // Full guard call must not throw (both refs have it → happy path)
+      // Precondition: both main refs now missing the proposal
+      expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(false);
+      expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(false);
+      // Root branch still has it
+      expect(proposalReachableFromRef(repo, rootBranch, proposalPath)).toBe(true);
+
+      // Guard must NOT false-fail: resume tolerance arm accepts root-branch reachability
       expect(() =>
         ensureProposalReachable(repo, "task-resume", proposalPath, "main", 1),
       ).not.toThrow();
-      expect(readEvents(harnessDir)).toHaveLength(0);
+      // No events emitted (guard took the root-branch resume arm, not the block path)
+      expect(readEvents(harnessDir).filter(
+        (e) => e.event_type === "proposal_unreachable" || e.event_type === "proposal_self_healed",
+      )).toHaveLength(0);
 
       cleanupWorktrees(repo, "task-resume", [{ name: "coder" }], 1, "solo");
     });

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
+import { tmpdir } from "os";
+import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureProposalReachable, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, proposalReachableFromRef, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError, withSyntheticHarness } from "../test-utils.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
@@ -1842,5 +1843,372 @@ describe("createWorktrees missing-checkout guard (gh-ludics-579 AC2)", () => {
     expect(existsSync(setup.rootWorktree)).toBe(true);
     expect(existsSync(setup.agentWorktrees.agent1!)).toBe(true);
     cleanupWorktrees(repo, "feat", [{ name: "agent1" }], 9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// proposal-reachability-self-heal-at-fork (AC6 regression tests)
+// Covers: AC1 both-refs check, AC2 self-heal, AC3 hard-fail,
+//         AC4 proposal-less no-op + resume tolerance, AC5 refresh-skip warning.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up a bare-origin + working-clone pair where the clone is fully up to date.
+ * The origin is a real local bare repo so `git push` and `git fetch` work
+ * without network access. Returns the clone path and the bare-origin path.
+ */
+function setupOriginClone(rootDir: string): { repo: string; origin: string } {
+  const origin = join(rootDir, "proposal-tests.git");
+  run(["git", "init", "--bare", "-b", "main", origin], rootDir);
+  const repo = join(rootDir, "proposal-tests-repo");
+  run(["git", "clone", origin, repo], rootDir);
+  run(["git", "config", "user.email", "test@example.com"], repo);
+  run(["git", "config", "user.name", "Test User"], repo);
+  writeFileSync(join(repo, "README.md"), "hello\n");
+  run(["git", "add", "README.md"], repo);
+  run(["git", "commit", "-m", "init"], repo);
+  run(["git", "push", "origin", "main"], repo);
+  return { repo, origin };
+}
+
+/** Read all events from a harness journal/events.jsonl file. */
+function readEvents(harnessDir: string): Record<string, unknown>[] {
+  const file = join(harnessDir, "journal", "events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf-8").trim().split("\n").filter(Boolean)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+/** Temporarily override LUDICS_HARNESS_DIR for a synchronous function; restores on return/throw. */
+function withHarnessDir<T>(fn: (harnessDir: string) => T): T {
+  const harnessDir = mkdtempSync(join(tmpdir(), "ludics-test-harness-"));
+  const saved = process.env.LUDICS_HARNESS_DIR;
+  process.env.LUDICS_HARNESS_DIR = harnessDir;
+  try {
+    return fn(harnessDir);
+  } finally {
+    if (saved === undefined) delete process.env.LUDICS_HARNESS_DIR;
+    else process.env.LUDICS_HARNESS_DIR = saved;
+    rmSync(harnessDir, { recursive: true, force: true });
+  }
+}
+
+describe("proposalReachableFromRef", () => {
+  test("AC1: returns true when <ref>:<path> is a valid git object", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/test.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+    expect(proposalReachableFromRef(repo, "main", "does/not/exist.md")).toBe(false);
+  });
+
+  test("AC1: returns false for origin/<main> when not yet pushed", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/local-only.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal (local only)"], repo);
+
+    // Locally reachable
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+    // Not yet on origin
+    expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(false);
+  });
+
+  test("AC1: both refs reachable after push", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/pushed.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+    run(["git", "push", "origin", "main"], repo);
+
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+    expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(true);
+  });
+});
+
+describe("AC6(iii): both-refs check — one ref missing triggers guard", () => {
+  test("only local (not pushed): guard self-heals by pushing, both refs pass after", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/local-push.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal (local)"], repo);
+
+    // Precondition: local=true, origin=false
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+    expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(false);
+
+    withHarnessDir((harnessDir) => {
+      // ensureProposalReachable should self-heal by pushing
+      expect(() =>
+        ensureProposalReachable(repo, "task-iii-local", proposalPath, "main", 1),
+      ).not.toThrow();
+
+      // After self-heal: both refs reachable
+      expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+      expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(true);
+
+      const selfHealEvent = readEvents(harnessDir).find(
+        (e) => e.event_type === "proposal_self_healed",
+      );
+      expect(selfHealEvent).toBeDefined();
+      expect(selfHealEvent!.proposal_path).toBe(proposalPath);
+    });
+  });
+
+  test("both refs reachable: guard is a no-op (positive control)", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/already-pushed.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+    run(["git", "push", "origin", "main"], repo);
+
+    withHarnessDir((harnessDir) => {
+      expect(() =>
+        ensureProposalReachable(repo, "task-iii-both", proposalPath, "main", 1),
+      ).not.toThrow();
+
+      // No events emitted: proposal was already reachable from both refs
+      expect(readEvents(harnessDir)).toHaveLength(0);
+    });
+  });
+});
+
+describe("AC6(i): self-heal path — on-disk but uncommitted artifact", () => {
+  test("commits only the proposal file, pushes, fork proceeds, emits proposal_self_healed", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/orphaned.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Orphaned Proposal\n");
+    // Artifact is on disk but NOT committed
+    expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(false);
+    expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(false);
+
+    withHarnessDir((harnessDir) => {
+      // createWorktrees with the proposal path triggers self-heal
+      const setup = createWorktrees(
+        repo, "task-self-heal", [{ name: "coder" }], "main", 1, "solo", proposalPath,
+      );
+
+      // Self-heal: proposal committed+pushed; both refs reachable
+      expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true);
+      expect(proposalReachableFromRef(repo, "origin/main", proposalPath)).toBe(true);
+
+      // Commit touched only the proposal file — use --name-only for clean filename list
+      const changedFiles = Bun.spawnSync(
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+        { cwd: repo, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> },
+      ).stdout.toString().trim().split("\n").filter(Boolean);
+      expect(changedFiles).toEqual([proposalPath]);
+
+      // proposal_self_healed event emitted
+      const events = readEvents(harnessDir);
+      const selfHeal = events.find((e) => e.event_type === "proposal_self_healed");
+      expect(selfHeal).toBeDefined();
+      expect(selfHeal!.task).toBe("task-self-heal");
+      expect(selfHeal!.proposal_path).toBe(proposalPath);
+
+      // Fork succeeded: worktrees exist and proposal is visible in them
+      expect(existsSync(setup.rootWorktree)).toBe(true);
+      expect(existsSync(join(setup.rootWorktree, proposalPath))).toBe(true);
+
+      cleanupWorktrees(repo, "task-self-heal", [{ name: "coder" }], 1, "solo");
+    });
+  });
+});
+
+describe("AC6(ii): hard-fail path — proposal absent from disk", () => {
+  test("throws clear error naming task+proposal, emits proposal_unreachable, no worktree forked", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/absent.md";
+    // Proposal file does NOT exist on disk at all
+
+    withHarnessDir((harnessDir) => {
+      expect(() =>
+        createWorktrees(
+          repo, "task-hard-fail", [{ name: "coder" }], "main", 1, "solo", proposalPath,
+        ),
+      ).toThrow(/proposal.*task-hard-fail.*not reachable/i);
+
+      // proposal_unreachable event emitted
+      const events = readEvents(harnessDir);
+      const unreachable = events.find((e) => e.event_type === "proposal_unreachable");
+      expect(unreachable).toBeDefined();
+      expect(unreachable!.task).toBe("task-hard-fail");
+      expect(unreachable!.proposal_path).toBe(proposalPath);
+
+      // No worktree was forked (root worktree must not exist)
+      const stem = orchWorktreeStem("proposal-tests-repo", "task-hard-fail", 1);
+      const rootWorktreePath = join(join(repo, ".."), stem);
+      expect(existsSync(rootWorktreePath)).toBe(false);
+    });
+  });
+});
+
+describe("AC6(iv): refresh-skip warning — main_refresh_skipped emitted when refresh skips + proposal pending", () => {
+  test("dirty working tree skips refresh; pending proposal emits main_refresh_skipped then self-heals", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/dirty-test.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Dirty Test Proposal\n");
+    // Create an unrelated dirty file → causes refresh to skip with reason "dirty"
+    writeFileSync(join(repo, "dirty-file.txt"), "uncommitted\n");
+
+    withHarnessDir((harnessDir) => {
+      // Verify refreshMainBranchFromRemote skips due to dirty tree
+      const result = refreshMainBranchFromRemote(repo, "main");
+      expect(result).toMatchObject({ skipped: true, reason: "dirty" });
+
+      // ensureProposalReachable: proposal not reachable (uncommitted) + refresh skipped
+      // → should emit main_refresh_skipped, then self-heal (commit+push)
+      expect(() =>
+        ensureProposalReachable(repo, "task-dirty", proposalPath, "main", 1, "dirty"),
+      ).not.toThrow();
+
+      const events = readEvents(harnessDir);
+
+      // AC5: main_refresh_skipped warning emitted with skip_reason and proposal_path
+      const skipWarn = events.find((e) => e.event_type === "main_refresh_skipped");
+      expect(skipWarn).toBeDefined();
+      expect(skipWarn!.skip_reason).toBe("dirty");
+      expect(skipWarn!.proposal_path).toBe(proposalPath);
+
+      // Self-heal succeeded (proposal was on disk)
+      const selfHeal = events.find((e) => e.event_type === "proposal_self_healed");
+      expect(selfHeal).toBeDefined();
+    });
+  });
+
+  test("control: clean ff-merge succeeds; both refs reachable; no main_refresh_skipped emitted", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/clean-test.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Clean Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+    run(["git", "push", "origin", "main"], repo);
+
+    withHarnessDir((harnessDir) => {
+      // Refresh succeeds (clean tree, on main, origin reachable)
+      const result = refreshMainBranchFromRemote(repo, "main");
+      expect(result).toMatchObject({ skipped: false });
+
+      expect(() =>
+        ensureProposalReachable(repo, "task-clean", proposalPath, "main", 1),
+      ).not.toThrow();
+
+      // No main_refresh_skipped event (refresh did not skip)
+      const events = readEvents(harnessDir);
+      expect(events.find((e) => e.event_type === "main_refresh_skipped")).toBeUndefined();
+    });
+  });
+});
+
+describe("AC6(v): proposal-less no-op — guard emits nothing, fork proceeds unchanged", () => {
+  test("no proposal (empty string): no error, no event, fork proceeds", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+
+    withHarnessDir((harnessDir) => {
+      expect(() =>
+        ensureProposalReachable(repo, "task-noproposal", "", "main", 1),
+      ).not.toThrow();
+      expect(readEvents(harnessDir)).toHaveLength(0);
+
+      // Also works via createWorktrees with no proposalPath
+      const setup = createWorktrees(
+        repo, "task-noproposal", [{ name: "coder" }], "main", 1, "solo",
+      );
+      expect(existsSync(setup.rootWorktree)).toBe(true);
+      expect(readEvents(harnessDir)).toHaveLength(0);
+      cleanupWorktrees(repo, "task-noproposal", [{ name: "coder" }], 1, "solo");
+    });
+  });
+
+  test("proposal: 'inline' (deprecated sentinel): no error, no event, fork proceeds", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+
+    withHarnessDir((harnessDir) => {
+      expect(() =>
+        ensureProposalReachable(repo, "task-inline", "inline", "main", 1),
+      ).not.toThrow();
+      expect(readEvents(harnessDir)).toHaveLength(0);
+    });
+  });
+});
+
+describe("AC4 resume tolerance: agent branch with proposal allows re-run without block", () => {
+  test("resume: root branch already has proposal → guard passes without self-heal", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginClone(TMP);
+    const proposalPath = "docs/proposals/resume-test.md";
+    mkdirSync(join(repo, "docs/proposals"), { recursive: true });
+    writeFileSync(join(repo, proposalPath), "# Resume Proposal\n");
+    run(["git", "add", proposalPath], repo);
+    run(["git", "commit", "-m", "add proposal"], repo);
+    run(["git", "push", "origin", "main"], repo);
+
+    withHarnessDir((harnessDir) => {
+      // First run: cold-start, creates worktrees (proposal reachable from both refs)
+      const setup = createWorktrees(
+        repo, "task-resume", [{ name: "coder" }], "main", 1, "solo", proposalPath,
+      );
+      expect(existsSync(setup.rootWorktree)).toBe(true);
+
+      // Simulate: local main no longer has the proposal (e.g., it was rebased away),
+      // but the root orchestration branch still does (it was forked from main with it).
+      // We test ensureProposalReachable directly with the root branch already existing.
+      const rootBranch = orchBranchName("task-resume", 1, "root");
+      expect(proposalReachableFromRef(repo, rootBranch, proposalPath)).toBe(true);
+
+      // Guard with no refreshSkip: if both main refs had it this passes; verifying
+      // resume tolerance by testing the helper directly with a fabricated scenario
+      // where localReachable=false but rootBranch has it.
+      // (Directly test that the root-branch arm prevents a false-fail on resume.)
+      // We cannot easily un-commit from local main without affecting origin, so we
+      // test the invariant via proposalReachableFromRef directly:
+      expect(proposalReachableFromRef(repo, "main", proposalPath)).toBe(true); // still true here
+
+      // Full guard call must not throw (both refs have it → happy path)
+      expect(() =>
+        ensureProposalReachable(repo, "task-resume", proposalPath, "main", 1),
+      ).not.toThrow();
+      expect(readEvents(harnessDir)).toHaveLength(0);
+
+      cleanupWorktrees(repo, "task-resume", [{ name: "coder" }], 1, "solo");
+    });
   });
 });

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -1,9 +1,10 @@
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, rmSync, rmdirSync, symlinkSync, writeFileSync } from "fs";
-import { basename, dirname, join, resolve } from "path";
+import { basename, dirname, join, normalize, resolve } from "path";
 import { PEER_SYNC_DIRNAME, peerSyncPath } from "./peer-sync.ts";
 import { slugify } from "./util.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import { findProjectConfig, type ProjectConfig } from "../config.ts";
+import { emitEvent } from "../events.ts";
 
 export interface WorktreeSetup {
   rootWorktree: string;
@@ -436,6 +437,167 @@ function lstatExistsLink(target: string): boolean {
   try { return lstatSync(target).isSymbolicLink(); } catch { return false; }
 }
 
+/** Skip reasons for {@link refreshMainBranchFromRemote}. */
+export type RefreshSkipReason = "no-origin" | "wrong-branch" | "dirty" | "fetch-failed" | "diverged";
+
+/** Return value for {@link refreshMainBranchFromRemote}: either a successful
+ *  fast-forward or a structured skip with the reason. */
+export type RefreshSkipResult = { skipped: false } | { skipped: true; reason: RefreshSkipReason };
+
+/**
+ * Check whether `<ref>:<proposalPath>` exists as a git object in `projectDir`.
+ * Uses `safeSyncOutput` so it never throws. Returns `false` on any error.
+ */
+export function proposalReachableFromRef(
+  projectDir: string,
+  ref: string,
+  proposalPath: string,
+): boolean {
+  return safeSyncOutput(
+    ["git", "cat-file", "-e", `${ref}:${proposalPath}`],
+    { cwd: projectDir },
+  ).ok;
+}
+
+/**
+ * Verify the proposal artifact is committed and reachable from both the local
+ * fork ref (`resolvedMainBranch`) **and** `origin/<resolvedMainBranch>` before
+ * slot-start forks worktrees.
+ *
+ * - No-ops when `proposalPath` is empty or the deprecated `"inline"` sentinel.
+ * - No-ops when the root orchestration branch for this task/slot already exists
+ *   locally and has the proposal in its tree (resume path — the proposal was
+ *   present when the branch was first forked).
+ * - Emits a `main_refresh_skipped` warning event when `refreshMainBranchFromRemote`
+ *   skipped (AC5) and the proposal is not yet locally reachable.
+ * - If the artifact is on disk but not committed, **self-heals** by staging and
+ *   committing only that one file on `resolvedMainBranch`, pushing to origin,
+ *   and emitting a `proposal_self_healed` event.
+ * - **Hard-fails** (throws) with a clear error and emits `proposal_unreachable`
+ *   when neither self-heal is possible. The throw surfaces through the same
+ *   adapter setup-failure path as the existing "project checkout not found" error.
+ *
+ * See `docs/proposals/proposal-reachability-self-heal-at-fork.md` AC1–AC5.
+ */
+export function ensureProposalReachable(
+  projectDir: string,
+  taskId: string,
+  proposalPath: string,
+  resolvedMainBranch: string,
+  slot: number | undefined,
+  refreshSkip?: RefreshSkipReason,
+): void {
+  // AC4: no-op for proposal-less tasks (absent or deprecated "inline" sentinel)
+  if (!proposalPath || proposalPath === "inline") return;
+
+  // Lightweight repo-relative validation (mirrors assertRepoRelativeProposalPath
+  // from task-launch.ts without the cross-package import)
+  const trimmed = proposalPath.trim();
+  if (!trimmed) return;
+  if (trimmed.startsWith("/") || trimmed.startsWith("~/")) return;
+  const norm = normalize(trimmed);
+  if (norm.startsWith("../") || norm === "..") return;
+
+  const originRef = `origin/${resolvedMainBranch}`;
+  const localReachable = proposalReachableFromRef(projectDir, resolvedMainBranch, trimmed);
+  const originReachable = proposalReachableFromRef(projectDir, originRef, trimmed);
+
+  // Happy path: proposal reachable from both refs.
+  if (localReachable && originReachable) return;
+
+  // AC4 resume tolerance: the root orchestration branch already exists (this is
+  // a resume), and the proposal is in its tree — it was present when first forked.
+  const rootBranch = orchBranchName(taskId, slot, "root");
+  if (
+    branchRefExists(projectDir, rootBranch) &&
+    proposalReachableFromRef(projectDir, rootBranch, trimmed)
+  ) return;
+
+  // AC5: emit warning when refreshMainBranchFromRemote skipped while proposal
+  // is not yet locally reachable (making the mode-(a) race visible).
+  if (refreshSkip && !localReachable) {
+    emitEvent({
+      event_type: "main_refresh_skipped",
+      source: "slot-start",
+      scope: "orchestration",
+      task: taskId,
+      slot,
+      proposal_path: trimmed,
+      skip_reason: refreshSkip,
+      message: `refreshMainBranchFromRemote skipped (${refreshSkip}) while proposal ${trimmed} is not yet reachable from ${resolvedMainBranch}`,
+    });
+  }
+
+  // AC2: try self-heal — commit the on-disk artifact then push.
+  // Guards: we must be on resolvedMainBranch with no pre-existing staged changes.
+  const proposalAbsPath = join(resolve(projectDir), trimmed);
+  const currentBranch = maybeGit(projectDir, ["branch", "--show-current"]).trim();
+  if (existsSync(proposalAbsPath) && currentBranch === resolvedMainBranch) {
+    // Stage only the proposal file if it is not yet locally committed.
+    if (!localReachable) {
+      const preStaged = maybeGit(projectDir, ["diff", "--cached", "--name-only"]).trim();
+      if (!preStaged) {
+        const addOk = safeSyncOutput(["git", "add", "--", trimmed], { cwd: projectDir }).ok;
+        if (addOk) {
+          const afterStaged = maybeGit(projectDir, ["diff", "--cached", "--name-only"])
+            .trim().split("\n").filter(Boolean);
+          if (afterStaged.length === 1 && afterStaged[0] === trimmed) {
+            const commitOk = safeSyncOutput(
+              ["git", "commit", "-m", `chore: commit proposal artifact for ${taskId}`, "--", trimmed],
+              { cwd: projectDir },
+            ).ok;
+            if (!commitOk) {
+              maybeGit(projectDir, ["reset", "HEAD", "--", trimmed]);
+              // fall through to block path
+            }
+          } else {
+            maybeGit(projectDir, ["reset", "HEAD", "--", trimmed]);
+            // fall through to block path
+          }
+        }
+      }
+    }
+    // Push if the proposal is now reachable locally (just committed, or was
+    // already committed locally but not pushed).
+    if (proposalReachableFromRef(projectDir, resolvedMainBranch, trimmed)) {
+      const pushOk = safeSyncOutput(
+        ["git", "push", "origin", resolvedMainBranch],
+        { cwd: projectDir },
+      ).ok;
+      if (pushOk) {
+        const afterLocal = proposalReachableFromRef(projectDir, resolvedMainBranch, trimmed);
+        const afterOrigin = proposalReachableFromRef(projectDir, originRef, trimmed);
+        if (afterLocal && afterOrigin) {
+          emitEvent({
+            event_type: "proposal_self_healed",
+            source: "slot-start",
+            scope: "orchestration",
+            task: taskId,
+            slot,
+            proposal_path: trimmed,
+            message: `Self-healed proposal artifact ${trimmed} for task ${taskId}: committed and pushed to ${resolvedMainBranch}`,
+          });
+          return;
+        }
+      }
+    }
+  }
+
+  // AC3: cannot self-heal — emit warning and hard-fail.
+  emitEvent({
+    event_type: "proposal_unreachable",
+    source: "slot-start",
+    scope: "orchestration",
+    task: taskId,
+    slot,
+    proposal_path: trimmed,
+    message: `Proposal ${trimmed} for task ${taskId} is not reachable from ${resolvedMainBranch}/origin and could not be self-healed`,
+  });
+  throw new Error(
+    `proposal ${trimmed} for task ${taskId} is not reachable from ${resolvedMainBranch}/origin and could not be self-healed`,
+  );
+}
+
 export function defaultMainBranch(projectDir: string): string {
   const remoteHead = maybeGit(projectDir, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]);
   if (remoteHead.startsWith("origin/")) return remoteHead.slice("origin/".length);
@@ -464,7 +626,10 @@ export function defaultMainBranch(projectDir: string): string {
  *
  * Never throws.
  */
-export function refreshMainBranchFromRemote(projectDir: string, mainBranch: string): void {
+export function refreshMainBranchFromRemote(
+  projectDir: string,
+  mainBranch: string,
+): RefreshSkipResult {
   const dir = resolve(projectDir);
   // `git remote` may list a name purely from leftover `remote.<name>.*`
   // config keys even when no URL is set; require `remote.origin.url` so we
@@ -472,20 +637,22 @@ export function refreshMainBranchFromRemote(projectDir: string, mainBranch: stri
   // noisy warning in test repos that set `remote.origin.gh-resolved` without
   // a real remote URL).
   const originUrl = safeSyncOutput(["git", "config", "--get", "remote.origin.url"], { cwd: dir });
-  if (!originUrl.ok || originUrl.stdout.trim().length === 0) return;
+  if (!originUrl.ok || originUrl.stdout.trim().length === 0) return { skipped: true, reason: "no-origin" };
   const current = maybeGit(dir, ["branch", "--show-current"]).trim();
-  if (current !== mainBranch) return;
+  if (current !== mainBranch) return { skipped: true, reason: "wrong-branch" };
   const dirty = maybeGit(dir, ["status", "--porcelain"]).trim();
-  if (dirty.length > 0) return;
+  if (dirty.length > 0) return { skipped: true, reason: "dirty" };
   const fetchResult = safeSyncOutput(["git", "fetch", "origin", mainBranch], { cwd: dir });
   if (!fetchResult.ok) {
     console.error(`ludics: refreshMainBranchFromRemote: git fetch origin ${mainBranch} failed in ${dir} — continuing with stale local state`);
-    return;
+    return { skipped: true, reason: "fetch-failed" };
   }
   const mergeResult = safeSyncOutput(["git", "merge", "--ff-only", `origin/${mainBranch}`], { cwd: dir });
   if (!mergeResult.ok) {
     console.error(`ludics: refreshMainBranchFromRemote: ff-only merge of origin/${mainBranch} failed in ${dir} — local branch has diverged from origin, continuing with stale local state`);
+    return { skipped: true, reason: "diverged" };
   }
+  return { skipped: false };
 }
 
 /**
@@ -534,6 +701,7 @@ export function createWorktrees(
   mainBranch?: string,
   slot?: number,
   mode: "duo" | "pair" | "solo" | "pilot" = "duo",
+  proposalPath?: string,
 ): WorktreeSetup {
   // gh-ludics-579 AC2: fail loudly with a clear, machine-attributed error when
   // the project checkout is absent on the executing machine, BEFORE any git op
@@ -560,7 +728,17 @@ export function createWorktrees(
   // Best-effort: any reason this can't proceed (no origin, wrong branch
   // checked out, dirty working tree, network failure, or local divergence) is
   // logged and skipped — see refreshMainBranchFromRemote for details.
-  refreshMainBranchFromRemote(projectDir, resolvedMainBranch);
+  const refreshResult = refreshMainBranchFromRemote(projectDir, resolvedMainBranch);
+
+  // Proposal reachability guard (AC1–AC5 of proposal-reachability-self-heal-at-fork).
+  // Runs after refresh (so a just-pushed proposal can be fetched) and before
+  // addWorktree (so the fork never starts from a proposal-less tree).
+  if (proposalPath) {
+    ensureProposalReachable(
+      projectDir, taskId, proposalPath, resolvedMainBranch, slot,
+      refreshResult.skipped ? refreshResult.reason : undefined,
+    );
+  }
 
   const parentDir = dirname(resolve(projectDir));
   const repoName = basename(resolve(projectDir));

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -1,10 +1,11 @@
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, renameSync, rmSync, rmdirSync, symlinkSync, writeFileSync } from "fs";
-import { basename, dirname, join, normalize, resolve } from "path";
+import { basename, dirname, join, resolve } from "path";
 import { PEER_SYNC_DIRNAME, peerSyncPath } from "./peer-sync.ts";
 import { slugify } from "./util.ts";
 import { safeSyncOutput } from "../spawn.ts";
 import { findProjectConfig, type ProjectConfig } from "../config.ts";
 import { emitEvent } from "../events.ts";
+import { assertRepoRelativeProposalPath } from "../adapters/task-launch.ts";
 
 export interface WorktreeSetup {
   rootWorktree: string;
@@ -489,14 +490,12 @@ export function ensureProposalReachable(
 ): void {
   // AC4: no-op for proposal-less tasks (absent or deprecated "inline" sentinel)
   if (!proposalPath || proposalPath === "inline") return;
-
-  // Lightweight repo-relative validation (mirrors assertRepoRelativeProposalPath
-  // from task-launch.ts without the cross-package import)
   const trimmed = proposalPath.trim();
   if (!trimmed) return;
-  if (trimmed.startsWith("/") || trimmed.startsWith("~/")) return;
-  const norm = normalize(trimmed);
-  if (norm.startsWith("../") || norm === "..") return;
+
+  // AC1: validate the path is repo-relative; throws for absolute, home-relative,
+  // or tree-escaping paths so invalid proposal: values fail setup rather than no-op.
+  assertRepoRelativeProposalPath(trimmed);
 
   const originRef = `origin/${resolvedMainBranch}`;
   const localReachable = proposalReachableFromRef(projectDir, resolvedMainBranch, trimmed);


### PR DESCRIPTION
## Summary

- **AC1**: Adds `proposalReachableFromRef(projectDir, ref, proposalPath)` using `git cat-file -e`; guard requires both local fork ref and `origin/<main>` to have the proposal. Path validation uses the authoritative `assertRepoRelativeProposalPath` from `task-launch.ts`; invalid paths now throw a clear setup error rather than silently no-opping.
- **AC2**: Self-heals orphaned-on-disk proposals by committing only that one file on `resolvedMainBranch` and pushing; re-verifies both refs before proceeding; emits `proposal_self_healed`.
- **AC3**: Hard-fails with actionable error before any `addWorktree` call when self-heal impossible (absent artifact, wrong/dirty branch, push rejected); emits `proposal_unreachable`.
- **AC4**: No-ops for `proposal: inline` and proposal-absent tasks; resume tolerant via root orchestration branch reachability check. Test now instantiates the actual condition: both main refs reset to pre-proposal init commit + artifact removed; guard passes only via the root-branch arm (removing it would throw).
- **AC5**: `refreshMainBranchFromRemote` return type changed from `void` to `RefreshSkipResult` exposing skip reason; guard emits `main_refresh_skipped` event when refresh skipped with a pending proposal.
- **AC6**: 14 regression tests in `worktrees.test.ts` covering all five AC6 sub-cases including the AC6(iii) origin-only arm (local=false, origin=true → hard-fails when artifact absent) and AC1 invalid-path throws.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (0 warnings)
- [x] `bun test src/orchestration/worktrees.test.ts` — 103 pass (14 new)
- [x] `bun test` — 3178 pass, 0 fail
- [x] `bun run build` — clean binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)