### PR TITLE
fix(duo): repair hierarchical-duo slotB launch on remote workers (gh-ludics-589)

### DIFF
--- a/scripts/lint-hooks.test.ts
+++ b/scripts/lint-hooks.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listHookScripts } from "./lint-hooks.ts";
@@ -60,5 +60,69 @@ describe("listHookScripts", () => {
       join(TMP, "ok.sh"),
       join(sub, "nested-ok.sh"),
     ]);
+  });
+});
+
+// gh-ludics-589 (Part C / AC6): ludics-on-stop.sh must never exec `orch on-stop`
+// with a blank first positional (which produced the `usage: ...` error that
+// blocked phase advancement). When the stop-event cwd is blank, the hook defaults
+// it to $PWD before the exec. End-to-end bash smoke test.
+describe("ludics-on-stop.sh blank-cwd default (gh-ludics-589)", () => {
+  let TMP = "";
+  const hookPath = join(import.meta.dir, "..", "templates", "hooks", "ludics-on-stop.sh");
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-onstop-hook-"));
+  });
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("blank stop-event cwd is replaced by $PWD before exec orch on-stop", () => {
+    // Sandbox HOME + PATH so the hook resolves OUR stub ludics (not the real
+    // ~/.local/bin one) and finds jq via /usr/bin. The stub records its argv.
+    const home = join(TMP, "home");
+    const binDir = join(home, ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const argvOut = join(TMP, "argv.txt");
+    const stub = join(binDir, "ludics");
+    writeFileSync(stub, `#!/bin/bash\nprintf '%s\\n' "$@" > "${argvOut}"\n`);
+    chmodSync(stub, 0o755);
+
+    // A live orchestration peer-sync dir (env-var routing requires a phase file).
+    const psDir = join(TMP, "peer-sync");
+    mkdirSync(psDir, { recursive: true });
+    writeFileSync(join(psDir, "phase"), "work\n");
+
+    // The agent's real working directory — what a blank cwd must default to.
+    const workDir = join(TMP, "worktree");
+    mkdirSync(workDir, { recursive: true });
+
+    const proc = Bun.spawnSync(["/bin/bash", hookPath], {
+      cwd: workDir,
+      env: {
+        HOME: home,
+        PATH: "/usr/bin:/bin",
+        LUDICS_PEER_SYNC_DIR: psDir,
+      },
+      // Claude Code Stop-hook JSON with an EMPTY cwd — the gh-ludics-589 trigger.
+      stdin: Buffer.from(JSON.stringify({ hook_event_name: "Stop", cwd: "" })),
+    });
+
+    expect(proc.exitCode).toBe(0);
+    // Split WITHOUT filtering empties — the empty cwd positional must remain
+    // observable. Drop only the single trailing newline from `printf '%s\n'`.
+    const argv = readFileSync(argvOut, "utf-8").split("\n");
+    if (argv.length && argv[argv.length - 1] === "") argv.pop();
+    // Invariant: the exec is exactly `orch on-stop <cwd> <peer-sync> <event>` with
+    // a NON-EMPTY <cwd>. Mutation: removing the `cwd="${cwd:-$PWD}"` default leaves
+    // argv[2] === "" (jq's `.cwd // ""`), flipping argv[2]/argv[3]/argv[4] — caught
+    // by both the non-empty check and the exact peer-sync/event slot assertions.
+    expect(argv).toHaveLength(5);
+    expect(argv[0]).toBe("orch");
+    expect(argv[1]).toBe("on-stop");
+    expect(argv[2]).not.toBe(""); // the cwd positional — defaulted to $PWD
+    expect(argv[3]).toBe(psDir);  // peer-sync dir stays in its own slot
+    expect(argv[4]).toBe("Stop");
   });
 });

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -897,3 +897,43 @@ cluster:
     expect(existsSync(harnessPath)).toBe(false);
   });
 });
