### PR TITLE
fix(federation): worker never writes tracked harness files; lock no-resurrection of cleared slot (gh-ludics-592)

### DIFF
--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -1759,6 +1759,34 @@ cluster:
     expect(out).not.toContain("detected dead orchestrator");
   });
 
+  test("gh-ludics-592: worker never resurrects a slot the controller-live freshSlots reports (empty)", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker context
+
+    // The exact incident: the worker's stale LOCAL harness clone still shows the
+    // slot LIVE (task-55a11fa3, owned by self), and a dead orchestrator sits in
+    // the worker cache — so a stale-clone-driven resume WOULD detect it and
+    // re-create tmux/worktree on an already-DONE task.
+    writeSlotJson(4, { ...emptySlotData(4), process: "orch-runner", task: "task-55a11fa3", mode: "t3code", machine: "minipc-wsl" });
+    writeWorkerOrchState(4, "task-55a11fa3");
+    writeWorkerT3codeState(4, DEAD_PID);
+
+    // But the controller cleared the slot: its controller-live freshSlots row is
+    // (empty) (process defaults to "(empty)" in emptySlotData).
+    const freshSlots = new Map<number, SlotData>([[4, emptySlotData(4)]]);
+
+    const out = await runCapturingErrors(freshSlots);
+
+    // Invariant: with the controller-live view saying (empty), the worker must
+    // NOT detect the dead orchestrator or attempt any resume/resurrection — the
+    // `(empty)` continue fires BEFORE any orch-state read or PID check. Harness
+    // condition: freshSlots row for slot 4 has process="(empty)" while the local
+    // clone says live. Mutation control: flipping the fresh row's process to a
+    // non-empty value (e.g. {...emptySlotData(4), process:"orch-runner", task:...,
+    // mode:"t3code", machine:"minipc-wsl"}) makes the loop reach detection →
+    // "detected dead orchestrator" appears → this assertion FAILS.
+    expect(out).not.toContain("detected dead orchestrator");
+  });
+
   test("AC2 positive control: controller WITH null freshSlots still reaches the loop (skip is worker-only)", async () => {
     process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller context
 

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3929,6 +3929,19 @@ async function workerKeepalive(): Promise<void> {
 
   // Resume dead orchestrator processes on this machine's slots
   await maybeResumeDeadOrchestrators(freshSlots);
+
+  // gh-ludics-592: reap this worker's OWN deferred-cleanup artifacts
+  // (worktrees/branches/tmux/peer-sync left by worker-owned slot stops). The
+  // manifest is routed to the worker cache (cleanupPendingPath → workerCacheDir),
+  // so this drains worker-local entries only — the controller cannot reap them
+  // (different filesystem). Gated internally by cleanupDelayHours, so it is a
+  // cheap no-op until an entry ages past the post-mortem window.
+  try {
+    const { processDeferredCleanups } = await import("./orchestration/deferred-cleanup.ts");
+    await processDeferredCleanups();
+  } catch (err) {
+    console.error("ludics: worker deferred cleanup failed:", err);
+  }
 }
 
 /** Poll controller for pending intents and execute them (pure pull model). */

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -57,7 +57,7 @@ describe("buildProposalNotificationActions — t3code-only format", () => {
 });
 
 import { afterEach, beforeEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -255,5 +255,85 @@ describe("notify ntfy.sh suppression under bun test", () => {
     }
     expect(calls).toBe(0);
     expect(result).toEqual({ httpCode: "200", stderr: "", body: "" });
+  });
+});
+
+// gh-ludics-592 (defect 2): a federation worker must never write the tracked
+// notifications log — a local write blocks `git pull --ff-only` and strands the
+// worker on a stale harness clone. notifyLog no-ops in worker context.
+describe("notify worker-context guard (gh-ludics-592)", () => {
+  let tmpDir: string;
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  const logPath = (): string => join(tmpDir, "harness", "journal", "notifications.jsonl");
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ludics-notify-worker-"));
+    process.env.HOME = tmpDir;
+    process.env.LUDICS_HARNESS_DIR = join(tmpDir, "harness");
+    process.env.LUDICS_CONFIG = writeClusterConfig(tmpDir);
+    mkdirSync(join(tmpDir, "harness", "journal"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_HARNESS_DIR === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS_DIR;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+  });
+
+  test("worker context: notifyAgents does NOT create the tracked notifications log", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker (role: worker)
+    const { notifyAgents } = await import("./notify.ts");
+
+    notifyAgents("worker-guard-probe", 1, "worker-guard-title");
+
+    // Invariant: a worker leaves journal/notifications.jsonl untouched, so the
+    // tracked tree stays clean and `git pull --ff-only` is never blocked.
+    // Harness condition: worker context (minipc-wsl has role: worker) — this is
+    // what makes isWorkerContext() true. Mutation control: removing the
+    // `if (isWorkerContext()) return;` guard makes this file appear → fails.
+    expect(existsSync(logPath())).toBe(false);
+  });
+
+  test("controller context positive control: notifyAgents DOES write the notifications log", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller (role: leader)
+    const { notifyAgents } = await import("./notify.ts");
+
+    notifyAgents("controller-guard-probe", 1, "controller-guard-title");
+
+    // On the controller the guard is inert: the tracked log is still written.
+    expect(existsSync(logPath())).toBe(true);
+    expect(readFileSync(logPath(), "utf-8")).toContain("controller-guard-probe");
   });
 });

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -11,12 +11,21 @@ import { readAllSlotJson } from "./slots/json.ts";
 import { getUrl } from "./network.ts";
 import { parseTaskFrontmatter } from "./tasks/markdown.ts";
 import { proposalLink } from "./dashboard.ts";
