### PR TITLE
fix(mag): grace window before auto-assign claims a newly-ready task

### DIFF
--- a/src/mag-auto-assign-grace.test.ts
+++ b/src/mag-auto-assign-grace.test.ts
@@ -1,0 +1,127 @@
+// Tests for the auto-assign grace window (lukstafi/ludics auto-assign race).
+//
+// The keepalive auto-fill grabs a task for an empty slot the instant the task
+// becomes assignable, which twice raced a deliberate manual launch within one
+// keepalive beat. The fix introduces a persisted per-task "first-seen-
+// assignable" debounce (`mag/auto-assign-seen.json`, task-id -> epochSeconds):
+// a freshly-assignable task must wait at least one full beat (~75s grace)
+// before the auto-fill may claim it.
+//
+// These tests pin the pure gate `autoAssignGraceGate(taskId, candidateSet,
+// nowSeconds, graceSeconds)` with an injected clock so they are deterministic:
+//   (a) a freshly-seen task is skipped on the first beat, then assigned once
+//       the grace elapses;
+//   (b) a task seen longer ago than the grace assigns immediately;
+//   (c) sidecar entries are cleared when a task leaves the candidate set.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+let TMP = "";
+
+function harnessDir(): string {
+  return join(TMP, "harness");
+}
+function seenFile(): string {
+  return join(harnessDir(), "mag", "auto-assign-seen.json");
+}
+function readSeen(): Record<string, number> {
+  if (!existsSync(seenFile())) return {};
+  return JSON.parse(readFileSync(seenFile(), "utf-8")) as Record<string, number>;
+}
+
+beforeEach(() => {
+  TMP = mkdtempSync(join(tmpdir(), "ludics-grace-"));
+  process.env.HOME = TMP;
+  // No config file: autoAssignGraceSeconds() falls back to the default, and
+  // the gate's grace arg is passed explicitly in every test anyway.
+  delete process.env.LUDICS_CONFIG;
+  process.env.LUDICS_HARNESS_DIR = harnessDir();
+  mkdirSync(join(harnessDir(), "mag"), { recursive: true });
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+  else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+  if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR;
+  else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+const GRACE = 75;
+
+describe("autoAssignGraceGate", () => {
+  // (a) Freshly-seen task: skipped on first beat, assigned after grace elapses.
+  test("freshly-seen task is skipped on first beat, then assigned after grace", async () => {
+    const { autoAssignGraceGate } = await import("./mag.ts");
+    const t0 = 1_000_000;
+
+    // First beat: task is newly assignable → record `now`, skip.
+    expect(autoAssignGraceGate("task-X", ["task-X"], t0, GRACE)).toBe(false);
+    expect(readSeen()["task-X"]).toBe(t0);
+
+    // A beat later, still inside the grace window → still skip.
+    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + 60, GRACE)).toBe(false);
+
+    // Past the grace window → proceed.
+    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + GRACE, GRACE)).toBe(true);
+    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + GRACE + 5, GRACE)).toBe(true);
+  });
+
+  // (b) A task whose first-seen epoch is already older than the grace assigns
+  //     immediately (a long-standing assignable task does not wait).
+  test("task seen longer ago than grace assigns immediately", async () => {
+    const { autoAssignGraceGate } = await import("./mag.ts");
+    const seenAt = 1_000_000;
+    // Pre-seed the sidecar via a prior beat at seenAt.
+    expect(autoAssignGraceGate("task-Y", ["task-Y"], seenAt, GRACE)).toBe(false);
+
+    // Now a much later beat: gate proceeds on the very first check past grace.
+    expect(autoAssignGraceGate("task-Y", ["task-Y"], seenAt + 10_000, GRACE)).toBe(true);
+  });
+
+  // (c) Sidecar entries are cleared when a task leaves the candidate set, so
+  //     re-entering resets the grace.
+  test("entries are cleared when a task leaves the candidate set", async () => {
+    const { autoAssignGraceGate } = await import("./mag.ts");
+    const t0 = 1_000_000;
+
+    // Two candidates seen.
+    autoAssignGraceGate("task-A", ["task-A", "task-B"], t0, GRACE);
+    expect(Object.keys(readSeen()).sort()).toEqual(["task-A", "task-B"]);
+
+    // Next beat: task-B has left the candidate set → its entry is cleared.
+    autoAssignGraceGate("task-A", ["task-A"], t0 + 10, GRACE);
+    expect(Object.keys(readSeen())).toEqual(["task-A"]);
+    // task-A's original first-seen epoch is preserved (grace not reset).
+    expect(readSeen()["task-A"]).toBe(t0);
+
+    // task-B re-enters later → grace resets (recorded at the new `now`), so it
+    // is skipped on this re-entry beat.
+    expect(autoAssignGraceGate("task-B", ["task-A", "task-B"], t0 + 200, GRACE)).toBe(false);
+    expect(readSeen()["task-B"]).toBe(t0 + 200);
+  });
+
+  // clearAutoAssignSeen drops a task's record (called after a real assignment),
+  // so a later re-entry restarts the grace.
+  test("clearAutoAssignSeen drops the record so re-entry restarts grace", async () => {
+    const { autoAssignGraceGate, clearAutoAssignSeen } = await import("./mag.ts");
+    const t0 = 1_000_000;
+    autoAssignGraceGate("task-Z", ["task-Z"], t0, GRACE);
+    expect(readSeen()["task-Z"]).toBe(t0);
+
+    clearAutoAssignSeen("task-Z");
+    expect("task-Z" in readSeen()).toBe(false);
+
+    // Re-entry records a fresh first-seen and is skipped this beat.
+    expect(autoAssignGraceGate("task-Z", ["task-Z"], t0 + 1000, GRACE)).toBe(false);
+    expect(readSeen()["task-Z"]).toBe(t0 + 1000);
+  });
+});