+
+// gh-ludics-589: the start() agent-construction loop must fail LOUD when an agent
+// name has no createWorktrees entry, rather than masking the missing key (the
+// old `setup.agentWorktrees[agent.name]!`) and launching a tmux session in $HOME.
+// The "tmux adapter cold-start CWD" describe above is the positive control: real
+// matching keys → distinct worktree cwds. This covers the missing-key branch.
+describe("resolveAgentLaunchPaths fail-loud (gh-ludics-589)", () => {
+  test("throws naming the missing key and available keys when an agent has no worktree", async () => {
+    const { resolveAgentLaunchPaths } = await import("./tmux-adapter.ts");
+    const setup = {
+      agentWorktrees: { coder: "/wt/coder" }, // reviewer key MISSING (the bug)
+      branches: { coder: "br-coder", reviewer: "br-reviewer" },
+    };
+    // Invariant: a missing worktree key surfaces as an error before any tmux
+    // session, naming the agent and the keys present. Mutation: restoring the `!`
+    // assertion returns `undefined` for worktreePath (no throw) → $HOME launch.
+    expect(() => resolveAgentLaunchPaths(setup, "reviewer", 4, "task-duo-b"))
+      .toThrow(/no worktree created for agent "reviewer".*have: coder/s);
+  });
+
+  test("throws for a missing branch key too (same bug class)", async () => {
+    const { resolveAgentLaunchPaths } = await import("./tmux-adapter.ts");
+    const setup = {
+      agentWorktrees: { coder: "/wt/coder", reviewer: "/wt/reviewer" },
+      branches: { coder: "br-coder" }, // reviewer branch MISSING
+    };
+    expect(() => resolveAgentLaunchPaths(setup, "reviewer", 4, "task-duo-b"))
+      .toThrow(/no branch created for agent "reviewer"/);
+  });
+
+  test("returns the worktree + branch when both keys are present (positive control)", async () => {
+    const { resolveAgentLaunchPaths } = await import("./tmux-adapter.ts");
+    const setup = {
+      agentWorktrees: { coder: "/wt/coder", reviewer: "/wt/reviewer" },
+      branches: { coder: "br-coder", reviewer: "br-reviewer" },
+    };
+    expect(resolveAgentLaunchPaths(setup, "reviewer", 4, "task-duo-b"))
+      .toEqual({ worktreePath: "/wt/reviewer", branch: "br-reviewer" });
+  });
+});

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -714,6 +714,36 @@ export async function sendPromptToAgent(
 // Adapter implementation
 // ---------------------------------------------------------------------------
 
+/**
+ * gh-ludics-589: resolve an agent's worktree path + branch from a
+ * `createWorktrees` setup, failing LOUD when the agent name has no entry instead
+ * of masking a missing key as `undefined`. The previous `setup.agentWorktrees[
+ * agent.name]!` non-null assertion turned a key mismatch (e.g. a swapped-slotB
+ * parse whose agent names don't match the worktree keys) into a tmux session
+ * launched with no cwd → `$HOME` (symptom 1) rather than the worktree. Throwing
+ * here surfaces the mismatch before any tmux session is created.
+ *
+ * Exported as a test seam (the real `start()` always feeds matching keys because
+ * `createWorktrees` keys by the same `orchestration.agents` names).
+ */
+export function resolveAgentLaunchPaths(
+  setup: { agentWorktrees: Record<string, string>; branches: Record<string, string> },
+  agentName: string,
+  slot: number,
+  taskId: string,
+): { worktreePath: string; branch: string } {
+  const worktreePath = setup.agentWorktrees[agentName];
+  const branch = setup.branches[agentName];
+  if (!worktreePath || !branch) {
+    throw new Error(
+      `slot ${slot} (task ${taskId}): no ${!worktreePath ? "worktree" : "branch"} created for agent "${agentName}" ` +
+      `(have: ${Object.keys(setup.agentWorktrees).join(", ") || "<none>"}) — ` +
+      `refusing to launch a tmux session without a worktree cwd.`
+    );
+  }
+  return { worktreePath, branch };
+}
+
 async function start(ctx: AdapterContext): Promise<string> {
   const workspaceRoot = normalizeWorkspacePath(ctx);
   const options = parseOrchestrationAdapterArgs(ctx.adapterArgs);
@@ -780,21 +810,24 @@ async function start(ctx: AdapterContext): Promise<string> {
   const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode, proposalPath_);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);
 
-  const agents: AgentConfig[] = orchestration.agents.map((agent, index) => ({
-    name: agent.name,
-    provider: agent.provider,
-    role: agent.role,
-    model: resolvedModels[index]!,
-    thinkingEffort: resolveAgentThinkingEffort(
-      agent as ParsedAgentToken,
-      index,
-      orchCfg,
-      orchestration.coderThinkingEffort,
-      orchestration.reviewerThinkingEffort,
-    ),
-    branch: setup.branches[agent.name]!,
-    worktreePath: setup.agentWorktrees[agent.name]!,
-  }));
+  const agents: AgentConfig[] = orchestration.agents.map((agent, index) => {
+    const { worktreePath, branch } = resolveAgentLaunchPaths(setup, agent.name, ctx.slot, taskId);
+    return {
+      name: agent.name,
+      provider: agent.provider,
+      role: agent.role,
+      model: resolvedModels[index]!,
+      thinkingEffort: resolveAgentThinkingEffort(
+        agent as ParsedAgentToken,
+        index,
+        orchCfg,
+        orchestration.coderThinkingEffort,
+        orchestration.reviewerThinkingEffort,
+      ),
+      branch,
+      worktreePath,
+    };
+  });
 
   initPeerSync(
     setup.peerSyncDir,

--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -444,6 +444,36 @@ describe("parsePendingIntent", () => {
     expect(parsePendingIntent({ ...valid, taskId: null })?.taskId).toBeUndefined();
   });
 
+  test("preserves optional adapterArgs and round-trips a duo string (gh-ludics-589)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    const duoArgs = "--pair --coder codex --reviewer claude-code --duo-peer-slot=3";
+    const out = parsePendingIntent({ ...valid, taskId: "task-99", adapterArgs: duoArgs });
+    // Invariant: the controller-authored expanded duo args survive the parse
+    // boundary verbatim. If this dropped/mangled adapterArgs, the worker would
+    // launch slotB with no peer/swapped providers — the exact gh-ludics-589 bug.
+    expect(out).toEqual({ action: "start", epoch: NOW, machine: "host-a", taskId: "task-99", adapterArgs: duoArgs });
+    // The peer-slot token specifically must round-trip (drives slotIsDuoMember + parseOrchestrationAdapterArgs).
+    expect(out?.adapterArgs).toContain("--duo-peer-slot=3");
+  });
+
+  test("legacy intent without adapterArgs still validates (optional field; gh-ludics-589)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    // Harness condition: a stop/resume intent file written before this field
+    // existed. Must not be rejected by the new branch.
+    expect(parsePendingIntent({ action: "resume", epoch: NOW, machine: "host-a" }))
+      .toEqual({ action: "resume", epoch: NOW, machine: "host-a" });
+    expect(parsePendingIntent({ ...valid })?.adapterArgs).toBeUndefined();
+  });
+
+  test("string-coerces non-string adapterArgs; drops empty/whitespace after coercion (gh-ludics-589)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, adapterArgs: 42 })?.adapterArgs).toBe("42");
+    // Empty / whitespace-only is dropped so it never overrides a populated worker read.
+    expect(parsePendingIntent({ ...valid, adapterArgs: "" })?.adapterArgs).toBeUndefined();
+    expect(parsePendingIntent({ ...valid, adapterArgs: "   " })?.adapterArgs).toBeUndefined();
+    expect(parsePendingIntent({ ...valid, adapterArgs: null })?.adapterArgs).toBeUndefined();
+  });
+
   test("rejects non-bool preserveState (no sensible coercion target)", async () => {
     const { parsePendingIntent } = await import("./cluster-http.ts");
     expect(parsePendingIntent({ ...valid, preserveState: "yes" })).toBeNull();

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -139,6 +139,12 @@ export interface PendingIntent {
   machine: string;
   taskId?: string;
   preserveState?: boolean;
+  /** Launch-time adapter args captured by the controller at dispatch (gh-ludics-589).
+   *  Carried on `start` intents so the worker launches with the correct expanded
+   *  duo args (swapped providers + `--duo-peer-slot`) even when its up-front
+   *  `freshSlots` snapshot raced the controller's two-slot publish. Optional, so
+   *  legacy `stop`/`resume` intents and older on-disk files remain valid. */
+  adapterArgs?: string;
 }
 
 /** Validate an untrusted intent payload (file-on-disk read, HTTP body) into
@@ -152,6 +158,7 @@ export interface PendingIntent {
  *    epochs as strings.
  *  - `machine` and `taskId`: string-coerce non-string values with `String(…)`
  *    so a single function returns either a fully-validated intent or `null`.
+ *  - `adapterArgs`: optional, string-coerce + drop-when-empty (mirrors taskId).
  *  - `preserveState`: optional bool, no coercion (no sensible target). */
 export function parsePendingIntent(raw: unknown): PendingIntent | null {
   if (!raw || typeof raw !== "object") return null;
@@ -180,6 +187,14 @@ export function parsePendingIntent(raw: unknown): PendingIntent | null {
   if (r.taskId !== undefined && r.taskId !== null) {
     const taskId = typeof r.taskId === "string" ? r.taskId : String(r.taskId);
     if (taskId !== "") out.taskId = taskId;
+  }
+
+  // adapterArgs (gh-ludics-589): same string-coerce + drop-when-empty contract as
+  // taskId. An empty/whitespace value is dropped so it never overrides a populated
+  // worker-side read; a non-empty value carries the controller's expanded duo args.
+  if (r.adapterArgs !== undefined && r.adapterArgs !== null) {
+    const adapterArgs = typeof r.adapterArgs === "string" ? r.adapterArgs : String(r.adapterArgs);
+    if (adapterArgs.trim() !== "") out.adapterArgs = adapterArgs;
   }
 
   if (r.preserveState !== undefined) {

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick, maybeResumeDeadOrchestrators } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick, maybeResumeDeadOrchestrators, fillBlankSnapshotArgsFromIntent } from "./mag.ts";
 import { emptySlotData, writeSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
 import type { RunGit } from "./git-runner.ts";
@@ -1973,5 +1973,43 @@ cluster:
 
     expect(out).toContain("circuit-breaker tripped for slot 1");
     expect(out).not.toContain("slot 2"); // slot 2 not detected/resumed this tick
+  });
+});
+
+// gh-ludics-589: the worker fills a blank snapshot slot's adapterArgs from the
+// controller-authored start intent, so a freshSlots snapshot that raced the
+// two-slot duo publish still launches slotB with the correct expanded args.
+describe("fillBlankSnapshotArgsFromIntent (gh-ludics-589 Part B)", () => {
+  const duoArgs = "--pair --coder codex --reviewer claude-code --duo-peer-slot=3";
+  function snap(slot: number, adapterArgs: string): SlotData {
+    return { ...emptySlotData(slot), process: "orch-runner", task: "task-duo-b", mode: "tmux", machine: "self-node", adapterArgs };
+  }
+
+  test("fills a BLANK snapshot entry from a start intent carrying expanded duo args", () => {
+    // Harness condition: the snapshot raced the publish — slotB's row is blank,
+    // but the start intent carries the controller's swapped providers + peer.
+    const filled = fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "start", adapterArgs: duoArgs });
+    // Invariant: the corrected row carries the swapped providers and peer slot, so
+    // the downstream slotStart/auto-fill never sees empty args. If the merge were
+    // dropped, filled would be null and slotB would launch with default providers.
+    expect(filled).not.toBeNull();
+    expect(filled!.adapterArgs).toBe(duoArgs);
+    expect(filled!.adapterArgs).toContain("--duo-peer-slot=3");
+    // Whitespace-only is treated as blank and filled too.
+    expect(fillBlankSnapshotArgsFromIntent(snap(4, "   "), { action: "start", adapterArgs: duoArgs })?.adapterArgs).toBe(duoArgs);
+  });
+
+  test("a POPULATED snapshot entry wins — intent does not clobber it", () => {
+    const existing = snap(4, "--pair --coder claude-code --reviewer codex --duo-peer-slot=3");
+    // Invariant: only a delivery gap (blank args) is repaired; a snapshot that
+    // already carries args is authoritative and untouched.
+    expect(fillBlankSnapshotArgsFromIntent(existing, { action: "start", adapterArgs: duoArgs })).toBeNull();
+  });
+
+  test("no-ops for non-start intents, missing intent args, and missing snapshot row", () => {
+    expect(fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "stop", adapterArgs: duoArgs })).toBeNull();
+    expect(fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "resume", adapterArgs: duoArgs })).toBeNull();
+    expect(fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "start" })).toBeNull();
+    expect(fillBlankSnapshotArgsFromIntent(undefined, { action: "start", adapterArgs: duoArgs })).toBeNull();
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3932,6 +3932,29 @@ async function workerKeepalive(): Promise<void> {
 }
 
 /** Poll controller for pending intents and execute them (pure pull model). */
