### PR TITLE
feat(lint): add lint:src-command-safety to scan src/ for unsafe ssh/spawn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Lint template variable safety
         run: bun run lint:template-safety
 
+      - name: Lint — src command safety
+        run: bun run lint:src-command-safety
+
       - name: Lint — no mock.module() in tests
         run: bun run lint:no-mock-module
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:no-mock-module": "bun run scripts/lint-no-mock-module.ts",
     "lint:no-nul-bytes": "bun run scripts/lint-no-nul-bytes.ts",
     "lint:no-shadow-util": "bun run scripts/lint-no-shadow-util.ts",
+    "lint:src-command-safety": "bun run scripts/lint-src-command-safety.ts",
     "smoke": "bun run scripts/smoke.ts"
   },
   "devDependencies": {

--- a/scripts/lint-src-command-safety.test.ts
+++ b/scripts/lint-src-command-safety.test.ts
@@ -73,6 +73,41 @@ describe("scanFile — path rule", () => {
     expect(issues).toHaveLength(2);
     expect(issues.map((i) => i.command).sort()).toEqual(["scp", "ssh"]);
   });
+
+  test("single-quoted 'ssh' argv literal is flagged (not only double-quoted)", () => {
+    // Regression: the original regex only matched "ssh" (double-quoted).
+    // A single-quoted ['ssh', host, script] must also be caught.
+    const source = "safeSyncOutput(['ssh', host, script], {});";
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "ssh", kind: "path" });
+  });
+
+  test("single-quoted 'scp' argv literal is flagged", () => {
+    const source = "safeSyncOutput(['scp', 'file.txt', 'remote:/path/'], {});";
+    const issues = scanFile(source, "src/upload.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "scp", kind: "path" });
+  });
+
+  test("block comment between [ and \"ssh\" does not bypass detection", () => {
+    // Regression: `[/* vetted? */ "ssh", host, script]` must be flagged.
+    // The original regex's `\\s*` did not match comment text, so the pattern
+    // silently passed. The mask-aware firstStringArg skips masked comment
+    // bytes and still finds "ssh" as the first real source element.
+    const source = 'safeSyncOutput([/* vetted? */ "ssh", host, script], {});';
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "ssh", kind: "path" });
+  });
+
+  test("line comment on previous line does not affect detection", () => {
+    // The comment is on a line by itself before the array — should not mask the [.
+    const source = "// see also safe patterns\nsafeSyncOutput([\"ssh\", host, script], {});";
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "ssh", kind: "path" });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lint-src-command-safety.test.ts
+++ b/scripts/lint-src-command-safety.test.ts
@@ -1,0 +1,231 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import {
+  SRC_COMMAND_SAFETY_ALLOWLIST,
+  scanFile,
+  runCli,
+} from "./lint-src-command-safety.ts";
+
+const repoRoot = join(import.meta.dir, "..");
+const scriptPath = join(import.meta.dir, "lint-src-command-safety.ts");
+
+// ---------------------------------------------------------------------------
+// SRC_COMMAND_SAFETY_ALLOWLIST — allowlist shape
+// ---------------------------------------------------------------------------
+
+describe("SRC_COMMAND_SAFETY_ALLOWLIST", () => {
+  test("contains exactly src/remote.ts as the sole vetted ssh chokepoint", () => {
+    expect(SRC_COMMAND_SAFETY_ALLOWLIST).toEqual(new Set(["src/remote.ts"]));
+    expect(SRC_COMMAND_SAFETY_ALLOWLIST.size).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanFile — path rule
+// Positive cases: ssh/scp/rsync argv literals in non-allowlisted src/ files
+// ---------------------------------------------------------------------------
+
+describe("scanFile — path rule", () => {
+  test("ssh argv literal in non-allowlisted path is flagged", () => {
+    const source =
+      'const r = safeSyncOutput(["ssh", "-o", "BatchMode=yes", host, script], {});';
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      file: "src/danger.ts",
+      line: 1,
+      command: "ssh",
+      kind: "path",
+    });
+  });
+
+  test("scp argv literal in non-allowlisted path is flagged", () => {
+    const source =
+      'safeSyncOutput(["scp", "-r", "file.txt", "remote:/path/"], {});';
+    const issues = scanFile(source, "src/uploader.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "scp", kind: "path" });
+  });
+
+  test("rsync argv literal in non-allowlisted path is flagged", () => {
+    const source =
+      'safeSyncOutput(["rsync", "-av", "src/", "remote:/dst/"], {});';
+    const issues = scanFile(source, "src/syncer.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "rsync", kind: "path" });
+  });
+
+  test("reports correct 1-based line number", () => {
+    const source =
+      "// header comment\nconst r = safeSyncOutput([\"scp\", \"file\", \"remote:path\"], {});\n";
+    const issues = scanFile(source, "src/foo.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.line).toBe(2);
+  });
+
+  test("flags multiple argv literals in the same file", () => {
+    const source = [
+      'safeSyncOutput(["ssh", host, cmd], {});',
+      'safeSyncOutput(["scp", src, dst], {});',
+    ].join("\n");
+    const issues = scanFile(source, "src/multi.ts");
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.command).sort()).toEqual(["scp", "ssh"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanFile — interpolation rule
+// Higher-severity injection shape: template literal with ${…} in the array
+// ---------------------------------------------------------------------------
+
+describe("scanFile — interpolation rule", () => {
+  test("ssh array with template-literal remote-script is flagged as interpolation", () => {
+    // Harness: source contains ["ssh", host, `cd ${cwd} || exit 255; ${cmd}`]
+    // The template literal carries ${cwd} and ${cmd} substitutions — the
+    // unquoted-shell-interpolation injection shape.
+    const source =
+      "const r = safeSyncOutput([\"ssh\", host, `cd ${cwd} || exit 255; ${cmd}`], {});";
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "ssh", kind: "interpolation" });
+  });
+
+  test("scp array with interpolated destination is flagged as interpolation", () => {
+    const source = "safeSyncOutput([\"scp\", \"file\", `${host}:/remote/path`], {});";
+    const issues = scanFile(source, "src/sync.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "scp", kind: "interpolation" });
+  });
+
+  test("rsync array with interpolated destination is flagged as interpolation", () => {
+    const source = "safeSyncOutput([\"rsync\", \"-av\", `${srcDir}/`, `${host}:/dst/`], {});";
+    const issues = scanFile(source, "src/sync.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ command: "rsync", kind: "interpolation" });
+  });
+
+  test("ssh array with plain string arguments (no template) is flagged as path, not interpolation", () => {
+    // buildRemoteScript() call — not a template literal inline in the array.
+    const source =
+      'const r = safeSyncOutput(["ssh", "-o", "BatchMode=yes", host, buildRemoteScript(cwd, cmd)], {});';
+    const issues = scanFile(source, "src/danger.ts");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.kind).toBe("path");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanFile — negative controls
+// ---------------------------------------------------------------------------
+
+describe("scanFile — negative controls", () => {
+  test("array with no ssh/scp/rsync is clean", () => {
+    const source = 'const r = safeSyncOutput(["ls", "-la", "/tmp"], {});';
+    expect(scanFile(source, "src/local.ts")).toHaveLength(0);
+  });
+
+  test('"ssh" token inside a line comment is not flagged', () => {
+    const source = '// ["ssh", "-o", "BatchMode=yes", host, script]\nconst x = 1;';
+    expect(scanFile(source, "src/foo.ts")).toHaveLength(0);
+  });
+
+  test('"ssh" token inside a block comment is not flagged', () => {
+    const source = '/* Use ["ssh", host, script] for remote exec */ const x = 1;';
+    expect(scanFile(source, "src/foo.ts")).toHaveLength(0);
+  });
+
+  test('"ssh" token inside a string literal is not flagged', () => {
+    const source = "const doc = 'call [\"ssh\", host, script] directly';\nconst x = 1;";
+    expect(scanFile(source, "src/foo.ts")).toHaveLength(0);
+  });
+
+  test('"ssh" token inside a template literal body is not flagged', () => {
+    const source = "const doc = `Pass [\"ssh\", host, script] to spawn`;\nconst x = 1;";
+    expect(scanFile(source, "src/foo.ts")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scanFile — allowlist exemption
+// ---------------------------------------------------------------------------
+
+describe("scanFile — allowlist exemption", () => {
+  test("src/remote.ts returns no issues regardless of content (path allowlist)", () => {
+    // Harness: inject the exact injection shape that would be flagged in any
+    // other file. The allowlist short-circuit must fire before any scanning.
+    const source =
+      "safeSyncOutput([\"ssh\", host, `cd ${cwd} || exit 255; ${cmd}`], {});";
+    const issues = scanFile(source, "src/remote.ts");
+    expect(issues).toHaveLength(0);
+  });
+
+  test("src/remote.ts (real file) passes the allowlist check", () => {
+    // Pre-assertion harness probe: read the actual src/remote.ts and confirm
+    // it contains the ssh call so the exemption is non-vacuous (it would be
+    // flagged in any other file).
+    const remoteSource = readFileSync(join(repoRoot, "src/remote.ts"), "utf-8");
+    expect(remoteSource).toContain('"ssh"'); // pre-condition: the call exists
+    const issues = scanFile(remoteSource, "src/remote.ts");
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// real-corpus — actual src/** tree is clean
+// ---------------------------------------------------------------------------
+
+describe("real corpus", () => {
+  test("actual src/ tree is clean under the rule (src/remote.ts allowlisted)", () => {
+    const errs: string[] = [];
+    const result = runCli({
+      writeErr: (m) => errs.push(m),
+      writeOut: () => {},
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.issues).toHaveLength(0);
+    expect(errs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI entrypoint — binary spawn tests
+// These test names begin "exits 0/1" so lint:test-spawn-coverage requires
+// that the enclosing describe block contains a Bun.spawnSync call.
+// ---------------------------------------------------------------------------
+
+describe("CLI entrypoint", () => {
+  test("exits 0 against the real src/ corpus", () => {
+    const proc = Bun.spawnSync({
+      cmd: ["bun", "run", scriptPath],
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toContain("✅");
+  });
+
+  test("exits 1 on a directory with a planted ssh violation", () => {
+    const tmpDir = mkdtempSync("/tmp/lint-src-command-safety-");
+    try {
+      writeFileSync(
+        join(tmpDir, "rogue.ts"),
+        'safeSyncOutput(["ssh", host, script], {});\n',
+      );
+      const proc = Bun.spawnSync({
+        cmd: ["bun", "run", scriptPath, tmpDir],
+        cwd: repoRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(proc.exitCode).toBe(1);
+      const stderr = proc.stderr.toString();
+      expect(stderr).toContain("❌");
+      expect(stderr).toContain('"ssh"');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/lint-src-command-safety.ts
+++ b/scripts/lint-src-command-safety.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env bun
+/**
+ * lint-src-command-safety.ts
+ *
+ * Scans src/** for unsafe ssh/remote-command construction:
+ *   - Path rule: any src/ file (outside the allowlist) whose real (non-comment,
+ *     non-string-literal) source contains an ssh/scp/rsync argv-array literal —
+ *     an array whose first element is "ssh", "scp", or "rsync" — is a violation.
+ *   - Interpolation rule: any such argv array (in a non-allowlisted file) whose
+ *     remote-script argument is a template literal containing a ${…} substitution
+ *     is the higher-severity unquoted-interpolation injection shape.
+ *
+ * src/remote.ts is the single vetted ssh chokepoint in the codebase.  All
+ * remote-exec routes through it. The path-based exemption encodes this
+ * invariant: only remote.ts may construct an ssh/scp/rsync argv directly.
+ * lint:src-command-safety is what enforces that invariant going forward.
+ *
+ * Reuses computeCodeMask from lint-test-spawn-coverage.ts so token matches
+ * do not fire inside comments or string literals.
+ *
+ * *.test.ts files inside src/ are skipped — test fixtures may legitimately
+ * contain ssh argv literals for harness or mock purposes.
+ *
+ * Exit code: 1 iff any issue found.
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative, sep } from "path";
+import { computeCodeMask } from "./lint-test-spawn-coverage.ts";
+
+const repoRoot = join(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+/**
+ * src/remote.ts is the sole vetted ssh chokepoint: all remote-exec in the
+ * codebase routes through this file.  The path-based exemption encodes the
+ * invariant that no other src/ file may construct an ssh/scp/rsync argv
+ * directly.  If a genuinely vetted new site appears, add it here with a
+ * comment explaining why it cannot route through remote.ts.
+ */
+export const SRC_COMMAND_SAFETY_ALLOWLIST = new Set(["src/remote.ts"]);
+
+// ---------------------------------------------------------------------------
+// Issue shape
+// ---------------------------------------------------------------------------
+
+/** "path" = ssh/scp/rsync argv literal in a non-allowlisted file.
+ *  "interpolation" = same, AND a template-literal-with-${} remote-script
+ *  element — the higher-severity unquoted-interpolation injection shape. */
+export type IssueKind = "path" | "interpolation";
+
+export interface CommandSafetyIssue {
+  /** Repo-relative path with forward slashes. */
+  file: string;
+  /** 1-based line number of the array literal. */
+  line: number;
+  /** The flagged command: "ssh", "scp", or "rsync". */
+  command: string;
+  /** Path violation or the more-specific interpolation-shape violation. */
+  kind: IssueKind;
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/** Matches an argv-array literal whose first element is "ssh", "scp", or "rsync". */
+const SSH_ARGV_RE = /\[\s*"(ssh|scp|rsync)"\s*[,\]]/g;
+
+function lineOf(source: string, idx: number): number {
+  let line = 1;
+  for (let i = 0; i < idx; i++) {
+    if (source[i] === "\n") line++;
+  }
+  return line;
+}
+
+/**
+ * Find the index of the `]` that closes the array opened at `startIdx`,
+ * skipping any bytes the mask marks as non-code (strings, comments,
+ * template bodies) so nested bracket characters inside those contexts do
+ * not unbalance the counter.
+ */
+function findArrayEnd(
+  source: string,
+  startIdx: number,
+  mask: Uint8Array,
+): number {
+  if (source[startIdx] !== "[") return -1;
+  let depth = 0;
+  for (let i = startIdx; i < source.length; i++) {
+    if (mask[i]) continue; // skip masked bytes
+    if (source[i] === "[") depth++;
+    else if (source[i] === "]") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Return true if the array span [arrayStart, arrayEnd] contains the
+ * unquoted-interpolation injection shape: an unmasked backtick (opening a
+ * template literal) followed by an unmasked `${` (a substitution opener
+ * inside that template).
+ *
+ * computeCodeMask marks template-body bytes as 1 (masked) and
+ * substitution-interior bytes as 0 (code), so an unmasked `${` inside the
+ * array span can only originate from a template-literal substitution — the
+ * exact injection surface we are looking for.
+ */
+function hasTemplateInterpolation(
+  source: string,
+  arrayStart: number,
+  arrayEnd: number,
+  mask: Uint8Array,
+): boolean {
+  let seenBacktick = false;
+  for (let i = arrayStart; i <= arrayEnd; i++) {
+    if (mask[i]) continue;
+    if (source[i] === "`") seenBacktick = true;
+    if (
+      seenBacktick &&
+      source[i] === "$" &&
+      i + 1 <= arrayEnd &&
+      source[i + 1] === "{"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Per-file scan (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan `source` (identified by repo-relative `relPath`) for
+ * ssh/scp/rsync argv-array violations.  Returns an empty array for
+ * allowlisted paths.
+ */
+export function scanFile(
+  source: string,
+  relPath: string,
+): CommandSafetyIssue[] {
+  if (SRC_COMMAND_SAFETY_ALLOWLIST.has(relPath)) return [];
+
+  const mask = computeCodeMask(source);
+  const issues: CommandSafetyIssue[] = [];
+
+  SSH_ARGV_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = SSH_ARGV_RE.exec(source)) !== null) {
+    if (mask[match.index]) continue; // inside comment, string, or template body
+
+    const line = lineOf(source, match.index);
+    const command = match[1]!;
+
+    const arrayEnd = findArrayEnd(source, match.index, mask);
+    const kind: IssueKind =
+      arrayEnd !== -1 &&
+      hasTemplateInterpolation(source, match.index, arrayEnd, mask)
+        ? "interpolation"
+        : "path";
+
+    issues.push({ file: relPath, line, command, kind });
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/** Recursively list *.ts source files under `dir`, returning absolute paths.
+ *  Skips dot-entries and *.test.ts files (test fixtures may legitimately
+ *  contain ssh argv literals for harness / mock purposes). */
+export function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  function walk(d: string): void {
+    for (const entry of readdirSync(d)) {
+      if (entry.startsWith(".")) continue;
+      const full = join(d, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (st.isFile() && entry.endsWith(".ts") && !entry.endsWith(".test.ts"))
+        out.push(full);
+    }
+  }
+  walk(dir);
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// runCli
+// ---------------------------------------------------------------------------
+
+export interface RunCliOptions {
+  /** Source dir to scan.  Defaults to <repo-root>/src. */
+  srcDir?: string;
+  /** Repo root used to compute repo-relative output paths.
+   *  Defaults to <srcDir>/.. (i.e. the repo root when srcDir is the real src/). */
+  repoRoot?: string;
+  /** Sink for offense lines (default: process.stderr.write). */
+  writeErr?: (msg: string) => void;
+  /** Sink for the success summary line (default: process.stdout.write). */
+  writeOut?: (msg: string) => void;
+}
+
+export interface RunCliResult {
+  exitCode: number;
+  issues: CommandSafetyIssue[];
+}
+
+export function runCli(options: RunCliOptions = {}): RunCliResult {
+  const srcDir = options.srcDir ?? join(repoRoot, "src");
+  const root = options.repoRoot ?? repoRoot;
+  const writeErr =
+    options.writeErr ??
+    ((msg) => {
+      process.stderr.write(msg + "\n");
+    });
+  const writeOut =
+    options.writeOut ??
+    ((msg) => {
+      process.stdout.write(msg + "\n");
+    });
+
+  const issues: CommandSafetyIssue[] = [];
+
+  for (const abs of listSourceFiles(srcDir)) {
+    const rel = relative(root, abs).split(sep).join("/");
+    const source = readFileSync(abs, "utf-8");
+    issues.push(...scanFile(source, rel));
+  }
+
+  for (const iss of issues) {
+    const detail =
+      iss.kind === "interpolation"
+        ? 'template-literal `${…}` remote-script — unquoted-interpolation injection shape'
+        : "ssh/scp/rsync argv literal (all remote-exec must route through src/remote.ts)";
+    writeErr(`❌  ${iss.file}:${iss.line}  "${iss.command}" — ${detail}`);
+  }
+
+  if (issues.length === 0) {
+    writeOut(
+      `✅  No unsafe ssh/remote-command construction in src/ (allowlisted: ${[...SRC_COMMAND_SAFETY_ALLOWLIST].join(", ")}).`,
+    );
+    return { exitCode: 0, issues };
+  }
+
+  writeErr(
+    `\n${issues.length} command-safety violation${issues.length === 1 ? "" : "s"} in src/.\n` +
+      `   All ssh/scp/rsync invocations must route through src/remote.ts.\n` +
+      `   If a new vetted site genuinely cannot route through that chokepoint,\n` +
+      `   add it to SRC_COMMAND_SAFETY_ALLOWLIST in scripts/lint-src-command-safety.ts\n` +
+      `   with a comment explaining why.`,
+  );
+  return { exitCode: 1, issues };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  // Optional first positional arg overrides the src directory so tests can
+  // exercise the real CLI exit-code paths against a temp directory (mirrors
+  // the lint-template-safety.ts convention).
+  const argDir = process.argv[2];
+  const srcDir = argDir ? argDir : join(repoRoot, "src");
+  const root = argDir ? argDir : repoRoot;
+  const result = runCli({ srcDir, repoRoot: root });
+  process.exit(result.exitCode);
+}

--- a/scripts/lint-src-command-safety.ts
+++ b/scripts/lint-src-command-safety.ts
@@ -67,8 +67,8 @@ export interface CommandSafetyIssue {
 // Detection helpers
 // ---------------------------------------------------------------------------
 
-/** Matches an argv-array literal whose first element is "ssh", "scp", or "rsync". */
-const SSH_ARGV_RE = /\[\s*"(ssh|scp|rsync)"\s*[,\]]/g;
+/** Command names whose presence as the first argv element is a violation. */
+const SSH_COMMANDS = new Set(["ssh", "scp", "rsync"]);
 
 function lineOf(source: string, idx: number): number {
   let line = 1;
@@ -76,6 +76,44 @@ function lineOf(source: string, idx: number): number {
     if (source[i] === "\n") line++;
   }
   return line;
+}
+
+/**
+ * Given an unmasked `[` at `bracketIdx`, scan forward through unmasked bytes
+ * to find the first string literal (double- or single-quoted) in the array.
+ * Masked bytes (comment bodies, string interiors, template bodies) are skipped
+ * so block/line comments between `[` and the first element do not suppress
+ * detection (e.g. `[/* vetted? *\/ "ssh", ...]` is still caught).
+ *
+ * Returns the string content if the first non-whitespace, non-masked byte is
+ * a quote character; returns null if any other code byte appears first (meaning
+ * the first element is not a string literal — a variable, template literal, ]).
+ */
+function firstStringArg(
+  source: string,
+  bracketIdx: number,
+  mask: Uint8Array,
+): string | null {
+  for (let i = bracketIdx + 1; i < source.length; i++) {
+    if (mask[i]) continue; // masked = comment body, string body, template body — skip
+    const c = source[i];
+    if (c === '"' || c === "'") {
+      // Opening of a string literal (unmasked quote in code).
+      // Collect the masked content bytes until the closing (unmasked) quote.
+      i++;
+      let content = "";
+      while (i < source.length) {
+        if (!mask[i]) break; // unmasked = closing quote (or unexpected code byte)
+        content += source[i];
+        i++;
+      }
+      return content;
+    }
+    // Any unmasked non-whitespace, non-string byte before a string means the
+    // first element is not a string literal — no match.
+    if (!/\s/.test(c)) return null;
+  }
+  return null;
 }
 
 /**
@@ -153,23 +191,24 @@ export function scanFile(
   const mask = computeCodeMask(source);
   const issues: CommandSafetyIssue[] = [];
 
-  SSH_ARGV_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
+  for (let i = 0; i < source.length; i++) {
+    if (mask[i]) continue;
+    if (source[i] !== "[") continue;
 
-  while ((match = SSH_ARGV_RE.exec(source)) !== null) {
-    if (mask[match.index]) continue; // inside comment, string, or template body
+    // Found an unmasked `[`. Use firstStringArg to resolve the first real
+    // (non-comment, non-whitespace) source element, handling single-quoted
+    // strings and comments between `[` and the first element correctly.
+    const cmd = firstStringArg(source, i, mask);
+    if (!cmd || !SSH_COMMANDS.has(cmd)) continue;
 
-    const line = lineOf(source, match.index);
-    const command = match[1]!;
-
-    const arrayEnd = findArrayEnd(source, match.index, mask);
+    const line = lineOf(source, i);
+    const arrayEnd = findArrayEnd(source, i, mask);
     const kind: IssueKind =
-      arrayEnd !== -1 &&
-      hasTemplateInterpolation(source, match.index, arrayEnd, mask)
+      arrayEnd !== -1 && hasTemplateInterpolation(source, i, arrayEnd, mask)
         ? "interpolation"
         : "path";
 
-    issues.push({ file: relPath, line, command, kind });
+    issues.push({ file: relPath, line, command: cmd, kind });
   }
 
   return issues;

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -70,8 +70,9 @@ export function buildRemoteScript(cwd: string, cmd: string): string {
  *
  * Remote env parity (e.g. `eval $(opam env)`) relies on the worker's login-shell
  * profile sourcing on the SSH command channel; deeper hardening is out of scope.
- * The `ssh` token in `scripts/lint-template-safety.ts`'s blocklist is
- * template-markdown-only (that lint never scans `src/`).
+ * This file is the sole vetted ssh chokepoint in src/; it is allowlisted in
+ * `scripts/lint-src-command-safety.ts` (`SRC_COMMAND_SAFETY_ALLOWLIST`), which
+ * enforces that no other src/ file constructs an ssh/scp/rsync argv directly.
  */
 export function runRemoteCommand(
   machine: ClusterMachine,


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-src-command-safety.ts` — a new sibling lint that scans `src/**` for unsafe `ssh`/`scp`/`rsync` argv-array construction, closing the coverage gap from `gh-ludics-578`.
- Enforces two rules: **path rule** (any ssh/scp/rsync literal in non-allowlisted `src/` files) and **interpolation rule** (template-literal-with-`${…}` remote-script in non-allowlisted files).
- `src/remote.ts` is allowlisted via `SRC_COMMAND_SAFETY_ALLOWLIST` as the sole vetted ssh chokepoint; all future ssh authors must land there or explicitly expand the allowlist.
- Reuses `computeCodeMask` from `lint-test-spawn-coverage.ts` so matches inside comments/strings are suppressed.
- Wired as `lint:src-command-safety` in `package.json` and as a CI step in `.github/workflows/ci.yml` (next to `Lint template variable safety`).
- Updates the stale JSDoc note in `src/remote.ts` to point at the new lint.

## Test plan

- [x] `bun test scripts/lint-src-command-safety.test.ts` — 20/20 tests pass
- [x] `bun run lint:src-command-safety` — exits 0 on real corpus
- [x] `bun run typecheck` — clean
- [x] `bun run lint:test-spawn-coverage` — 35 exits-named tests covered (includes new "exits 0/1" tests that spawn the binary)
- [x] `bun run lint:no-nul-bytes`, `lint:cli-readme`, `lint:template-safety` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)