--- a/src/mag-auto-assign-grace.test.ts
+++ b/src/mag-auto-assign-grace.test.ts
@@ -7,12 +7,19 @@
 // a freshly-assignable task must wait at least one full beat (~75s grace)
 // before the auto-fill may claim it.
 //
-// These tests pin the pure gate `autoAssignGraceGate(taskId, candidateSet,
-// nowSeconds, graceSeconds)` with an injected clock so they are deterministic:
-//   (a) a freshly-seen task is skipped on the first beat, then assigned once
-//       the grace elapses;
-//   (b) a task seen longer ago than the grace assigns immediately;
-//   (c) sidecar entries are cleared when a task leaves the candidate set.
+// The bookkeeping is split into two pieces (Codex PR #591 review), each pinned
+// here with an injected clock so the tests are deterministic:
+//
+//   - `autoAssignGraceGate(taskId, nowSeconds, graceSeconds)` — runs ONLY for a
+//     task that has already passed every assignment-eligibility check and is
+//     about to be assigned. It records first-seen on first sight and reports
+//     whether the grace elapsed. A task that never reaches the gate (because it
+//     isn't actually assignable this beat) is therefore never recorded/aged.
+//
+//   - `reconcileAutoAssignSeen(candidateSet, nowSeconds)` — runs UNCONDITIONALLY
+//     every beat against the full current candidate set, clearing entries for
+//     tasks that have left the set (so re-entry resets the grace) and pruning
+//     stale entries, independent of whether any candidate reaches the gate.
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
@@ -56,6 +63,7 @@ afterEach(() => {
 });
 
 const GRACE = 75;
+const PRUNE = 24 * 60 * 60;
 
 describe("autoAssignGraceGate", () => {
   // (a) Freshly-seen task: skipped on first beat, assigned after grace elapses.
@@ -64,15 +72,15 @@ describe("autoAssignGraceGate", () => {
     const t0 = 1_000_000;
 
     // First beat: task is newly assignable → record `now`, skip.
-    expect(autoAssignGraceGate("task-X", ["task-X"], t0, GRACE)).toBe(false);
+    expect(autoAssignGraceGate("task-X", t0, GRACE)).toBe(false);
     expect(readSeen()["task-X"]).toBe(t0);
 
     // A beat later, still inside the grace window → still skip.
-    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + 60, GRACE)).toBe(false);
+    expect(autoAssignGraceGate("task-X", t0 + 60, GRACE)).toBe(false);
 
     // Past the grace window → proceed.
-    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + GRACE, GRACE)).toBe(true);
-    expect(autoAssignGraceGate("task-X", ["task-X"], t0 + GRACE + 5, GRACE)).toBe(true);
+    expect(autoAssignGraceGate("task-X", t0 + GRACE, GRACE)).toBe(true);
+    expect(autoAssignGraceGate("task-X", t0 + GRACE + 5, GRACE)).toBe(true);
   });
 
   // (b) A task whose first-seen epoch is already older than the grace assigns
@@ -81,47 +89,102 @@ describe("autoAssignGraceGate", () => {
     const { autoAssignGraceGate } = await import("./mag.ts");
     const seenAt = 1_000_000;
     // Pre-seed the sidecar via a prior beat at seenAt.
-    expect(autoAssignGraceGate("task-Y", ["task-Y"], seenAt, GRACE)).toBe(false);
+    expect(autoAssignGraceGate("task-Y", seenAt, GRACE)).toBe(false);
 
     // Now a much later beat: gate proceeds on the very first check past grace.
-    expect(autoAssignGraceGate("task-Y", ["task-Y"], seenAt + 10_000, GRACE)).toBe(true);
+    expect(autoAssignGraceGate("task-Y", seenAt + 10_000, GRACE)).toBe(true);
   });
 
