### PR TITLE
Auto-refresh project base branch at orchestration start + end (gh-ludics-600)

### DIFF
--- a/src/orchestration/runner.lifecycle.test.ts
+++ b/src/orchestration/runner.lifecycle.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { isAgentDone } from "./phases.ts";
 import * as phases from "./phases.ts";
 import { updateTurnLifecycle } from "./transport-t3code.ts";
-import { detectAndNudgeSettledNoSignal, detectAndRecoverVanishedTmuxSessions, ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests, __resetVanishedRecoveryStateForTests } from "./runner.ts";
+import { detectAndNudgeSettledNoSignal, detectAndRecoverVanishedTmuxSessions, enterPhase, ensureTtydAlive, refreshAgentStatuses, runOrchestration, runWrongFilenameRecovery, __resetTtydCheckGateForTests, __resetVanishedRecoveryStateForTests } from "./runner.ts";
 import * as tmuxAdapter from "../adapters/tmux-adapter.ts";
 import * as tmux from "../adapters/tmux.ts";
 import * as notify from "../notify.ts";
@@ -2384,5 +2384,93 @@ describe("detectAndRecoverVanishedTmuxSessions", () => {
       emitSpy.mockRestore();
       notifySpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gh-ludics-600 AC(b): end-hook freshness — entering merge-execute refreshes the
+// project's local base branch to origin BEFORE the merge is dispatched.
+// ---------------------------------------------------------------------------
+
+describe("enterPhase merge-execute end hook (gh-ludics-600 AC b)", () => {
+  const TMP = join(import.meta.dir, ".test-tmp-merge-refresh");
+
+  function gitRun(cmd: string[], cwd: string): void {
+    const r = Bun.spawnSync(cmd, { cwd, stdout: "pipe", stderr: "pipe", env: process.env as Record<string, string> });
+    if (r.exitCode !== 0) throw new Error(r.stderr.toString().trim() || cmd.join(" "));
+  }
+  function rev(repo: string, ref: string): string {
+    return Bun.spawnSync(["git", "rev-parse", ref], { cwd: repo }).stdout.toString().trim();
+  }
+  // Bare origin with `main` pushed, a project clone that lags, and origin then
+  // advanced one commit so the local clone's `main` is 1 commit behind origin.
+  function setupOriginAhead(): { repo: string; upstreamSha: string } {
+    const origin = join(TMP, "origin.git");
+    const repo = join(TMP, "repo");
+    const seed = join(TMP, "seed");
+    gitRun(["git", "init", "--bare", "-b", "main", origin], TMP);
+    gitRun(["git", "clone", origin, seed], TMP);
+    gitRun(["git", "config", "user.email", "t@e.com"], seed);
+    gitRun(["git", "config", "user.name", "T"], seed);
+    writeFileSync(join(seed, "README.md"), "seed\n");
+    gitRun(["git", "add", "README.md"], seed);
+    gitRun(["git", "commit", "-m", "seed"], seed);
+    gitRun(["git", "push", "origin", "main"], seed);
+    gitRun(["git", "clone", origin, repo], TMP);
+    gitRun(["git", "config", "user.email", "t@e.com"], repo);
+    gitRun(["git", "config", "user.name", "T"], repo);
+    writeFileSync(join(seed, "added.txt"), "upstream\n");
+    gitRun(["git", "add", "added.txt"], seed);
+    gitRun(["git", "commit", "-m", "advance"], seed);
+    gitRun(["git", "push", "origin", "main"], seed);
+    return { repo, upstreamSha: rev(seed, "main") };
+  }
+
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  // Invariant: on entry to merge-execute the local base equals origin/<base>
+  // (fast-forwarded) AND that fresh tip is in place before the merge skill is
+  // dispatched. The assertion `dispatchBaseSha === upstreamSha` fails if the
+  // end-hook runs after dispatch or not at all; `rev(repo,"main") === upstreamSha`
+  // fails if the refresh never runs. Harness condition: local `main` starts 1
+  // commit behind origin (precondition asserted), so a no-op refresh cannot make
+  // the assertions pass vacuously. Mutation: deleting the `state.phase ===
+  // "merge-execute"` end-hook block leaves both SHAs at the stale tip.
+  test("entering merge-execute fast-forwards local base to origin before merge dispatch", async () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo, upstreamSha } = setupOriginAhead();
+    // Precondition: local base is behind origin (the case the AC guards).
+    expect(rev(repo, "main")).not.toBe(upstreamSha);
+
+    const captured: { dispatchBaseSha: string | null } = { dispatchBaseSha: null };
+    const transport: OrchestrationTransport = {
+      async sendTurn() {
+        // Captured at merge dispatch time — must already be the refreshed tip.
+        captured.dispatchBaseSha = rev(repo, "main");
+        return "cmd-merge";
+      },
+      async sendEnter() {},
+      async refreshAgentTransportState() {},
+      async interruptAgent() {},
+    };
+
+    const state = makeState({
+      phase: "merge-execute",
+      mode: "solo",
+      projectDir: repo,
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "x", worktreePath: repo },
+      ],
+    });
+
+    await enterPhase(state, transport);
+
+    // End hook fast-forwarded the local base to origin …
+    expect(rev(repo, "main")).toBe(upstreamSha);
+    // … and it happened before the merge skill was dispatched.
+    expect(captured.dispatchBaseSha).toBe(upstreamSha);
   });
 });

