### PR TITLE
fix(cluster): leader-immune teardown + launchd self-heal (gh-ludics-587)

### DIFF
--- a/src/cluster.test.ts
+++ b/src/cluster.test.ts
@@ -11,6 +11,7 @@ import {
   resolveController,
   clusterCurrentMachineName,
   heartbeatsDir,
+  hostPrefixMatchesMachineName,
 } from "./cluster.ts";
 
 // We test the pure logic helpers by importing and exercising them directly.
@@ -265,5 +266,57 @@ cluster:
   it("returns null when the cluster is disabled (no config)", () => {
     delete process.env.LUDICS_CONFIG;
     expect(selectOnlineCapableMachine({ gpu: "nvidia" })).toBeNull();
+  });
+});
+
+// gh-ludics-587: the loose `prefix.includes(mName)` substring match in
+// clusterCurrentMachine could let a short machine name false-match an unrelated
+// host prefix (and thereby mis-resolve identity → tear down the wrong node's
+// units). hostPrefixMatchesMachineName replaces it with a boundaried match:
+// equal, or a `-`/`.`-boundaried suffix of the host prefix.
+describe("hostPrefixMatchesMachineName — boundaried prefix↔name match (gh-ludics-587)", () => {
+  it("POSITIVE: documented legitimate case lukaszs-mac-studio ↔ mac-studio", () => {
+    expect(hostPrefixMatchesMachineName("lukaszs-mac-studio", "mac-studio")).toBe(true);
+  });
+
+  it("POSITIVE: exact equality", () => {
+    expect(hostPrefixMatchesMachineName("mac-studio", "mac-studio")).toBe(true);
+    expect(hostPrefixMatchesMachineName("minipc-wsl", "minipc-wsl")).toBe(true);
+  });
+
+  it("POSITIVE: dot-boundaried suffix", () => {
+    expect(hostPrefixMatchesMachineName("host.mac-studio", "mac-studio")).toBe(true);
+  });
+
+  it("NEGATIVE: short name does NOT substring-match a longer prefix (the bug)", () => {
+    expect(hostPrefixMatchesMachineName("mac-studio", "mac")).toBe(false);
+  });
+
+  it("NEGATIVE: unrelated roster member does not match another's host", () => {
+    expect(hostPrefixMatchesMachineName("macbook-pro", "mac-studio")).toBe(false);
+    expect(hostPrefixMatchesMachineName("mac-studio", "macbook-pro")).toBe(false);
+    expect(hostPrefixMatchesMachineName("minipc-wsl", "mac-studio")).toBe(false);
+  });
+
+  it("NEGATIVE: empty args are fail-safe false", () => {
+    expect(hostPrefixMatchesMachineName("", "mac-studio")).toBe(false);
+    expect(hostPrefixMatchesMachineName("mac-studio", "")).toBe(false);
+  });
+
+  it("boundaried-suffix semantics: mac-studio ↔ studio IS true (the '-' boundary matches)", () => {
+    // Documenting actual logic: `mac-studio`.endsWith(`-studio`) holds, so this is
+    // a boundaried suffix and returns true. This is acceptable — no current roster
+    // name is a boundaried suffix of another roster member's host.
+    expect(hostPrefixMatchesMachineName("mac-studio", "studio")).toBe(true);
+  });
+
+  it("no current-roster name false-matches another roster member's host prefix", () => {
+    const names = ["mac-studio", "macbook-pro", "minipc-wsl"];
+    for (const host of names) {
+      for (const name of names) {
+        if (host === name) continue;
+        expect(hostPrefixMatchesMachineName(host, name)).toBe(false);
+      }
+    }
   });
 });

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -75,6 +75,24 @@ export function clusterMachine(name: string): ClusterMachine | undefined {
   return clusterMachines().find((m) => m.name === name);
 }
 
