### PR TITLE
fix(dashboard): theme-aware styling for Stale tab

### DIFF
--- a/templates/dashboard/dashboard.test.ts
+++ b/templates/dashboard/dashboard.test.ts
@@ -92,6 +92,86 @@ describe("style.css contains pending-action-badge class", () => {
   });
 });
 
+// task-44558ae0: the Stale panel's task-title link previously had no CSS rule,
+// so the <a class="task-title stale-link"> fell back to the browser-default
+// blue anchor color — theme-invariant and unreadable on Night/OLED. These
+// tests pin the theme-aware, non-blue title color and the warm-accent hover,
+// mirroring the sibling .needs-confirm-link / .unanswered-q-link rules.
+describe("style.css — Stale panel theme-aware link (task-44558ae0)", () => {
+  const stylePath = join(import.meta.dir, "style.css");
+  const style = readFileSync(stylePath, "utf-8");
+
+  function ruleFor(selector: string): string {
+    // Escape selector for a regex, then match its declaration block.
+    const esc = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const m = style.match(new RegExp(`${esc}\\s*\\{[^}]*\\}`));
+    expect(m).not.toBeNull();
+    return m![0];
+  }
+
+  test(".stale-link base color is the load-bearing theme token, never blue", () => {
+    const rule = ruleFor(".stale-link");
+    // Load-bearing title color resolves to --text-primary (#e8e6e3 / #1c1917 /
+    // #ffffff across Night/Day/OLED) — high-contrast and non-blue on all three.
+    expect(rule).toContain("color: var(--text-primary)");
+    // At rest the link is not underlined (matches siblings).
+    expect(rule).toContain("text-decoration: none");
+    // Guard against any blue literal / UA-default anchor color creeping back.
+    expect(rule.toLowerCase()).not.toContain("blue");
+    expect(rule).not.toMatch(/#(?:3b82f6|2563eb|0000ff|00f\b)/i);
+  });
+
+  test(".stale-link:hover mirrors siblings: warm accent + underline", () => {
+    const rule = ruleFor(".stale-link:hover");
+    // --accent is warm red/orange (#e85d4a / #c9362c / #ff4040) — never blue.
+    expect(rule).toContain("color: var(--accent)");
+    expect(rule).toContain("text-decoration: underline");
+  });
+
+  test(".stale-item is a flex row and .stale-actions right-aligns the buttons", () => {
+    const item = ruleFor(".stale-item");
+    expect(item).toContain("display: flex");
+    expect(item).toContain("align-items: center");
+    const actions = ruleFor(".stale-actions");
+    expect(actions).toContain("margin-left: auto");
+    expect(actions).toContain("flex-shrink: 0");
+  });
+
+  // Positive control: the matcher distinguishes presence from absence — the
+  // sibling link this fix mirrors must still pin --text-primary. If this
+  // assertion ever fails, the test infra (not just the Stale rule) is broken.
+  test("sibling .needs-confirm-link base color is still var(--text-primary)", () => {
+    expect(ruleFor(".needs-confirm-link")).toContain("color: var(--text-primary)");
+  });
+});
+
+// task-44558ae0 (AC4/AC5): the priority chip geometry (fixed box, centering,
+// radius) was scoped to `.ready-queue .priority`, so the same badge span in
+// the Stale / Needs-Confirmation / Unanswered / Deferred panels rendered as a
+// bare inline letter. The geometry selector is broadened to bare `.priority`
+// (values unchanged) so every badge gets the chip; Ready Queue is unchanged.
+describe("style.css — priority chip geometry is global (task-44558ae0)", () => {
+  const stylePath = join(import.meta.dir, "style.css");
+  const style = readFileSync(stylePath, "utf-8");
+
+  test("geometry lives on an unscoped .priority rule with the fixed-chip box", () => {
+    const m = style.match(/(^|[^a-zA-Z-])\.priority\s*\{[^}]*\}/m);
+    expect(m).not.toBeNull();
+    const rule = m![0];
+    expect(rule).toContain("display: inline-flex");
+    expect(rule).toContain("width: 20px");
+    expect(rule).toContain("height: 20px");
+    expect(rule).toContain("border-radius: var(--radius-sm)");
+    expect(rule).toContain("justify-content: center");
+  });
+
+  test("the chip geometry is no longer scoped to .ready-queue .priority", () => {
+    // Mutation guard: reverting the selector to `.ready-queue .priority` makes
+    // this assertion fail, which is the whole point of the broadening.
+    expect(style).not.toContain(".ready-queue .priority");
+  });
+});
+
 // gh-ludics-535: the Mag queue renderer must surface unresolved deliveries
 // as an "Unresolved deliveries" panel between Pending and Recent. `inFlight`
 // is always an array (possibly empty). These tests extract the real

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -1054,7 +1054,7 @@ main {
     gap: 0.4rem;
 }
 
-.ready-queue .priority {
+.priority {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -1187,6 +1187,33 @@ main {
 }
 
 .deferred-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 0.25em;
+    flex-shrink: 0;
+}
+
+/* ── Stale ─────────────────────────────────────────────────── */
+.stale-item {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.25em 0.4em;
+    cursor: default;
+}
+
+.stale-link {
+    color: var(--text-primary);
+    text-decoration: none;
+    font-size: 0.82rem;
+}
+
+.stale-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.stale-actions {
     margin-left: auto;
     display: flex;
     gap: 0.25em;


### PR DESCRIPTION
## Summary

The Dashboard **Stale** panel was barely readable on **OLED** and entirely unreadable on **Night**: its task-title links rendered as `<a class="task-title stale-link">` but no `.stale-link` rule existed in `style.css`, so the anchor fell back to the **browser-default blue link color** — theme-invariant and low-luminance.

This is a *missing-rule* fix (no blue literal existed to recolor), mirroring the sibling `.needs-confirm-link` / `.unanswered-q-link` precedent.

## Changes (CSS-only)

`templates/dashboard/style.css`:
- Add `.stale-link` — base `color: var(--text-primary)` (theme-aware, non-blue, high-contrast on Night `#e8e6e3` / Day `#1c1917` / OLED `#ffffff`) and `.stale-link:hover` — warm `var(--accent)` + underline.
- Add `.stale-item` (flex row) and `.stale-actions` (right-aligned Revive/Abandon buttons).
- Broaden the priority chip geometry selector `.ready-queue .priority` → bare `.priority` (**declarations byte-identical**) so every dashboard `.priority` badge — Ready Queue, Needs Confirmation, Unanswered, Deferred, Stale — renders as a centered chip. Ready Queue is visually unchanged; the other four gain the chip (the intended consistent treatment).

`dashboard.js` markup and `src/dashboard.ts` backend were already correct and stay untouched.

## Tests

`templates/dashboard/dashboard.test.ts` — 6 new regression tests pinning the theme tokens, the warm-accent+underline hover, the flex/right-align layout, the global chip geometry, the absence of `.ready-queue .priority`, plus a `.needs-confirm-link` positive control.

- `bun test templates/dashboard/dashboard.test.ts templates/dashboard/task.test.ts` — 65 pass
- `bun run typecheck`, `bun run lint` — clean
- `bun run build; ludics init --no-triggers` — installed; verified the rules landed in the served `~/self-improve/harness/dashboard/style.css`
- Full `bun test` — 3292 pass; the 2 failures (`remote slotStop (non-force)`, `slotAssign machine default in federated setup`) are pre-existing and unrelated to this CSS change.

Proposal: `docs/proposals/dashboard-stale-tab-theme-aware-styling.md` (all 6 ACs verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)