--- a/src/orchestration/runner.pr-comments.test.ts
+++ b/src/orchestration/runner.pr-comments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach, spyOn, setDefaultTimeout
 import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { pairReviewVerdict } from "./phases.ts";
+import * as phases from "./phases.ts";
 import { applyPhaseSideEffects, checkAndAnnotatePrBodyDrift, maybePostCodexReviewRequests, checkAndRedispatchPrComments, resetPrCommentsState, validateAgentPrFiles } from "./runner.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 import * as notify from "../notify.ts";
@@ -533,6 +534,79 @@ describe("checkAndRedispatchPrComments conflict detection", () => {
     await checkAndRedispatchPrComments(state, transport);
     expect(transport.sendTurnCalls).toHaveLength(1);
     expect(transport.sendTurnCalls[0]!.agent).toBe("coder");
+  });
+
+  // gh-ludics-600 AC(d): base-integration conflicts route to the CODER ONLY.
+  // These two tests force `agentParticipatesInPhase` true for BOTH agents so the
+  // `agent.role === "coder"` filter in checkAndRedispatchPrComments is the SOLE
+  // guard under test (otherwise the phase's coder-only participation rule would
+  // shadow the filter and the test would pass vacuously). Mutation: removing
+  // `&& agent.role === "coder"` makes the reviewer redispatch under both setups.
+  function makeDuoConflictState(): OrchestrationState {
+    return makeConflictState({
+      mode: "duo",
+      prMergeableStates: { coder: "clean", reviewer: "clean" },
+      agents: [
+        { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
+        { name: "reviewer", provider: "codex", role: "reviewer", model: "o3-pro", branch: "b", worktreePath: "/tmp/b" },
+      ],
+      agentStates: {
+        coder: {
+          status: "pr-comments-done", statusEpoch: nowSec, statusMessage: "",
+          prUrl: "https://github.com/test/repo/pull/42", interrupted: false,
+          turnLifecycle: null,
+        },
+        reviewer: {
+          status: "pr-comments-done", statusEpoch: nowSec, statusMessage: "",
+          prUrl: "https://github.com/test/repo/pull/43", interrupted: false,
+          turnLifecycle: null,
+        },
+      },
+    });
+  }
+
+  test("reviewer-only dirty PR does NOT redispatch (coder-only handoff)", async () => {
+    const participatesSpy = spyOn(phases, "agentParticipatesInPhase").mockReturnValue(true);
+    try {
+      verificationSpy.mockImplementation((url: string) => {
+        if (url.includes("pull/43")) {
+          return { exists: true, state: "open", merged: false, mergeableState: "dirty", reason: "ok" };
+        }
+        return { exists: true, state: "open", merged: false, mergeableState: "clean", reason: "ok" };
+      });
+      const transport = makeConflictTransport();
+      const state = makeDuoConflictState();
+      await checkAndRedispatchPrComments(state, transport);
+      // No redispatch at all — the dirty PR belongs to the reviewer, and the
+      // coder-only filter drops it even though the reviewer fully participates.
+      expect(transport.sendTurnCalls).toHaveLength(0);
+      // Edge tracking still updates for the reviewer (so a later coder-side
+      // conflict isn't masked by a stale "clean" entry).
+      expect(state.prMergeableStates!.reviewer).toBe("dirty");
+    } finally {
+      participatesSpy.mockRestore();
+    }
+  });
+
+  // When BOTH PRs go dirty in the same poll, exactly one redispatch fires and it
+  // targets the coder — never both agents (avoids a two-agent resolution race).
+  test("both coder + reviewer dirty redispatches the coder only (never both)", async () => {
+    const participatesSpy = spyOn(phases, "agentParticipatesInPhase").mockReturnValue(true);
+    try {
+      verificationSpy.mockReturnValue({
+        exists: true, state: "open", merged: false, mergeableState: "dirty", reason: "ok",
+      });
+      const transport = makeConflictTransport();
+      const state = makeDuoConflictState();
+      await checkAndRedispatchPrComments(state, transport);
+      expect(transport.sendTurnCalls).toHaveLength(1);
+      expect(transport.sendTurnCalls[0]!.agent).toBe("coder");
+      // Both PRs' states are still tracked.
+      expect(state.prMergeableStates!.coder).toBe("dirty");
+      expect(state.prMergeableStates!.reviewer).toBe("dirty");
+    } finally {
+      participatesSpy.mockRestore();
+    }
   });
 
   test("does NOT advance prCommentsLastCheckAt on conflict dispatch", async () => {

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -27,7 +27,7 @@ import { readSlotJson, writeSlotJson } from "../slots/json.ts";
 import { setSlotLivenessOnData } from "../slots/index.ts";
 // workerReportStatus replaced by clusterReportWorkerSignal (lazy import)
 import { clusterRole } from "../cluster.ts";
-import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch } from "./worktrees.ts";
+import { autoCommitWorktree, countCommitsAhead, defaultMainBranch, pushBranch, refreshMainBranchFromRemote } from "./worktrees.ts";
 import type { OrchestrationTransport } from "./transport.ts";
 import { agentPortRole, readTmuxSlotState, startTmuxAgentSessionsForOrchestratedSlot, startTtyd, tmuxSessionName, ttydLogPath, ttydMatchesSession, writeTmuxOrchestrationSiblingState, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { tmuxHasSession } from "../adapters/tmux.ts";
@@ -1326,7 +1326,10 @@ export function resetPrCommentsState(state: OrchestrationState): void {
   state.prCodexReviewFallbackPosted = undefined;
 }
 
-async function enterPhase(
+// Exported as a test seam (gh-ludics-600): the merge-execute end-hook lives on
+// this entry path and is otherwise only reachable through the full
+// runOrchestration loop. Not part of the public API.
+export async function enterPhase(
   state: OrchestrationState,
   transport: OrchestrationTransport,
 ): Promise<void> {
@@ -1363,6 +1366,18 @@ async function enterPhase(
   // Dedup is "newly needing rebase" per round per phase-category.
   if (staleBaseCategoryOf(state) !== null) {
     warnStaleBase(state);
+  }
+
+  // End hook (gh-ludics-600 AC b): on entry to merge-execute, fast-forward the
+  // project's local base branch to origin BEFORE the merge is dispatched, so the
+  // merge lands on current main. Reuses the start-hook helper (ff-only /
+  // GIT_TERMINAL_PROMPT=0 / bounded timeout / skip-on-dirty-or-diverged). Runs
+  // in projectDir (shared remote refs), not a worktree. Best-effort: the helper
+  // swallows every failure internally and never throws — merge entry never
+  // wedges. Idempotent: a no-op when the local base is already current. The
+  // enterPhase phaseDispatched early-return bounds this to once per entry.
+  if (state.phase === "merge-execute") {
+    refreshMainBranchFromRemote(state.projectDir, defaultMainBranch(state.projectDir));
   }
 
   markActiveAgents(state);
@@ -1703,8 +1718,12 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
       state.prMergeableStates[agent.name] = current;
     }
 
-    // Edge trigger: fire only on transition TO dirty
-    if (current === "dirty" && previous !== "dirty") {
+    // Edge trigger: fire only on transition TO dirty, AND only for the coder
+    // (gh-ludics-600 AC d: base-integration conflicts route to the coder only —
+    // never the reviewer — mirroring the PR-conflict default and avoiding a
+    // two-agent resolution race). The prMergeableStates tracking above still
+    // updates for every agent, so reviewer-PR edge detection stays accurate.
+    if (current === "dirty" && previous !== "dirty" && agent.role === "coder") {
       conflictAgents.push(agent);
     }
   }

--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureProposalReachable, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, maybeGit, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, proposalReachableFromRef, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError, withSyntheticHarness } from "../test-utils.ts";
+import * as spawnMod from "../spawn.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-worktrees");
 
@@ -1783,6 +1784,58 @@ describe("refreshMainBranchFromRemote", () => {
     // Warning was emitted so the operator can see why ff failed.
     expect(captured.some((l) => l.includes("ff-only merge") && l.includes("diverged"))).toBe(true);
   });
+
+  // gh-ludics-600 safety property: the fetch must be bounded so a credential
+  // prompt or network hang cannot wedge slot startup / merge entry. Spy on
+  // safeSyncOutput and assert the `git fetch origin <base>` invocation carries
+  // GIT_TERMINAL_PROMPT=0 and a positive numeric timeout. Mutation: dropping the
+  // env/timeout opts from the fetch call makes the two assertions below fail.
+  test("fetch is bounded: GIT_TERMINAL_PROMPT=0 + a positive timeout on git fetch", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginAhead(TMP);
+    const real = spawnMod.safeSyncOutput;
+    const calls: Array<{ cmd: string[]; opts?: { env?: Record<string, string>; timeout?: number } }> = [];
+    const spy = spyOn(spawnMod, "safeSyncOutput").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, opts });
+      return real(cmd, opts);
+    });
+    try {
+      refreshMainBranchFromRemote(repo, "main");
+    } finally {
+      spy.mockRestore();
+    }
+    const fetchCall = calls.find((c) => c.cmd[0] === "git" && c.cmd[1] === "fetch");
+    expect(fetchCall).toBeDefined();
+    expect(fetchCall!.opts?.env?.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(typeof fetchCall!.opts?.timeout).toBe("number");
+    expect(fetchCall!.opts!.timeout!).toBeGreaterThan(0);
+  });
+
+  // LUDICS_WARN_FETCH_TIMEOUT_MS overrides the 10s default (shared knob with
+  // warnStaleBase). Asserts the env-derived value reaches the fetch call.
+  test("fetch timeout honours LUDICS_WARN_FETCH_TIMEOUT_MS override", () => {
+    if (!Bun.which("git")) return;
+    mkdirSync(TMP, { recursive: true });
+    const { repo } = setupOriginAhead(TMP);
+    const real = spawnMod.safeSyncOutput;
+    const calls: Array<{ cmd: string[]; opts?: { timeout?: number } }> = [];
+    const prev = process.env.LUDICS_WARN_FETCH_TIMEOUT_MS;
+    process.env.LUDICS_WARN_FETCH_TIMEOUT_MS = "4321";
+    const spy = spyOn(spawnMod, "safeSyncOutput").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, opts });
+      return real(cmd, opts);
+    });
+    try {
+      refreshMainBranchFromRemote(repo, "main");
+    } finally {
+      spy.mockRestore();
+      if (prev === undefined) delete process.env.LUDICS_WARN_FETCH_TIMEOUT_MS;
+      else process.env.LUDICS_WARN_FETCH_TIMEOUT_MS = prev;
+    }
+    const fetchCall = calls.find((c) => c.cmd[0] === "git" && c.cmd[1] === "fetch");
+    expect(fetchCall!.opts?.timeout).toBe(4321);
+  });
 });
 
 describe("createWorktrees refreshes main before forking", () => {
@@ -1800,6 +1853,13 @@ describe("createWorktrees refreshes main before forking", () => {
     const worktreeSha = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: setup.rootWorktree }).stdout.toString().trim();
     expect(worktreeSha).toBe(upstreamSha);
     expect(existsSync(join(setup.rootWorktree, "added.txt"))).toBe(true);
+    // gh-ludics-600 AC(a) literal: the worktree forks from the refreshed tip —
+    // merge-base(HEAD, origin/main) == origin/main, i.e. 0 commits behind.
+    // Mutation: stashing the refreshMainBranchFromRemote call in createWorktrees
+    // makes the fork-point lag origin (mergeBase != originSha).
+    const originSha = Bun.spawnSync(["git", "rev-parse", "origin/main"], { cwd: repo }).stdout.toString().trim();
+    const mergeBase = Bun.spawnSync(["git", "merge-base", "HEAD", "origin/main"], { cwd: setup.rootWorktree }).stdout.toString().trim();
+    expect(mergeBase).toBe(originSha);
     cleanupWorktrees(repo, "feat", [{ name: "agent1" }], 7);
   });
 });