-  // (c) Sidecar entries are cleared when a task leaves the candidate set, so
-  //     re-entering resets the grace.
-  test("entries are cleared when a task leaves the candidate set", async () => {
+  // (d) The gate records/ages ONLY the task it is called with — a task that
+  //     never reaches the gate (not assignable this beat) is never recorded.
+  //     This is the Codex fix #1 invariant: eligibility gates the recording.
+  test("gate records only the task it is invoked for, not other candidates", async () => {
     const { autoAssignGraceGate } = await import("./mag.ts");
     const t0 = 1_000_000;
 
-    // Two candidates seen.
-    autoAssignGraceGate("task-A", ["task-A", "task-B"], t0, GRACE);
+    // Only the assignable task reaching the gate is recorded; a sibling
+    // candidate that failed a downstream eligibility check is never passed in,
+    // so it is never aged.
+    expect(autoAssignGraceGate("task-assignable", t0, GRACE)).toBe(false);
+    expect(Object.keys(readSeen())).toEqual(["task-assignable"]);
+    expect("task-not-yet-assignable" in readSeen()).toBe(false);
+  });
+});
+
+describe("reconcileAutoAssignSeen", () => {
+  // (c) Entries are cleared when a task leaves the candidate set, so re-entering
+  //     resets the grace. This runs unconditionally each beat — independent of
+  //     whether any candidate reaches the gate.
+  test("entries are cleared when a task leaves the candidate set", async () => {
+    const { autoAssignGraceGate, reconcileAutoAssignSeen } = await import("./mag.ts");
+    const t0 = 1_000_000;
+
+    // Two candidates recorded via the gate (both reach it on their beat).
+    autoAssignGraceGate("task-A", t0, GRACE);
+    autoAssignGraceGate("task-B", t0, GRACE);
     expect(Object.keys(readSeen()).sort()).toEqual(["task-A", "task-B"]);
 
-    // Next beat: task-B has left the candidate set → its entry is cleared.
-    autoAssignGraceGate("task-A", ["task-A"], t0 + 10, GRACE);
+    // Next beat: reconcile against a candidate set without task-B → its entry
+    // is cleared, task-A's original first-seen is preserved.
+    reconcileAutoAssignSeen(["task-A"], t0 + 10);
     expect(Object.keys(readSeen())).toEqual(["task-A"]);
-    // task-A's original first-seen epoch is preserved (grace not reset).
     expect(readSeen()["task-A"]).toBe(t0);
 
-    // task-B re-enters later → grace resets (recorded at the new `now`), so it
-    // is skipped on this re-entry beat.
-    expect(autoAssignGraceGate("task-B", ["task-A", "task-B"], t0 + 200, GRACE)).toBe(false);
+    // task-B re-enters and reaches the gate later → grace resets (recorded at
+    // the new `now`), so it is skipped on this re-entry beat.
+    expect(autoAssignGraceGate("task-B", t0 + 200, GRACE)).toBe(false);
     expect(readSeen()["task-B"]).toBe(t0 + 200);
   });
 
+  // Codex fix #2: a recorded task that leaves the candidate set on a beat where
+  // NOTHING reaches the gate (e.g. all slots busy → early return before any
+  // assignment) is still cleared, because reconcile runs unconditionally.
+  test("clears a departed task even when no candidate reaches the gate", async () => {
+    const { autoAssignGraceGate, reconcileAutoAssignSeen } = await import("./mag.ts");
+    const t0 = 1_000_000;
+
+    // task-busy was recorded as assignable on an earlier beat.
+    autoAssignGraceGate("task-busy", t0, GRACE);
+    expect(readSeen()["task-busy"]).toBe(t0);
+
+    // Later beat: task-busy has left the candidate set (e.g. manually assigned
+    // while all slots were occupied). No candidate is assigned this beat, but
+    // reconcile against the empty candidate set still clears the stale entry.
+    reconcileAutoAssignSeen([], t0 + 30);
+    expect("task-busy" in readSeen()).toBe(false);
+
+    // When it later re-enters and reaches the gate, it gets a FRESH grace
+    // window rather than inheriting the old (already-aged) timestamp.
+    expect(autoAssignGraceGate("task-busy", t0 + 40, GRACE)).toBe(false);
+    expect(readSeen()["task-busy"]).toBe(t0 + 40);
+  });
+
+  // Stale entries past the prune bound are dropped even if still in the set.
+  test("prunes entries older than the prune bound", async () => {
+    const { autoAssignGraceGate, reconcileAutoAssignSeen } = await import("./mag.ts");
+    const t0 = 1_000_000;
+    autoAssignGraceGate("task-old", t0, GRACE);
+
+    // Still in the candidate set, but now far past the prune window → dropped.
+    reconcileAutoAssignSeen(["task-old"], t0 + PRUNE + 1);
+    expect("task-old" in readSeen()).toBe(false);
+  });
+});
+
+describe("clearAutoAssignSeen", () => {
   // clearAutoAssignSeen drops a task's record (called after a real assignment),
   // so a later re-entry restarts the grace.
   test("clearAutoAssignSeen drops the record so re-entry restarts grace", async () => {
     const { autoAssignGraceGate, clearAutoAssignSeen } = await import("./mag.ts");
     const t0 = 1_000_000;
-    autoAssignGraceGate("task-Z", ["task-Z"], t0, GRACE);
+    autoAssignGraceGate("task-Z", t0, GRACE);
     expect(readSeen()["task-Z"]).toBe(t0);
 
     clearAutoAssignSeen("task-Z");
     expect("task-Z" in readSeen()).toBe(false);
 
     // Re-entry records a fresh first-seen and is skipped this beat.
-    expect(autoAssignGraceGate("task-Z", ["task-Z"], t0 + 1000, GRACE)).toBe(false);
+    expect(autoAssignGraceGate("task-Z", t0 + 1000, GRACE)).toBe(false);
     expect(readSeen()["task-Z"]).toBe(t0 + 1000);
   });
 });

