### PR TITLE
fix(dashboard): sort Unanswered Questions pane reverse-chronologically

### DIFF
--- a/src/dashboard.test.ts
+++ b/src/dashboard.test.ts
@@ -519,6 +519,33 @@ describe("deferred-launch sorting", () => {
   });
 });
 
+describe("unanswered-questions sorting", () => {
+  function writeQuestionTask(id: string, title: string, created: string | null): void {
+    const tasksDir = join(harnessDir(), "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    const createdLine = created ? `created: "${created}"` : "created: null";
+    writeFileSync(
+      join(tasksDir, `${id}.md`),
+      `---\nid: ${id}\ntitle: "${title}"\nstatus: ready\npriority: B\n${createdLine}\ncontext: ludics\nhas_questions: true\n---\n\n# ${title}\n`,
+    );
+  }
+
+  test("tasks sorted by created date descending, null last", async () => {
+    writeQuestionTask("task-uq-oldest", "Oldest", "2026-01-01");
+    writeQuestionTask("task-uq-newest", "Newest", "2026-04-15");
+    writeQuestionTask("task-uq-middle", "Middle", "2026-03-10");
+    writeQuestionTask("task-uq-no-date", "No date", null);
+
+    const { dashboardGenerate } = await import("./dashboard.ts");
+    silenceConsoleError(() => dashboardGenerate());
+
+    const outFile = join(harnessDir(), "dashboard", "data", "unanswered-questions.json");
+    const items = JSON.parse(readFileSync(outFile, "utf-8")) as Record<string, unknown>[];
+    const ids = items.map((item) => item.id);
+    expect(ids).toEqual(["task-uq-newest", "task-uq-middle", "task-uq-oldest", "task-uq-no-date"]);
+  });
+});
+
 describe("needs-confirmation sorting", () => {
   function writeNeedsConfirmationTask(id: string, title: string, created: string | null): void {
     const tasksDir = join(harnessDir(), "tasks");

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -541,6 +541,7 @@ const needsConfirmationConfig: FilteredTaskTileConfig = {
 const unansweredQuestionsConfig: FilteredTaskTileConfig = {
   filter: (task) => task.hasQuestions && !task.isCompleted,
   extraFields: () => ({}),
+  sort: byCreatedDescNullLast,
 };
 
 const deferredLaunchConfig: FilteredTaskTileConfig = {


### PR DESCRIPTION
The **Unanswered Questions** pane rendered tasks in unspecified (filter) order, while the sibling panes — **Deferred Launch**, **Needs Confirmation**, **Stale** — all sort by created-date descending, nulls last (`byCreatedDescNullLast`).

This adds the same `sort` to `unansweredQuestionsConfig` so newest questions surface first, matching Deferred Launch as requested.

- `src/dashboard.ts` — one-line config change (`sort: byCreatedDescNullLast`).
- `src/dashboard.test.ts` — new `unanswered-questions sorting` test mirroring the existing deferred-launch sort test.

`bun test src/dashboard.test.ts`: 118/118 pass. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)