+import { isWorkerContext } from "./orchestration/state.ts";
 
 function notificationLogFile(): string {
   return join(harnessDir(), "journal", "notifications.jsonl");
 }
 
 function notifyLog(tier: string, message: string, priority: number, title: string): void {
+  // gh-ludics-592: a federation worker must never dirty the tracked
+  // notifications log — a local write there blocks `git pull --ff-only` and
+  // strands the worker on a stale harness clone (the resurrection incident).
+  // The network ntfy send (notifySend / notifyPublishMessage) is NOT guarded
+  // and still surfaces the notification; only the controller-owned tracked log
+  // is suppressed. Mirrors journalAppend's worker-forward guard. The dashboard
+  // reads the controller's notifications.jsonl, so observability is unaffected.
+  if (isWorkerContext()) return;
   const logFile = notificationLogFile();
   mkdirSync(join(harnessDir(), "journal"), { recursive: true });
 

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -735,12 +735,14 @@ describe("explicit harnessDir argument (isolation)", () => {
   });
 });
 
-// gh-ludics-592 (defect 2): a federation worker must never write the tracked
-// deferred-cleanup manifest (mag/cleanup-pending.json) — a local write blocks
-// `git pull --ff-only` and strands the worker on a stale harness clone. The
-// manifest is the controller's post-mortem queue; saveDeferredCleanups no-ops
-// in worker context.
-describe("deferred-cleanup worker-context guard (gh-ludics-592)", () => {
+// gh-ludics-592 (defect 2): a federation worker must never write the TRACKED
+// deferred-cleanup manifest (harness/mag/cleanup-pending.json) — a local write
+// blocks `git pull --ff-only` and strands the worker on a stale harness clone.
+// But the entry must NOT be dropped: it records worker-local artifacts
+// (worktrees/branches/tmux/peer-sync) only the worker can reap. So on a worker
+// the manifest is ROUTED to the non-harness worker cache ($HOME/.ludics-orch-cache,
+// à la gh-580), where the worker's own processDeferredCleanups drain reads it.
+describe("deferred-cleanup worker-context routing (gh-ludics-592)", () => {
   let wtmp: string;
   const SAVED_HOME = process.env.HOME;
   const SAVED_HARNESS = process.env.LUDICS_HARNESS_DIR;
@@ -774,6 +776,11 @@ cluster:
   }
 
   const harnessPath = (): string => join(wtmp, "harness");
+  // The literal tracked-harness manifest path (NOT via cleanupPendingPath, which
+  // re-routes to the worker cache in worker context).
+  const trackedManifest = (): string => join(wtmp, "harness", "mag", "cleanup-pending.json");
+  // The worker-cache manifest path: workerCacheDir() === $HOME/.ludics-orch-cache.
+  const workerCacheManifest = (): string => join(wtmp, ".ludics-orch-cache", "cleanup-pending.json");
 
   beforeEach(() => {
     wtmp = join(import.meta.dir, ".test-tmp-deferred-cleanup-worker");
@@ -791,18 +798,61 @@ cluster:
     if (SAVED_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = SAVED_MACHINE;
   });
 
-  test("worker context: recordDeferredCleanup does NOT write the tracked manifest", () => {
+  test("worker context: recordDeferredCleanup routes to the worker cache, not the tracked manifest", () => {
     process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker (role: worker)
     const harness = harnessPath();
 
     recordDeferredCleanup(makeEntry({ taskId: "task-worker-guard" }), harness);
 
-    // Invariant: a worker leaves mag/cleanup-pending.json untouched, so the
-    // tracked tree stays clean and `git pull --ff-only` is never blocked.
+    // Invariant A (tree clean): the TRACKED harness manifest is never created on
+    // a worker, so `git pull --ff-only` is never blocked. Mutation control:
+    // reverting cleanupPendingPath's worker branch makes this file appear → fails.
+    expect(existsSync(trackedManifest())).toBe(false);
+    // Invariant B (not dropped): the entry IS persisted to the worker cache,
+    // where the worker's own drain can reap the worker-local artifacts the
+    // controller cannot see. Mutation control: a `return` no-op (the prior
+    // implementation) leaves this file absent → fails.
+    expect(existsSync(workerCacheManifest())).toBe(true);
+    // And it round-trips via loadDeferredCleanups (which re-routes to the cache).
     // Harness condition: worker context (minipc-wsl role: worker) → isWorkerContext() true.
-    // Mutation control: removing the `if (isWorkerContext()) return;` guard
-    // makes this file appear → assertion fails.
-    expect(existsSync(cleanupPendingPath(harness))).toBe(false);
+    const loaded = loadDeferredCleanups(harness);
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]!.taskId).toBe("task-worker-guard");
+  });
+
+  test("worker context: cancelDeferredCleanup updates the worker-cache manifest, tracked tree stays clean", () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker
+    const harness = harnessPath();
+
+    recordDeferredCleanup(makeEntry({ taskId: "task-a", slot: 1 }), harness);
+    recordDeferredCleanup(makeEntry({ taskId: "task-b", slot: 2 }), harness);
+    cancelDeferredCleanup("task-a", 1, harness);
+
+    // The cancel rewrites the worker-cache manifest (never the tracked tree).
+    expect(existsSync(trackedManifest())).toBe(false);
+    const loaded = loadDeferredCleanups(harness);
+    expect(loaded.map((e) => e.taskId)).toEqual(["task-b"]);
+  });
+
+  test("worker context: processDeferredCleanups drains the worker-cache manifest (the keepalive reap path)", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker
+    const harness = harnessPath();
+
+    // An aged entry (30h ago > cleanupDelayHours) with no artifacts so no step is
+    // retryable — it must drain on the first pass. This is the mechanism
+    // workerKeepalive now invokes so a worker reaps its OWN local cleanup.
+    recordDeferredCleanup(
+      makeEntry({ taskId: "task-drain", branches: [], worktreePaths: [], peerSyncLink: null, tmuxSessionNames: [] }),
+      harness,
+    );
+    expect(existsSync(workerCacheManifest())).toBe(true);
+
+    await processDeferredCleanups(undefined, harness);
+
+    // Invariant: the worker's drain reads + rewrites the WORKER-CACHE manifest
+    // (not the tracked tree), reaping the aged entry. Harness condition: worker
+    // context + an entry older than the post-mortem cutoff.
+    expect(existsSync(trackedManifest())).toBe(false);
     expect(loadDeferredCleanups(harness)).toEqual([]);
   });
 

--- a/src/orchestration/deferred-cleanup.test.ts
+++ b/src/orchestration/deferred-cleanup.test.ts
@@ -734,3 +734,89 @@ describe("explicit harnessDir argument (isolation)", () => {
     }
   });
 });