--- a/src/mag-remote-dispatch-path.test.ts
+++ b/src/mag-remote-dispatch-path.test.ts
@@ -84,6 +84,20 @@ function writeReadyTask(): void {
       + `  relates_to: []\n  subtask_of: null\ncontext: cudajit\nuses_browser: false\n`
       + `created: 2026-05-01\nsource: manual\n---\n# task-cudajit-remote\n`,
   );
+  // The keepalive auto-assign gate (mag/auto-assign-seen.json) holds a freshly-
+  // assignable task back for one beat (~75s grace). These tests assert the
+  // immediate single-call dispatch behavior, so seed the task as seen long ago
+  // (past any grace) to exercise the actual assignment path on the first call.
+  const magDir = join(TMP, "mag");
+  mkdirSync(magDir, { recursive: true });
+  // Seen ~10 minutes ago: past the grace window but well within the prune
+  // horizon, so the gate proceeds on the first call rather than skipping or
+  // pruning-then-re-recording the entry as fresh.
+  const seenAt = Math.floor(Date.now() / 1000) - 600;
+  writeFileSync(
+    join(magDir, "auto-assign-seen.json"),
+    JSON.stringify({ "task-cudajit-remote": seenAt }),
+  );
 }
 
 beforeEach(() => {

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3266,17 +3266,32 @@ export function getSortedReadyCandidates(config?: LudicsFullConfig): ReadyCandid
 // A newly-assignable task (just flipped ready+elaborated+has-proposal) must
 // wait at least one full keepalive beat before the auto-fill may claim it,
 // giving a predictable manual-intervention window. We persist the first epoch
-// at which each candidate was seen assignable in a sidecar
-// (`mag/auto-assign-seen.json`, keyed task-id -> epochSeconds). On each beat
-// the gate is applied to the task about to be assigned, AFTER all existing
-// eligibility filters and BEFORE the actual slotAssign — mirroring the
-// `autoProposalDebounced` / `markAutoProposalQueued` sidecar-debounce pattern.
+// at which each candidate was seen *genuinely assignable* in a sidecar
+// (`mag/auto-assign-seen.json`, keyed task-id -> epochSeconds).
+//
+// The bookkeeping is split into two independent steps so that recording/aging
+// and stale-entry cleanup don't interfere (Codex PR #591 review):
+//
+//   1. `reconcileAutoAssignSeen(candidateSet, now)` — runs EVERY beat against
+//      the full current candidate set, *independent* of whether any candidate
+//      reaches the gate or is assigned. It drops entries for tasks that left
+//      the candidate set (so re-entry resets the grace) and prunes anything
+//      older than the bound. This guarantees a task that leaves between gate
+//      ticks (e.g. manually assigned while all slots are busy) still has its
+//      stale grace cleared.
+//
+//   2. `autoAssignGraceGate(taskId, now)` — runs ONLY for the single task that
+//      has passed every assignment-eligibility check (duo slot-count, machine
+//      selection, project-path resolution) and is about to be `slotAssign`ed
+//      this beat. It records `now` as the first-seen epoch the first time a
+//      genuinely-assignable task is observed, and returns whether the grace
+//      has elapsed. Because recording happens only here, a task that isn't
+//      actually assignable on a given beat is never aged toward its grace.
 //
 // This naturally lets a long-standing assignable task assign immediately (its
 // recorded `seen` is already older than the grace), while only FRESH
-// transitions wait ~1 beat. Entries are cleared when a task leaves the
-// candidate set (so re-entering resets the grace) and once it is actually
-// assigned; stale entries are pruned to keep the file bounded.
+// transitions wait ~1 beat. Entries are also cleared once a task is actually
+// assigned (`clearAutoAssignSeen`), so re-entry resets the grace.
 
 const AUTO_ASSIGN_GRACE_DEFAULT_SECONDS = 75;
 // Prune sidecar entries older than this (well past any plausible grace) so the
@@ -3334,15 +3349,53 @@ export function clearAutoAssignSeen(taskId: string): void {
 }
 
 /**
- * Reconcile the first-seen sidecar against the current assignable candidate set
- * and decide whether `taskId` (the task about to be assigned) may proceed this
- * beat.
+ * Reconcile the first-seen sidecar against the current candidate set,
+ * UNCONDITIONALLY each beat (independent of whether any candidate reaches the
+ * gate or is assigned). This is what guarantees a task whose grace was recorded
+ * but which later leaves the candidate set between gate ticks still gets its
+ * stale entry cleared.
  *
  * Side effects (persisted to `mag/auto-assign-seen.json`):
- *   - Records `nowSeconds` for any candidate not yet tracked.
  *   - Clears entries for tasks no longer in `candidateSet` (left the set →
  *     grace resets on re-entry).
  *   - Prunes entries older than AUTO_ASSIGN_SEEN_PRUNE_SECONDS.
+ *
+ * NOTE: this does NOT record/age candidates — that is deliberately deferred to
+ * `autoAssignGraceGate`, which runs only for a task that has passed every
+ * assignment-eligibility check, so a not-yet-assignable task is never aged.
+ *
+ * `nowSeconds` is injectable so tests can drive the clock deterministically;
+ * callers in normal runtime pass `Math.floor(Date.now() / 1000)`.
+ *
+ * @internal exported for tests
+ */
+export function reconcileAutoAssignSeen(
+  candidateSet: Iterable<string>,
+  nowSeconds: number,
+): void {
+  const candidates = new Set(candidateSet);
+  const seen = readAutoAssignSeen();
+  let dirty = false;
+
+  for (const id of Object.keys(seen)) {
+    if (!candidates.has(id) || nowSeconds - seen[id]! >= AUTO_ASSIGN_SEEN_PRUNE_SECONDS) {
+      delete seen[id];
+      dirty = true;
+    }
+  }
+
+  if (dirty) writeAutoAssignSeen(seen);
+}
+
+/**
+ * Decide whether `taskId` — the single task that has already passed EVERY
+ * assignment-eligibility check and is about to be `slotAssign`ed this beat —
+ * may proceed, recording its first-seen-assignable epoch on first sight.
+ *
+ * Side effect: records `nowSeconds` for `taskId` if not yet tracked. Because
+ * this runs only for a genuinely-assignable task (after duo slot-count, machine
+ * selection, and project-path checks), a task that isn't actually assignable on
+ * a given beat is never recorded/aged toward its grace.
  *
  * Returns `true` iff `taskId` has been tracked for at least the grace window
  * (i.e. `nowSeconds - seen >= grace`). A freshly-seen task returns `false`
@@ -3355,34 +3408,15 @@ export function clearAutoAssignSeen(taskId: string): void {
  */
 export function autoAssignGraceGate(
   taskId: string,
-  candidateSet: Iterable<string>,
   nowSeconds: number,
   graceSeconds: number = autoAssignGraceSeconds(),
 ): boolean {
-  const candidates = new Set(candidateSet);
   const seen = readAutoAssignSeen();
-  let dirty = false;
-
-  // Clear entries for tasks no longer in the candidate set, and prune stale.
-  for (const id of Object.keys(seen)) {
-    if (!candidates.has(id) || nowSeconds - seen[id]! >= AUTO_ASSIGN_SEEN_PRUNE_SECONDS) {
-      delete seen[id];
-      dirty = true;
-    }
+  if (!(taskId in seen)) {
+    seen[taskId] = nowSeconds;
+    writeAutoAssignSeen(seen);
   }
-
-  // Ensure every current candidate is tracked (record `now` on first sight).
-  for (const id of candidates) {
-    if (!(id in seen)) {
-      seen[id] = nowSeconds;
-      dirty = true;
-    }
-  }
-
-  const proceed = taskId in seen && nowSeconds - seen[taskId]! >= graceSeconds;
-
-  if (dirty) writeAutoAssignSeen(seen);
-  return proceed;
+  return nowSeconds - seen[taskId]! >= graceSeconds;
 }
 
 // --- Auto-fill empty slots ---
@@ -3404,9 +3438,28 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
     }
   }
 
+  const candidates = getSortedReadyCandidates(config);
+
+  // Reconcile the grace sidecar UNCONDITIONALLY every beat — independent of
+  // whether any slot is empty or any candidate reaches the gate. The candidate
+  // set is every currently-assignable task (ready + has a proposal). A recorded
+  // task that has left this set (e.g. manually assigned while all slots were
+  // busy, or status/deps changed) gets its stale grace entry cleared here, even
+  // on a beat that returns early below (Codex PR #591 review). Recording/aging
+  // of first-seen is NOT done here — that is deferred to the gate, which runs
+  // only for a genuinely-assignable task.
+  reconcileAutoAssignSeen(
+    candidates
+      .filter((c) => {
+        const f = join(harnessDir(), "tasks", `${c.id}.md`);
+        return existsSync(f) && readFileSync(f, "utf-8").includes("\nproposal:");
+      })
+      .map((c) => c.id),
+    Math.floor(Date.now() / 1000),
+  );
+
   if (emptySlots.length === 0) return;
 
-  const candidates = getSortedReadyCandidates(config);
   if (candidates.length > 0) {
     const top5 = candidates.slice(0, 5).map((c) => `${c.id}(p=${c.priority},ep=${effectivePriorityValue(c.priority, c.project)},elab=${c.elaborated})`);
     console.error(`ludics: auto-fill candidates (top 5): ${top5.join(", ")}`);
@@ -3476,24 +3529,20 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
     throw e;
   }
 
-  // Grace window (auto-assign race): a task must be seen assignable for at
-  // least one full keepalive beat before the auto-fill may claim it. Applied
-  // AFTER all eligibility filters (and the t3code-paused early-return above)
-  // and BEFORE either slotAssign branch, so both duo- and single-assign are
-  // gated. The candidate set passed to the gate is every remaining assignable
-  // candidate (those with a proposal), so a task that leaves the set has its
-  // grace reset on re-entry. Gates auto-ASSIGN only — auto-launch/start stays
-  // separately gated by deferred_launch / confidence.
-  const assignableCandidateSet = candidates
-    .filter((c) => {
-      const f = join(harnessDir(), "tasks", `${c.id}.md`);
-      return existsSync(f) && readFileSync(f, "utf-8").includes("\nproposal:");
-    })
-    .map((c) => c.id);
-  if (!autoAssignGraceGate(task.id, assignableCandidateSet, Math.floor(Date.now() / 1000))) {
+  // Grace gate (auto-assign race): a task must be seen GENUINELY ASSIGNABLE for
+  // at least one full keepalive beat before the auto-fill may claim it. The gate
+  // is invoked ONLY after the task has passed every assignment-eligibility check
+  // below (duo slot-count, machine selection, project-path resolution) — see the
+  // `gatePassed` checks before each `slotAssign` — so a task that isn't actually
+  // assignable on this beat is never recorded/aged toward its grace (Codex PR
+  // #591 review). Gates auto-ASSIGN only — auto-launch/start stays separately
+  // gated by deferred_launch / confidence.
+  const gateNow = Math.floor(Date.now() / 1000);
+  const graceGateOk = (): boolean => {
+    if (autoAssignGraceGate(task.id, gateNow)) return true;
     console.error(`ludics: ${task.id} newly assignable — grace window, will assign next beat`);
-    return;
-  }
+    return false;
+  };
 
   // Hierarchical duo: need 2 empty slots; assign both with swapped coder/reviewer
   if (isDuo) {
@@ -3531,6 +3580,10 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
       }
       throw e;
     }
