### PR TITLE
fix(gh-ludics-590): harden worker onboarding against jq off-PATH + ttyd login-service squat

### DIFF
--- a/scripts/lint-hooks.test.ts
+++ b/scripts/lint-hooks.test.ts
@@ -133,7 +133,14 @@ describe("ludics-on-stop.sh blank-cwd default (gh-ludics-589)", () => {
 describe("ludics-on-stop.sh jq resolution (gh-ludics-590)", () => {
   let TMP = "";
   const hookPath = join(import.meta.dir, "..", "templates", "hooks", "ludics-on-stop.sh");
-  const realJq = "/usr/bin/jq";
+  // Resolve the real jq dynamically rather than hard-coding /usr/bin/jq — on Homebrew
+  // macOS jq lives in /opt/homebrew/bin (or /usr/local/bin), so a hard-coded
+  // /usr/bin/jq symlink would dangle and make the positive test platform-dependent.
+  const realJq = Bun.which("jq");
+  // Coreutils for the sandbox PATH, resolved dynamically (POSIX paths differ across
+  // distros); fall back to the conventional location when `which` can't find them.
+  const realCat = Bun.which("cat") ?? "/bin/cat";
+  const realDirname = Bun.which("dirname") ?? "/usr/bin/dirname";
 
   // The hook unconditionally prepends /opt/homebrew/bin and we cannot strip jq from
   // those dirs; if jq is reachable there, the jq-absent assertion below is not
@@ -155,9 +162,8 @@ describe("ludics-on-stop.sh jq resolution (gh-ludics-590)", () => {
   function makeCoreutilsOnlyBin(): string {
     const bin = join(TMP, "sysbin");
     mkdirSync(bin, { recursive: true });
-    for (const tool of ["/bin/cat", "/usr/bin/dirname"]) {
-      symlinkSync(tool, join(bin, tool.split("/").pop()!));
-    }
+    symlinkSync(realCat, join(bin, "cat"));
+    symlinkSync(realDirname, join(bin, "dirname"));
     return bin;
   }
 
@@ -169,14 +175,14 @@ describe("ludics-on-stop.sh jq resolution (gh-ludics-590)", () => {
     chmodSync(stub, 0o755);
   }
 
-  test("resolves jq present only at $HOME/.local/bin/jq (not on PATH) and execs orch on-stop", () => {
+  test.skipIf(!realJq)("resolves jq present only at $HOME/.local/bin/jq (not on PATH) and execs orch on-stop", () => {
     const home = join(TMP, "home");
     const argvOut = join(TMP, "argv.txt");
     stubLudics(home, argvOut);
     // jq lives ONLY under the sandbox HOME's local bin — not on the sandbox PATH.
     // The hook's `$HOME/.local/bin` prepend + `command -v jq` resolves it (absolute).
     // Symlink (not copy): copying a macOS system binary breaks its dyld/codesign load.
-    symlinkSync(realJq, join(home, ".local", "bin", "jq"));
+    symlinkSync(realJq!, join(home, ".local", "bin", "jq"));
 
     const psDir = join(TMP, "peer-sync");
     mkdirSync(psDir, { recursive: true });

--- a/scripts/lint-hooks.test.ts
+++ b/scripts/lint-hooks.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listHookScripts } from "./lint-hooks.ts";
@@ -125,4 +125,108 @@ describe("ludics-on-stop.sh blank-cwd default (gh-ludics-589)", () => {
     expect(argv[3]).toBe(psDir);  // peer-sync dir stays in its own slot
     expect(argv[4]).toBe("Stop");
   });
+});
+
+// gh-ludics-590: the hook must resolve jq to an absolute path (mirroring ludics_bin),
+// adding $HOME/.local/bin to PATH, and FAIL LOUD when jq is genuinely unresolvable
+// rather than swallowing the 127 → empty cwd → confusing downstream `usage:` error.
+describe("ludics-on-stop.sh jq resolution (gh-ludics-590)", () => {
+  let TMP = "";
+  const hookPath = join(import.meta.dir, "..", "templates", "hooks", "ludics-on-stop.sh");
+  const realJq = "/usr/bin/jq";
+
+  // The hook unconditionally prepends /opt/homebrew/bin and we cannot strip jq from
+  // those dirs; if jq is reachable there, the jq-absent assertion below is not
+  // exercisable. (Env-dependent-CLI rule — see worker-conventions baseline guidance.)
+  const jqReachableViaHardcodedPrepend =
+    existsSync("/opt/homebrew/bin/jq") || existsSync("/usr/local/bin/jq");
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-onstop-jq-"));
+  });
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  // A PATH dir holding ONLY the coreutils the hook needs (cat for stdin, dirname for
+  // the marker walk-up) — deliberately WITHOUT jq, so the only jq the hook can find is
+  // one we place under the sandbox HOME. Proves PATH/fallback resolution, not a leak
+  // from the real system PATH.
+  function makeCoreutilsOnlyBin(): string {
+    const bin = join(TMP, "sysbin");
+    mkdirSync(bin, { recursive: true });
+    for (const tool of ["/bin/cat", "/usr/bin/dirname"]) {
+      symlinkSync(tool, join(bin, tool.split("/").pop()!));
+    }
+    return bin;
+  }
+
+  function stubLudics(home: string, argvOut: string): void {
+    const binDir = join(home, ".local", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const stub = join(binDir, "ludics");
+    writeFileSync(stub, `#!/bin/bash\nprintf '%s\\n' "$@" > "${argvOut}"\n`);
+    chmodSync(stub, 0o755);
+  }
+
+  test("resolves jq present only at $HOME/.local/bin/jq (not on PATH) and execs orch on-stop", () => {
+    const home = join(TMP, "home");
+    const argvOut = join(TMP, "argv.txt");
+    stubLudics(home, argvOut);
+    // jq lives ONLY under the sandbox HOME's local bin — not on the sandbox PATH.
+    // The hook's `$HOME/.local/bin` prepend + `command -v jq` resolves it (absolute).
+    // Symlink (not copy): copying a macOS system binary breaks its dyld/codesign load.
+    symlinkSync(realJq, join(home, ".local", "bin", "jq"));
+
+    const psDir = join(TMP, "peer-sync");
+    mkdirSync(psDir, { recursive: true });
+    writeFileSync(join(psDir, "phase"), "work\n");
+    const workDir = join(TMP, "worktree");
+    mkdirSync(workDir, { recursive: true });
+
+    const proc = Bun.spawnSync(["/bin/bash", hookPath], {
+      cwd: workDir,
+      env: { HOME: home, PATH: makeCoreutilsOnlyBin(), LUDICS_PEER_SYNC_DIR: psDir },
+      stdin: Buffer.from(JSON.stringify({ hook_event_name: "Stop", cwd: workDir })),
+    });
+
+    // Invariant: with jq findable only via $HOME/.local/bin, the hook still parses the
+    // cwd and execs `orch on-stop <cwd> <peer-sync> Stop`. Mutation — reverting the
+    // PATH prepend + fallback loop (back to bare `jq`) leaves jq unresolvable here →
+    // exit 1 and no exec, flipping every assertion below.
+    expect(proc.exitCode).toBe(0);
+    const argv = readFileSync(argvOut, "utf-8").split("\n");
+    if (argv.length && argv[argv.length - 1] === "") argv.pop();
+    expect(argv).toEqual(["orch", "on-stop", workDir, psDir, "Stop"]);
+  });
+
+  test.skipIf(jqReachableViaHardcodedPrepend)(
+    "jq unresolvable → exits non-zero, stderr names jq, ludics never invoked",
+    () => {
+      const home = join(TMP, "home"); // no $HOME/.local/bin/jq created
+      const argvOut = join(TMP, "argv.txt");
+      stubLudics(home, argvOut);
+
+      const psDir = join(TMP, "peer-sync");
+      mkdirSync(psDir, { recursive: true });
+      writeFileSync(join(psDir, "phase"), "work\n");
+      const workDir = join(TMP, "worktree");
+      mkdirSync(workDir, { recursive: true });
+
+      const proc = Bun.spawnSync(["/bin/bash", hookPath], {
+        cwd: workDir,
+        env: { HOME: home, PATH: makeCoreutilsOnlyBin(), LUDICS_PEER_SYNC_DIR: psDir },
+        stdin: Buffer.from(JSON.stringify({ hook_event_name: "Stop", cwd: workDir })),
+      });
+
+      // Invariant: an unresolvable jq fails LOUD (exit≠0, stderr names jq) and the hook
+      // never hands a positional to `ludics orch on-stop`. Mutation — dropping the
+      // `[[ -z "$jq_bin" ]] && exit 1` guard lets the bare-jq path produce an empty cwd
+      // and (after the gh-589 $PWD default) silently exec ludics, so argvOut would
+      // exist and exitCode would be 0.
+      expect(proc.exitCode).not.toBe(0);
+      expect(proc.stderr.toString()).toContain("jq");
+      expect(existsSync(argvOut)).toBe(false);
+    },
+  );
 });

--- a/scripts/lint-test-isolation.test.ts
+++ b/scripts/lint-test-isolation.test.ts
@@ -920,7 +920,12 @@ describe("integration", () => {
     // newly trip rule-3 (transitive runtime config.ts import). Both are pure-unit —
     // they exercise projectConfigPath on string `path` fixtures, which never touches
     // config/cluster — so no real harness is needed; +2.
-    const expectedWarningCount = 22;
+    // 23 after gh-ludics-590: src/init.test.ts exercises the new checkJqPrereq() jq
+    // hard-gate by spying safeSyncOutput on the spawn-module namespace (forces only
+    // `which jq`). It transitively imports src/config.ts via src/init.ts, tripping
+    // rule-3, but is pure-unit — it never reads real config/harness state — so no
+    // synthetic harness is needed; +1.
+    const expectedWarningCount = 23;
     if (result.warningCount !== expectedWarningCount) {
       throw new Error(
         formatPinMismatch(

--- a/scripts/setup-wsl-preflight.test.ts
+++ b/scripts/setup-wsl-preflight.test.ts
@@ -45,3 +45,36 @@ describe("setup.sh WSL2 worker persistence preflight (AC 8)", () => {
     expect(SETUP).toMatch(/else\s*\n\s*fail "loginctl not available/);
   });
 });
+
+// gh-ludics-590: a worker must never finish onboarding jq-less (the orchestration
+// on-stop hook + Mag queue hard-depend on jq), and the Debian ttyd package's
+// auto-enabled login service must be disabled so it stops squatting slot-1 port 7681.
+describe("setup.sh jq install + ttyd login-service disable (gh-ludics-590)", () => {
+  test("installs jq via the install_pkg pattern, before ludics init", () => {
+    // Invariant: jq is installed at onboarding, ordered before `ludics init` (so the
+    // init jq hard-gate can't fail a freshly-onboarded worker). Mutation — deleting
+    // the block leaves install_pkg jq absent; moving it after init flips the order.
+    expect(SETUP).toMatch(/if command -v jq &>\/dev\/null; then[\s\S]*?else[\s\S]*?install_pkg jq/);
+    const jqIdx = SETUP.indexOf("install_pkg jq");
+    const initIdx = SETUP.indexOf("ludics init --no-triggers");
+    expect(jqIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeGreaterThan(jqIdx);
+  });
+
+  test("disables ttyd.service behind Linux/systemctl/unit-exists guards, after the ttyd block", () => {
+    // Invariant: the disable helper guards on Linux + systemctl + the unit existing
+    // (no-op elsewhere) and runs `systemctl disable --now ttyd.service`. Mutation —
+    // dropping any guard, or the disable command, fails this match.
+    expect(SETUP).toMatch(
+      /disable_ttyd_login_service\(\)\s*\{\s*\n\s*is_linux \|\| return 0\s*\n\s*command -v systemctl &>\/dev\/null \|\| return 0\s*\n\s*if systemctl list-unit-files ttyd\.service[\s\S]*?grep -q '\^ttyd\\\.service'[\s\S]*?sudo systemctl disable --now ttyd\.service/,
+    );
+    // The helper is actually CALLED, and the call comes after the ttyd dependency
+    // block (so a previously-enabled unit is fixed regardless of this run's install).
+    const defIdx = SETUP.indexOf("disable_ttyd_login_service()");
+    const callIdx = SETUP.search(/^disable_ttyd_login_service$/m);
+    const ttydIdx = SETUP.indexOf("install_pkg ttyd");
+    expect(defIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(ttydIdx); // call after the ttyd block
+    expect(callIdx).toBeGreaterThan(defIdx);  // bash: defined before invoked
+  });
+});

--- a/setup.sh
+++ b/setup.sh
@@ -50,6 +50,18 @@ install_pkg() {
   fi
 }
 
+# gh-ludics-590: disable the Debian/Ubuntu ttyd-package login service that squats
+# slot-1's port 7681. No-op on macOS / distros without systemd or the unit.
+disable_ttyd_login_service() {
+  is_linux || return 0
+  command -v systemctl &>/dev/null || return 0
+  if systemctl list-unit-files ttyd.service 2>/dev/null | grep -q '^ttyd\.service'; then
+    warn "disabling auto-enabled ttyd.service (squats slot port 7681)"
+    sudo systemctl disable --now ttyd.service \
+      || warn "could not disable ttyd.service — disable manually"
+  fi
+}
+
 # bun
 export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
 export PATH="$BUN_INSTALL/bin:$PATH"
@@ -98,6 +110,17 @@ else
   info "gh: $(gh --version | head -1)"
 fi
 
+# jq (gh-ludics-590): the orchestration on-stop hook + Mag queue hard-depend on jq.
+# Without it a worker silently breaks (every agent stop errors, phase signals lost),
+# so install it at onboarding rather than degrading to bun fallbacks unflagged.
+if command -v jq &>/dev/null; then
+  info "jq: $(jq --version)"
+else
+  warn "jq not found — installing..."
+  install_pkg jq
+  info "jq installed"
+fi
+
 # ttyd (web terminal)
 if command -v ttyd &>/dev/null; then
   info "ttyd: $(ttyd --version 2>&1 | head -1)"
@@ -106,6 +129,13 @@ else
   install_pkg ttyd
   info "ttyd installed"
 fi
+
+# gh-ludics-590: the Debian/Ubuntu ttyd package ships and ENABLES a login
+# ttyd.service on port 7681 at boot — exactly the port ludics computes for the
+# slot-1 coder web terminal. Keep the binary, drop the auto-enabled squatter.
+# Called unconditionally (not only when we just installed ttyd) so hosts where the
+# package was enabled on a previous run are also fixed.
+disable_ttyd_login_service
 
 # ── Step 2: Build & initialize Ludics ────────────────────────────────────────
 

--- a/src/adapters/tmux-adapter.test.ts
+++ b/src/adapters/tmux-adapter.test.ts
@@ -465,6 +465,98 @@ describe("ttydMatchesSession — exact session-identity match (task-1373e911)", 
   });
 });
 
+// gh-ludics-590: a foreign process (e.g. the Debian ttyd package's auto-enabled
+// login service on 7681) bound to a slot's ttyd port must be surfaced LOUDLY at the
+// bind point, not fail silently. Detection only (ports stay hardcoded).
+describe("foreignTtydPortConflict (gh-ludics-590)", () => {
+  test("port held → diagnostic names the exact port, slot, role, and remediation", async () => {
+    const { foreignTtydPortConflict } = await import("./tmux-adapter.ts");
+    // Harness condition: probe reports the port BOUND.
+    const msg = foreignTtydPortConflict(1, "coder", () => true);
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("7681");
+    expect(msg).toContain("slot 1");
+    expect(msg).toContain("coder");
+    expect(msg).toContain("sudo systemctl disable --now ttyd.service");
+  });
+
+  test("port computed per (slot,role): slot-2 reviewer names 7684, not 7681", async () => {
+    const { foreignTtydPortConflict } = await import("./tmux-adapter.ts");
+    // Mutation guard: hardcoding 7681 in the message (instead of ttydPort(slot,role))
+    // would make this fail — 7681 + (2-1)*2 + 1 = 7684.
+    const msg = foreignTtydPortConflict(2, "reviewer", () => true)!;
+    // Target the COMPUTED-port phrase, not the literal 7681 (which legitimately
+    // appears in the static Debian-default remediation hint).
+    expect(msg).toContain("ttyd port 7684");
+    expect(msg).toContain("slot 2 reviewer");
+    expect(msg).not.toContain("ttyd port 7681");
+  });
+
+  test("port free → null (does not block launch)", async () => {
+    const { foreignTtydPortConflict } = await import("./tmux-adapter.ts");
+    expect(foreignTtydPortConflict(1, "coder", () => false)).toBeNull();
+  });
+
+  test("probe throws → null (conservative; transient probe failure never blocks)", async () => {
+    const { foreignTtydPortConflict } = await import("./tmux-adapter.ts");
+    expect(
+      foreignTtydPortConflict(1, "coder", () => {
+        throw new Error("lsof exploded");
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("startTtyd surfaces a foreign port conflict AFTER stale cleanup (gh-ludics-590)", () => {
+  let spawnMod: typeof import("../spawn.ts");
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    for (const s of spies.splice(0)) s.mockRestore();
+  });
+
+  test("port still bound after pkill → console.error names slot/role/port; spawn still happens; probe runs after pkill", async () => {
+    spawnMod = await import("../spawn.ts");
+    const calls: string[][] = [];
+    const safeSpy = spyOn(spawnMod, "safeSyncOutput").mockImplementation((argv: string[]) => {
+      calls.push(argv);
+      // The stale-ttyd cleanup pkill succeeds/no-ops.
+      if (argv[0] === "pkill") return { ok: true, exitCode: 0, stdout: "", stderr: "", timedOut: false };
+      // The port probe reports slot-1 coder port (7681) BOUND by a foreign listener.
+      if (argv.includes("-iTCP:7681")) {
+        return { ok: true, exitCode: 0, stdout: "ttyd 999 root 6u IPv4 TCP *:7681 (LISTEN)", stderr: "", timedOut: false };
+      }
+      return { ok: false, exitCode: 1, stdout: "", stderr: "", timedOut: false };
+    });
+    spies.push(safeSpy);
+    // Stub the real ttyd spawn so the test binds nothing.
+    const spawnSpy = spyOn(Bun, "spawn").mockReturnValue({ pid: 4242, unref() {} } as never);
+    spies.push(spawnSpy as unknown as { mockRestore: () => void });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    spies.push(errSpy);
+
+    const { startTtyd } = await import("./tmux-adapter.ts");
+    const pid = startTtyd(1, "coder", "coder", "task-abc");
+
+    // Invariant 1 — warn, not abort: the conflict is surfaced via console.error but
+    // startTtyd still spawns (returns the stub pid). Mutation: changing the warn to a
+    // throw would make `startTtyd` reject and `pid`/spawn assertions fail.
+    expect(pid).toBe(4242);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const diag = (errSpy.mock.calls.find((c) => String(c[0]).includes("ttyd port"))?.[0] as string) ?? "";
+    expect(diag).toContain("slot 1");
+    expect(diag).toContain("coder");
+    expect(diag).toContain("7681");
+
+    // Invariant 2 — the probe runs AFTER the stale-ttyd pkill cleanup (reviewer trap:
+    // probing first would false-positive on our own not-yet-killed ttyd). Mutation:
+    // moving the conflict check above the pkill flips this ordering assertion.
+    const pkillIdx = calls.findIndex((c) => c[0] === "pkill");
+    const probeIdx = calls.findIndex((c) => c.includes("-iTCP:7681"));
+    expect(pkillIdx).toBeGreaterThanOrEqual(0);
+    expect(probeIdx).toBeGreaterThan(pkillIdx);
+  });
+});
+
 describe("readTmuxSlotState read-boundary preserves sparse ttydRestartCounts", () => {
   let tmpDir = "";
 

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -425,11 +425,57 @@ export function buildTtydSpawnArgs(
   return setsidWrap(["bash", "-c", cmd]);
 }
 
+/**
+ * gh-ludics-590: detect a FOREIGN process bound to a slot's computed ttyd port at the
+ * point ludics would bind it. The Debian/Ubuntu ttyd package auto-enables a login
+ * ttyd.service on port 7681 (slot-1 coder) that our `pkill -f "ttyd.*--port N"` cleanup
+ * does NOT match (it starts ttyd via `-p`/config, not `--port`), so the per-slot ttyd
+ * silently fails to bind. Returns a loud diagnostic naming slot + role + port +
+ * remediation when the port is held, else null. Conservative on probe failure (treat
+ * as free → never blocks launch). `probe` is injectable for tests.
+ */
+export function foreignTtydPortConflict(
+  slot: number,
+  role: "coder" | "reviewer",
+  probe?: (port: number) => boolean,
+): string | null {
+  const port = ttydPort(slot, role);
+  const check =
+    probe ??
+    ((p: number): boolean => {
+      const lsofBin = process.platform === "darwin" ? "/usr/sbin/lsof" : "lsof";
+      const r = safeSyncOutput([lsofBin, "-nP", `-iTCP:${p}`, "-sTCP:LISTEN"]);
+      if (r.ok && r.stdout.trim()) return true;
+      // Linux minimal images may lack lsof — fall back to ss.
+      const ss = safeSyncOutput(["ss", "-ltnH", `sport = :${p}`]);
+      return ss.ok && ss.stdout.trim().length > 0;
+    });
+  let bound = false;
+  try {
+    bound = check(port);
+  } catch {
+    return null;
+  }
+  if (!bound) return null;
+  return (
+    `ludics: ttyd port ${port} (slot ${slot} ${role}) is already bound by another ` +
+    `process — the per-slot web terminal cannot start. On Debian/Ubuntu the ttyd ` +
+    `package auto-enables a login service on 7681; run 'sudo systemctl disable --now ttyd.service'.`
+  );
+}
+
 export function startTtyd(slot: number, agentName: string, role: "coder" | "reviewer", taskId?: string): number {
   const port = ttydPort(slot, role);
 
   // Kill any stale ttyd on this port
   safeSyncOutput(["pkill", "-f", `ttyd.*--port ${port}`]);
+
+  // gh-ludics-590: after clearing our own stale ttyd, a still-bound port means a
+  // FOREIGN process holds it (e.g. the Debian ttyd login service). Surface it loudly
+  // rather than letting the bind fail silently. Non-fatal: the agent/tmux session is
+  // already functional; only the web terminal is affected, so we warn and still spawn.
+  const conflict = foreignTtydPortConflict(slot, role);
+  if (conflict) console.error(conflict);
 
   // Use setsidWrap to detach ttyd into its own process session so it survives
   // when the parent (launchd oneshot keepalive) exits. The bash wrapper

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as spawnMod from "./spawn.ts";
+import { checkJqPrereq } from "./init.ts";
+
+// gh-ludics-590: `ludics init` must HARD-fail when jq is absent, mirroring the
+// existing `which tmux` / `which ttyd` gates — a worker must not onboard jq-less
+// (the orchestration on-stop hook + Mag queue hard-depend on jq).
+describe("checkJqPrereq (gh-ludics-590 init jq hard gate)", () => {
+  const spies: Array<{ mockRestore: () => void }> = [];
+  afterEach(() => {
+    for (const s of spies.splice(0)) s.mockRestore();
+  });
+
+  function spyWhich(jqResolves: boolean) {
+    // Force only the `which jq` probe; delegate every other argv to the real impl
+    // so we exercise the exact gate predicate, not a blanket stub.
+    const real = spawnMod.safeSyncOutput;
+    const spy = spyOn(spawnMod, "safeSyncOutput").mockImplementation((argv: string[]) => {
+      if (argv[0] === "which" && argv[1] === "jq") {
+        return {
+          ok: jqResolves,
+          exitCode: jqResolves ? 0 : 1,
+          stdout: jqResolves ? "/usr/bin/jq" : "",
+          stderr: "",
+          timedOut: false,
+        };
+      }
+      return real(argv);
+    });
+    spies.push(spy);
+    return spy;
+  }
+
+  test("exits non-zero with an install hint naming jq when `which jq` fails", () => {
+    // Harness condition: `which jq` reports NOT ok — the jq-absent worker state.
+    const whichSpy = spyWhich(false);
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    spies.push(errSpy);
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    spies.push(exitSpy);
+
+    // Invariant: jq-absent ⇒ process.exit(1). Mutation — turning the gate into a
+    // soft warn (no exit) makes this throw never fire and the assertion fails.
+    expect(() => checkJqPrereq()).toThrow("process.exit(1)");
+    // The gate predicate actually probed `which jq` (not a vacuous pass).
+    expect(whichSpy.mock.calls.some((c) => (c[0] as string[]).join(" ") === "which jq")).toBe(true);
+    // Install hints must name jq and BOTH per-OS commands (AC 5).
+    const msg = (errSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(msg).toContain("jq");
+    expect(msg).toContain("brew install jq");
+    expect(msg).toContain("apt install jq");
+  });
+
+  test("does NOT exit when `which jq` succeeds", () => {
+    // Harness condition: `which jq` reports ok — the gate must be a pass-through.
+    spyWhich(true);
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    spies.push(exitSpy);
+
+    // Invariant: jq present ⇒ no exit. Catches an over-eager gate that exits regardless.
+    expect(() => checkJqPrereq()).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/init.ts
+++ b/src/init.ts
@@ -93,6 +93,16 @@ export async function runInit(args: string[]): Promise<void> {
     installSkills(root, repoDir, statePath);
   }
 
+  // 6b. jq prerequisite — HARD gate (gh-ludics-590). The orchestration on-stop hook
+  // and the Mag queue both hard-depend on jq to parse JSON; a jq-less worker silently
+  // breaks (every agent stop errors, phase signals lost). Fail loud BEFORE installing
+  // the stop hook so the operator sees the dependency failure, not a downstream
+  // `usage:` red herring. Unconditional (not --no-hooks-guarded): per the resolved
+  // proposal question, "a worker must not complete init without jq."
+  console.log("\n--- jq prerequisite ---");
+  checkJqPrereq();
+  console.log("  jq: available");
+
   // 7. Stop hook (Claude Code + Codex)
   if (!noHooks) {
     installStopHook(root);
@@ -377,6 +387,22 @@ function installSkills(root: string, repoDir: string, statePath: string): void {
     count++;
   }
   console.log(`copied ${count} skill(s) to ${destDir}`);
+}
+
+/**
+ * Hard gate: ludics requires `jq` (the orchestration on-stop hook + Mag queue parse
+ * JSON with it). Mirrors the existing `which tmux` / `which ttyd` gates — exits the
+ * process with an install hint when jq is not resolvable. gh-ludics-590.
+ */
+export function checkJqPrereq(): void {
+  if (!safeSyncOutput(["which", "jq"]).ok) {
+    console.error(
+      "error: ludics requires jq (orchestration on-stop hook + Mag queue parse JSON).\n" +
+      "  macOS: brew install jq\n" +
+      "  Linux: apt install jq  (or dnf/pacman)"
+    );
+    process.exit(1);
+  }
 }
 
 function installStopHook(root: string): void {

--- a/templates/hooks/ludics-on-stop.sh
+++ b/templates/hooks/ludics-on-stop.sh
@@ -21,8 +21,32 @@
 # Loop prevention (Mag): when the queue is empty, mag_queue_pop outputs nothing
 # (exit 0), so Claude stops naturally.
 
-# Ensure Bash 4+ and tools like jq/yq are available (macOS system bash is v3)
-export PATH="/opt/homebrew/bin:$PATH"
+# Ensure Bash 4+ and tools like jq/yq are available (macOS system bash is v3).
+# $HOME/.local/bin is added additively (gh-ludics-590): on Linux workers jq often
+# lives there, and the macOS Homebrew prepend stays so Mac workers/leader are unaffected.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
+
+# Resolve jq to an absolute path (gh-ludics-590), mirroring the ludics_bin fallback
+# below. The orchestration on-stop hook hard-depends on jq to parse the Stop-hook JSON
+# (cwd / hook_event_name) and the marker-file walk-up reads; a bare `jq` on a
+# macOS-centric PATH silently exits 127 → empty cwd → lost phase signals. Resolve it
+# once here, before the mode branch, so BOTH the Claude-stdin and Codex notify paths
+# (the marker-file reads) use the resolved binary.
+jq_bin="$(command -v jq 2>/dev/null || true)"
+if [[ -z "$jq_bin" ]]; then
+  for bin in "$HOME/.local/bin/jq" "$HOME/.local/ludics/bin/jq"; do
+    if [[ -x "$bin" ]]; then
+      jq_bin="$bin"
+      break
+    fi
+  done
+fi
+if [[ -z "$jq_bin" ]]; then
+  # Fail loud naming jq — do NOT hand an empty/defaulted cwd to `ludics orch on-stop`,
+  # which surfaces only as a confusing downstream `usage:` error (gh-ludics-590).
+  echo "ludics-on-stop: jq not found (need jq on PATH or in \$HOME/.local/bin) — cannot parse Stop-hook JSON; orchestration phase signals would be lost. Install jq (macOS: brew install jq / Linux: apt install jq)." >&2
+  exit 1
+fi
 
 # Detect invocation mode: Codex passes "codex" as $1; Claude Code provides JSON on stdin.
 invocation_mode="${1:-claude}"
@@ -36,13 +60,13 @@ else
   input=$(cat)
 
   # Ignore subagent stops; only handle top-level Stop events.
-  hook_event_name=$(echo "$input" | jq -r '.hook_event_name // ""' 2>/dev/null)
+  hook_event_name=$(echo "$input" | "$jq_bin" -r '.hook_event_name // ""' 2>/dev/null)
   if [[ "$hook_event_name" == "SubagentStop" ]]; then
     exit 0
   fi
 
   # Extract cwd from the stop event
-  cwd=$(echo "$input" | jq -r '.cwd // ""' 2>/dev/null)
+  cwd=$(echo "$input" | "$jq_bin" -r '.cwd // ""' 2>/dev/null)
 fi
 
 # gh-ludics-589: never exec `ludics orch on-stop` (or `mag on-stop`) with a blank
@@ -91,8 +115,8 @@ if [[ -z "$peer_sync_dir" ]]; then
   check_dir="$cwd"
   while [[ -n "$check_dir" && "$check_dir" != "/" ]]; do
     if [[ -f "$check_dir/.ludics-orchestration.json" ]]; then
-      marker_peer_sync=$(jq -r '.peerSyncDir // ""' "$check_dir/.ludics-orchestration.json" 2>/dev/null)
-      marker_agent_name=$(jq -r '.agentName // ""' "$check_dir/.ludics-orchestration.json" 2>/dev/null)
+      marker_peer_sync=$("$jq_bin" -r '.peerSyncDir // ""' "$check_dir/.ludics-orchestration.json" 2>/dev/null)
+      marker_agent_name=$("$jq_bin" -r '.agentName // ""' "$check_dir/.ludics-orchestration.json" 2>/dev/null)
       if [[ -n "$marker_peer_sync" && -f "$marker_peer_sync/phase" ]]; then
         peer_sync_dir="$marker_peer_sync"
         export LUDICS_PEER_SYNC_DIR="$marker_peer_sync"


### PR DESCRIPTION
## Summary

On a Linux worker (root-caused live on `minipc-wsl`) the orchestration on-stop hook silently breaks when `jq` isn't on the hook's PATH: **every** agent stop fails, `.peer-sync/<agent>.stop.json` is never written, phase-completion signals are lost, and orchestration only limps on keepalive dead-detection — stalling at steps that need a real turn signal (e.g. the coder's final "merge the PR"). The failure surfaces only as a confusing downstream `usage:` error. A related gotcha: the Debian/Ubuntu `ttyd` package auto-enables a login service squatting slot-1's port 7681.

Closes the "installing/failing-to-install a ludics prereq silently breaks ludics" class across all four fix surfaces.

## Changes

1. **`templates/hooks/ludics-on-stop.sh`** — resolve `jq` to an absolute path (`command -v jq` → fallback over `$HOME/.local/bin/jq`, `$HOME/.local/ludics/bin/jq`), add `$HOME/.local/bin` to PATH (additive; `/opt/homebrew/bin` stays), resolve once before the mode branch so both Claude-stdin and Codex notify (marker-file) paths use it, and **fail loud** (stderr names `jq`, exit non-zero) when jq is genuinely unresolvable instead of handing an empty cwd downstream. All four `jq` sites use `"$jq_bin"`. The gh-ludics-589 blank-cwd `$PWD` default is preserved (the missing-jq guard exits strictly earlier).
2. **`src/init.ts`** — `checkJqPrereq()` HARD gate (`process.exit(1)` + per-OS install hint), mirroring the existing which-tmux/which-ttyd gates; called unconditionally before the stop-hook install.
3. **`setup.sh`** — install `jq` via the `install_pkg` pattern (before `ludics init`); `disable_ttyd_login_service()` (Linux + systemctl + unit-exists guarded; no-op elsewhere) called unconditionally after the ttyd block so previously-enabled hosts are also fixed.
4. **`src/adapters/tmux-adapter.ts`** — `foreignTtydPortConflict()`, called in `startTtyd` after the stale-ttyd `pkill`; warns loudly (naming slot/role/port + `systemctl disable --now ttyd.service`) when a foreign process holds the computed port. Detection only — hardcoded ports kept. Warn, not throw (the agent/tmux session is functional; only the web terminal is affected).

## Tests

- `scripts/lint-hooks.test.ts` — two bash smoke tests: jq resolvable only at `$HOME/.local/bin/jq` resolves and execs `orch on-stop`; jq unresolvable exits non-zero, stderr names jq, ludics never invoked.
- `src/init.test.ts` (new) — jq-absent ⇒ `process.exit(1)` + message names jq/brew/apt; jq-present ⇒ no exit.
- `scripts/setup-wsl-preflight.test.ts` — jq install block + ordering before init; guarded ttyd-service disable + post-ttyd call site.
- `src/adapters/tmux-adapter.test.ts` — helper names exact port/slot/role/remediation (slot-2 reviewer → 7684 mutation guard), null when free / when probe throws; `startTtyd` test proves the probe runs after pkill, the diagnostic fires, and spawn still happens.
- `scripts/lint-test-isolation.test.ts` — warning pin 22→23 for the pure-unit init test.

Full suite: 3275 pass, 2 fail (both pre-existing and unrelated: remote slotStop intent; federated machine-default hostname). Build + eslint + `lint:src-command-safety` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)