+/**
+ * Whether a system hostname prefix (the part before the first dot, lowercased)
+ * should be considered to identify a configured machine `machineName`.
+ *
+ * Boundaried match — return true only when the machine name equals the host
+ * prefix, OR is a boundaried suffix of it (separated by `-` or `.`). This
+ * preserves the legitimate case `lukaszs-mac-studio` ↔ `mac-studio` while
+ * rejecting an unbounded substring false-match such as a short name `mac`
+ * matching host prefix `mac-studio`. Both args are expected already
+ * lowercased/normalized by the caller; we normalize defensively (it's cheap).
+ */
+export function hostPrefixMatchesMachineName(hostPrefix: string, machineName: string): boolean {
+  const hp = hostPrefix.replace(/\.$/, "").toLowerCase();
+  const mn = machineName.replace(/\.$/, "").toLowerCase();
+  if (!hp || !mn) return false;
+  return hp === mn || hp.endsWith("-" + mn) || hp.endsWith("." + mn);
+}
+
 export function clusterCurrentMachine(): ClusterMachine | undefined {
   if (!clusterEnabled()) return undefined;
 
@@ -110,9 +128,9 @@ export function clusterCurrentMachine(): ClusterMachine | undefined {
     const prefix = normalized.split(".")[0];
     const nameMatch = machines.find((m) => {
       const mName = m.name.toLowerCase();
-      // Exact match, or machine name appears in hostname prefix
+      // Exact (full-host) match, or boundaried prefix/suffix match
       // (e.g., name "mac-studio" matches hostname "lukaszs-mac-studio.fritz.box")
-      return mName === normalized || mName === prefix || prefix.includes(mName);
+      return mName === normalized || hostPrefixMatchesMachineName(prefix, mName);
     });
     if (nameMatch) return nameMatch;
   }
@@ -249,6 +267,20 @@ export function clusterShouldRunMag(): boolean {
 export async function clusterTick(): Promise<void> {
   console.error("ludics: cluster: running tick...");
   heartbeatPublish();
+
+  // Self-heal: on a confidently-identified leader (the 300s `com.ludics.cluster`
+  // trigger carries the plist `LUDICS_CLUSTER_MACHINE_NAME` override, so this
+  // path KNOWS it is the leader), re-enable any controller unit launchd has been
+  // left in its persistent `disabled` state (gh-ludics-587). Workers must never
+  // run this. Dynamic import avoids a module-load cycle (triggers.ts imports
+  // cluster.ts), mirroring the cluster-http.ts dynamic-import pattern above.
+  // Best-effort: next tick retries.
+  if (clusterRole() === "controller") {
+    await import("./triggers.ts")
+      .then(({ reconcileControllerUnits }) => reconcileControllerUnits())
+      .catch(() => {});
+  }
+
   console.error("ludics: cluster: tick complete");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,10 +266,15 @@ Commands:
 
   status                       Overview of slots + tasks
   briefing [--auto]            Morning briefing (--auto skips if last sequence < 90min ago)
-  init [--no-hooks] [--no-dashboard] [--no-triggers] [--restart-t3code]
+  init [--no-hooks] [--no-dashboard] [--no-triggers] [--restart-t3code] [--reconcile-controller-units]
                                Initialize config, harness, hooks, dashboard, and triggers
+                               (--reconcile-controller-units: also tear down controller-only
+                                units when this node is a confidently-identified worker)
   stop [pause|uninstall]       Stop scheduled activity (default: pause)
-  triggers install             Install launchd/systemd triggers
+  triggers install [--reconcile-controller-units]
+                               Install launchd/systemd triggers
+                               (--reconcile-controller-units: tear down stale controller-only
+                                units on a confidently-identified worker)
   triggers pause               Pause/disable triggers without deleting unit files
   triggers status              Show trigger status
   triggers uninstall           Remove all triggers

--- a/src/init.ts
+++ b/src/init.ts
@@ -57,6 +57,10 @@ export async function runInit(args: string[]): Promise<void> {
   const noDashboard = args.includes("--no-dashboard");
   const noTriggers = args.includes("--no-triggers");
   const handoff = args.includes("--handoff");
+  // gh-ludics-587: only an explicit opt-in tears down controller units. Without
+  // it, init never disables controller units (protects the leader from a
+  // mis-resolved identity on a plain-shell `ludics init`).
+  const reconcileControllerUnits = args.includes("--reconcile-controller-units");
 
   const root = ludicsRoot();
 
@@ -163,7 +167,7 @@ export async function runInit(args: string[]): Promise<void> {
   if (!noTriggers && configOk) {
     console.log("\n--- Triggers ---");
     try {
-      triggersInstall();
+      triggersInstall({ reconcileControllerUnits });
     } catch (err) {
       console.warn(`warning: triggers install failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -12,7 +12,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readFileSync } from "fs";
-import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, plistEnvXml, magKeepaliveServiceBody } from "./triggers.ts";
+import { triggerAllowedForRole, CONTROLLER_ONLY_TRIGGER_NAMES, removeControllerTriggerUnits, shouldTeardownControllerUnits, shouldRunTeardown, isUnitDisabledInPrintOutput, plistEnvXml, magKeepaliveServiceBody } from "./triggers.ts";
 import type { ClusterMachine } from "./cluster.ts";
 
 const CONTROLLER_ONLY = ["dashboard", "ntfy-subscribe", "morning", "health", "sync", "watch"] as const;
@@ -207,5 +207,70 @@ describe("magKeepaliveServiceBody — KillMode=process hardening (gh-ludics-584)
     // `systemdServiceBody` template would push this above 1.
     const matches = src.match(/\\nKillMode=process/g) ?? [];
     expect(matches.length).toBe(1);
+  });
+});
+
+// gh-ludics-587: controller-unit teardown is now an explicit opt-in. The pure
+// `shouldRunTeardown` seam composes the operator flag with the existing
+// leader-immunity guard. Routine installs (no flag) must NEVER run the
+// destructive teardown loop — that was the root cause of the leader disabling its
+// own dashboard on a mis-resolved `ludics init` from a plain shell.
+describe("shouldRunTeardown — teardown is explicit opt-in atop leader-immunity (gh-ludics-587)", () => {
+  const machine = (role: string): ClusterMachine => ({
+    name: "n", host: "n.ts.net", os: "macos", role, always_on: true, gpu: "",
+  });
+
+  test("no flag → NEVER tear down, even for an identified worker", () => {
+    expect(shouldRunTeardown({}, machine("worker"))).toBe(false);
+    expect(shouldRunTeardown({ reconcileControllerUnits: false }, machine("worker"))).toBe(false);
+  });
+
+  test("flag set + identified worker → tear down", () => {
+    expect(shouldRunTeardown({ reconcileControllerUnits: true }, machine("worker"))).toBe(true);
+    expect(shouldRunTeardown({ reconcileControllerUnits: true }, machine("console"))).toBe(true);
+  });
+
+  test("flag set but leader → still false (leader-immunity guard preserved)", () => {
+    expect(shouldRunTeardown({ reconcileControllerUnits: true }, machine("leader"))).toBe(false);
+  });
+
+  test("flag set but unknown identity (undefined) → false (transient-miss safety net)", () => {
+    expect(shouldRunTeardown({ reconcileControllerUnits: true }, undefined)).toBe(false);
+  });
+});
+
+// gh-ludics-587: self-heal parses `launchctl print-disabled gui/$uid` output to
+// decide whether a controller unit needs re-enabling. The parser is the
+// unit-testable seam; the surrounding reconcile shells out to launchctl.
+describe("isUnitDisabledInPrintOutput — detects disabled controller labels (gh-ludics-587)", () => {
+  const sample = [
+    'com.apple.disabled list for <gui> {',
+    '\t\t"com.ludics.dashboard" => disabled',
+    '\t\t"com.ludics.mag" => enabled',
+    '\t\t"com.ludics.health" => true', // launchctl historically prints true/false too
+    '}',
+  ].join("\n");
+
+  test("returns true for an explicitly disabled label", () => {
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.dashboard")).toBe(true);
+  });
+
+  test("returns false for an enabled label", () => {
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.mag")).toBe(false);
+  });
+
+  test("returns false for an absent label", () => {
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.sync")).toBe(false);
+  });
+
+  test("returns false for a non-'disabled' value (e.g. 'true')", () => {
+    // Fail-safe: only the literal `=> disabled` re-enables; any other token is left alone.
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.health")).toBe(false);
+  });
+
+  test("empty / garbage input → false (fail-safe)", () => {
+    expect(isUnitDisabledInPrintOutput("", "com.ludics.dashboard")).toBe(false);
+    expect(isUnitDisabledInPrintOutput("not launchctl output at all", "com.ludics.dashboard")).toBe(false);
+    expect(isUnitDisabledInPrintOutput("\n\n   \n", "com.ludics.dashboard")).toBe(false);
   });
 });

--- a/src/triggers.test.ts
+++ b/src/triggers.test.ts
@@ -247,7 +247,8 @@ describe("isUnitDisabledInPrintOutput — detects disabled controller labels (gh
     'com.apple.disabled list for <gui> {',
     '\t\t"com.ludics.dashboard" => disabled',
     '\t\t"com.ludics.mag" => enabled',
-    '\t\t"com.ludics.health" => true', // launchctl historically prints true/false too
+    '\t\t"com.ludics.health" => true',  // boolean spelling on some macOS versions = disabled
+    '\t\t"com.ludics.sync" => false',   // boolean spelling = enabled
     '}',
   ].join("\n");
 
@@ -260,12 +261,17 @@ describe("isUnitDisabledInPrintOutput — detects disabled controller labels (gh
   });
 
   test("returns false for an absent label", () => {
-    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.sync")).toBe(false);
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.ntfy-subscribe")).toBe(false);
   });
 
-  test("returns false for a non-'disabled' value (e.g. 'true')", () => {
-    // Fail-safe: only the literal `=> disabled` re-enables; any other token is left alone.
-    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.health")).toBe(false);
+  test("treats the boolean 'true' spelling as disabled (gh-ludics-587 Codex review)", () => {
+    // Some macOS versions print `"<label>" => true` for a disabled override
+    // instead of `=> disabled`; both must trigger the self-heal.
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.health")).toBe(true);
+  });
+
+  test("treats the boolean 'false' spelling as enabled", () => {
+    expect(isUnitDisabledInPrintOutput(sample, "com.ludics.sync")).toBe(false);
   });
 
   test("empty / garbage input → false (fail-safe)", () => {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -65,6 +65,22 @@ export function shouldTeardownControllerUnits(machine: ClusterMachine | undefine
 }
 
 /**
+ * Pure decision seam (gh-ludics-587): whether a given `triggersInstall` run should
+ * actually tear down controller-only units. Teardown is now an explicit opt-in —
+ * routine `ludics init` / `triggers install` must NEVER tear down (a mis-resolved
+ * identity from a plain shell could otherwise disable the *leader's own*
+ * controller units). Only `--reconcile-controller-units` enables it, AND the
+ * leader-immunity guard `shouldTeardownControllerUnits` still applies on top
+ * (undefined identity or a leader machine is never torn down).
+ */
+export function shouldRunTeardown(
+  opts: { reconcileControllerUnits?: boolean },
+  machine: ClusterMachine | undefined,
+): boolean {
+  return opts.reconcileControllerUnits === true && shouldTeardownControllerUnits(machine);
+}
+
+/**
  * Disable + delete any installed unit(s) for trigger `name`. Used on a worker to
  * actively remove controller-only units left over from a prior standalone /
  * controller install (AC 7): skip-only logging in the install paths does not stop
@@ -111,6 +127,100 @@ export function removeControllerTriggerUnits(
       }
     } else {
       for (const ext of ["timer", "service", "path"]) removeUnit(`ludics-${name}.${ext}`);
+    }
+  }
+}
+
+/**
+ * Pure decision seam (gh-ludics-587): does `launchctl print-disabled gui/$uid`
+ * output mark `label` as disabled? launchctl prints one line per known label in
+ * the form `\t\t"com.ludics.dashboard" => disabled` (or `=> enabled`). Returns
+ * true only for an explicit `"<label>" => disabled` entry; an enabled, absent, or
+ * empty/garbage output yields false (fail-safe — never re-enable on a parse miss).
+ */
+export function isUnitDisabledInPrintOutput(printDisabledOutput: string, label: string): boolean {
+  if (!printDisabledOutput) return false;
+  for (const line of printDisabledOutput.split("\n")) {
+    const m = line.match(/"([^"]+)"\s*=>\s*(\w+)/);
+    if (m && m[1] === label && m[2] === "disabled") return true;
+  }
+  return false;
+}
+
+/**
+ * Self-heal (gh-ludics-587): re-enable any controller-only unit that launchd (or
+ * systemd) has left in its persistent `disabled` state. Run every cluster tick on
+ * a confidently-identified leader (see `clusterTick`). IDEMPOTENT and SILENT when
+ * nothing is disabled — no bootstrap churn while all units are healthy.
+ *
+ * darwin: parse `launchctl print-disabled gui/$uid` once; for each disabled
+ * controller label whose plist still exists, re-enable → bootout (ignore) →
+ * bootstrap → kickstart. Missing plist → one-line warning suggesting `ludics
+ * init`, then skip (don't regenerate here). linux: mirror minimally via
+ * `systemctl --user is-enabled` / `enable --now`. Fail-safe: any shell/parse
+ * failure → don't touch.
+ */
+export function reconcileControllerUnits(platform: NodeJS.Platform = process.platform): void {
+  if (platform === "darwin") {
+    const agentsDir = join(process.env.HOME!, "Library/LaunchAgents");
+    if (!existsSync(agentsDir)) return;
+    const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+
+    const printRes = safeSyncOutput(["launchctl", "print-disabled", `gui/${uid}`]);
+    if (!printRes.ok) return; // fail-safe: cannot determine disabled state → don't touch
+    const printOut = printRes.stdout;
+
+    const reenableLabel = (label: string): void => {
+      if (!isUnitDisabledInPrintOutput(printOut, label)) return; // healthy → silent no-op
+      const plist = join(agentsDir, `${label}.plist`);
+      if (!existsSync(plist)) {
+        console.warn(
+          `ludics: cluster: controller unit ${label.replace("com.ludics.", "")} is disabled but its plist is missing — run 'ludics init' to reinstall it`,
+        );
+        return;
+      }
+      safeSyncOutput(["launchctl", "enable", `gui/${uid}/${label}`]);
+      safeSyncOutput(["launchctl", "bootout", `gui/${uid}/${label}`]); // ignore failure (may not be loaded)
+      safeSyncOutput(["launchctl", "bootstrap", `gui/${uid}`, plist]);
+      safeSyncOutput(["launchctl", "kickstart", "-k", `gui/${uid}/${label}`]);
+      console.log(`ludics: cluster: re-enabled disabled controller unit: ${label.replace("com.ludics.", "")}`);
+    };
+
+    for (const name of CONTROLLER_ONLY_TRIGGER_NAMES) {
+      if (name === "watch") {
+        for (const f of readdirSync(agentsDir)) {
+          if (f.startsWith("com.ludics.watch-") && f.endsWith(".plist")) {
+            reenableLabel(f.replace(".plist", ""));
+          }
+        }
+      } else {
+        reenableLabel(`com.ludics.${name}`);
+      }
+    }
+  } else if (platform === "linux") {
+    const systemdDir = join(process.env.HOME!, ".config/systemd/user");
+    if (!existsSync(systemdDir)) return;
+
+    const reenableUnit = (unit: string): void => {
+      const f = join(systemdDir, unit);
+      if (!existsSync(f)) return;
+      const res = safeSyncOutput(["systemctl", "--user", "is-enabled", unit]);
+      // is-enabled prints "disabled" (and exits non-zero) when masked/disabled.
+      if (res.stdout.trim() !== "disabled") return; // enabled/static/healthy → silent no-op
+      safeSyncOutput(["systemctl", "--user", "enable", "--now", unit]);
+      console.log(`ludics: cluster: re-enabled disabled controller unit: ${unit}`);
+    };
+
+    for (const name of CONTROLLER_ONLY_TRIGGER_NAMES) {
+      if (name === "watch") {
+        for (const f of readdirSync(systemdDir)) {
+          if (f.startsWith("ludics-watch-") && (f.endsWith(".service") || f.endsWith(".path") || f.endsWith(".timer"))) {
+            reenableUnit(f);
+          }
+        }
+      } else {
+        for (const ext of ["timer", "path", "service"]) reenableUnit(`ludics-${name}.${ext}`);
+      }
     }
   }
 }
@@ -924,20 +1034,25 @@ function currentPlatform(): string {
   return result.stdout;
 }
 
-export function triggersInstall(): void {
-  // AC 7: on a worker, actively remove any controller-only units left by a prior
-  // standalone/controller install before (re)installing. The install paths below
-  // only *skip* controller units (they don't stop ones already running), so
-  // without this an upgraded worker keeps a stale dashboard/briefing/health/etc.
-  // unit alive — split-brain that the role gate is meant to prevent.
-  const currentMachine = clusterCurrentMachine();
-  if (shouldTeardownControllerUnits(currentMachine)) {
-    for (const name of CONTROLLER_ONLY_TRIGGER_NAMES) removeControllerTriggerUnits(name);
-  } else if (!currentMachine) {
-    console.error(
-      "ludics: triggers: this host is not in cluster.machines (Tailscale down + hostname mismatch?) — " +
-      "skipping controller-unit teardown to avoid destroying leader duties on a transient identity miss",
-    );
+export function triggersInstall(opts: { reconcileControllerUnits?: boolean } = {}): void {
+  // gh-ludics-587: controller-unit teardown is now an explicit opt-in
+  // (`--reconcile-controller-units`). Routine `ludics init` / `triggers install`
+  // must NEVER tear down — a manual/remote run from a plain shell can mis-resolve
+  // identity and otherwise disable the *leader's own* controller units. When the
+  // operator deliberately reconciles a genuinely-reconfigured worker, the AC-7
+  // teardown still runs, but only under the leader-immunity guard
+  // (`shouldTeardownControllerUnits`): an unidentified host or a leader machine is
+  // never torn down.
+  if (opts.reconcileControllerUnits) {
+    const currentMachine = clusterCurrentMachine();
+    if (shouldTeardownControllerUnits(currentMachine)) {
+      for (const name of CONTROLLER_ONLY_TRIGGER_NAMES) removeControllerTriggerUnits(name);
+    } else if (!currentMachine) {
+      console.error(
+        "ludics: triggers: this host is not in cluster.machines (Tailscale down + hostname mismatch?) — " +
+        "skipping controller-unit teardown to avoid destroying leader duties on a transient identity miss",
+      );
+    }
   }
 
   const platform = currentPlatform();
@@ -1000,7 +1115,7 @@ export async function runTriggers(args: string[]): Promise<void> {
 
   switch (sub) {
     case "install":
-      triggersInstall();
+      triggersInstall({ reconcileControllerUnits: args.includes("--reconcile-controller-units") });
       break;
     case "pause":
     case "disable":

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -133,16 +133,22 @@ export function removeControllerTriggerUnits(
 
 /**
  * Pure decision seam (gh-ludics-587): does `launchctl print-disabled gui/$uid`
- * output mark `label` as disabled? launchctl prints one line per known label in
- * the form `\t\t"com.ludics.dashboard" => disabled` (or `=> enabled`). Returns
- * true only for an explicit `"<label>" => disabled` entry; an enabled, absent, or
- * empty/garbage output yields false (fail-safe — never re-enable on a parse miss).
+ * output mark `label` as disabled? launchctl prints one line per known label as
+ * `\t\t"com.ludics.dashboard" => <state>`. The `<state>` token varies by macOS
+ * version: some emit `disabled`/`enabled`, others emit the boolean `true`
+ * (disabled) / `false` (enabled). Treat BOTH `disabled` and `true` as disabled so
+ * the self-heal works across versions (the federation spans multiple Macs). Any
+ * other / absent / empty / garbage output yields false (fail-safe — never
+ * re-enable on a parse miss).
  */
 export function isUnitDisabledInPrintOutput(printDisabledOutput: string, label: string): boolean {
   if (!printDisabledOutput) return false;
   for (const line of printDisabledOutput.split("\n")) {
     const m = line.match(/"([^"]+)"\s*=>\s*(\w+)/);
-    if (m && m[1] === label && m[2] === "disabled") return true;
+    if (m && m[1] === label) {
+      const state = m[2].toLowerCase();
+      return state === "disabled" || state === "true";
+    }
   }
   return false;
 }


### PR DESCRIPTION
Fixes #587.

The leader's `com.ludics.dashboard` (and other controller-only) launchd units were periodically left in launchd's persistent `disabled` state — dashboard on :7678 down until a manual `launchctl enable + bootstrap + kickstart`. Root cause: `triggersInstall()` tore down controller units whenever the *running process* resolved this node to a non-leader. A manual/remote `ludics init` from a plain shell (no `LUDICS_CLUSTER_MACHINE_NAME` env override) could mis-resolve identity and disable the **leader's own** units. There was also no automatic recovery.

In federation v2 there is no controller election — the leader is statically configured (`role: leader`). So the leader must be immune to self-teardown, and a disabled controller unit must self-heal.

## Changes

**1a — Harden the identity matcher (`src/cluster.ts`).** New pure `hostPrefixMatchesMachineName(hostPrefix, machineName)` with boundaried semantics (`=== name`, or `-name`/`.name` suffix) replaces the unbounded `prefix.includes(mName)` in `clusterCurrentMachine()`. Preserves the legit `lukaszs-mac-studio ↔ mac-studio` match; rejects a short name like `mac` matching host `mac-studio`. The leader can now only ever resolve to its own entry or `undefined` — both skip teardown.

**1b — Teardown is now explicit opt-in (`src/triggers.ts`, `init.ts`, `index.ts`).** Routine `ludics init` / `triggers install` no longer tear down controller units. The destructive path runs only under the new `--reconcile-controller-units` flag (on both `init` and `triggers install`), and even then the `shouldTeardownControllerUnits` leader-immunity guard still applies (undefined identity or a leader machine is never torn down). New pure seam `shouldRunTeardown(opts, machine)`. Genuine worker cleanup (AC-7) is preserved, just deliberate.

**2 — Self-heal reconcile (`src/triggers.ts` + `src/cluster.ts`).** New `reconcileControllerUnits()` runs every cluster tick on a confidently-identified leader (`clusterRole() === "controller"`, via a dynamic import in `clusterTick` to avoid the cluster↔triggers cycle). It parses `launchctl print-disabled` once and, for each disabled controller unit (all `CONTROLLER_ONLY_TRIGGER_NAMES`, expanding `watch`) whose plist still exists, re-enables it (`enable → bootout → bootstrap → kickstart`). Missing plist → one-line warning, skip. Idempotent and silent when healthy; fail-safe on any shell/parse failure. New pure parser `isUnitDisabledInPrintOutput(output, label)`. Self-heals within one ≤5-min tick.

### Why it doesn't fight deliberate disables
- A global `triggers pause` also disables the `cluster` trigger → the tick stops → self-heal can't run.
- A config-disabled trigger (`enabled: false`) is never installed (`installSimpleTrigger` early-returns) → never appears in `print-disabled` → untouched.
- A teardown-removed unit has its plist unlinked → the `existsSync` guard warns-and-skips rather than resurrecting it.

## Tests
Pure seams modeled on `3c6c641`: `hostPrefixMatchesMachineName` (positive + roster cross-matrix negatives), `shouldRunTeardown` opt-in matrix, `isUnitDisabledInPrintOutput` (disabled/enabled/absent/empty/garbage). Existing `shouldTeardownControllerUnits` / `removeControllerTriggerUnits` tests pass unchanged.

- `bun run build`: ✅
- `bun test src/triggers.test.ts src/cluster.test.ts`: 84 pass / 0 fail
- Full suite: 3208 pass / 4 fail — the 4 (`slotAssign machine default in federated setup`, `remote slotStop non-force intent`, each ×2) are **pre-existing** (verified by stashing this change; they also appear in today's test-health baseline), environment-dependent, and unrelated.

## Out of scope (deferred)
Part 1b's optional persisted last-known-good identity file is deferred — the matcher hardening + leader-immunity close the bug, and per the task's Q2 constraint identity must stay node-local (never written to the git-synced `config.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)