+
+// gh-ludics-592 (defect 2): a federation worker must never write the tracked
+// deferred-cleanup manifest (mag/cleanup-pending.json) — a local write blocks
+// `git pull --ff-only` and strands the worker on a stale harness clone. The
+// manifest is the controller's post-mortem queue; saveDeferredCleanups no-ops
+// in worker context.
+describe("deferred-cleanup worker-context guard (gh-ludics-592)", () => {
+  let wtmp: string;
+  const SAVED_HOME = process.env.HOME;
+  const SAVED_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  const SAVED_CONFIG = process.env.LUDICS_CONFIG;
+  const SAVED_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  const harnessPath = (): string => join(wtmp, "harness");
+
+  beforeEach(() => {
+    wtmp = join(import.meta.dir, ".test-tmp-deferred-cleanup-worker");
+    mkdirSync(join(wtmp, "harness", "mag"), { recursive: true });
+    process.env.HOME = wtmp;
+    process.env.LUDICS_HARNESS_DIR = join(wtmp, "harness");
+    process.env.LUDICS_CONFIG = writeClusterConfig(wtmp);
+  });
+
+  afterEach(() => {
+    try { rmSync(wtmp, { recursive: true, force: true }); } catch { /* ignore */ }
+    if (SAVED_HOME === undefined) delete process.env.HOME; else process.env.HOME = SAVED_HOME;
+    if (SAVED_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = SAVED_HARNESS;
+    if (SAVED_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = SAVED_CONFIG;
+    if (SAVED_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = SAVED_MACHINE;
+  });
+
+  test("worker context: recordDeferredCleanup does NOT write the tracked manifest", () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker (role: worker)
+    const harness = harnessPath();
+
+    recordDeferredCleanup(makeEntry({ taskId: "task-worker-guard" }), harness);
+
+    // Invariant: a worker leaves mag/cleanup-pending.json untouched, so the
+    // tracked tree stays clean and `git pull --ff-only` is never blocked.
+    // Harness condition: worker context (minipc-wsl role: worker) → isWorkerContext() true.
+    // Mutation control: removing the `if (isWorkerContext()) return;` guard
+    // makes this file appear → assertion fails.
+    expect(existsSync(cleanupPendingPath(harness))).toBe(false);
+    expect(loadDeferredCleanups(harness)).toEqual([]);
+  });
+
+  test("controller context positive control: recordDeferredCleanup DOES write and round-trips", () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller (role: leader)
+    const harness = harnessPath();
+
+    recordDeferredCleanup(makeEntry({ taskId: "task-controller-guard" }), harness);
+
+    // On the controller the guard is inert: the manifest is written and the
+    // entry round-trips via loadDeferredCleanups.
+    expect(existsSync(cleanupPendingPath(harness))).toBe(true);
+    const loaded = loadDeferredCleanups(harness);
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]!.taskId).toBe("task-controller-guard");
+  });
+});

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -2,11 +2,11 @@
 // Entries are processed during briefing prep after a configurable delay.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import { harnessDir as defaultHarnessDir, cleanupDelayHours } from "../config.ts";
 import * as spawn from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