+
+    // All eligibility checks passed — now apply the grace gate (records/ages
+    // first-seen only because the task is genuinely assignable this beat).
+    if (!graceGateOk()) return;
 
     await slotAssign(slotA, task.id, autoAdapter, "", projectPath, expansion.slotA.args, machine);
     await slotAssign(slotB, task.id, autoAdapter, "", projectPath, expansion.slotB.args, machine);
@@ -3571,6 +3624,10 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
       }
       throw e;
     }
+
+    // All eligibility checks passed — now apply the grace gate (records/ages
+    // first-seen only because the task is genuinely assignable this beat).
+    if (!graceGateOk()) return;
 
     // Assign task to the empty slot using the auto-selected adapter, path, and flags
     await slotAssign(slot, task.id, autoAdapter, "", projectPath, autoArgs, machine);

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3261,6 +3261,130 @@ export function getSortedReadyCandidates(config?: LudicsFullConfig): ReadyCandid
   return candidates;
 }
 
+// --- Auto-assign grace window (lukstafi/ludics auto-assign race) ---
+//
+// A newly-assignable task (just flipped ready+elaborated+has-proposal) must
+// wait at least one full keepalive beat before the auto-fill may claim it,
+// giving a predictable manual-intervention window. We persist the first epoch
+// at which each candidate was seen assignable in a sidecar
+// (`mag/auto-assign-seen.json`, keyed task-id -> epochSeconds). On each beat
+// the gate is applied to the task about to be assigned, AFTER all existing
+// eligibility filters and BEFORE the actual slotAssign — mirroring the
+// `autoProposalDebounced` / `markAutoProposalQueued` sidecar-debounce pattern.
+//
+// This naturally lets a long-standing assignable task assign immediately (its
+// recorded `seen` is already older than the grace), while only FRESH
+// transitions wait ~1 beat. Entries are cleared when a task leaves the
+// candidate set (so re-entering resets the grace) and once it is actually
+// assigned; stale entries are pruned to keep the file bounded.
+
+const AUTO_ASSIGN_GRACE_DEFAULT_SECONDS = 75;
+// Prune sidecar entries older than this (well past any plausible grace) so the
+// file stays bounded even if a task somehow never leaves via the normal paths.
+const AUTO_ASSIGN_SEEN_PRUNE_SECONDS = 24 * 60 * 60;
+
+function autoAssignSeenFile(): string {
+  return join(harnessDir(), "mag", "auto-assign-seen.json");
+}
+
+/** Grace window in seconds; configurable via `mag.auto_assign_grace_seconds`. */
+function autoAssignGraceSeconds(): number {
+  const config = loadConfigSync();
+  const mag = config.mag as Record<string, unknown> | undefined;
+  const configured = Number(mag?.auto_assign_grace_seconds);
+  if (Number.isFinite(configured) && configured > 0) return configured;
+  return AUTO_ASSIGN_GRACE_DEFAULT_SECONDS;
+}
+
+function readAutoAssignSeen(): Record<string, number> {
+  const f = autoAssignSeenFile();
+  if (!existsSync(f)) return {};
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(f, "utf-8"));
+    if (!isPlainObject(parsed)) return {};
+    const out: Record<string, number> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      const n = Number(v);
+      if (Number.isFinite(n)) out[k] = n;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeAutoAssignSeen(seen: Record<string, number>): void {
+  const f = autoAssignSeenFile();
+  mkdirSync(dirname(f), { recursive: true });
+  writeJsonFile(f, seen);
+}
+
+/**
+ * Drop the first-seen-assignable record for a task (best-effort). Called once a
+ * task is actually assigned, so a later re-entry into the candidate set resets
+ * its grace window.
+ *
+ * @internal exported for tests
+ */
+export function clearAutoAssignSeen(taskId: string): void {
+  const seen = readAutoAssignSeen();
+  if (!(taskId in seen)) return;
+  delete seen[taskId];
+  writeAutoAssignSeen(seen);
+}
+
+/**
+ * Reconcile the first-seen sidecar against the current assignable candidate set
+ * and decide whether `taskId` (the task about to be assigned) may proceed this
+ * beat.
+ *
+ * Side effects (persisted to `mag/auto-assign-seen.json`):
+ *   - Records `nowSeconds` for any candidate not yet tracked.
+ *   - Clears entries for tasks no longer in `candidateSet` (left the set →
+ *     grace resets on re-entry).
+ *   - Prunes entries older than AUTO_ASSIGN_SEEN_PRUNE_SECONDS.
+ *
+ * Returns `true` iff `taskId` has been tracked for at least the grace window
+ * (i.e. `nowSeconds - seen >= grace`). A freshly-seen task returns `false`
+ * (skip this beat — assign next beat).
+ *
+ * `nowSeconds` is injectable so tests can drive the clock deterministically;
+ * callers in normal runtime pass `Math.floor(Date.now() / 1000)`.
+ *
+ * @internal exported for tests
+ */
+export function autoAssignGraceGate(
+  taskId: string,
+  candidateSet: Iterable<string>,
+  nowSeconds: number,
+  graceSeconds: number = autoAssignGraceSeconds(),
+): boolean {
+  const candidates = new Set(candidateSet);
+  const seen = readAutoAssignSeen();
+  let dirty = false;
+
+  // Clear entries for tasks no longer in the candidate set, and prune stale.
+  for (const id of Object.keys(seen)) {
+    if (!candidates.has(id) || nowSeconds - seen[id]! >= AUTO_ASSIGN_SEEN_PRUNE_SECONDS) {
+      delete seen[id];
+      dirty = true;
+    }
+  }
+
+  // Ensure every current candidate is tracked (record `now` on first sight).
+  for (const id of candidates) {
+    if (!(id in seen)) {
+      seen[id] = nowSeconds;
+      dirty = true;
+    }
+  }
+
+  const proceed = taskId in seen && nowSeconds - seen[taskId]! >= graceSeconds;
+
+  if (dirty) writeAutoAssignSeen(seen);
+  return proceed;
+}
+
 // --- Auto-fill empty slots ---
 
 /** @internal exported for tests */