+/**
+ * gh-ludics-589: when the up-front freshSlots snapshot raced the controller's
+ * two-slot hierarchical-duo publish, a `start` intent's controller-authored
+ * `adapterArgs` (swapped `--coder`/`--reviewer` + `--duo-peer-slot`) fills a
+ * BLANK snapshot entry so the worker launches slotB with the correct expanded
+ * args rather than tripping the empty-args auto-fill or a stale local
+ * `slot-N.json`. Returns the corrected `SlotData` when a fill applies, else
+ * `null`. Pure — exported as a test seam (the live `processSlotIntents` is not
+ * unit-reachable without the controller HTTP stack).
+ *
+ * A populated snapshot entry always wins (only a genuinely blank/whitespace
+ * `adapterArgs` is filled); non-`start` intents and intents without `adapterArgs`
+ * are no-ops.
+ */
+export function fillBlankSnapshotArgsFromIntent(
+  snap: SlotData | undefined,
+  intent: { action: string; adapterArgs?: string },
+): SlotData | null {
+  if (intent.action !== "start" || !intent.adapterArgs) return null;
+  if (!snap || (snap.adapterArgs ?? "").trim()) return null;
+  return { ...snap, adapterArgs: intent.adapterArgs };
+}
+
 async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Promise<void> {
   const currentMachine = clusterCurrentMachineName();
   if (!currentMachine) return;
@@ -3957,6 +3980,15 @@ async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Pro
         }
         let shouldAck = true;
         try {
+          // gh-ludics-589: if the up-front freshSlots snapshot raced the
+          // controller's two-slot duo publish, this slot's adapterArgs may be
+          // blank in the snapshot while the start intent carries the
+          // controller-authored expanded args. Fill the blank snapshot entry from
+          // the intent so slotStart launches with the correct providers/peer
+          // instead of tripping the empty-args auto-fill (or falling through to a
+          // stale local slot-N.json).
+          const filled = fillBlankSnapshotArgsFromIntent(freshSlots.get(slotNum), intent);
+          if (filled) freshSlots.set(slotNum, filled);
           // Set fresh controller state so slot operations use it instead of stale local harness
           setWorkerSlotsOverride(freshSlots);
           try {

--- a/src/orchestration/index.test.ts
+++ b/src/orchestration/index.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import { orchDiff, runOrchestrationCli } from "./index.ts";
-import { makeTmpDir, setupOrchTestState } from "./runner.test-helpers.ts";
+import { orchDiff, orchOnStop, runOrchestrationCli } from "./index.ts";
+import { makeTmpDir, makePeerSyncDir, setupOrchTestState } from "./runner.test-helpers.ts";
+import { readStopHookRecord } from "./peer-sync.ts";
 
 function makeRepo(dir: string): void {
   mkdirSync(dir, { recursive: true });
@@ -220,5 +221,64 @@ describe("runOrchestrationCli unknown-subcommand listing (gh-ludics-438)", () =>
     const useEntries = useMatch![1]!.split(/,\s*/);
     expect(useEntries).not.toContain("run-internal");
     expect(useEntries).not.toContain("on-stop");
+  });
+});
+
+// gh-ludics-589 (Part C): a blank cwd must be handled gracefully by orchOnStop —
+// no `usage: ...` + exit(1) that blocks phase advancement. A blank cwd from ANY
+// cause (the shell hook also defaults it to $PWD as defense in depth) falls
+// through to env/marker peer-sync resolution + env/status agent attribution.
+describe("orchOnStop blank-cwd handling (gh-ludics-589)", () => {
+  const ORIG_PSD = process.env.LUDICS_PEER_SYNC_DIR;
+  const ORIG_AGENT = process.env.LUDICS_AGENT_NAME;
+
+  afterEach(() => {
+    if (ORIG_PSD === undefined) delete process.env.LUDICS_PEER_SYNC_DIR;
+    else process.env.LUDICS_PEER_SYNC_DIR = ORIG_PSD;
+    if (ORIG_AGENT === undefined) delete process.env.LUDICS_AGENT_NAME;
+    else process.env.LUDICS_AGENT_NAME = ORIG_AGENT;
+  });
+
+  test("orchOnStop([]) / orchOnStop([\"\"]) return without usage error or process.exit", () => {
+    delete process.env.LUDICS_PEER_SYNC_DIR; // nothing resolves → silent no-op
+    delete process.env.LUDICS_AGENT_NAME;
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code}) called`);
+    }) as never);
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Invariant: a blank cwd never reaches `process.exit(1)` / the usage error.
+      // Mutation: restoring `if (!cwd) { usage; process.exit(1); }` makes exitSpy
+      // fire (and throw) here.
+      expect(() => orchOnStop([])).not.toThrow();
+      expect(() => orchOnStop([""])).not.toThrow();
+      expect(exitSpy).not.toHaveBeenCalled();
+      const usagePrinted = errSpy.mock.calls.some(c => String(c[0] ?? "").includes("usage: ludics orch on-stop"));
+      expect(usagePrinted).toBe(false);
+    } finally {
+      errSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("blank cwd still attributes via LUDICS_AGENT_NAME and writes a stop record", () => {
+    // Harness condition: a live orchestration (phase + token + worktrees) with the
+    // agent identified only by env — exactly the slotB case where the worktree-cwd
+    // match is unavailable because cwd is blank.
+    const dir = makePeerSyncDir(
+      { root: "/wt/root", coder: "/wt/coder", reviewer: "/wt/reviewer" },
+      { coder: "working" },
+    );
+    process.env.LUDICS_PEER_SYNC_DIR = dir;
+    process.env.LUDICS_AGENT_NAME = "coder";
+
+    // Invariant: with a blank cwd, env attribution fires and a stop record lands,
+    // so the runner sees turn completion. Mutation: the old exit(1) on blank cwd
+    // would abort before any attribution and no record would be written.
+    orchOnStop([""]);
+    const rec = readStopHookRecord(dir, "coder");
+    expect(rec).not.toBeNull();
+    expect(rec!.agent).toBe("coder");
+    expect(rec!.phaseToken).toBe("phase-test-token");
   });
 });

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -195,11 +195,15 @@ export async function runOrchestrationCli(args: string[]): Promise<void> {
  * the CLI arg when it couldn't resolve the dir, so the env var kicks in.
  */
 export function orchOnStop(args: string[]): void {
-  const [cwd, cliPeerSyncDir, hookEventName] = args;
-  if (!cwd) {
-    console.error("usage: ludics orch on-stop <cwd> [peer-sync-dir] [hook-event-name]");
-    process.exit(1);
-  }
+  // gh-ludics-589: a blank cwd (the shell hook couldn't resolve it — from ANY
+  // cause, not just gh-ludics-590's jq/PATH gap) must NOT produce a usage error +
+  // exit(1) that blocks phase advancement. Fall through to env/marker peer-sync
+  // resolution and env/status-file agent attribution; if nothing resolves we
+  // return silently (exit 0). The shell hook also defaults a blank cwd to $PWD
+  // (defense in depth), so this graceful path is the second layer.
+  const cwd = args[0] ?? "";
+  const cliPeerSyncDir = args[1];
+  const hookEventName = args[2];
 
   // Resolve peerSyncDir: CLI arg (if valid) > env var > give up.
   const peerSyncDir = resolvePeerSyncDir({ cliArg: cliPeerSyncDir || undefined });
@@ -232,7 +236,9 @@ export function orchOnStop(args: string[]): void {
   }
 
   // Marker-file attribution: .ludics-orchestration.json written by orchestration setup.
-  if (!agentName) {
+  // Guard on a non-empty cwd (gh-ludics-589): readAgentMarkerFile("") would join
+  // against process.cwd() and could mis-attribute; a blank cwd has no marker.
+  if (!agentName && cwd) {
     const marker = readAgentMarkerFile(cwd);
     if (marker && worktreeAgentNames.includes(marker.agentName)) {
       agentName = marker.agentName;

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -3188,6 +3188,25 @@ cluster:
     expect(slotIsDuoMember(3)).toBe(false); // slotA itself is not named by anyone here
   });
 
+  test("slotIsDuoMember ignores a STALE peer token from a sibling on a different task (PR #594 review)", () => {
+    // Scenario: slots 1+2 ran a duo for task-old; the duo broke (clearDuoPeerLink
+    // cleared sibling 2's orchestration duoPeerSlot but NOT its stored adapterArgs,
+    // which still says --duo-peer-slot=1). slot 1 is then reused for a fresh SOLO
+    // task-new with empty args.
+    setWorkerSlotsOverride(new Map<number, SlotData>([
+      // slot 1: reused solo, NEW task, empty args (would auto-fill).
+      [1, { ...emptySlotData(1), process: "orch-runner", task: "task-new", mode: "tmux", adapterArgs: "" }],
+      // slot 2: stale leftover — still names slot 1 as peer, but on the OLD task.
+      [2, { ...emptySlotData(2), process: "orch-runner", task: "task-old", mode: "tmux", adapterArgs: "--pair --coder codex --reviewer claude-code --duo-peer-slot=1" }],
+    ]));
+    // Invariant: a duo pair shares a task; a peer token whose sibling is on a
+    // different task is stale and must NOT block the reused slot's auto-fill.
+    // Mutation: dropping the same-task guard flips this back to true → the solo
+    // reuse throws instead of auto-filling (the exact false positive the reviewer
+    // flagged).
+    expect(slotIsDuoMember(1)).toBe(false);
+  });
+
   test("autoFillAdapterArgs REFUSES (throws) a duo slot with empty args — no default-pair fallback (AC1)", async () => {
     setWorkerSlotsOverride(new Map<number, SlotData>([
       [3, duoSibling(3, 4)],
@@ -3212,9 +3231,11 @@ cluster:
     writeTask(tasksDir, "task-solo-fill", "Solo fill");
     void slotAssign(1, "task-solo-fill", "t3code");
     const data = readSlotJson(1, harness);
-    // Override carries an UNRELATED duo pair on other slots — slot 1 is solo and
-    // must not be swept up by the duo refusal.
+    // Override carries an UNRELATED duo pair on other slots — slot 1 (its own task)
+    // is solo and must not be swept up by the duo refusal. slot 1 is present in the
+    // override so the same-task guard sees its real task, not an empty self.
     setWorkerSlotsOverride(new Map<number, SlotData>([
+      [1, data],
       [3, duoSibling(3, 4)],
       [4, blankDuoSlotB(4)],
     ]));

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride, persistSlotLiveness } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride, persistSlotLiveness, slotIsDuoMember } from "./index.ts";
+import * as clusterHttpMod from "../cluster-http.ts";
 import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
 import * as spawnMod from "../spawn.ts";
@@ -3094,5 +3095,190 @@ cluster:
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(readSlotJson(1).liveness).toBeNull();
+  });
+});
+
+// gh-ludics-589: hierarchical-duo slotB launch hardening.
+//   Part A (fail-loud): a duo member whose expanded adapterArgs failed to reach
+//     the worker must NOT auto-fill a default pair (which would discard swapped
+//     providers + --duo-peer-slot and get persisted back as durable corruption).
+//   Part B (delivery): the controller's start intent carries the launch-time
+//     adapterArgs so the worker launches with the correct expanded duo args.
+describe("duo slotB launch hardening (gh-ludics-589)", () => {
+  type SlotData = import("./types.ts").SlotData;
+
+  function duoSibling(slot: number, peer: number): SlotData {
+    // A healthy duo sibling (slotA): its args still name `slot`'s peer even when
+    // `slot`'s own args are blank — the signal slotIsDuoMember keys on.
+    return {
+      ...emptySlotData(slot),
+      process: "orch-runner",
+      task: "task-duo",
+      mode: "tmux",
+      adapterArgs: `--pair --coder codex --reviewer claude-code --duo-peer-slot=${peer}`,
+    };
+  }
+  function blankDuoSlotB(slot: number, machine = ""): SlotData {
+    // slotB as it arrives on the worker when delivery failed: blank args.
+    return { ...emptySlotData(slot), process: "orch-runner", task: "task-duo", mode: "tmux", machine, adapterArgs: "" };
+  }
+
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  // A cluster where THIS host is a worker (self-node), so isWorkerContext() is
+  // true and remote dispatch to worker-a is reachable. Pins the machine name via
+  // env (like the slotResume worker-override tests) rather than relying on
+  // hostname matching, which is unreliable on dev boxes.
+  function writeWorkerClusterConfig(): void {
+    const cfgDir = join(TMP, ".config", "ludics");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.yaml"), `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 4
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: self-node
+      host: self-node.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+    - name: worker-a
+      host: worker-a.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    process.env.LUDICS_CONFIG = join(cfgDir, "config.yaml");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "self-node";
+  }
+
+  afterEach(() => {
+    setWorkerSlotsOverride(null);
+    clearIntent(1);
+    clearIntent(4);
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+  });
+
+  test("slotIsDuoMember is true only for the slot a sibling names as its peer (Part A signal)", () => {
+    // Harness condition: slot 3 (slotA) names slot 4 (slotB) as its duo peer;
+    // slot 4's own args are blank. A solo slot 1 coexists with NO peer reference.
+    setWorkerSlotsOverride(new Map<number, SlotData>([
+      [1, { ...emptySlotData(1), process: "orch-runner", task: "task-solo", mode: "tmux", adapterArgs: "--pair --coder claude-code --reviewer codex" }],
+      [3, duoSibling(3, 4)],
+      [4, blankDuoSlotB(4)],
+    ]));
+    // Invariant: membership is decided by the *number* in --duo-peer-slot=<n>,
+    // not the mere presence of the token. Mutation: dropping `Number(m[1]) ===
+    // slotNum` (matching any sibling with any peer token) would flip slot 1 to
+    // true; dropping the regex entirely would flip slot 4 to false.
+    expect(slotIsDuoMember(4)).toBe(true);  // named by sibling 3
+    expect(slotIsDuoMember(1)).toBe(false); // solo — never named, despite the 3↔4 pair
+    expect(slotIsDuoMember(3)).toBe(false); // slotA itself is not named by anyone here
+  });
+
+  test("autoFillAdapterArgs REFUSES (throws) a duo slot with empty args — no default-pair fallback (AC1)", async () => {
+    setWorkerSlotsOverride(new Map<number, SlotData>([
+      [3, duoSibling(3, 4)],
+      [4, blankDuoSlotB(4)],
+    ]));
+    const data = blankDuoSlotB(4);
+    const ctx = makeAdapterContext(4, data);
+    // Invariant: empty args on a duo member is a delivery failure, not an
+    // operator default request. The refusal fires BEFORE selectOrchestrationFlags,
+    // so no `--pair --coder <default>` string is ever produced. Mutation: removing
+    // the slotIsDuoMember guard makes this resolve to a default pair instead of
+    // throwing (and the message would be the unrelated "task file not found").
+    await expect(autoFillAdapterArgs(ctx, data)).rejects.toThrow(/duo member with empty adapterArgs/);
+  });
+
+  test("autoFillAdapterArgs still auto-fills a SOLO slot with empty args (AC3 negative control)", async () => {
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-solo-fill", "Solo fill");
+    void slotAssign(1, "task-solo-fill", "t3code");
+    const data = readSlotJson(1, harness);
+    // Override carries an UNRELATED duo pair on other slots — slot 1 is solo and
+    // must not be swept up by the duo refusal.
+    setWorkerSlotsOverride(new Map<number, SlotData>([
+      [3, duoSibling(3, 4)],
+      [4, blankDuoSlotB(4)],
+    ]));
+    const ctx = makeAdapterContext(1, data);
+    // Invariant: a slot no sibling references still auto-fills as before. If the
+    // duo guard over-fired (number-blind), this would throw and fail here.
+    const result = await autoFillAdapterArgs(ctx, data);
+    expect(result).not.toBeNull();
+    expect(result!.args).toContain("--pair");
+    expect(result!.args).toContain("--coder");
+  });
+
+  test("slotStart does NOT persist default args back to the controller for a refused duo slot (AC2)", async () => {
+    // Worker context: this host = self-node (a worker, not the leader/controller),
+    // so isWorkerContext() is true and WITHOUT the fix slotStart would auto-fill
+    // and POST the default pair via clusterPostSlotUpdate.
+    writeWorkerClusterConfig();
+    const postSpy = spyOn(clusterHttpMod, "clusterPostSlotUpdate");
+
+    // slotB (1) is owned by THIS host (self-node) so slotStart runs local
+    // execution (not remote dispatch), reaching the auto-fill decision; slot 2
+    // (slotA) names slot 1 as its duo peer.
+    setWorkerSlotsOverride(new Map<number, SlotData>([
+      [2, duoSibling(2, 1)],
+      [1, blankDuoSlotB(1, "self-node")],
+    ]));
+
+    // Invariant: the refusal unwinds slotStart before the clusterPostSlotUpdate
+    // write-back, so a transient empty read never becomes durable controller
+    // corruption. Mutation: removing the duo guard makes slotStart auto-fill and
+    // call clusterPostSlotUpdate({ adapterArgs: <default pair> }) → spy fires.
+    await expect(slotStart(1)).rejects.toThrow(/duo member with empty adapterArgs/);
+    for (const call of postSpy.mock.calls) {
+      expect(JSON.stringify(call[1] ?? {})).not.toContain("adapterArgs");
+    }
+    postSpy.mockRestore();
+  });
+
+  test("remote start dispatch records a start intent carrying the expanded adapterArgs (Part B / AC4)", async () => {
+    writeWorkerClusterConfig();
+    const harness = join(TMP, "ludics-state", "harness");
+    mkdirSync(join(harness, "tasks"), { recursive: true });
+    writeSlotJson(2, emptySlotData(2), harness);
+
+    // Fresh heartbeat so worker-a is reachable.
+    const hbDir = getHeartbeatsDir();
+    mkdirSync(hbDir, { recursive: true });
+    writeFileSync(join(hbDir, "worker-a.json"), JSON.stringify({ epoch: Math.floor(Date.now() / 1000) }));
+
+    const duoArgs = "--pair --coder codex --reviewer claude-code --duo-peer-slot=3";
+    // Write slotB (1) directly with the expanded duo args + a remote machine
+    // (worker-a ≠ self-node), bypassing slotAssign's adapter-match guard.
+    writeSlotJson(1, { ...emptySlotData(1), process: "orch-runner", task: "task-duo-b", mode: "tmux", machine: "worker-a", adapterArgs: duoArgs }, harness);
+
+    await slotStart(1); // remote → records a start intent and returns
+
+    // Invariant: the controller captures launch-time args at dispatch, so the
+    // worker can launch slotB self-contained even if its freshSlots snapshot
+    // raced the two-slot publish. Mutation: dropping `adapterArgs` from the start
+    // payload leaves intent.adapterArgs undefined and this assertion fails.
+    const intent = getIntentForDashboard(1);
+    expect(intent).not.toBeNull();
+    expect(intent!.action).toBe("start");
+    expect(intent!.adapterArgs).toContain("--duo-peer-slot=3");
+    expect(intent!.adapterArgs).toContain("--coder codex");
   });
 });

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1035,12 +1035,23 @@ async function ensureRemoteMachineReachable(
  * referenced this way, so it is correctly NOT flagged. No `SlotData` field and no
  * migration — derived entirely from existing args.
  *
+ * The match additionally requires the sibling to share this slot's `task`. A
+ * genuine duo pair is assigned to the same task id by both `slotAssign` calls, so
+ * this is always true for a real delivery failure. It guards against a STALE peer
+ * token: `clearDuoPeerLink` clears the sibling's orchestration `duoPeerSlot` when
+ * a duo breaks but does NOT rewrite the sibling's stored `adapterArgs`, so a later
+ * SOLO reuse of this slot would otherwise be mis-flagged by the leftover
+ * `--duo-peer-slot=<slotNum>` token (the new task has a different id → no match).
+ *
  * Exported as a test seam (mirrors `autoFillAdapterArgs`).
  */
 export function slotIsDuoMember(slotNum: number): boolean {
   const all = readAllSlots();
+  const selfTask = all.get(slotNum)?.task ?? "";
+  if (!selfTask) return false; // no task → not a duo delivery failure
   for (const [other, sd] of all) {
     if (other === slotNum) continue;
+    if ((sd?.task ?? "") !== selfTask) continue; // stale-token / unrelated-pair guard
     const args = sd?.adapterArgs ?? "";
     const m = args.match(/--duo-peer-slot=(\d+)/);
     if (m && Number(m[1]) === slotNum) return true;

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -1023,12 +1023,54 @@ async function ensureRemoteMachineReachable(
  * the original inline block. Does *not* call `runAdapterAction`, `t3code.start`,
  * or `ensureServer`, and does not persist or journal — that is the caller's job.
  */
+/**
+ * Detect whether `slotNum` is a hierarchical-duo member whose own `adapterArgs`
+ * failed to arrive, by scanning the *other* slots (worker override / fresh
+ * snapshot when active, else local slot json) for a sibling that names this slot
+ * as its duo peer via `--duo-peer-slot=<slotNum>` (gh-ludics-589).
+ *
+ * This is the duo-membership signal that survives an empty `adapterArgs`: a duo
+ * slotB with blank args cannot self-report its peer, but its healthy sibling
+ * slotA still carries `--duo-peer-slot=<slotB>`. A genuine solo slot is never
+ * referenced this way, so it is correctly NOT flagged. No `SlotData` field and no
+ * migration — derived entirely from existing args.
+ *
+ * Exported as a test seam (mirrors `autoFillAdapterArgs`).
+ */
+export function slotIsDuoMember(slotNum: number): boolean {
+  const all = readAllSlots();
+  for (const [other, sd] of all) {
+    if (other === slotNum) continue;
+    const args = sd?.adapterArgs ?? "";
+    const m = args.match(/--duo-peer-slot=(\d+)/);
+    if (m && Number(m[1]) === slotNum) return true;
+  }
+  return false;
+}
+
 export async function autoFillAdapterArgs(
   ctx: AdapterContext,
   data: SlotData,
 ): Promise<{ args: string; effort: string; updatedData: SlotData } | null> {
   if (!(ctx.mode === "t3code" || ctx.mode === "tmux") || ctx.adapterArgs.trim()) {
     return null;
+  }
+
+  // gh-ludics-589 (Part A, fail-loud safety net): empty adapterArgs on a duo
+  // member is a *delivery failure*, not "operator wants defaults". Auto-filling a
+  // default pair here would discard the swapped providers and --duo-peer-slot, and
+  // slotStart would then persist that wrong default back to the controller via
+  // clusterPostSlotUpdate — turning a transient empty read into durable
+  // corruption. Refuse loudly so Mag can retry (the intent stays unacked). The
+  // throw also unwinds slotStart before the clusterPostSlotUpdate write-back, so
+  // no wrong default is ever persisted (AC2). Solo slots fall through and auto-fill
+  // exactly as before (AC3).
+  if (slotIsDuoMember(ctx.slot)) {
+    throw new Error(
+      `slot ${ctx.slot}: duo member with empty adapterArgs — refusing to auto-fill a default pair. ` +
+      `The expanded duo args (swapped --coder/--reviewer + --duo-peer-slot) failed to reach this worker. ` +
+      `Retry the launch so the controller-authored args are delivered.`
+    );
   }
 
   const taskId = ctx.taskId;
@@ -1093,7 +1135,15 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
 
   // Remote dispatch: record intent in controller memory (pure pull model)
   if (ctx.machine && isRemoteMachine(ctx.machine)) {
-    await ensureRemoteMachineReachable(slotNum, ctx.machine, "start", ctx.mode, { taskId: ctx.taskId });
+    // gh-ludics-589: capture the launch-time adapterArgs in the start intent so the
+    // worker launches with the correct expanded duo args (swapped providers +
+    // --duo-peer-slot) even if its up-front freshSlots snapshot raced the
+    // controller's two-slot publish. The controller's slot state is authoritative
+    // here. Pass undefined (not "") when empty so parsePendingIntent drops it.
+    await ensureRemoteMachineReachable(slotNum, ctx.machine, "start", ctx.mode, {
+      taskId: ctx.taskId,
+      adapterArgs: ctx.adapterArgs.trim() ? ctx.adapterArgs : undefined,
+    });
     return;
   }
 

--- a/templates/hooks/ludics-on-stop.sh
+++ b/templates/hooks/ludics-on-stop.sh
@@ -45,6 +45,15 @@ else
   cwd=$(echo "$input" | jq -r '.cwd // ""' 2>/dev/null)
 fi
 
+# gh-ludics-589: never exec `ludics orch on-stop` (or `mag on-stop`) with a blank
+# first positional — that shifts the positional args and produced a `usage: ludics
+# orch on-stop <cwd> ...` error that blocked phase advancement. A blank cwd can
+# arise from ANY cause (e.g. jq missing → empty `.cwd`, owned by gh-ludics-590);
+# default it to $PWD so the exec always receives a real directory.
+if [[ -z "$cwd" ]]; then
+  cwd="$PWD"
+fi
+
 # Resolve ludics binary
 ludics_bin=""
 if command -v ludics >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes hierarchical-duo **second-slot (slotB)** launch on remote workers, where slotB came up with agents in `$HOME`, unswapped providers, `duoPeerSlot=None`, and no per-phase work prompts while slotA was healthy. Closes the root cause + the separable `orch on-stop` blank-cwd defect.

Resolves gh-ludics-589. Proposal: `docs/proposals/duo-slotb-launch-fix.md`.

## Root cause

On the worker, slotB's `slotStart` ran with **empty `adapterArgs`** (the up-front `freshSlots` snapshot raced the controller's two-slot publish, and/or `readSlot` fell through to a stale local clone). Empty args tripped `autoFillAdapterArgs` into regenerating a **default pair** (unswapped providers, no `--duo-peer-slot`), which `slotStart` then persisted back to the controller — turning a transient empty read into durable corruption. Symptoms 1–4, 6 cascade from this.

## Changes

**Part B — delivery (primary, race-free):** carry the controller-authored launch-time `adapterArgs` on the `start` `PendingIntent` (optional field, string-coerce + drop-empty like `taskId`). On the worker, `processSlotIntents` fills a *blank* `freshSlots` entry from the intent (`fillBlankSnapshotArgsFromIntent`) before `slotStart`, so slotB launches with the correct swapped providers + `--duo-peer-slot`.

**Part A — fail-loud safety net:** when args are still empty *and* the slot is a duo member (detected via a sibling naming it in `--duo-peer-slot=<n>` — `slotIsDuoMember`, no schema change), `autoFillAdapterArgs` throws instead of auto-filling a default pair. The throw unwinds `slotStart` before the `clusterPostSlotUpdate` write-back, so no wrong default is persisted. Solo slots with empty args auto-fill unchanged.

**Part B — worktree fail-loud:** `resolveAgentLaunchPaths` replaces the `setup.agentWorktrees[agent.name]!` / `branches[agent.name]!` non-null assertions in `tmux-adapter.ts`, throwing (naming the missing key) before any tmux session instead of launching in `$HOME`.

**Part C — blank-cwd guard (symptom 5):** `ludics-on-stop.sh` defaults a blank `$cwd` to `$PWD` before exec; `orchOnStop` drops the `usage:` + `exit(1)` on empty cwd, falling through to env/marker peer-sync resolution + env/status agent attribution. Disjoint from gh-ludics-590's jq/PATH install surface.

## Tests

+18 unit tests (3240 pass / 2 fail — the 2 failures are pre-existing, host-name-dependent cluster tests unrelated to this change). Coverage: `parsePendingIntent` adapterArgs round-trip/legacy/coerce; `slotIsDuoMember` number-discrimination; duo refusal + solo negative control; no write-back on refusal; start intent carries args; `fillBlankSnapshotArgsFromIntent`; tmux fail-loud; `orchOnStop` blank-cwd no-op + env attribution; hook bash-spawn smoke (mutation-verified).

`bun run typecheck`, `bun run lint`, `bun run build`, and the touched-surface lints (`template-safety`, `no-nul-bytes`, `contracts`, `test-isolation`, `test-spawn-coverage`, `no-mock-module`) all pass.

## Scope note

`src/adapters/t3code.ts:1116-1117` has the same latent worktree/branch assertion (same bug class as AC5) but is OUT of the proposal's named scope (tmux only), t3code integration is paused (gh-539), and fixing it would add a cross-adapter import. Deferred to a follow-up per scope discipline — happy to fold in if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 1 (Codex P2)

Constrained `slotIsDuoMember` to require the referencing sibling share this slot's `task`, so a stale `--duo-peer-slot=<n>` token (left in stored `adapterArgs` when `clearDuoPeerLink` breaks a duo) no longer mis-flags a later solo reuse of the slot. Mutation-verified regression test added (commit 1685669).