-import { isWorkerContext } from "./state.ts";
+import { isWorkerContext, workerCacheDir } from "./state.ts";
 import { removeWorktreeByPath, deleteBranches, orchBranchName, purgeOrphanDirIfRecoverable } from "./worktrees.ts";
 import { removePeerSyncLink } from "./peer-sync.ts";
 
@@ -25,6 +25,17 @@ export interface CleanupEntry {
 }
 
 export function cleanupPendingPath(harnessDir: string = defaultHarnessDir()): string {
+  // gh-ludics-592 (defect 2): on a federation worker, route the deferred-cleanup
+  // manifest OFF the tracked harness tree into the non-harness worker cache
+  // ($HOME/.ludics-orch-cache, à la gh-ludics-580). A worker writing
+  // mag/cleanup-pending.json under the harness blocks `git pull --ff-only` and
+  // strands it on a stale clone (the resurrection incident). Routing (vs
+  // dropping) PRESERVES the entry so the worker's own cleanup drain
+  // (processDeferredCleanups in workerKeepalive) can still reap the worker-local
+  // worktree/branches/tmux/peer-sync artifacts — which only the worker can reap
+  // (the controller is a different filesystem). load/save/process all resolve
+  // through here, so the worker reads and writes the same cache manifest.
+  if (isWorkerContext()) return join(workerCacheDir(), "cleanup-pending.json");
   return join(harnessDir, "mag", "cleanup-pending.json");
 }
 
