### PR TITLE
gh-ludics-584: worker runner cgroup-escape + resume circuit-breaker

### DIFF
--- a/docs/proposals/gh-ludics-584-worker-runner-cgroup-escape.md
+++ b/docs/proposals/gh-ludics-584-worker-runner-cgroup-escape.md
@@ -51,26 +51,42 @@ framework code, buildable and testable on mac-studio.
 
 ## Acceptance Criteria
 
-1. **The detached runner survives the worker keepalive oneshot exit.** On
-   Linux, the runner is launched into its own process scope/cgroup that is
-   **not** reaped when `ludics-mag.service` finishes, so an orchestration
-   started or resumed by the worker keepalive keeps running and advances past
-   `setup` (operator-verified live on minipc-wsl; see AC 7).
+1. **The detached runner survives the worker keepalive oneshot exit.** The
+   `setsid`-detached runner is **not** reaped when `ludics-mag.service`
+   finishes, so an orchestration started or resumed by the worker keepalive
+   keeps running and advances past `setup` (operator-verified live on
+   minipc-wsl; see AC 7). On Linux this is delivered by the generated unit's
+   `KillMode=process` (AC 2), which kills only the keepalive's main process on
+   oneshot exit and leaves the detached descendant alive.
 
-2. **The escape is applied in BOTH layers** (per the user-resolved design,
-   Q2 → both):
-   - **TS spawn path** (`src/orchestration/process.ts`): a **Linux-only**
-     branch detaches the runner out of the parent cgroup; the existing
-     `setsid`/perl path is **unchanged on macOS** and on Linux where the
-     escape mechanism is unavailable (graceful fallback).
+2. **The cgroup escape is delivered by the generated systemd unit; the TS spawn
+   path keeps the pid-preserving `setsid` wrapper.** *(Design note — supersedes
+   the original Q2 "both layers" plan, per PR #586 review.)* The original plan
+   also wrapped the runner in `systemd-run --user --scope` in
+   `src/orchestration/process.ts`. That mechanism is **incompatible** with the
+   runner's pid-based sibling self-guard: `systemd-run --scope` runs the command
+   under a long-lived supervisor, so `Bun.spawn`'s pid is the **wrapper**, not
+   the runner. `slotResume` persists that wrapper pid as the sibling
+   orchestration pid, and the runner's self-guard (`src/orchestration/runner.ts`)
+   then exits on the live-pid mismatch (`recordedPid !== process.pid` with a
+   *live* `recordedPid`; the gh-509 reclaim only triggers for a *dead* recorded
+   pid). A transient scope's `MainPID` is not reliably queryable to recover the
+   real runner pid, so the TS-layer cgroup escape is **dropped** in favor of:
    - **Generated systemd unit** (`src/triggers.ts`, the `mag` keepalive unit):
-     the `ludics-mag.service` body is hardened so a detached descendant is not
-     reaped on oneshot exit.
+     `KillMode=process` so a detached descendant is not reaped on oneshot exit.
+     This is the load-bearing fix (the proposal's own Approach §2 already noted
+     `KillMode=process` "protects *any* keepalive descendant from cgroup reaping
+     … [when] the fallback `setsid` path is taken").
+   - **TS spawn path** (`src/orchestration/process.ts`): retains the existing
+     `setsid`/perl wrapper, which `exec`s the runner in place so `proc.pid` is
+     the runner's real pid (required by the self-guard and liveness checks), and
+     additionally captures stdout (AC 6).
 
 3. **Controller / standalone behavior is unchanged.** macOS (launchd) keepalive,
    the long-lived controller `mag start`, and standalone runs spawn the runner
-   exactly as before. The Linux-only detection is a runtime check (platform +
-   mechanism availability), not a compile-time switch.
+   exactly as before (`setsid`/perl, unchanged). `KillMode=process` is added
+   only to the Linux-generated `mag` unit, so non-Linux nodes are untouched by
+   construction.
 
 4. **Resume-loop circuit-breaker with escalation** (Q3 → yes, in this task):
    `maybeResumeDeadOrchestrators` (`src/mag.ts`) detects when a slot has been
@@ -92,12 +108,12 @@ framework code, buildable and testable on mac-studio.
    silent-death diagnosis doesn't require guessing which sink was used.
 
 7. **The cgroup behavior is operator-verified live** on the Linux worker
-   (minipc-wsl): a remote `--pair` orchestration started from the controller
-   advances past `setup` and the runner pid is stable across keepalive ticks.
-   The proposal calls this out explicitly as an operator step — the in-repo
-   tests assert the falsifiable *proxies* (per-OS spawn shape + circuit-breaker
-   + stdout capture), since the cgroup reaping itself can only be reproduced
-   under systemd.
+   (minipc-wsl): after re-init regenerates the `KillMode=process` unit, a remote
+   `--pair` orchestration started from the controller advances past `setup` and
+   the runner pid is stable across keepalive ticks. The proposal calls this out
+   explicitly as an operator step — the in-repo tests assert the falsifiable
+   *proxies* (`KillMode=process` unit body + circuit-breaker + stdout capture),
+   since the cgroup reaping itself can only be reproduced under systemd.
 
 ## Context
 
@@ -181,6 +197,14 @@ capture. The skeleton below is straightforward; the agents own the details.
 
 ### 1. TS spawn path — Linux cgroup-escape branch (`src/orchestration/process.ts`)
 
+> **⚠️ Superseded by AC 2 (PR #586 review).** This `systemd-run --scope`
+> approach was found incompatible with the runner's pid-based sibling
+> self-guard (the wrapper pid would be persisted and the runner would exit on
+> the live-pid mismatch). The cgroup escape is delivered solely by the unit's
+> `KillMode=process` (§2); the TS spawn path keeps the pid-preserving `setsid`
+> wrapper and only adds stdout capture (§4). The original sketch is retained
+> below for the analysis trail.
+
 Move the runner into its own transient scope so it leaves the keepalive's
 cgroup. The cleanest mechanism is `systemd-run --user --scope --collect`:
 
@@ -256,15 +280,14 @@ visibility gap that made this hard to diagnose.
 
 Build/verify: `bun run build` then `bun test` in `~/ludics`.
 
-1. **Per-OS spawn shape** (`src/orchestration/process.test.ts` or extend
-   `util.test.ts`): drive the new `runnerLaunchCommand` helper with explicit
-   `{ platform, systemdRunPath, hasUserSystemd }` overrides and assert:
-   - Linux + `systemd-run` present + user systemd → argv begins with
-     `systemd-run --user --scope --collect …` and the original
-     `orch run-internal N` command is the tail;
-   - Linux + `systemd-run` absent → falls back to the `setsidWrap` shape;
-   - macOS (`darwin`) → unchanged `setsid`/perl wrapper (no `systemd-run`).
-   This is the falsifiable proxy for "the runner escapes the parent cgroup."
+1. ~~**Per-OS spawn shape** (`runnerLaunchCommand`)~~ — **superseded (AC 2):** the
+   `systemd-run` branch was dropped, so there is no per-OS spawn-shape helper.
+   The falsifiable proxy for "the runner escapes the parent cgroup" is instead
+   the **`KillMode=process` unit-body test** (`src/triggers.test.ts`): the
+   generated `mag` `systemdServiceBody` contains `KillMode=process`, and no
+   other oneshot body does (scope negative-control). The stdout-capture test
+   (`src/orchestration/process.test.ts`) additionally asserts the runner's real
+   pid is returned and stdout/stderr share the per-slot log fd.
 
 2. **Circuit-breaker** (extend `src/mag.test.ts`): seed a slot with a dead
    orchestrator pid and persisted no-progress state at the threshold; assert

--- a/scripts/snapshots/state.shape.snapshot.json
+++ b/scripts/snapshots/state.shape.snapshot.json
@@ -39,6 +39,7 @@
   "OrchestrationState": [
     "agentStates",
     "agents",
+    "autoResumeNoProgress",
     "backend",
     "branches",
     "config",

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -1782,3 +1782,196 @@ cluster:
     expect(out).toContain("no persisted t3code state");
   });
 });
