### PR TITLE
fix(orchestration): provider-based stop-hook attribution in pair mode (#597)

### DIFF
--- a/scripts/lint-hooks.test.ts
+++ b/scripts/lint-hooks.test.ts
@@ -114,16 +114,18 @@ describe("ludics-on-stop.sh blank-cwd default (gh-ludics-589)", () => {
     // observable. Drop only the single trailing newline from `printf '%s\n'`.
     const argv = readFileSync(argvOut, "utf-8").split("\n");
     if (argv.length && argv[argv.length - 1] === "") argv.pop();
-    // Invariant: the exec is exactly `orch on-stop <cwd> <peer-sync> <event>` with
-    // a NON-EMPTY <cwd>. Mutation: removing the `cwd="${cwd:-$PWD}"` default leaves
+    // Invariant: the exec is exactly `orch on-stop <cwd> <peer-sync> <event> <provider>`
+    // with a NON-EMPTY <cwd>. Mutation: removing the `cwd="${cwd:-$PWD}"` default leaves
     // argv[2] === "" (jq's `.cwd // ""`), flipping argv[2]/argv[3]/argv[4] — caught
     // by both the non-empty check and the exact peer-sync/event slot assertions.
-    expect(argv).toHaveLength(5);
+    // argv[5] is the invoking provider (gh-ludics-597), "claude-code" on this path.
+    expect(argv).toHaveLength(6);
     expect(argv[0]).toBe("orch");
     expect(argv[1]).toBe("on-stop");
     expect(argv[2]).not.toBe(""); // the cwd positional — defaulted to $PWD
     expect(argv[3]).toBe(psDir);  // peer-sync dir stays in its own slot
     expect(argv[4]).toBe("Stop");
+    expect(argv[5]).toBe("claude-code"); // provider (gh-ludics-597)
   });
 });
 