@@ -3352,6 +3476,25 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
     throw e;
   }
 
+  // Grace window (auto-assign race): a task must be seen assignable for at
+  // least one full keepalive beat before the auto-fill may claim it. Applied
+  // AFTER all eligibility filters (and the t3code-paused early-return above)
+  // and BEFORE either slotAssign branch, so both duo- and single-assign are
+  // gated. The candidate set passed to the gate is every remaining assignable
+  // candidate (those with a proposal), so a task that leaves the set has its
+  // grace reset on re-entry. Gates auto-ASSIGN only — auto-launch/start stays
+  // separately gated by deferred_launch / confidence.
+  const assignableCandidateSet = candidates
+    .filter((c) => {
+      const f = join(harnessDir(), "tasks", `${c.id}.md`);
+      return existsSync(f) && readFileSync(f, "utf-8").includes("\nproposal:");
+    })
+    .map((c) => c.id);
+  if (!autoAssignGraceGate(task.id, assignableCandidateSet, Math.floor(Date.now() / 1000))) {
+    console.error(`ludics: ${task.id} newly assignable — grace window, will assign next beat`);
+    return;
+  }
+
   // Hierarchical duo: need 2 empty slots; assign both with swapped coder/reviewer
   if (isDuo) {
     if (emptySlots.length < 2) {
@@ -3404,6 +3547,7 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
       message: `auto-assigned duo ${task.id} to slots ${slotA}+${slotB} with effort=${task.effort}${machine ? ` on ${machine}` : ""}`,
     });
     console.error(`ludics: auto-assigned duo ${task.id} to slots ${slotA}+${slotB} with effort=${task.effort} (${autoAdapter})${machine ? ` on ${machine}` : ""}`);