--- a/src/orchestration/worktrees.ts
+++ b/src/orchestration/worktrees.ts
@@ -641,7 +641,20 @@ export function refreshMainBranchFromRemote(
   if (current !== mainBranch) return { skipped: true, reason: "wrong-branch" };
   const dirty = maybeGit(dir, ["status", "--porcelain"]).trim();
   if (dirty.length > 0) return { skipped: true, reason: "dirty" };
-  const fetchResult = safeSyncOutput(["git", "fetch", "origin", mainBranch], { cwd: dir });
+  // Safety (gh-ludics-600): bound the fetch exactly as warnStaleBase does, so a
+  // credential prompt or network hang cannot wedge slot startup (start hook) or
+  // merge entry (end hook). `GIT_TERMINAL_PROMPT=0` disables interactive prompts;
+  // a timeout (ms) caps wall-clock cost — default 10s, overridable via
+  // LUDICS_WARN_FETCH_TIMEOUT_MS (shared knob with warnStaleBase). A timeout
+  // returns ok:false, falling through to the `fetch-failed` skip below.
+  const timeoutRaw = process.env.LUDICS_WARN_FETCH_TIMEOUT_MS;
+  const timeoutParsed = timeoutRaw !== undefined ? parseInt(timeoutRaw, 10) : NaN;
+  const fetchTimeoutMs = Number.isFinite(timeoutParsed) && timeoutParsed > 0 ? timeoutParsed : 10_000;
+  const fetchResult = safeSyncOutput(["git", "fetch", "origin", mainBranch], {
+    cwd: dir,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" } as Record<string, string>,
+    timeout: fetchTimeoutMs,
+  });
   if (!fetchResult.ok) {
     console.error(`ludics: refreshMainBranchFromRemote: git fetch origin ${mainBranch} failed in ${dir} — continuing with stale local state`);
     return { skipped: true, reason: "fetch-failed" };


### PR DESCRIPTION
Closes #600 (in part — implements the resolved design: keep the project's local base branch fresh via fetch + ff-only at start and end; route base-integration conflicts to the coder only; **no** task-branch rebase / force-push).

## What changed

1. **Fetch hardening** (`refreshMainBranchFromRemote`, `worktrees.ts`) — the base-freshness fetch now mirrors `warnStaleBase`'s policy: `GIT_TERMINAL_PROMPT=0` + a bounded timeout (`LUDICS_WARN_FETCH_TIMEOUT_MS`, default 10s). Previously it lacked both, so a credential prompt or network hang could wedge slot startup or merge entry. A timeout returns `ok:false` → existing `fetch-failed` skip. *(This closes the assumption gap the planning round flagged — the proposal claimed the policy already matched, but it did not.)*

2. **End hook (AC b, new)** — on entry to `merge-execute`, `enterPhase` fast-forwards the local base to `origin/<base>` **before** the merge skill is dispatched, so the merge lands on current main. Reuses the start-hook helper (ff-only / prompt-guard / timeout / skip-on-dirty-or-diverged); idempotent and best-effort (never wedges merge entry).

3. **Coder-only conflict handoff (AC d)** — the PR clean→dirty conflict edge in `checkAndRedispatchPrComments` now enqueues only the **coder** for redispatch, never the reviewer (avoids a two-agent resolution race). `prMergeableStates` edge tracking still updates for every agent.

4. **Start hook (AC a)** — already implemented in `createWorktrees`; this PR adds the refresh-then-fork equality coverage the AC requires.

Per the proposal's conditional clause, **no new rebase template / no `redispatchForConflict` parameterization**: `merge-execute` has no in-worktree rebase dispatch path, so the rebase-flavoured variant does not apply and would be dead code. AC(e): no `git push --force` / `--force-with-lease` introduced (verified `git diff main...HEAD | grep -- '--force'` → none).

## Tests (+5, all mutation-verified)

- `worktrees.test.ts` — fetch carries `GIT_TERMINAL_PROMPT=0` + positive timeout; honours the env override; start-hook fork-point equals `origin/main`.
- `runner.lifecycle.test.ts` — entering `merge-execute` ff's the local base **before** dispatch (origin-ahead repo, dispatch-time SHA capture).
- `runner.pr-comments.test.ts` — reviewer-only dirty PR → 0 redispatch; both dirty → exactly 1, the coder. (`agentParticipatesInPhase` spied true so the role filter is the sole guard.)

Full suite: 3291 pass / 2 fail (both pre-existing, unrelated: `remote slotStop (non-force)`, `slotAssign machine default in federated setup`). Typecheck + all lint sub-scripts clean. AC self-check in `.peer-sync/workflow-feedback-coder.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)