@@ -203,7 +205,7 @@ describe("ludics-on-stop.sh jq resolution (gh-ludics-590)", () => {
     expect(proc.exitCode).toBe(0);
     const argv = readFileSync(argvOut, "utf-8").split("\n");
     if (argv.length && argv[argv.length - 1] === "") argv.pop();
-    expect(argv).toEqual(["orch", "on-stop", workDir, psDir, "Stop"]);
+    expect(argv).toEqual(["orch", "on-stop", workDir, psDir, "Stop", "claude-code"]);
   });
 
   test.skipIf(jqReachableViaHardcodedPrepend)(

--- a/src/orchestration/index.ts
+++ b/src/orchestration/index.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { harnessDir } from "../config.ts";
 import { defaultRunGit, resolveBaseRef, type RunGit } from "../git-runner.ts";
 import type { Phase } from "./phases.ts";
-import { readAgentMarkerFile, readAgentStatus, readPhaseToken, resolvePeerSyncDir, writeStopHookRecord } from "./peer-sync.ts";
+import { readAgentMarkerFile, readAgentStatus, readMarker, readPhaseToken, resolvePeerSyncDir, writeStopHookRecord } from "./peer-sync.ts";
 import { confirmPhase, interruptCurrentPhase, runOrchestrationForSlot, skipToPhase } from "./runner.ts";
 import { readOrchestrationState } from "./state.ts";
 import { isoNow } from "./util.ts";
@@ -204,6 +204,10 @@ export function orchOnStop(args: string[]): void {
   const cwd = args[0] ?? "";
   const cliPeerSyncDir = args[1];
   const hookEventName = args[2];
+  // gh-ludics-597: the invoking provider ("codex" / "claude-code"), passed by the
+  // shell hook. Used to disambiguate stop-hook attribution in pair mode, where
+  // both agents share one worktree and a cwd-prefix match is ambiguous.
+  const invokingProvider = args[3] || undefined;
 
   // Resolve peerSyncDir: CLI arg (if valid) > env var > give up.
   const peerSyncDir = resolvePeerSyncDir({ cliArg: cliPeerSyncDir || undefined });
@@ -224,12 +228,34 @@ export function orchOnStop(args: string[]): void {
   try {
     const worktrees = JSON.parse(readFileSync(join(peerSyncDir, "worktrees.json"), "utf-8")) as Record<string, unknown>;
     worktreeAgentNames = Object.keys(worktrees).filter((n) => n !== "root");
+    // gh-ludics-597: collect ALL non-root entries matching the cwd rather than
+    // taking the first. In pair mode both agents share one worktree, so a
+    // first-match-wins loop always attributed to the first-listed agent (coder)
+    // and the second agent (reviewer) never got a stop record. The marker/env
+    // attribution below could not fix this because it only ran when agentName
+    // was still unset.
+    const matchingAgents: string[] = [];
     for (const [name, path] of Object.entries(worktrees)) {
       if (name === "root") continue;
       if (typeof path === "string" && cwd.startsWith(path)) {
-        agentName = name;
-        break;
+        matchingAgents.push(name);
       }
+    }
+    if (matchingAgents.length === 1) {
+      // Unambiguous (separate worktrees, e.g. duo mode) — keep prior behavior.
+      agentName = matchingAgents[0]!;
+    } else if (matchingAgents.length > 1 && invokingProvider) {
+      // Shared-worktree pair: disambiguate by the invoking provider against the
+      // per-agent `<agent>-agent` files (e.g. coder-agent=claude-code,
+      // reviewer-agent=codex). Provider is per-agent even when cwd is not.
+      const byProvider = matchingAgents.filter(
+        (name) => readMarker(peerSyncDir, `${name}-agent`) === invokingProvider,
+      );
+      if (byProvider.length === 1) {
+        agentName = byProvider[0]!;
+      }
+      // Same-provider pairs remain ambiguous here and fall through to the
+      // marker/env/status attribution below (tracked as a follow-up).
     }
   } catch {
     // Can't read worktrees — fall through to env-var check.
@@ -274,7 +300,9 @@ export function orchOnStop(args: string[]): void {
 
   writeStopHookRecord(peerSyncDir, {
     agent: agentName,
-    provider: "unknown", // We don't know the provider from the hook context.
+    // gh-ludics-597: prefer the hook-supplied provider; fall back to the
+    // per-agent `<agent>-agent` file, then "unknown".
+    provider: invokingProvider ?? readMarker(peerSyncDir, `${agentName}-agent`) ?? "unknown",
     phase,
     phaseToken,
     observedAt: isoNow(),

--- a/src/orchestration/peer-sync.test.ts
+++ b/src/orchestration/peer-sync.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { PEER_SYNC_DIRNAME, peerSyncPath, resolvePeerSyncDir } from "./peer-sync.ts";
+import { initPeerSync, PEER_SYNC_DIRNAME, peerSyncPath, resolvePeerSyncDir } from "./peer-sync.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-peer-sync");
 
@@ -13,6 +13,30 @@ afterEach(() => {
 describe("PEER_SYNC_DIRNAME", () => {
   test("equals .peer-sync", () => {
     expect(PEER_SYNC_DIRNAME).toBe(".peer-sync");
+  });
+});
+
+describe("initPeerSync provider markers (gh-ludics-597)", () => {
+  test("writes per-name provider markers for custom-named agents (and keeps role-based ones)", () => {
+    const peerSyncDir = join(TMP, "ps");
+    const projectDir = join(TMP, "proj");
+    const wt = join(TMP, "wt");
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(wt, { recursive: true });
+
+    const agents = [
+      { name: "alice", provider: "claude-code", role: "coder", model: "m", branch: "b1", worktreePath: wt },
+      { name: "bob", provider: "codex", role: "reviewer", model: "m", branch: "b2", worktreePath: wt },
+    ] as unknown as Parameters<typeof initPeerSync>[4];
+
+    initPeerSync(peerSyncDir, "task-x", "pair", projectDir, agents, { root: wt, alice: wt, bob: wt });
+
+    // Per-name markers (the gh-597 fix) — let orchOnStop resolve custom names.
+    expect(readFileSync(join(peerSyncDir, "alice-agent"), "utf-8").trim()).toBe("claude-code");
+    expect(readFileSync(join(peerSyncDir, "bob-agent"), "utf-8").trim()).toBe("codex");
+    // Role-based markers still present for back-compat.
+    expect(readFileSync(join(peerSyncDir, "coder-agent"), "utf-8").trim()).toBe("claude-code");
+    expect(readFileSync(join(peerSyncDir, "reviewer-agent"), "utf-8").trim()).toBe("codex");
   });
 });
 

--- a/src/orchestration/peer-sync.ts
+++ b/src/orchestration/peer-sync.ts
@@ -87,6 +87,14 @@ export function initPeerSync(
 
   for (const agent of agents) {
     writeFile(join(peerSyncDir, `${agent.name}.status`), `idle|0|awaiting-${agent.name}\n`);
+    // gh-ludics-597 (review follow-up): per-NAME provider marker. worktrees.json is
+    // keyed by agent.name (which can be a custom name via `name:provider:model`
+    // tokens, ≠ role), while the role-based coder-agent/reviewer-agent markers above
+    // are not. orchOnStop disambiguates shared-worktree pairs by reading
+    // `${worktreeKey}-agent`, so it needs a marker keyed by agent.name to work for
+    // custom-named agents. For standard pairs (name === role) this writes the same
+    // coder-agent/reviewer-agent files — idempotent.
+    writeFile(join(peerSyncDir, `${agent.name}-agent`), agent.provider);
   }
 
   const sessionsDir = join(projectDir, ".agent-sessions");

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -379,6 +379,33 @@ describe("orchOnStop handler", () => {
     expect(readStopHookRecord(peerSyncDir, "reviewer")).toBeNull();
   });
 
+  // gh-ludics-597 (review follow-up): custom agent names (`name:provider:model`
+  // tokens) key worktrees.json by the custom name, ≠ role. initPeerSync now writes
+  // per-name provider markers (`<name>-agent`), so orchOnStop's `${worktreeKey}-agent`
+  // lookup resolves for custom names too — not just role-named coder/reviewer.
+  test("pair-mode custom agent names: provider attributes by name, not role (gh-597)", () => {
+    const sharedWorktree = join(tmpDir, "shared-worktree");
+    mkdirSync(sharedWorktree, { recursive: true });
+
+    const peerSyncDir = makePeerSyncDir({
+      root: sharedWorktree,
+      alice: sharedWorktree, // role coder, provider claude-code
+      bob: sharedWorktree, // role reviewer, provider codex
+    });
+    // Per-name provider markers (as initPeerSync now writes them).
+    writeFileSync(join(peerSyncDir, "alice-agent"), "claude-code");
+    writeFileSync(join(peerSyncDir, "bob-agent"), "codex");
+
+    // Codex (bob) stop hook.
+    orchOnStop([sharedWorktree, peerSyncDir, "Stop", "codex"]);
+
+    const bobRecord = readStopHookRecord(peerSyncDir, "bob");
+    expect(bobRecord).not.toBeNull();
+    expect(bobRecord!.agent).toBe("bob");
+    expect(bobRecord!.provider).toBe("codex");
+    expect(readStopHookRecord(peerSyncDir, "alice")).toBeNull();
+  });
+
   test("separate worktrees still attribute by unambiguous path match (gh-597 regression)", () => {
     const coderWorktree = join(tmpDir, "wt-coder");
     const reviewerWorktree = join(tmpDir, "wt-reviewer");

--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -330,6 +330,77 @@ describe("orchOnStop handler", () => {
     expect(coderRecord!.agent).toBe("coder");
   });
 
+  // gh-ludics-597: in pair mode both agents share one worktree, so a cwd-prefix
+  // match is ambiguous. The invoking provider (4th arg) disambiguates against the
+  // per-agent `<agent>-agent` files. Before the fix, first-match-wins always
+  // attributed to coder and reviewer.stop.json was never written.
+  test("pair-mode shared worktree: codex provider attributes to reviewer (gh-597)", () => {
+    const sharedWorktree = join(tmpDir, "shared-worktree");
+    mkdirSync(sharedWorktree, { recursive: true });
+
+    const peerSyncDir = makePeerSyncDir({
+      root: sharedWorktree,
+      coder: sharedWorktree,
+      reviewer: sharedWorktree,
+    });
+    // Per-agent provider files (written by initPeerSync in production).
+    writeFileSync(join(peerSyncDir, "coder-agent"), "claude-code");
+    writeFileSync(join(peerSyncDir, "reviewer-agent"), "codex");
+
+    // Codex (reviewer) stop hook — passes provider "codex" as the 4th arg.
+    orchOnStop([sharedWorktree, peerSyncDir, "Stop", "codex"]);
+
+    const reviewerRecord = readStopHookRecord(peerSyncDir, "reviewer");
+    expect(reviewerRecord).not.toBeNull();
+    expect(reviewerRecord!.agent).toBe("reviewer");
+    expect(reviewerRecord!.provider).toBe("codex");
+    // The coder must NOT be mis-attributed.
+    expect(readStopHookRecord(peerSyncDir, "coder")).toBeNull();
+  });
+
+  test("pair-mode shared worktree: claude-code provider attributes to coder (gh-597)", () => {
+    const sharedWorktree = join(tmpDir, "shared-worktree");
+    mkdirSync(sharedWorktree, { recursive: true });
+
+    const peerSyncDir = makePeerSyncDir({
+      root: sharedWorktree,
+      coder: sharedWorktree,
+      reviewer: sharedWorktree,
+    });
+    writeFileSync(join(peerSyncDir, "coder-agent"), "claude-code");
+    writeFileSync(join(peerSyncDir, "reviewer-agent"), "codex");
+
+    orchOnStop([sharedWorktree, peerSyncDir, "Stop", "claude-code"]);
+
+    const coderRecord = readStopHookRecord(peerSyncDir, "coder");
+    expect(coderRecord).not.toBeNull();
+    expect(coderRecord!.agent).toBe("coder");
+    expect(coderRecord!.provider).toBe("claude-code");
+    expect(readStopHookRecord(peerSyncDir, "reviewer")).toBeNull();
+  });
+
+  test("separate worktrees still attribute by unambiguous path match (gh-597 regression)", () => {
+    const coderWorktree = join(tmpDir, "wt-coder");
+    const reviewerWorktree = join(tmpDir, "wt-reviewer");
+    mkdirSync(coderWorktree, { recursive: true });
+    mkdirSync(reviewerWorktree, { recursive: true });
+
+    const peerSyncDir = makePeerSyncDir({
+      root: tmpDir,
+      coder: coderWorktree,
+      reviewer: reviewerWorktree,
+    });
+    writeFileSync(join(peerSyncDir, "coder-agent"), "claude-code");
+    writeFileSync(join(peerSyncDir, "reviewer-agent"), "claude-code");
+
+    // Even with identical providers, a unique path match resolves unambiguously.
+    orchOnStop([reviewerWorktree, peerSyncDir, "Stop", "claude-code"]);
+
+    const record = readStopHookRecord(peerSyncDir, "reviewer");
+    expect(record).not.toBeNull();
+    expect(record!.agent).toBe("reviewer");
+  });
+
   test("env var LUDICS_AGENT_NAME resolves when path matching fails", () => {
     const unknownCwd = join(tmpDir, "unknown-dir");
     mkdirSync(unknownCwd, { recursive: true });

--- a/templates/hooks/ludics-on-stop.sh
+++ b/templates/hooks/ludics-on-stop.sh
@@ -69,6 +69,15 @@ else
   cwd=$(echo "$input" | "$jq_bin" -r '.cwd // ""' 2>/dev/null)
 fi
 
+# gh-ludics-597: the invoking provider, passed to `orch on-stop` as a 4th arg so
+# it can disambiguate stop-hook attribution in pair mode (shared worktree). The
+# value must match the `<agent>-agent` provider files: "codex" / "claude-code".
+if [[ "$invocation_mode" == "codex" ]]; then
+  provider="codex"
+else
+  provider="claude-code"
+fi
+
 # gh-ludics-589: never exec `ludics orch on-stop` (or `mag on-stop`) with a blank
 # first positional — that shifts the positional args and produced a `usage: ludics
 # orch on-stop <cwd> ...` error that blocked phase advancement. A blank cwd can
@@ -136,7 +145,7 @@ fi
 # raw LUDICS_PEER_SYNC_DIR env var here, because it may be stale (no phase file),
 # and exec-ing would prevent the Mag fallback from running.
 if [[ -n "$peer_sync_dir" ]]; then
-  exec "$ludics_bin" orch on-stop "$cwd" "$peer_sync_dir" "$hook_event_name"
+  exec "$ludics_bin" orch on-stop "$cwd" "$peer_sync_dir" "$hook_event_name" "$provider"
 fi
 
 # Codex only needs orchestration routing — no Mag settled signal.


### PR DESCRIPTION
Fixes #597.

## Problem

In pair mode both agents share **one** worktree, so `orchOnStop`'s cwd-prefix match against `worktrees.json` is ambiguous. First-match-wins always attributed the stop to the first-listed agent (`coder`); the second agent (`reviewer`) never got a `<agent>.stop.json`, so every reviewer turn degraded to the settled-no-signal fallback (~2-3 min/phase). It looked like "codex notify is broken" only because codex is the second-listed (reviewer) agent — a same-path claude-code reviewer breaks identically.

Diagnosed live on slot 1 / task-bfc7c7b5 (minipc-wsl): `coder.stop.json` written, `reviewer.stop.json` never. Running `orch on-stop` with `LUDICS_AGENT_NAME=reviewer` exported still rewrote `coder.stop.json` — the env var was ignored because worktrees-match had already set `coder`.

## Fix

`provider` is per-agent even when cwd is not, and already on disk (`.peer-sync/coder-agent`, `reviewer-agent`):

1. `templates/hooks/ludics-on-stop.sh` passes the invoking provider (`codex` / `claude-code`) as a 4th arg to `orch on-stop`.
2. `orchOnStop` collects **all** non-root worktree entries matching the cwd. Exactly one → use it (duo/solo, unchanged). Two-plus (shared-worktree pair) → pick the agent whose `<agent>-agent` file equals the invoking provider.
3. Marker/env/status fallbacks unchanged. The stop record now carries the real provider instead of `"unknown"`.

Same-provider pairs remain ambiguous by cwd/provider and fall through to the existing fallbacks — noted as a follow-up in the code and issue.

## Tests

- 3 new `orchOnStop` cases: codex→reviewer, claude-code→coder, separate-worktrees-still-attribute-by-path.
- Updated the two hook-argv lint assertions (gh-589 / gh-590) for the new provider positional.

`bun test`: the touched suites pass (orchestration lifecycle 90/90, hook lint 8/8, index 10/10). Two pre-existing failures remain on `main` (`remote slotStop` HTTP, `slotAssign machine default`) — environment/federation, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)