@@ -71,18 +82,15 @@ export function saveDeferredCleanups(
   entries: CleanupEntry[],
   harnessDir: string = defaultHarnessDir(),
 ): void {
-  // gh-ludics-592 (defect 2): cleanup-pending.json is the controller-owned
-  // post-mortem queue, drained by processDeferredCleanups during controller
-  // briefing prep (which reads the HARNESS file, never the worker cache). A
-  // federation worker must never write it — a local write blocks
-  // `git pull --ff-only` and strands the worker on a stale harness clone (the
-  // resurrection incident). No-op in worker context so the tree stays clean.
-  // (Keyed on cluster role, not the harnessDir argument, so controller/
-  // standalone callers passing an explicit harnessDir are never redirected.)
-  if (isWorkerContext()) return;
+  // gh-ludics-592 (defect 2): the destination is resolved by cleanupPendingPath,
+  // which on a worker routes to the non-harness worker cache so the tracked tree
+  // stays clean (`git pull --ff-only` never blocked) while the entry is still
+  // PRESERVED for the worker's own cleanup drain. mkdir the resolved file's
+  // directory rather than assuming `<harnessDir>/mag` (the worker cache dir
+  // differs from the harness mag dir).
   try {
     const file = cleanupPendingPath(harnessDir);
-    mkdirSync(join(harnessDir, "mag"), { recursive: true });
+    mkdirSync(dirname(file), { recursive: true });
     const tmp = file + ".tmp";
     writeFileSync(tmp, JSON.stringify(entries, null, 2) + "\n");
     renameSync(tmp, file);

--- a/src/orchestration/deferred-cleanup.ts
+++ b/src/orchestration/deferred-cleanup.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 import { harnessDir as defaultHarnessDir, cleanupDelayHours } from "../config.ts";
 import * as spawn from "../spawn.ts";
 import type { OrchestrationState } from "./state.ts";
+import { isWorkerContext } from "./state.ts";
 import { removeWorktreeByPath, deleteBranches, orchBranchName, purgeOrphanDirIfRecoverable } from "./worktrees.ts";
 import { removePeerSyncLink } from "./peer-sync.ts";
 
@@ -70,6 +71,15 @@ export function saveDeferredCleanups(
   entries: CleanupEntry[],
   harnessDir: string = defaultHarnessDir(),
 ): void {
+  // gh-ludics-592 (defect 2): cleanup-pending.json is the controller-owned
+  // post-mortem queue, drained by processDeferredCleanups during controller
+  // briefing prep (which reads the HARNESS file, never the worker cache). A
+  // federation worker must never write it — a local write blocks
+  // `git pull --ff-only` and strands the worker on a stale harness clone (the
+  // resurrection incident). No-op in worker context so the tree stays clean.
+  // (Keyed on cluster role, not the harnessDir argument, so controller/
+  // standalone callers passing an explicit harnessDir are never redirected.)
+  if (isWorkerContext()) return;
   try {
     const file = cleanupPendingPath(harnessDir);
     mkdirSync(join(harnessDir, "mag"), { recursive: true });

--- a/src/queue.test.ts
+++ b/src/queue.test.ts
@@ -840,3 +840,108 @@ describe("harness teardown restoration", () => {
     }
   });
 });
+
+// gh-ludics-592 (defect 2): a federation worker must never create or mutate the
+// tracked Mag queue file (mag/queue.jsonl) or its .lock dir — a local write
+// blocks `git pull --ff-only` and strands the worker on a stale harness clone.
+// Every write/mutate API no-ops in worker context, returning an API-compatible
+// "nothing to do" result.
+describe("queue worker-context guard (gh-ludics-592)", () => {
+  let wtmp: string;
+  const SAVED_HOME = process.env.HOME;
+  const SAVED_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  const SAVED_CONFIG = process.env.LUDICS_CONFIG;
+  const SAVED_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+  function writeClusterConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  const qFile = (): string => join(wtmp, "harness", "mag", "queue.jsonl");
+  const qLock = (): string => join(wtmp, "harness", "mag", "queue.jsonl.lock");
+
+  beforeEach(() => {
+    wtmp = mkdtempSync(join(tmpdir(), "ludics-queue-worker-"));
+    process.env.HOME = wtmp;
+    process.env.LUDICS_HARNESS_DIR = join(wtmp, "harness");
+    process.env.LUDICS_CONFIG = writeClusterConfig(wtmp);
+    mkdirSync(join(wtmp, "harness", "mag"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(wtmp, { recursive: true, force: true });
+    if (SAVED_HOME === undefined) delete process.env.HOME; else process.env.HOME = SAVED_HOME;
+    if (SAVED_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = SAVED_HARNESS;
+    if (SAVED_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = SAVED_CONFIG;
+    if (SAVED_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = SAVED_MACHINE;
+  });
+
+  test("worker context: enqueue/reinsert APIs write nothing and return API-compatible values", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker (role: worker)
+    const { queueRequest, queueRequestAtHead, queueReinsertHead, queueReinsertHeadWithFreshId, queuePending } = await loadQueue();
+
+    // Invariant: no tracked queue file (or lock dir) is created by a worker, so
+    // the tree stays clean and `git pull --ff-only` is never blocked.
+    // Harness condition: worker context (minipc-wsl role: worker) → isWorkerContext() true.
+    expect(queueRequest({ action: "briefing" })).toBe("");
+    expect(queueRequestAtHead({ action: "briefing" })).toBe("");
+    queueReinsertHead(JSON.stringify({ id: "x", action: "briefing" }));
+    // returns a syntactically valid req-* id without reinserting
+    expect(queueReinsertHeadWithFreshId({ action: "briefing" }, "orig-id")).toMatch(/^req-/);
+
+    expect(existsSync(qFile())).toBe(false);
+    expect(existsSync(qLock())).toBe(false);
+    expect(queuePending()).toBe(false);
+  });
+
+  test("worker context: pop/mutation APIs write nothing and return empty/not-found/mismatch", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl"; // worker
+    const { queuePopOne, queuePopAll, queuePromoteToTop, queueCancel, queuePopExpected } = await loadQueue();
+
+    expect(queuePopOne()).toBeNull();
+    expect(queuePopAll()).toEqual([]);
+    expect(queuePromoteToTop("any-id")).toEqual({ status: "not-found" });
+    expect(queueCancel("any-id")).toEqual({ status: "not-found" });
+    expect(queuePopExpected("any-line")).toEqual({ status: "empty" });
+
+    // Mutation control: removing any `if (isWorkerContext())` guard makes the
+    // corresponding call create/rewrite the queue file or its lock dir → fails.
+    expect(existsSync(qFile())).toBe(false);
+    expect(existsSync(qLock())).toBe(false);
+  });
+
+  test("controller context positive control: queueRequest DOES write and queueList round-trips", async () => {
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "leader-box"; // controller (role: leader)
+    const { queueRequest, queueList } = await loadQueue();
+
+    const id = queueRequest({ action: "briefing" });
+    expect(id).toMatch(/^req-/);
+    expect(existsSync(qFile())).toBe(true);
+    const list = queueList();
+    expect(list.length).toBe(1);
+    expect(list[0]!.action).toBe("briefing");
+    expect(list[0]!.id).toBe(id);
+  });
+});

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -5,10 +5,21 @@ import { join, dirname } from "path";
 import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
 import { atomicWriteFileSync, isPlainObject, writeJsonFileCompact } from "./json.ts";
+import { isWorkerContext } from "./orchestration/state.ts";
 
 function queueFile(): string {
   return join(harnessDir(), "mag", "queue.jsonl");
 }
+
+// gh-ludics-592 (defect 2): the Mag request queue (mag/queue.jsonl) is the
+// controller-coordinator's — only the controller drains it. A federation worker
+// must never create or mutate the tracked queue file (nor its .lock dir): a
+// local write blocks `git pull --ff-only` and strands the worker on a stale
+// harness clone (the resurrection incident). Every write/mutate public API
+// early-returns BEFORE `withQueueLock` in worker context, returning an
+// API-compatible "nothing to do" result. Read-only helpers are untouched. A
+// worker never drains the queue, so suppressing the write half is a no-op
+// functionally — it only keeps the tree clean.
 
 const LOCK_MAX_ATTEMPTS = 50;
 const LOCK_RETRY_MS = 100;
@@ -154,6 +165,7 @@ export interface QueueRequestExtras {
 }
 
 export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): string {
+  if (isWorkerContext()) return ""; // worker: never write the tracked queue (gh-ludics-592)
   const file = queueFile();
   mkdirSync(dirname(file), { recursive: true });
 
@@ -204,6 +216,7 @@ function writeQueueLines(lines: string[]): void {
 }
 
 export function queueReinsertHead(line: string): void {
+  if (isWorkerContext()) return; // worker: never write the tracked queue (gh-ludics-592)
   withQueueLock(() => {
     const lines = readQueueLines();
     writeQueueLines([line, ...lines]);
@@ -218,6 +231,7 @@ export function queueReinsertHead(line: string): void {
  * docs/proposals/auto-compact-after-checkpoints.md).
  */
 export function queueRequestAtHead(req: QueueAction, extras?: QueueRequestExtras): string {
+  if (isWorkerContext()) return ""; // worker: never write the tracked queue (gh-ludics-592)
   const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   const requestId = nextRequestId();
   const baseRecord: Record<string, unknown> = { id: requestId, ...req, timestamp };
@@ -266,6 +280,8 @@ export function queueReinsertHeadWithFreshId(
   record: Record<string, unknown>,
   originalId: string,
 ): string {
+  // worker: return a syntactically valid id without reinserting (gh-ludics-592)
+  if (isWorkerContext()) return nextRequestId();
   const newId = nextRequestId();
   const updated = { ...record, id: newId, "re-fired-from": originalId };
   queueReinsertHead(JSON.stringify(updated));
@@ -273,6 +289,7 @@ export function queueReinsertHeadWithFreshId(
 }
 
 export function queuePopOne(): string | null {
+  if (isWorkerContext()) return null; // worker: never drain/rewrite the tracked queue (gh-ludics-592)
   const result = withQueueLock(() => {
     const lines = readQueueLines();
     if (lines.length === 0) return null;
@@ -287,6 +304,7 @@ export function queuePopOne(): string | null {
 }
 
 export function queuePopAll(): string[] {
+  if (isWorkerContext()) return []; // worker: never drain/rewrite the tracked queue (gh-ludics-592)
   const lines = withQueueLock(() => {
     const all = readQueueLines();
     if (all.length === 0) return [];
@@ -312,6 +330,7 @@ function findLineIndexById(lines: string[], id: string): number {
 }
 
 export function queuePromoteToTop(id: string): QueuePromoteResult {
+  if (isWorkerContext()) return { status: "not-found" }; // worker: never rewrite the tracked queue (gh-ludics-592)
   const result = withQueueLock<QueuePromoteResult>(() => {
     const lines = readQueueLines();
     const idx = findLineIndexById(lines, id);
@@ -333,6 +352,7 @@ export type QueueCancelResult =
   | { status: "not-found" };
 
 export function queueCancel(id: string): QueueCancelResult {
+  if (isWorkerContext()) return { status: "not-found" }; // worker: never rewrite the tracked queue (gh-ludics-592)
   const result = withQueueLock<QueueCancelResult>(() => {
     const lines = readQueueLines();
     const idx = findLineIndexById(lines, id);
@@ -355,6 +375,7 @@ export type QueueDequeueResult =
   | { status: "popped"; line: string; request: Record<string, unknown> | null };
 
 export function queuePopExpected(expectedLine?: string): QueueDequeueResult {
+  if (isWorkerContext()) return { status: "empty" }; // worker: never drain/rewrite the tracked queue (gh-ludics-592)
   return withQueueLock(() => {
     const lines = readQueueLines();
     if (lines.length === 0) return { status: "empty" };


### PR DESCRIPTION
Fixes the gh-ludics-592 incident: a remote worker (`minipc-wsl`) kept
**resurrecting a slot the controller had cleared** and a detached orchestration
continued on an already-**done** task, autonomously opening + merging a PR —
invisible to the controller/dashboard.

Two independent defects; both addressed.

## Defect 2 (root cause) — worker dirties its tracked harness tree

The worker wrote tracked harness runtime files, so `git pull --ff-only` aborted
and the worker was stranded ~15 commits behind — it never received the
controller's cleared `slot-4.json` (nor the deployed 580/584 fixes). Per the
resolved question (fix shape **(a)**), every worker-exercised tracked-harness
writer now keeps the tree clean under `isWorkerContext()` (mirroring the
existing `journalAppend`/`emitEvent` worker guards), so `--ff-only` always
succeeds:

- `src/notify.ts` — `notifyLog` no-ops on a worker (`journal/notifications.jsonl`).
  The network ntfy send still fires; only the controller-owned local log is
  suppressed. (AC1)
- `src/queue.ts` — all 9 write/mutate APIs (`queueRequest`, `queueRequestAtHead`,
  `queueReinsertHead`, `queueReinsertHeadWithFreshId`, `queuePopOne`/`All`,
  `queuePromoteToTop`, `queueCancel`, `queuePopExpected`) early-return **before**
  `withQueueLock`, so neither `mag/queue.jsonl` nor its `.lock` dir is created;
  each returns an API-compatible value. The queue is the controller-coordinator's
  — only the controller drains it. (AC2)
- `src/orchestration/deferred-cleanup.ts` — `cleanupPendingPath` **routes** the
  manifest to the non-harness worker cache (`$HOME/.ludics-orch-cache`, à la
  gh-580) on a worker, so the tracked tree stays clean while the entry is
  **preserved** (not dropped). `workerKeepalive` now calls
  `processDeferredCleanups` so the worker reaps its OWN worker-local artifacts
  (worktrees/branches/tmux/peer-sync) — the controller can't (different
  filesystem). (AC3; addresses Codex P2 review.)

Exhaustive writer sweep (AC4): `journalAppend`/`emitEvent` already guarded;
`persistState` already routes to the worker cache (gh-580); `writeSlotJson`,
`saveSessionConclusionState`, the subscriber/pending-revise writers, and
`writeResult` are controller-only paths, not worker-exercised. No automatic
`reset --hard`/`stash` backstop added — `src/state.ts` untouched (AC7).

## Defect 1 (confirm + lock) — worker resume reconciliation

`maybeResumeDeadOrchestrators` already `continue`s on a controller-live
`freshSlots` row reporting `(empty)` before any orch-state read or PID check, and
never falls back to the stale local clone when a fresh view exists. No code
change needed; added the regression test reproducing the exact incident (stale
local clone shows the slot live, `freshSlots` says `(empty)` → no resurrection),
mutation-verified non-vacuous. (AC5)

## Tests (AC6)

11 new tests: per-writer worker-guard tests with controller positive controls in
`src/notify.test.ts`, `src/queue.test.ts`, `src/orchestration/deferred-cleanup.test.ts`
(routing + cancel + keepalive-drain), plus the resurrection lock in
`src/mag.test.ts`.

Full suite: 3274 pass / 2 fail — both fails are **pre-existing env-dependent
baseline** failures in `src/slots/index.test.ts` (`remote slotStop (non-force)…`,
`slotAssign machine default…`), unrelated to this change. typecheck, lint, build
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)