+
+// gh-ludics-584: resume-loop circuit-breaker. When the keepalive auto-resumes a
+// slot that keeps dying in the SAME (taskId, phase) without advancing, it must
+// stop re-spawning after N consecutive no-advance ticks, mark the slot
+// escalated, raise a priority notification, and emit a structured event —
+// instead of churning a dying runner every ~2 min forever. These run in
+// CONTROLLER context (leader-box) so emitEvent/notify/persistSlotLiveness write
+// locally and are directly observable.
+describe("maybeResumeDeadOrchestrators — resume circuit-breaker (gh-ludics-584)", () => {
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  let TMP = "";
+  const DEAD_PID = 2147483647; // INT32_MAX — never a live process
+  const THRESHOLD = 3; // mirrors MAX_CONSECUTIVE_NO_ADVANCE_RESUMES
+
+  function harness(): string { return join(TMP, "harness"); }
+
+  function writeConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+mag:
+  autonomy_level:
+    start_sessions: auto
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  // Controller harness writers: orch state + t3code (dead pid) live in the
+  // harness tree. `threads: []` → slotResume throws "no persisted t3code state"
+  // *after* the machine gate, a deterministic process-free failure that proves
+  // slotResume was reached (the positive control / no-throttle path).
+  function writeOrchState(slot: number, taskId: string, phase: string, noProgress?: { taskId: string; phase: string; consecutiveTicks: number }): void {
+    mkdirSync(join(harness(), "orchestration"), { recursive: true });
+    writeFileSync(join(harness(), "orchestration", `slot-${slot}.json`), JSON.stringify({
+      slot, taskId, phase, mode: "pair",
+      ...(noProgress ? { autoResumeNoProgress: noProgress } : {}),
+    }));
+  }
+  function writeT3codeState(slot: number, pid: number): void {
+    mkdirSync(join(harness(), "t3code"), { recursive: true });
+    writeFileSync(join(harness(), "t3code", `slot-${slot}.json`), JSON.stringify({
+      slot, threads: [], orchestration: { stateFile: "x", mode: "pair", pid },
+    }));
+  }
+  function writeSlot(slot: number, taskId: string, liveness: SlotData["liveness"] = null): void {
+    writeSlotJson(slot, { ...emptySlotData(slot), process: "orch-runner", task: taskId, mode: "t3code", machine: "leader-box", path: join(TMP, "wt"), liveness });
+  }
+
+  async function runCapturingErrors(fresh: Map<number, SlotData> | null): Promise<string> {
+    const logs: string[] = [];
+    const spy = spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    try {
+      await maybeResumeDeadOrchestrators(fresh);
+    } finally {
+      spy.mockRestore();
+    }
+    return logs.join("\n");
+  }
+
+  function readSlotLiveness(slot: number): unknown {
+    const raw = JSON.parse(readFileSync(join(harness(), "slots", `slot-${slot}.json`), "utf-8"));
+    return raw.liveness;
+  }
+  function readEvents(): string {
+    const p = join(harness(), "journal", "events.jsonl");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+  function readNotifications(): string {
+    const p = join(harness(), "journal", "notifications.jsonl");
+    return existsSync(p) ? readFileSync(p, "utf-8") : "";
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-mag-cb-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_CONFIG = writeConfig(TMP);
+    process.env.LUDICS_HARNESS_DIR = harness();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller context
+    mkdirSync(harness(), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("TRIP: same (task,phase) at threshold-1 → no resume, slot escalated, priority-5 notify, event emitted", async () => {
+    // Harness condition: prior persisted count = THRESHOLD-1 (=2) for the SAME
+    // (taskId, phase) the orchestrator is still stuck in → this detection makes
+    // ticks reach THRESHOLD and trips the breaker.
+    writeSlot(1, "task-66a3bbff");
+    writeOrchState(1, "task-66a3bbff", "setup", { taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: THRESHOLD - 1 });
+    writeT3codeState(1, DEAD_PID);
+
+    const out = await runCapturingErrors(null);
+
+    // Invariant: the breaker tripped — it did NOT reach slotResume. If it had,
+    // the t3code branch would log "no persisted t3code state". Its absence is
+    // what proves no re-spawn happened.
+    expect(out).toContain("circuit-breaker tripped for slot 1");
+    expect(out).not.toContain("no persisted t3code state");
+    expect(out).not.toContain("detected dead orchestrator for slot 1 (pid"); // the resume log
+
+    // Invariant: the slot is marked escalated in authoritative state so the
+    // other auto-loops (and the next tick's liveness skip) stop touching it.
+    expect(readSlotLiveness(1)).toBe("escalated");
+
+    // Invariant: one priority-5 notification names the wedge.
+    const notifs = readNotifications();
+    expect(notifs).toContain('"priority":5');
+    expect(notifs).toContain("orchestration wedged");
+
+    // Invariant: a structured circuit-break event is emitted with the count.
+    const events = readEvents();
+    expect(events).toContain("orchestration_resume_circuit_break");
+    expect(events).toContain(`"count":${THRESHOLD}`);
+  });
+
+  test("NO-THROTTLE positive control: recorded phase differs (advanced) → counter resets, resume IS attempted", async () => {
+    // Harness condition: a HIGH prior count (5) but recorded against a DIFFERENT
+    // phase ("plan") than the current orchestrator phase ("setup") — i.e. the
+    // orchestrator advanced between ticks. sameWork=false → ticks resets to 1 <
+    // THRESHOLD → resume proceeds, never throttled.
+    writeSlot(1, "task-66a3bbff");
+    writeOrchState(1, "task-66a3bbff", "setup", { taskId: "task-66a3bbff", phase: "plan", consecutiveTicks: 5 });
+    writeT3codeState(1, DEAD_PID);
+
+    const out = await runCapturingErrors(null);
+
+    expect(out).not.toContain("circuit-breaker tripped");
+    // Reached slotResume (proves not throttled) — fails on the t3code state check.
+    expect(out).toContain("detected dead orchestrator for slot 1");
+    expect(out).toContain("no persisted t3code state");
+  });
+
+  test("LIVENESS SKIP: an already-escalated slot is never re-detected or re-escalated", async () => {
+    // Harness condition: slot liveness already "escalated" (a prior trip, or an
+    // operator). The loop must skip it entirely — no detection, no second
+    // escalation/notification. Without the skip the breaker would re-fire each tick.
+    writeSlot(1, "task-66a3bbff", "escalated");
+    writeOrchState(1, "task-66a3bbff", "setup", { taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: THRESHOLD });
+    writeT3codeState(1, DEAD_PID);
+
+    const out = await runCapturingErrors(null);
+
+    expect(out).not.toContain("detected dead orchestrator");
+    expect(out).not.toContain("circuit-breaker tripped");
+  });
+
+  test("RATE LIMIT: a trip on slot 1 consumes the per-invocation action — slot 2 is left untouched this tick", async () => {
+    // Harness condition: slot 1 trips (escalation), slot 2 is independently
+    // resumable. Escalation does `resumed += 1`, so the loop must not also act
+    // on slot 2 in the same invocation. Mutation control: dropping `resumed += 1`
+    // from the trip path would let slot 2 be detected → this assertion FAILS.
+    writeSlot(1, "task-aaa");
+    writeOrchState(1, "task-aaa", "setup", { taskId: "task-aaa", phase: "setup", consecutiveTicks: THRESHOLD - 1 });
+    writeT3codeState(1, DEAD_PID);
+    writeSlot(2, "task-bbb");
+    writeOrchState(2, "task-bbb", "setup");
+    writeT3codeState(2, DEAD_PID);
+
+    const out = await runCapturingErrors(null);
+
+    expect(out).toContain("circuit-breaker tripped for slot 1");
+    expect(out).not.toContain("slot 2"); // slot 2 not detected/resumed this tick
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -20,7 +20,7 @@ import { isRemoteMachine } from "./remote.ts";
 import { stateMarkDirty } from "./state.ts";
 import { journalAppend } from "./journal.ts";
 import { emitEvent } from "./events.ts";
-import { readOrchestrationState } from "./orchestration/state.ts";
+import { readOrchestrationState, persistState } from "./orchestration/state.ts";
 import { isElaborated } from "./tasks/elaboration.ts";
 import { tasksAbandon, tasksNeedsConfirmationList } from "./tasks/index.ts";
 import { buildAffinityLookup, type AffinityInput } from "./tasks/affinity.ts";
@@ -30,7 +30,7 @@ import {
   expirePendingFollowupRevises,
 } from "./notify.ts";
 import { updateFrontmatterField, removeFrontmatterField, parseTaskFrontmatter, priorityValue, TERMINAL_STATUSES } from "./tasks/markdown.ts";
-import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask } from "./slots/index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotStop, taskCompleteDirectly, markSlotSetupFailed, findSlotForTask, persistSlotLiveness } from "./slots/index.ts";
 import { expandDuoSlots } from "./slots/duo-expand.ts";
 import { readSlotState } from "./t3code/server.ts";
 import { captureLastMessage, captureLastMessageHash, readTmuxSlotState } from "./adapters/tmux-adapter.ts";
@@ -3474,6 +3474,15 @@ function isWorkerNode(): boolean {
   return !!clusterCurrentMachineName() && !clusterIsController();
 }
 
+/**
+ * gh-ludics-584 resume circuit-breaker threshold: stop re-spawning after this
+ * many consecutive keepalive ticks that found the orchestrator dead in the SAME
+ * (taskId, phase) with no advance. At the ~2-min worker keepalive cadence this
+ * is ~4-6 min of pure no-progress before escalating to a single actionable
+ * alert instead of looping forever.
+ */
+const MAX_CONSECUTIVE_NO_ADVANCE_RESUMES = 3;
+
 export async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, SlotData> | null): Promise<void> {
   if (startSessionsAutonomy() === "manual") return;
 
@@ -3497,6 +3506,16 @@ export async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, Slot
     // IMPORTANT: use `slotProcess` not `process` to avoid shadowing the global
     const slotProcess = data.process;
     if (!slotProcess || slotProcess === "(empty)") continue;
+
+    // gh-ludics-584: skip slots an operator (or our own circuit-breaker) has
+    // marked interrupted/escalated — both require an explicit `ludics slot N
+    // resume` to clear. Mirrors maybeAutoStartSlots/maybeFillEmptySlots. On a
+    // worker `data` is the controller-live freshSlots row, so this reads the
+    // authoritative liveness, not a stale local clone. Without this skip the
+    // breaker's escalation would not stick: the slot would be re-detected dead
+    // and re-escalated/re-notified every tick.
+    const slotLiveness = data.liveness ?? "";
+    if (slotLiveness === "interrupted" || slotLiveness === "escalated") continue;
 
     const mode = data.mode ?? "";
     if (mode !== "t3code" && mode !== "tmux") continue;
@@ -3526,6 +3545,62 @@ export async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, Slot
     }
     if (alive) continue;
 
+    // gh-ludics-584 circuit-breaker: count consecutive dead-runner detections
+    // in the SAME (taskId, phase). A different (taskId, phase) than last time
+    // means real progress (or a new task) → reset to 1. Same → increment. When
+    // the count reaches the threshold, the runner is dying without ever
+    // advancing (the worker cgroup-reap loop): stop re-spawning, mark the slot
+    // escalated, and raise one priority alert instead of looping forever.
+    const rec = orchState.autoResumeNoProgress;
+    const sameWork = !!rec && rec.taskId === taskId && rec.phase === orchState.phase;
+    const ticks = sameWork ? rec!.consecutiveTicks + 1 : 1;
+
+    if (ticks >= MAX_CONSECUTIVE_NO_ADVANCE_RESUMES) {
+      console.error(
+        `ludics: orchestration resume circuit-breaker tripped for slot ${slotNum} ` +
+        `(task ${taskId}, phase ${orchState.phase}, ${ticks} consecutive no-advance ` +
+        `resumes) — halting auto-resume and escalating`,
+      );
+      // Persist the tripped count so the record reflects reality even though we
+      // won't resume (informational; the escalated liveness is what stops the loop).
+      orchState.autoResumeNoProgress = { taskId, phase: orchState.phase, consecutiveTicks: ticks };
+      persistState(orchState, orchState.harnessDir);
+      // Worker-authoritative escalation (POSTs to controller on a worker; no
+      // stale local read — see persistSlotLiveness).
+      try {
+        await persistSlotLiveness(slotNum, "escalated");
+      } catch (err) {
+        console.error(
+          `ludics: failed to mark slot ${slotNum} escalated: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      notifyOutgoing(
+        `slot ${slotNum} orchestration wedged: runner for task ${taskId} died ` +
+        `${ticks}× in phase "${orchState.phase}" without advancing (last dead pid ` +
+        `${pid}) — auto-resume halted; run \`ludics slot ${slotNum} resume\` after fixing`,
+        5,
+        "ludics orchestration stuck",
+      );
+      emitEvent({
+        event_type: "orchestration_resume_circuit_break",
+        source: "keepalive",
+        scope: "slot",
+        slot: slotNum,
+        task: taskId,
+        phase: orchState.phase,
+        deadPid: pid,
+        threshold: MAX_CONSECUTIVE_NO_ADVANCE_RESUMES,
+        count: ticks,
+        message: `resume circuit-breaker tripped for slot ${slotNum}: ${ticks} consecutive ` +
+          `no-advance resumes in phase=${orchState.phase} (task ${taskId})`,
+      });
+      // Escalation consumes this invocation's single action so the loop does
+      // not also resume/churn another slot in the same tick.
+      resumed += 1;
+      continue;
+    }
+
     console.error(
       `ludics: detected dead orchestrator for slot ${slotNum} ` +
       `(pid ${pid}, task ${taskId}, phase ${orchState.phase}) — auto-resuming`,
@@ -3549,6 +3624,21 @@ export async function maybeResumeDeadOrchestrators(freshSlots?: Map<number, Slot
         if (setWorkerSlotsOverride) setWorkerSlotsOverride(null);
       }
       resumed += 1;
+      // gh-ludics-584: record the no-advance counter AFTER a successful resume
+      // (a throwing resume must not advance it). Re-read post-resume so we write
+      // against the freshest state (slotResume may have rewritten it); the phase
+      // is whatever the resume produced — if it advanced, next tick's sameWork
+      // compares against the new phase and resets to 1.
+      try {
+        const post = readOrchestrationState(slotNum) ?? orchState;
+        post.autoResumeNoProgress = { taskId, phase: post.phase, consecutiveTicks: ticks };
+        persistState(post, post.harnessDir);
+      } catch (err) {
+        console.error(
+          `ludics: failed to persist resume counter for slot ${slotNum}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       emitEvent({
         event_type: "orchestration_auto_resume",
         source: "keepalive",

--- a/src/orchestration/process.test.ts
+++ b/src/orchestration/process.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { mkdirSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runnerLaunchCommand, startOrchestrationProcess } from "./process.ts";
+
+describe("runnerLaunchCommand", () => {
+  const cmd = ["/path/to/ludics", "orch", "run-internal", "3"];
+
+  test("Linux + systemd-run present + user systemd → systemd-run --user --scope --collect, original command at tail", () => {
+    const argv = runnerLaunchCommand(cmd, {
+      platform: "linux",
+      systemdRunPath: "/usr/bin/systemd-run",
+      hasUserSystemd: true,
+    });
+    // The cgroup-escape invariant: the runner is launched into its own transient
+    // scope, NOT as a direct setsid child of the reaping cgroup.
+    expect(argv.slice(0, 4)).toEqual(["/usr/bin/systemd-run", "--user", "--scope", "--collect"]);
+    // The orch run-internal command must survive verbatim as the tail.
+    expect(argv.slice(4)).toEqual(cmd);
+  });
+
+  test("Linux + systemd-run absent → falls back to setsidWrap shape (no systemd-run)", () => {
+    const argv = runnerLaunchCommand(cmd, {
+      platform: "linux",
+      systemdRunPath: null,
+      hasUserSystemd: true,
+      resolvedSetsid: "/usr/bin/setsid",
+    });
+    expect(argv[0]).not.toBe("systemd-run");
+    expect(argv).toEqual(["/usr/bin/setsid", ...cmd]);
+  });
+
+  test("Linux + systemd-run present but no user systemd → falls back to setsidWrap", () => {
+    const argv = runnerLaunchCommand(cmd, {
+      platform: "linux",
+      systemdRunPath: "/usr/bin/systemd-run",
+      hasUserSystemd: false,
+      resolvedSetsid: "/usr/bin/setsid",
+    });
+    expect(argv).not.toContain("systemd-run");
+    expect(argv).toEqual(["/usr/bin/setsid", ...cmd]);
+  });
+
+  test("macOS (darwin) → unchanged setsid/perl wrapper, never systemd-run", () => {
+    const argv = runnerLaunchCommand(cmd, {
+      platform: "darwin",
+      // even if a (nonsensical) systemd-run path were resolved, darwin must not use it
+      systemdRunPath: "/usr/bin/systemd-run",
+      hasUserSystemd: true,
+      resolvedSetsid: null, // force the perl POSIX fallback branch of setsidWrap
+    });
+    expect(argv).not.toContain("--scope");
+    expect(argv[0]).toBe("perl");
+    expect(argv.slice(-cmd.length)).toEqual(cmd);
+  });
+});
+
+describe("startOrchestrationProcess stdio", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    while (spies.length) spies.pop()!.mockRestore();
+  });
+
+  test("directs both stdout and stderr to the per-slot log fd (stdout no longer discarded)", async () => {
+    const harnessDir = mkdtempSync(join(tmpdir(), "ludics-584-proc-"));
+    mkdirSync(join(harnessDir, "orchestration"), { recursive: true });
+    const captured: Array<Record<string, unknown>> = [];
+    const spawnSpy = spyOn(Bun, "spawn").mockImplementation((_argv: unknown, opts: unknown) => {
+      captured.push(opts as Record<string, unknown>);
+      // Pretend the runner is alive (exitCode null) so the immediate-exit check passes.
+      return { pid: 4242, exitCode: null, unref() {} } as never;
+    });
+    spies.push(spawnSpy);
+    const sleepSpy = spyOn(Bun, "sleep").mockResolvedValue(undefined as never);
+    spies.push(sleepSpy);
+
+    const pid = await startOrchestrationProcess(3, harnessDir, "task-abc");
+    expect(pid).toBe(4242);
+
+    expect(captured.length).toBe(1);
+    const opts = captured[0]!;
+    // Regression invariant: stdout must NOT be "ignore" (the gh-ludics-584 bug)
+    // and must share the exact fd used for stderr.
+    expect(opts.stdout).not.toBe("ignore");
+    expect(typeof opts.stdout).toBe("number");
+    expect(opts.stdout).toBe(opts.stderr);
+    expect(opts.stdin).toBe("ignore");
+  });
+});

--- a/src/orchestration/process.test.ts
+++ b/src/orchestration/process.test.ts
@@ -2,59 +2,7 @@ import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { runnerLaunchCommand, startOrchestrationProcess } from "./process.ts";
-
-describe("runnerLaunchCommand", () => {
-  const cmd = ["/path/to/ludics", "orch", "run-internal", "3"];
-
-  test("Linux + systemd-run present + user systemd → systemd-run --user --scope --collect, original command at tail", () => {
-    const argv = runnerLaunchCommand(cmd, {
-      platform: "linux",
-      systemdRunPath: "/usr/bin/systemd-run",
-      hasUserSystemd: true,
-    });
-    // The cgroup-escape invariant: the runner is launched into its own transient
-    // scope, NOT as a direct setsid child of the reaping cgroup.
-    expect(argv.slice(0, 4)).toEqual(["/usr/bin/systemd-run", "--user", "--scope", "--collect"]);
-    // The orch run-internal command must survive verbatim as the tail.
-    expect(argv.slice(4)).toEqual(cmd);
-  });
-
-  test("Linux + systemd-run absent → falls back to setsidWrap shape (no systemd-run)", () => {
-    const argv = runnerLaunchCommand(cmd, {
-      platform: "linux",
-      systemdRunPath: null,
-      hasUserSystemd: true,
-      resolvedSetsid: "/usr/bin/setsid",
-    });
-    expect(argv[0]).not.toBe("systemd-run");
-    expect(argv).toEqual(["/usr/bin/setsid", ...cmd]);
-  });
-
-  test("Linux + systemd-run present but no user systemd → falls back to setsidWrap", () => {
-    const argv = runnerLaunchCommand(cmd, {
-      platform: "linux",
-      systemdRunPath: "/usr/bin/systemd-run",
-      hasUserSystemd: false,
-      resolvedSetsid: "/usr/bin/setsid",
-    });
-    expect(argv).not.toContain("systemd-run");
-    expect(argv).toEqual(["/usr/bin/setsid", ...cmd]);
-  });
-
-  test("macOS (darwin) → unchanged setsid/perl wrapper, never systemd-run", () => {
-    const argv = runnerLaunchCommand(cmd, {
-      platform: "darwin",
-      // even if a (nonsensical) systemd-run path were resolved, darwin must not use it
-      systemdRunPath: "/usr/bin/systemd-run",
-      hasUserSystemd: true,
-      resolvedSetsid: null, // force the perl POSIX fallback branch of setsidWrap
-    });
-    expect(argv).not.toContain("--scope");
-    expect(argv[0]).toBe("perl");
-    expect(argv.slice(-cmd.length)).toEqual(cmd);
-  });
-});
+import { startOrchestrationProcess } from "./process.ts";
 
 describe("startOrchestrationProcess stdio", () => {
   const spies: Array<{ mockRestore: () => void }> = [];
@@ -76,6 +24,8 @@ describe("startOrchestrationProcess stdio", () => {
     spies.push(sleepSpy);
 
     const pid = await startOrchestrationProcess(3, harnessDir, "task-abc");
+    // gh-ludics-584: the returned pid must be the runner's own pid (setsid/perl
+    // exec in place). The mocked spawn returns 4242 as that pid.
     expect(pid).toBe(4242);
 
     expect(captured.length).toBe(1);

--- a/src/orchestration/process.test.ts
+++ b/src/orchestration/process.test.ts
@@ -66,8 +66,8 @@ describe("startOrchestrationProcess stdio", () => {
     const harnessDir = mkdtempSync(join(tmpdir(), "ludics-584-proc-"));
     mkdirSync(join(harnessDir, "orchestration"), { recursive: true });
     const captured: Array<Record<string, unknown>> = [];
-    const spawnSpy = spyOn(Bun, "spawn").mockImplementation((_argv: unknown, opts: unknown) => {
-      captured.push(opts as Record<string, unknown>);
+    const spawnSpy = spyOn(Bun, "spawn").mockImplementation((...args: unknown[]) => {
+      captured.push(args[1] as Record<string, unknown>);
       // Pretend the runner is alive (exitCode null) so the immediate-exit check passes.
       return { pid: 4242, exitCode: null, unref() {} } as never;
     });

--- a/src/orchestration/process.ts
+++ b/src/orchestration/process.ts
@@ -6,15 +6,63 @@ import { join } from "path";
 import { ludicsSelfCommand, setsidWrap } from "./util.ts";
 
 /**
+ * Build the argv that launches the detached orchestration runner so it
+ * outlives the process that spawned it.
+ *
+ * On a federation **worker** the keepalive is a `Type=oneshot`
+ * `ludics-mag.service` whose default `KillMode=control-group` reaps the entire
+ * cgroup — including a `setsid`-detached, `unref()`'d runner — the moment the
+ * oneshot's main process exits (gh-ludics-584). `setsid` escapes the
+ * controlling tty but NOT the systemd cgroup. On Linux with a user systemd
+ * instance we therefore launch the runner via
+ * `systemd-run --user --scope --collect`, which runs it in its own transient
+ * *scope* unit (its own cgroup, created by the caller — so the runner stays its
+ * own main process and `Bun.spawn`'s pid/exit semantics are preserved). The
+ * `--collect` flag garbage-collects the scope when the runner exits.
+ *
+ * Everywhere else (macOS, or Linux without `systemd-run`/a user session) we
+ * keep the existing `setsidWrap` behavior unchanged. Inputs default from the
+ * environment but are overridable so tests can drive each branch without
+ * touching the real OS — mirroring `setsidWrap(cmd, resolvedSetsid?)`.
+ */
+export function runnerLaunchCommand(
+  command: string[],
+  opts: {
+    platform?: NodeJS.Platform;
+    systemdRunPath?: string | null;
+    hasUserSystemd?: boolean;
+    resolvedSetsid?: string | null;
+  } = {},
+): string[] {
+  const platform = opts.platform ?? process.platform;
+  const systemdRunPath = opts.systemdRunPath !== undefined
+    ? opts.systemdRunPath
+    : (platform === "linux" ? (Bun.which("systemd-run") ?? null) : null);
+  // A user systemd instance is required for `--user`; gate on a user-session
+  // signal rather than probing (cheap, no subprocess). Conservative: when this
+  // is uncertain we fall through to setsidWrap.
+  const hasUserSystemd = opts.hasUserSystemd !== undefined
+    ? opts.hasUserSystemd
+    : !!(process.env.XDG_RUNTIME_DIR || process.env.DBUS_SESSION_BUS_ADDRESS);
+
+  if (platform === "linux" && systemdRunPath && hasUserSystemd) {
+    return [systemdRunPath, "--user", "--scope", "--collect", ...command];
+  }
+  return setsidWrap(command, opts.resolvedSetsid);
+}
+
+/**
  * Spawn the orchestration runner as a detached background process for a slot.
  * Returns the PID of the spawned process. Throws if the process exits immediately.
  */
 export async function startOrchestrationProcess(slot: number, harnessDir: string, taskId: string): Promise<number> {
   const logPath = join(harnessDir, "orchestration", `slot-${slot}-${taskId}.log`);
   const logFd = openSync(logPath, "a");
-  const proc = Bun.spawn(setsidWrap(ludicsSelfCommand(["orch", "run-internal", String(slot)])), {
+  const proc = Bun.spawn(runnerLaunchCommand(ludicsSelfCommand(["orch", "run-internal", String(slot)])), {
     stdin: "ignore",
-    stdout: "ignore",
+    // gh-ludics-584: capture stdout too (merged into the same per-slot log fd as
+    // stderr) so a silent runner death is diagnosable without guessing the sink.
+    stdout: logFd,
     stderr: logFd,
     env: {
       ...(process.env as Record<string, string>),

--- a/src/orchestration/process.ts
+++ b/src/orchestration/process.ts
@@ -6,59 +6,28 @@ import { join } from "path";
 import { ludicsSelfCommand, setsidWrap } from "./util.ts";
 
 /**
- * Build the argv that launches the detached orchestration runner so it
- * outlives the process that spawned it.
- *
- * On a federation **worker** the keepalive is a `Type=oneshot`
- * `ludics-mag.service` whose default `KillMode=control-group` reaps the entire
- * cgroup — including a `setsid`-detached, `unref()`'d runner — the moment the
- * oneshot's main process exits (gh-ludics-584). `setsid` escapes the
- * controlling tty but NOT the systemd cgroup. On Linux with a user systemd
- * instance we therefore launch the runner via
- * `systemd-run --user --scope --collect`, which runs it in its own transient
- * *scope* unit (its own cgroup, created by the caller — so the runner stays its
- * own main process and `Bun.spawn`'s pid/exit semantics are preserved). The
- * `--collect` flag garbage-collects the scope when the runner exits.
- *
- * Everywhere else (macOS, or Linux without `systemd-run`/a user session) we
- * keep the existing `setsidWrap` behavior unchanged. Inputs default from the
- * environment but are overridable so tests can drive each branch without
- * touching the real OS — mirroring `setsidWrap(cmd, resolvedSetsid?)`.
- */
-export function runnerLaunchCommand(
-  command: string[],
-  opts: {
-    platform?: NodeJS.Platform;
-    systemdRunPath?: string | null;
-    hasUserSystemd?: boolean;
-    resolvedSetsid?: string | null;
-  } = {},
-): string[] {
-  const platform = opts.platform ?? process.platform;
-  const systemdRunPath = opts.systemdRunPath !== undefined
-    ? opts.systemdRunPath
-    : (platform === "linux" ? (Bun.which("systemd-run") ?? null) : null);
-  // A user systemd instance is required for `--user`; gate on a user-session
-  // signal rather than probing (cheap, no subprocess). Conservative: when this
-  // is uncertain we fall through to setsidWrap.
-  const hasUserSystemd = opts.hasUserSystemd !== undefined
-    ? opts.hasUserSystemd
-    : !!(process.env.XDG_RUNTIME_DIR || process.env.DBUS_SESSION_BUS_ADDRESS);
-
-  if (platform === "linux" && systemdRunPath && hasUserSystemd) {
-    return [systemdRunPath, "--user", "--scope", "--collect", ...command];
-  }
-  return setsidWrap(command, opts.resolvedSetsid);
-}
-
-/**
  * Spawn the orchestration runner as a detached background process for a slot.
  * Returns the PID of the spawned process. Throws if the process exits immediately.
+ *
+ * gh-ludics-584: on a federation **worker** the keepalive is a `Type=oneshot`
+ * `ludics-mag.service` whose default `KillMode=control-group` reaps the entire
+ * cgroup — including this `setsid`-detached, `unref()`'d runner — the moment the
+ * oneshot's main process exits, so the runner never advances past `setup`. The
+ * fix lives in the generated unit (`KillMode=process`, see `src/triggers.ts`):
+ * once the keepalive's main process is the only thing killed on exit, the
+ * detached descendant survives. We deliberately do NOT wrap the runner in
+ * `systemd-run --user --scope` here: a scope runs the command under a
+ * long-lived `systemd-run` supervisor, so `Bun.spawn`'s pid would be that
+ * wrapper, not the runner — `slotResume` persists it as the sibling
+ * orchestration pid and the runner's pid-based self-guard (`runner.ts`) then
+ * exits on the live-pid mismatch (the gh-509 reclaim only triggers for a *dead*
+ * recorded pid). `setsid`/`perl` exec the runner in place, so `proc.pid` is the
+ * runner's real pid. See the gh-ludics-584 proposal AC 2 note.
  */
 export async function startOrchestrationProcess(slot: number, harnessDir: string, taskId: string): Promise<number> {
   const logPath = join(harnessDir, "orchestration", `slot-${slot}-${taskId}.log`);
   const logFd = openSync(logPath, "a");
-  const proc = Bun.spawn(runnerLaunchCommand(ludicsSelfCommand(["orch", "run-internal", String(slot)])), {
+  const proc = Bun.spawn(setsidWrap(ludicsSelfCommand(["orch", "run-internal", String(slot)])), {
     stdin: "ignore",
     // gh-ludics-584: capture stdout too (merged into the same per-slot log fd as
     // stderr) so a silent runner death is diagnosable without guessing the sink.

--- a/src/orchestration/state.autoresume-migrate.test.ts
+++ b/src/orchestration/state.autoresume-migrate.test.ts
@@ -1,0 +1,84 @@
+// gh-ludics-584: migration triple for the resume circuit-breaker field
+// `OrchestrationState.autoResumeNoProgress` — positive backfill (legacy state
+// without the field loads clean), negative-control coercion/drop of corrupt
+// persisted values, and a JSON round-trip fidelity check.
+
+import { describe, expect, test } from "bun:test";
+import {
+  defaultOrchestrationConfig,
+  migrateState,
+  type OrchestrationState,
+} from "./state.ts";
+
+function baseState(): OrchestrationState {
+  return {
+    slot: 3,
+    taskId: "task-66a3bbff",
+    mode: "pair",
+    phase: "setup",
+    round: 1,
+    mergeRound: 0,
+    agents: [],
+    agentStates: {},
+    config: defaultOrchestrationConfig(),
+    phaseStartedAt: 0,
+    startedAt: new Date().toISOString(),
+    projectDir: "/tmp/project",
+    rootWorktree: "/tmp/root",
+    peerSyncDir: "/tmp/peer-sync",
+    threadIds: {},
+    backend: "tmux",
+  };
+}
+
+describe("migrateState — autoResumeNoProgress (gh-ludics-584)", () => {
+  test("positive: legacy state without the field loads with it undefined, no throw", () => {
+    const legacy = baseState();
+    expect("autoResumeNoProgress" in legacy).toBe(false);
+    const migrated = migrateState(legacy, 3);
+    // Invariant: absent field stays absent (new-field default), not fabricated.
+    expect(migrated.autoResumeNoProgress).toBeUndefined();
+  });
+
+  test("negative control: corrupt record with non-string taskId/phase is dropped", () => {
+    const state = baseState();
+    // Simulate a malformed on-disk record (e.g. truncated/old write).
+    (state as unknown as { autoResumeNoProgress: unknown }).autoResumeNoProgress = {
+      taskId: 123, phase: null, consecutiveTicks: 2,
+    };
+    const migrated = migrateState(state, 3);
+    // Invariant: a malformed key cannot drive the same-(taskId,phase) compare,
+    // so the whole record is dropped rather than silently mis-counting.
+    expect(migrated.autoResumeNoProgress).toBeUndefined();
+  });
+
+  test("negative control: valid key with bad consecutiveTicks is clamped to 0", () => {
+    const state = baseState();
+    (state as unknown as { autoResumeNoProgress: unknown }).autoResumeNoProgress = {
+      taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: -5,
+    };
+    const migrated = migrateState(state, 3);
+    expect(migrated.autoResumeNoProgress).toEqual({
+      taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: 0,
+    });
+  });
+
+  test("negative control: NaN/non-number consecutiveTicks is clamped to 0", () => {
+    const state = baseState();
+    (state as unknown as { autoResumeNoProgress: unknown }).autoResumeNoProgress = {
+      taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: "oops",
+    };
+    const migrated = migrateState(state, 3);
+    expect(migrated.autoResumeNoProgress?.consecutiveTicks).toBe(0);
+  });
+
+  test("round-trip: a valid record survives serialize → parse → migrate unchanged", () => {
+    const state = baseState();
+    state.autoResumeNoProgress = { taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: 2 };
+    const roundTripped = JSON.parse(JSON.stringify(state)) as OrchestrationState;
+    const migrated = migrateState(roundTripped, 3);
+    expect(migrated.autoResumeNoProgress).toEqual({
+      taskId: "task-66a3bbff", phase: "setup", consecutiveTicks: 2,
+    });
+  });
+});

--- a/src/orchestration/state.autoresume-migrate.test.ts
+++ b/src/orchestration/state.autoresume-migrate.test.ts
@@ -3,12 +3,17 @@
 // without the field loads clean), negative-control coercion/drop of corrupt
 // persisted values, and a JSON round-trip fidelity check.
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   defaultOrchestrationConfig,
   migrateState,
   type OrchestrationState,
 } from "./state.ts";
+import { withSyntheticHarness } from "../test-utils.ts";
+
+// migrateState/defaultOrchestrationConfig transitively read config; isolate the
+// harness env so this file keeps the lint:test-isolation pin.
+withSyntheticHarness(beforeEach, afterEach);
 
 function baseState(): OrchestrationState {
   return {

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -322,6 +322,13 @@ export interface OrchestrationState {
    *  backfilled from the readOrchestrationState() harnessDir arg for legacy
    *  state files. Consumers should read via `state.harnessDir ?? defaultHarnessDir()`. */
   harnessDir?: string;
+  /** gh-ludics-584 resume circuit-breaker: how many consecutive keepalive
+   *  auto-resume detections found the orchestrator dead in the SAME (taskId,
+   *  phase) with no advance. Reset when the phase advances or the task changes.
+   *  Persisted (worker cache survives oneshot ticks) so the count accumulates
+   *  across the separate per-tick worker keepalive processes. Single-line by
+   *  design so the lint:state-migration field extractor records one field. */
+  autoResumeNoProgress?: { taskId: string; phase: Phase; consecutiveTicks: number };
 }
 
 export const DEFAULT_TIMEOUTS: Record<string, number> = {
@@ -629,6 +636,25 @@ export function migrateState(state: OrchestrationState, slot: number): Orchestra
       nudgeCooldownSeconds: ss.nudgeCooldownSeconds ?? DEFAULT_SUBSTANTIVE_STALL_CONFIG.nudgeCooldownSeconds,
       maxNudgeAttempts: ss.maxNudgeAttempts ?? DEFAULT_SUBSTANTIVE_STALL_CONFIG.maxNudgeAttempts,
     };
+  }
+  // gh-ludics-584: normalize the resume circuit-breaker record read from disk.
+  // Absent → stays undefined (new-field default). Present-but-corrupt → drop the
+  // whole record when taskId/phase are not strings (a malformed key can't drive
+  // the same-phase comparison), else clamp a bad/negative consecutiveTicks to 0
+  // so the breaker counts forward from a sane floor rather than tripping/looping
+  // on garbage. (lint:state-migration read-boundary coercion for the new field.)
+  if (state.autoResumeNoProgress !== undefined) {
+    const arp = state.autoResumeNoProgress as unknown as {
+      taskId?: unknown; phase?: unknown; consecutiveTicks?: unknown;
+    };
+    if (typeof arp.taskId !== "string" || typeof arp.phase !== "string") {
+      delete state.autoResumeNoProgress;
+    } else {
+      const ticks = arp.consecutiveTicks;
+      if (typeof ticks !== "number" || !Number.isFinite(ticks) || ticks < 0) {
+        state.autoResumeNoProgress.consecutiveTicks = 0;
+      }
+    }
   }
   return state;
 }

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride, persistSlotLiveness } from "./index.ts";
 import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
 import * as spawnMod from "../spawn.ts";
@@ -2989,5 +2989,110 @@ cluster:
     // "offline — cannot resume" and the assertions below would fail.
     await expect(slotResume(1)).rejects.toThrow("no persisted t3code state");
     await expect(slotResume(1)).rejects.not.toThrow("offline — cannot resume");
+  });
+});
+
+// gh-ludics-584: persistSlotLiveness must persist to AUTHORITATIVE state
+// worker-first — the worker branch POSTs to the controller WITHOUT reading the
+// local slot clone, because that clone may be stale/empty (gh-ludics-580) and an
+// `(empty)` clone would otherwise early-return and silently drop the escalation
+// the resume circuit-breaker depends on.
+describe("persistSlotLiveness — worker-first authoritative liveness (gh-ludics-584)", () => {
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(): void {
+    const cfgDir = join(TMP, ".config", "ludics");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.yaml"), `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: self-node
+      host: self-node.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    process.env.LUDICS_CONFIG = join(cfgDir, "config.yaml");
+  }
+
+  afterEach(() => {
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+  });
+
+  test("worker + STALE/EMPTY local clone → POSTs {liveness} to controller, never reads local (stale-clone case)", async () => {
+    writeClusterConfig();
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "self-node"; // worker context
+
+    // The #580 trap: the local clone is EMPTY (process="(empty)"). A readSlot-
+    // first helper would early-return here and NEVER escalate the authoritative
+    // slot. The controller-live slot is active, so escalation MUST still POST.
+    writeSlotJson(1, emptySlotData(1)); // local clone = (empty)
+
+    // Observe the real worker transport: clusterPostSlotUpdate → resolveAndPost
+    // → clusterHttpPost → global `fetch`. Spying `fetch` (a true global) is
+    // reliable, unlike spying the dynamically-imported cluster-http namespace.
+    const calls: Array<{ url: string; body: unknown }> = [];
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), body: JSON.parse(String(init?.body ?? "{}")) });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch);
+    try {
+      await persistSlotLiveness(1, "escalated");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+
+    // Invariant: the authoritative (controller) slot is updated despite the
+    // empty local clone. Mutation control: a `readSlot()`-before-branch helper
+    // would early-return on (empty) → zero POSTs → this fails.
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.url).toContain("/api/cluster/slot-update");
+    expect(calls[0]!.body).toMatchObject({ slot: 1, liveness: "escalated" });
+
+    // And the worker branch must NOT have written the local clone.
+    expect(readSlotJson(1).liveness).toBeNull();
+  });
+
+  test("controller/standalone → writes liveness to the local authoritative slot, no HTTP POST", async () => {
+    // Default writeConfig() (beforeEach) has no cluster block → isWorkerContext
+    // is false → local harness is authoritative.
+    writeSlotJson(1, { ...emptySlotData(1), process: "orch-runner", task: "task-x", machine: "" });
+
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    try {
+      await persistSlotLiveness(1, "escalated");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(readSlotJson(1).liveness).toBe("escalated");
+  });
+
+  test("controller/standalone + (empty) slot → no-op (no write, no POST)", async () => {
+    writeSlotJson(1, emptySlotData(1)); // process = "(empty)"
+
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    try {
+      await persistSlotLiveness(1, "escalated");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(readSlotJson(1).liveness).toBeNull();
   });
 });

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -192,6 +192,36 @@ function writeSlotOrHttp(slotNum: number, data: SlotData): void {
   writeSlotJson(slotNum, data);
 }
 
+/**
+ * Persist a slot's liveness to the AUTHORITATIVE store, worker-first
+ * (gh-ludics-584).
+ *
+ * Unlike `writeSlotOrHttp`, the worker branch here does NOT read the local
+ * slot clone: `readSlot()` falls back to the (possibly stale/empty) local
+ * `slot-N.json` whenever `workerSlotsOverride` is not active (gh-ludics-580),
+ * and an `(empty)` clone would early-return before the controller POST — so
+ * the keepalive resume circuit-breaker's `escalated` mark would never reach the
+ * controller-authoritative state and the loop would keep re-detecting the slot
+ * as non-escalated. We therefore POST directly on a worker (no local read) and
+ * `await` it so it lands before the keepalive oneshot process exits. The breaker
+ * only calls this for a slot already confirmed active via controller-live
+ * `freshSlots`, so skipping the local `(empty)` guard on the worker is safe.
+ */
+export async function persistSlotLiveness(slotNum: number, liveness: SlotLiveness): Promise<void> {
+  validateRange(slotNum, slotsCount());
+  if (isWorkerContext()) {
+    const { clusterPostSlotUpdate } = await import("../cluster-http.ts");
+    await clusterPostSlotUpdate(slotNum, { liveness: liveness ?? undefined });
+    return;
+  }
+  // Controller / standalone: the local harness is authoritative.
+  ensureSlotsDir();
+  const data = readSlot(slotNum);
+  if (data.process === "(empty)") return;
+  setSlotLivenessOnData(data, liveness);
+  writeSlotJson(slotNum, data);
+}
+
 function validateRange(slot: number, count: number): void {
   if (slot < 1 || slot > count) {
     throw new Error(`slot out of range: ${slot} (1-${count})`);

--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -11,7 +11,8 @@ import { describe, test, expect } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, plistEnvXml } from "./triggers.ts";
+import { readFileSync } from "fs";
+import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, plistEnvXml, magKeepaliveServiceBody } from "./triggers.ts";
 import type { ClusterMachine } from "./cluster.ts";
 
 const CONTROLLER_ONLY = ["dashboard", "ntfy-subscribe", "morning", "health", "sync", "watch"] as const;
@@ -172,5 +173,39 @@ describe("plistEnvXml — bakes LUDICS_CLUSTER_MACHINE_NAME when resolvable", ()
     const xml = plistEnvXml(null);
     expect(xml).not.toContain("LUDICS_CLUSTER_MACHINE_NAME");
     expect(xml).toContain("<key>PATH</key>");
+  });
+});
+
+// gh-ludics-584: the generated worker `ludics-mag.service` must carry
+// `KillMode=process` so the oneshot keepalive does NOT reap the detached
+// orchestration runner via its cgroup on exit. Without this line the worker
+// resume loop never advances past `setup` (the runner is SIGTERM'd each tick).
+describe("magKeepaliveServiceBody — KillMode=process hardening (gh-ludics-584)", () => {
+  test("emits Type=oneshot, KillMode=process, and the mag start ExecStart", () => {
+    const body = magKeepaliveServiceBody("/usr/local/bin/ludics");
+    // Invariant: the cgroup-reap-protection line is present (its absence is the bug).
+    expect(body).toContain("KillMode=process");
+    expect(body).toContain("Type=oneshot");
+    expect(body).toContain("ExecStart=/usr/local/bin/ludics mag start");
+  });
+
+  test("does NOT hardcode a stale bin path (uses the passed bin)", () => {
+    const body = magKeepaliveServiceBody("/opt/custom/ludics");
+    expect(body).toContain("ExecStart=/opt/custom/ludics mag start");
+    expect(body).not.toContain("/usr/local/bin/ludics");
+  });
+
+  // Negative control / scope guard: KillMode must be applied ONLY to the mag
+  // unit — the other oneshot trigger bodies (startup, morning, health, watch)
+  // intentionally have no long-lived descendants and must not gain it. The mag
+  // body is the single source; a leak into another inline systemdServiceBody
+  // would push this count above 1.
+  test("KillMode appears in exactly one unit body in triggers.ts (mag unit only)", () => {
+    const src = readFileSync(new URL("./triggers.ts", import.meta.url), "utf-8");
+    // Match the template-literal form `\nKillMode=process` (an actual unit-body
+    // line), not prose mentions in doc comments. A leak into another inline
+    // `systemdServiceBody` template would push this above 1.
+    const matches = src.match(/\\nKillMode=process/g) ?? [];
+    expect(matches.length).toBe(1);
   });
 });

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -349,6 +349,21 @@ function enableSystemdUnit(unitName: string): void {
   safeSyncOutput(["systemctl", "--user", "restart", unitName]);
 }
 
+/**
+ * systemd `[Service]` body for the Mag keepalive oneshot.
+ *
+ * `KillMode=process` (gh-ludics-584) is the critical line: the default
+ * `KillMode=control-group` reaps the unit's *entire* cgroup when the oneshot
+ * exits, killing the detached orchestration runner the keepalive just spawned
+ * (the worker resume loop). `process` kills only the unit's main process,
+ * leaving detached descendants alive — belt-and-suspenders alongside the
+ * `systemd-run --scope` cgroup-escape in `runnerLaunchCommand`. Scoped to the
+ * `mag` unit only; the other oneshot triggers have no long-lived descendants.
+ */
+export function magKeepaliveServiceBody(bin: string): string {
+  return `[Service]\nType=oneshot\nKillMode=process\nExecStart=${bin} mag start\n`;
+}
+
 type SimpleTriggerSpec = {
   /** macOS plist scheduling lines (between Label and EnvironmentVariables) */
   plistScheduling: string;
@@ -459,7 +474,7 @@ function installSimpleTriggers(): void {
     magEnabled === true || magEnabled === "true",
     {
       plistScheduling: `  <key>RunAtLoad</key>\n  <true/>\n  <key>StartInterval</key>\n  <integer>${keepaliveInterval}</integer>`,
-      systemdServiceBody: `[Service]\nType=oneshot\nExecStart=${bin} mag start\n`,
+      systemdServiceBody: magKeepaliveServiceBody(bin),
       systemdActivationUnit: "timer",
       systemdActivationBody: `[Unit]\nDescription=ludics Mag keepalive timer\n\n[Timer]\nOnBootSec=60\nOnUnitActiveSec=${keepaliveInterval}s\nUnit=ludics-mag.service\n\n[Install]\nWantedBy=timers.target\n`,
     },

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -356,8 +356,12 @@ function enableSystemdUnit(unitName: string): void {
  * `KillMode=control-group` reaps the unit's *entire* cgroup when the oneshot
  * exits, killing the detached orchestration runner the keepalive just spawned
  * (the worker resume loop). `process` kills only the unit's main process,
- * leaving detached descendants alive — belt-and-suspenders alongside the
- * `systemd-run --scope` cgroup-escape in `runnerLaunchCommand`. Scoped to the
+ * leaving the `setsid`-detached runner alive. This is the load-bearing
+ * cgroup-escape fix: the runner is spawned via `setsid`/`perl` (which exec the
+ * runner in place, preserving its real pid for the sibling self-guard), so the
+ * escape cannot live in the TS spawn path — a `systemd-run --scope` wrapper
+ * would change `Bun.spawn`'s pid to the supervisor and break the runner's
+ * pid-based self-guard (see `src/orchestration/process.ts`). Scoped to the
  * `mag` unit only; the other oneshot triggers have no long-lived descendants.
  */
 export function magKeepaliveServiceBody(bin: string): string {

--- a/templates/systemd/ludics-mag.service
+++ b/templates/systemd/ludics-mag.service
@@ -18,6 +18,10 @@ After=network.target
 
 [Service]
 Type=oneshot
+# gh-ludics-584: kill only the main process on stop, not the whole cgroup —
+# otherwise the detached orchestration runner spawned by `mag start` is reaped
+# when this oneshot exits (the worker resume loop).
+KillMode=process
 # Update this path to your ludics installation
 ExecStart=/usr/local/bin/ludics mag start
 


### PR DESCRIPTION
## Summary

Fixes the worker-side orchestration runner that dies in `setup` → infinite auto-resume loop (remote tmux pair never advances). On a federation **worker** (Linux), the `Type=oneshot` `ludics-mag.service` keepalive's default `KillMode=control-group` reaps the `setsid`-detached runner when the oneshot exits, so the keepalive re-resumes a dying runner every ~2 min forever. Four workstreams (all in proposal §Scope):

1. **Cgroup escape via the generated systemd unit** (`src/triggers.ts` + `templates/systemd/ludics-mag.service`) — `KillMode=process` on the **mag** keepalive unit so the oneshot kills only its main process on exit and the `setsid`-detached runner survives. This is the load-bearing fix.
2. **TS spawn path** (`src/orchestration/process.ts`) — keeps the existing `setsid`/perl wrapper, which `exec`s the runner in place so `proc.pid` is the runner's **real pid** (required by the sibling self-guard + liveness checks), and now **captures stdout** (was discarded → silent death undiagnosable).
3. **Resume circuit-breaker** (`src/mag.ts`) — after `MAX_CONSECUTIVE_NO_ADVANCE_RESUMES` (3) consecutive ticks dead in the same `(taskId, phase)`, stop resuming, mark slot `escalated`, raise a priority-5 notification, emit `orchestration_resume_circuit_break`. A slot that advances phase resets the counter. Counter persisted on `OrchestrationState.autoResumeNoProgress` so it survives the per-tick worker oneshot processes. New `persistSlotLiveness` (`src/slots/index.ts`) persists the `escalated` mark **worker-first** (POSTs to the controller without reading the stale/empty local clone — the #580 trap).
4. **stdout capture** — runner stdout merged into the per-slot log fd.

## Design change vs. the original plan (Codex P1 — addressed)

The original plan also wrapped the runner in `systemd-run --user --scope` in the TS spawn path (the user-resolved "both layers" decision). **Codex correctly flagged this as a P1:** `systemd-run --scope` runs the command under a long-lived supervisor, so `Bun.spawn`'s pid is the **wrapper**, not the runner. `slotResume` persists that wrapper pid as the sibling orchestration pid, and the runner's pid-based self-guard (`runner.ts`) then exits on the live-pid mismatch (the gh-509 reclaim only fires for a *dead* recorded pid) — so workers with user systemd would spawn a runner that dies immediately and the loop stays broken.

A transient scope's `MainPID` is not reliably queryable to recover the real runner pid, so the `systemd-run` branch is **dropped** in favor of `KillMode=process` alone — which the proposal's own Approach §2 already designed to protect the `setsid` fallback runner. The proposal AC 1/2/3/7 are revised in this PR with the rationale.

## Tests

`process.test.ts` (stdout capture + runner-pid returned), `triggers.test.ts` (`KillMode=process` body + scope negative-control), `state.autoresume-migrate.test.ts` (migration triple), circuit-breaker trip/no-throttle/liveness-skip/rate-limit (`mag.test.ts`), `persistSlotLiveness` worker-POST-on-empty-clone via the real `fetch` transport (`slots/index.test.ts`). Full suite **3181 pass / 0 fail**. `typecheck`, `eslint`, `lint:state-migration`, `lint:test-isolation`, `lint:no-mock-module`, `lint:no-nul-bytes`, `lint:cli-readme` green; `bun run build` succeeds.

## Operator step (AC7, not unit-testable)

cgroup reaping only reproduces under systemd. On minipc-wsl: deploy the built binary, refresh triggers so `ludics-mag.service` carries `KillMode=process`, launch a remote `--pair` orchestration, and confirm the runner pid is stable across ≥2 keepalive ticks, the phase advances past `setup`, and both stdout+stderr land in `orchestration/slot-<slot>-<task>.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)