+    clearAutoAssignSeen(task.id);
   } else {
     const slot = emptySlots[0]!;
 
@@ -3443,6 +3587,7 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
       message: `auto-assigned ${task.id} to slot ${slot} with effort=${task.effort}: ${autoArgs}${machine ? ` on ${machine}` : ""}`,
     });
     console.error(`ludics: auto-assigned ${task.id} to slot ${slot} with effort=${task.effort} (${autoAdapter} ${autoArgs})${machine ? ` on ${machine}` : ""}`);
+    clearAutoAssignSeen(task.id);
   }
 
   // No need to queue draft-proposal here — we only assign tasks that

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -122,6 +122,10 @@ mag:
   startup_watchdog_seconds: 60    # Seconds to wait for Mag startup before declaring failure (default: 60)
   startup_helper_stuck_seconds: 45  # Seconds before a startup helper is considered stuck (default: 45)
   cleanup_delay_hours: 25         # Hours to wait before cleaning up completed task worktrees (default: 25, max: 72)
+  auto_assign_grace_seconds: 75   # Grace window before the keepalive auto-fill may claim a newly-assignable
+                                  # task for an empty slot (default: 75 — reliably spans one 60s beat). A
+                                  # freshly-ready task waits ~1 beat before auto-assign, giving a predictable
+                                  # manual-intervention window. Gates auto-ASSIGN only, not auto-launch/start.
 
   # Orchestration settings (overridable per-task via adapter -A args)
   orchestration:


### PR DESCRIPTION
## Motivation

The keepalive auto-fill grabs a task for an empty slot the instant the task becomes assignable. Twice recently a task flipped to `ready` and was auto-assigned (to the **wrong slot**, in pair mode) within one keepalive beat — before a deliberate manual launch could happen, forcing teardown. We want a **grace window**: a newly-assignable task must wait at least one full keepalive beat before the auto-fill may claim it, giving a predictable intervention window.

## Design

A persisted per-task **first-seen-assignable debounce** on the auto-**ASSIGN** / slot-fill path. This gates auto-assign **only** — auto-launch/start stays separately gated by `deferred_launch` / confidence. It mirrors the existing `autoProposalDebounced` / `markAutoProposalQueued` sidecar-debounce pattern.

- Sidecar `mag/auto-assign-seen.json` (under `harnessDir()`), keyed `task-id -> epochSeconds`.
- `autoAssignGraceGate(taskId, candidateSet, nowSeconds, graceSeconds)` — per beat, applied to the task about to be assigned, after all existing eligibility filters (and the t3code-paused early-return) and **before** either `slotAssign` branch:
  - Not yet tracked → record `now`, **skip this beat** (logs `… newly assignable — grace window, will assign next beat`).
  - Tracked and `now - seen >= grace` → **proceed**.
  - Tracked but still within grace → skip.
  - This naturally lets a **long-standing** assignable task assign immediately (its `seen` is already old); only **fresh** transitions wait ~1 beat.
- Clears sidecar entries for tasks that **left the candidate set** (grace resets on re-entry) and prunes stale entries (24h) to keep the file bounded.
- `clearAutoAssignSeen(taskId)` drops a task's record once it's actually assigned — called in **both** the duo- and single-slot-assign branches.
- `GRACE_SECONDS` defaults to **75** (reliably spans one 60s beat), configurable via `mag.auto_assign_grace_seconds` (read via the standard `config.mag` pattern; default applies when unset). Documented in `templates/config.reference.yaml`.

Normal ludics runtime code, so `Date.now()` is used at the call site; the gate itself takes an explicit `nowSeconds` for deterministic testing.

## Tests

New `src/mag-auto-assign-grace.test.ts` drives the pure gate with an injected clock:
- (a) freshly-seen task is skipped on the first beat, then assigned after grace elapses;
- (b) a task seen longer ago than grace assigns immediately;
- (c) entries are cleared when a task leaves the candidate set (and grace resets on re-entry);
- plus `clearAutoAssignSeen` re-entry behavior.

Existing `maybeFillEmptySlots` dispatch tests (`mag-remote-dispatch-path.test.ts`) seed the sidecar past-grace so they still exercise the immediate-assign path.

## Verification

- `bun run build` ✅
- `bun run lint:config-reference` ✅ (new `mag.auto_assign_grace_seconds` key documented)
- `bun test` on the touched files (mag dedup / remote-dispatch / t3code-flag / new grace test + lint-config-helpers floor-count) ✅

**Caveat:** the full suite has **2 pre-existing failures** in `src/slots/index.test.ts` (`remote slotStop …`, `slotAssign machine default … self-matches`) — confirmed failing on clean `origin/main` (they are node-name/cluster-env dependent), unrelated to this change. This PR introduces no new failures.

Do **not** auto-merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)