### PR TITLE
fix(health): container/child test-failure auto-filer (gh-ludics-605)

### DIFF
--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -807,6 +807,42 @@ describe("test-health container/child auto-filer (gh-ludics-605)", () => {
     expect(children()).toHaveLength(1);
   });
 
+  test("same-day, today's child marked done + suite still red + no other active child → child REOPENED to ready", () => {
+    // A claimed same-day fix that didn't hold: the only (dated) child is done,
+    // the container stays ready (verify never closes it), and a fresh same-day
+    // child would collide on the date fingerprint. Reopen in place so the
+    // episode is actionable again today instead of waiting for the UTC rollover.
+    failingRun();
+    const childId = children()[0]!.id;
+    const childFile = join(tasksDir(), `${childId}.md`);
+    transitionStatus(childFile, parseTaskFrontmatter(readFileSync(childFile, "utf-8")).status ?? "ready", "done");
+    expect(children()[0]!.status).toBe("done");
+
+    failingRun();
+
+    // No new child filed (date collision); the existing one is reopened.
+    expect(children()).toHaveLength(1);
+    expect(children()[0]!.id).toBe(childId);
+    expect(children()[0]!.status).toBe("ready");
+  });
+
+  test("same-day, today's child marked abandoned + suite still red → child STAYS abandoned (respects set-aside)", () => {
+    // A deliberate same-day set-aside must be respected: transitionStatus only
+    // reopens done/merged, so abandoned/stale are left untouched and NO fresh
+    // same-day child is filed. A new child is filed tomorrow under a new date.
+    failingRun();
+    const childId = children()[0]!.id;
+    const childFile = join(tasksDir(), `${childId}.md`);
+    transitionStatus(childFile, parseTaskFrontmatter(readFileSync(childFile, "utf-8")).status ?? "ready", "abandoned");
+    expect(children()[0]!.status).toBe("abandoned");
+
+    failingRun();
+
+    expect(children()).toHaveLength(1);
+    expect(children()[0]!.id).toBe(childId);
+    expect(children()[0]!.status).toBe("abandoned"); // untouched
+  });
+
   for (const terminal of ["done", "abandoned", "stale"] as const) {
     test(`re-break after container terminal (${terminal}) → container revived to ready + fresh child`, () => {
       failingRun();

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -6,6 +6,7 @@ import type { RemoteRunResult } from "./remote.ts";
 import { heartbeatsDir } from "./cluster.ts";
 import { tmpdir } from "os";
 import { _resetPostponedProjectsCache } from "./config.ts";
+import { parseTaskFrontmatter, transitionStatus } from "./tasks/markdown.ts";
 import { captureConsoleError, withSyntheticHarness } from "./test-utils.ts";
 
 function makeTmpDir(): string {
@@ -524,7 +525,9 @@ describe("test-health capability gating (gh-ludics-578)", () => {
     // Same result shape as a local run; a genuine non-zero result files a task.
     expect(result).toMatchObject({ skipped: false, passed: false });
     expect(existsSync(testHealthStatePath())).toBe(true); // state persisted
-    expect(taskFiles()).toHaveLength(1); // fix-task filed
+    // gh-ludics-605: container/child model files TWO tasks — the `leaf: false`
+    // umbrella container plus one dated episode child `subtask_of` it.
+    expect(taskFiles()).toHaveLength(2); // container + dated child
   });
 
   // --- AC5: routing degrades to skip-not-fail ---
@@ -641,5 +644,219 @@ describe("test-health capability gating (gh-ludics-578)", () => {
     const { lines } = captureConsoleError(() => runAllTestHealth({ project: "ocaml-cudajit", force: true }));
     expect(lines.some((l) => l.includes("[test-health] ocaml-cudajit: skipped (requirements-unmet)"))).toBe(true);
     expect(taskFiles()).toEqual([]);
+  });
+});
+
+describe("test-health container/child auto-filer (gh-ludics-605)", () => {
+  // Drive failing runs through the remote-exec seam (a nvidia-gated project
+  // routed to an online worker returning ok:false), which flows through the
+  // exact same finalizeExecutedRun → fileTestFailureEpisode path as a local
+  // failure. Inspect the resulting task files on disk.
+  let TMP = "";
+  const ORIG = {
+    HOME: process.env.HOME,
+    CONFIG: process.env.LUDICS_CONFIG,
+    HARNESS: process.env.LUDICS_HARNESS_DIR,
+    MACHINE: process.env.LUDICS_CLUSTER_MACHINE_NAME,
+  };
+  const ORIGINAL_REMOTE = _remoteTestExec.fn;
+
+  const CLUSTER = `cluster:
+  transport: tailscale
+  machines:
+    - name: mac-studio
+      host: mac-studio.ts.net
+      role: leader
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+    - name: minipc-wsl
+      host: minipc-wsl.ts.net
+      role: worker
+      os: linux
+      gpu: nvidia
+`;
+
+  function writeConfig(): void {
+    const cfgPath = join(TMP, "config.yaml");
+    writeFileSync(cfgPath, `state_repo: test/state\nstate_path: harness\n${CLUSTER}`);
+    process.env.LUDICS_CONFIG = cfgPath;
+  }
+
+  function writeHeartbeat(name: string, ageSeconds: number): void {
+    const dir = heartbeatsDir();
+    mkdirSync(dir, { recursive: true });
+    const epoch = Math.floor(Date.now() / 1000) - ageSeconds;
+    writeFileSync(join(dir, `${name}.json`), JSON.stringify({ node: name, epoch }));
+  }
+
+  const PROJECT = "ludics" as const;
+  function project() {
+    return { name: PROJECT, repo: "ex/ludics", requirements: { gpu: "nvidia" }, test_command: "dune runtest", path: "~/ludics" } as const;
+  }
+
+  function tasksDir(): string {
+    return join(TMP, "tasks");
+  }
+
+  function readTask(file: string): { id: string; status?: string; leaf?: boolean; subtask_of: string | null; title?: string; body: string } {
+    const content = readFileSync(join(tasksDir(), file), "utf-8");
+    const fm = parseTaskFrontmatter(content);
+    const bodyIdx = content.indexOf("\n---", 3);
+    return {
+      id: fm.id!,
+      status: fm.status,
+      leaf: fm.leaf,
+      subtask_of: fm.dependencies?.subtask_of ?? null,
+      title: fm.title,
+      body: bodyIdx >= 0 ? content.slice(bodyIdx) : content,
+    };
+  }
+
+  function allTasks() {
+    const dir = tasksDir();
+    if (!existsSync(dir)) return [];
+    return readdirSync(dir).filter((f) => f.endsWith(".md")).map(readTask);
+  }
+
+  function container() {
+    return allTasks().find((t) => t.leaf === false && t.subtask_of === null);
+  }
+  function children() {
+    const c = container();
+    return c ? allTasks().filter((t) => t.subtask_of === c.id) : [];
+  }
+
+  /** Trigger one failing run; failures stderr drives the child body. */
+  function failingRun(stderr = "FAILED: 3 tests broke"): void {
+    _remoteTestExec.fn = () => ({ kind: "ran", ok: false, stdout: "", stderr, timedOut: false } as RemoteRunResult);
+    checkProjectTestHealth(project(), { force: true });
+  }
+
+  /**
+   * Simulate the existing dated child belonging to a *prior day* so today's
+   * date-stamped child gets a distinct fingerprint (filename). Renames the file
+   * to a stable past-dated id and rewrites its `id:`/`title:` to a past date,
+   * freeing today's fingerprint for a fresh child. Returns the new (past) id.
+   */
+  function agePriorChildToPastDay(childId: string): string {
+    const oldFile = join(tasksDir(), `${childId}.md`);
+    const pastId = "task-past-episode";
+    const content = readFileSync(oldFile, "utf-8")
+      .replace(/^id: .+$/m, `id: ${pastId}`)
+      .replace(/— \d{4}-\d{2}-\d{2}/g, "— 2000-01-01");
+    const newFile = join(tasksDir(), `${pastId}.md`);
+    writeFileSync(newFile, content);
+    rmSync(oldFile);
+    return pastId;
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-health-605-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_HARNESS_DIR = TMP;
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // incapable → routes to worker
+    _resetPostponedProjectsCache();
+    writeConfig();
+    writeHeartbeat("minipc-wsl", 10);
+  });
+
+  afterEach(() => {
+    _remoteTestExec.fn = ORIGINAL_REMOTE;
+    if (ORIG.HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIG.HOME;
+    if (ORIG.CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIG.CONFIG;
+    if (ORIG.HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIG.HARNESS;
+    if (ORIG.MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIG.MACHINE;
+    _resetPostponedProjectsCache();
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  test("first failure → container (leaf:false, ready) + one dated child subtask_of it, child carries failures excerpt", () => {
+    failingRun("FAILED: assertion in foo_test");
+
+    const c = container();
+    expect(c).toBeDefined();
+    expect(c!.leaf).toBe(false);
+    expect(c!.status).toBe("ready");
+    expect(c!.title).toBe(`Fix broken test suite: ${PROJECT}`);
+
+    const kids = children();
+    expect(kids).toHaveLength(1);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(kids[0]!.title).toBe(`Fix broken test suite: ${PROJECT} — ${today}`);
+    expect(kids[0]!.subtask_of).toBe(c!.id);
+    // Failures excerpt embedded in the child body (not the container).
+    expect(kids[0]!.body).toContain("FAILED: assertion in foo_test");
+    expect(c!.body).not.toContain("FAILED: assertion in foo_test");
+  });
+
+  test("active episode (container ready + open child) → NO new task on re-break", () => {
+    failingRun();
+    const before = allTasks().length;
+    expect(children()).toHaveLength(1);
+
+    // Re-break while the child is still open (ready).
+    failingRun();
+    expect(allTasks().length).toBe(before); // no new files
+    expect(children()).toHaveLength(1);
+  });
+
+  test("same-day double-break → no duplicate child", () => {
+    failingRun();
+    failingRun(); // identical day
+    expect(children()).toHaveLength(1);
+  });
+
+  for (const terminal of ["done", "abandoned", "stale"] as const) {
+    test(`re-break after container terminal (${terminal}) → container revived to ready + fresh child`, () => {
+      failingRun();
+      const c = container()!;
+      const firstChildId = children()[0]!.id;
+
+      // Age the prior child to a past day (so today's child is a fresh
+      // fingerprint), resolve it, then close the container to the terminal
+      // status under test.
+      const pastId = agePriorChildToPastDay(firstChildId);
+      const childFile = join(tasksDir(), `${pastId}.md`);
+      transitionStatus(childFile, parseTaskFrontmatter(readFileSync(childFile, "utf-8")).status ?? "ready", "done");
+      const containerFile = join(tasksDir(), `${c.id}.md`);
+      transitionStatus(containerFile, "ready", terminal);
+
+      failingRun();
+
+      const revived = container()!;
+      expect(revived.status).toBe("ready"); // revived
+      expect(revived.leaf).toBe(false); // still a container
+      // A fresh dated child exists (today's), distinct from the resolved one.
+      const today = new Date().toISOString().slice(0, 10);
+      const fresh = children().find((k) => k.title === `Fix broken test suite: ${PROJECT} — ${today}`);
+      expect(fresh).toBeDefined();
+      expect(fresh!.id).not.toBe(pastId);
+    });
+  }
+
+  test("self-heal guard: container non-terminal but child already resolved → fresh child filed (signal not lost)", () => {
+    // Models the verify-container-completion interaction: the sweep queues
+    // verify when all children are terminal, but verify only NOTIFIES — it does
+    // NOT close the container. So the container can sit `ready` with a resolved
+    // child while the suite is still red. The active-episode no-op is keyed on
+    // an OPEN child, not container status, so a fresh child is filed.
+    failingRun();
+    const firstChildId = children()[0]!.id;
+
+    // Age the prior child to a past day and resolve it (as the downstream user
+    // action after verify-container-completion would), but leave the container
+    // `ready` — verify never closes it.
+    const pastId = agePriorChildToPastDay(firstChildId);
+    const childFile = join(tasksDir(), `${pastId}.md`);
+    transitionStatus(childFile, parseTaskFrontmatter(readFileSync(childFile, "utf-8")).status ?? "ready", "done");
+    expect(container()!.status).toBe("ready"); // container still open
+
+    failingRun();
+
+    const today = new Date().toISOString().slice(0, 10);
+    const fresh = children().find((k) => k.title === `Fix broken test suite: ${PROJECT} — ${today}`);
+    expect(fresh).toBeDefined(); // signal preserved: a new open episode exists
+    expect(fresh!.id).not.toBe(pastId);
   });
 });

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,8 +1,9 @@
-import { existsSync, readFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, readdirSync, mkdirSync } from "fs";
 import { writeJsonFile } from "./json.ts";
 import { join } from "path";
 import { type ProjectConfig, loadConfigSync, harnessDir, resolveProjectPath, postponedProjectSet, t3codeIntegrationEnabled } from "./config.ts";
 import { tasksCreate } from "./tasks/index.ts";
+import { addFrontmatterField, transitionStatus, appendToSection, setDependencyScalar, parseTaskFrontmatter, TERMINAL_STATUSES } from "./tasks/markdown.ts";
 import { safeSyncOutput } from "./spawn.ts";
 import { clusterCurrentMachine, selectOnlineCapableMachine } from "./cluster.ts";
 import { runRemoteCommand } from "./remote.ts";
@@ -174,10 +175,116 @@ function finalizeExecutedRun(
   saveTestHealthState(state);
 
   if (!passed) {
-    tasksCreate(`Fix broken test suite: ${project.name}`, project.name, "A");
+    fileTestFailureEpisode(project.name, failures);
   }
 
   return { skipped: false, passed, duration, failures };
+}
+
+/** Statuses that mean a child episode is no longer doing work. Mirrors
+ *  `containerCompletionSweep`'s `TERMINAL_FOR_CHILD` ({done, abandoned}) plus
+ *  the broader terminal set so a `stale`/`merged` child never counts as an
+ *  active episode. A child in any of these states is "resolved"; one in any
+ *  other status (ready/in-progress/etc.) is an active open episode. */
+const CHILD_RESOLVED_STATUSES: ReadonlySet<string> = new Set([
+  ...TERMINAL_STATUSES, // done, abandoned, merged, stale
+]);
+
+/**
+ * Container/child auto-filer for a failing test suite (gh-ludics-605).
+ *
+ * The per-project umbrella task ("Fix broken test suite: <proj>") is a
+ * `leaf: false` container; each failure *episode* is a dated child filed
+ * `subtask_of` it. This replaces the old status-blind `tasksCreate` call, which
+ * went permanently silent once the single per-project task reached a terminal
+ * status (the fingerprint existence check is status-blind — issue #605).
+ *
+ * `tasksCreate` itself stays pure (idempotent fingerprint create); ALL policy
+ * lives here.
+ *
+ *   res = tasksCreate(container-title)             // pure
+ *   if res.created:  promote to container + file first dated child
+ *   else (exists):
+ *     terminal status  -> revive to `ready`, ensure container, file fresh child
+ *     non-terminal AND has an active (open) child -> NO-OP (episode in flight)
+ *     non-terminal AND no active child -> file a fresh dated child
+ *
+ * The "non-terminal but no active child" branch is the self-heal guard
+ * (see PR notes): `verify-container-completion` only NOTIFIES — it never closes
+ * the container — so a container can sit `ready` with all children already
+ * resolved while the suite is still red. Keying the no-op on an *active child*
+ * (not merely on container status) means a still-failing suite always carries
+ * an open episode instead of silently losing the signal.
+ */
+function fileTestFailureEpisode(projectName: string, failures: string | undefined): void {
+  const res = tasksCreate(`Fix broken test suite: ${projectName}`, projectName, "A");
+
+  if (res.created) {
+    addFrontmatterField(res.path, "leaf", "false"); // promote fresh task to container (stays `ready`)
+    createEpisodeChild(projectName, failures, res.id);
+    return;
+  }
+
+  const status = parseTaskFrontmatter(readFileSync(res.path, "utf-8")).status ?? "ready";
+
+  if (TERMINAL_STATUSES.includes(status)) {
+    // Container was closed (done/abandoned/merged/stale): revive + fresh child.
+    transitionStatus(res.path, status, "ready");
+    addFrontmatterField(res.path, "leaf", "false"); // idempotent ensure-container
+    createEpisodeChild(projectName, failures, res.id);
+    return;
+  }
+
+  // Container is non-terminal. No-op only if an active (open) child episode
+  // already exists; otherwise file a fresh dated child so a still-red suite
+  // never loses its open episode.
+  if (hasActiveChild(res.id)) return;
+  addFrontmatterField(res.path, "leaf", "false"); // idempotent ensure-container
+  createEpisodeChild(projectName, failures, res.id);
+}
+
+/** True iff the container has at least one child (`subtask_of: <parentId>`)
+ *  whose status is NOT resolved (i.e. an open episode is in flight). */
+function hasActiveChild(parentId: string): boolean {
+  const dir = join(harnessDir(), "tasks");
+  if (!existsSync(dir)) return false;
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".md")) continue;
+    let fm;
+    try {
+      fm = parseTaskFrontmatter(readFileSync(join(dir, f), "utf-8"));
+    } catch {
+      continue;
+    }
+    if (fm.dependencies?.subtask_of !== parentId) continue;
+    if (!CHILD_RESOLVED_STATUSES.has(fm.status ?? "ready")) return true;
+  }
+  return false;
+}
+
+/**
+ * File one dated failure-episode child task `subtask_of` the container.
+ *
+ * Title is episode-unique by date (`… — YYYY-MM-DD`) — a stable child title
+ * would reintroduce the same fingerprint muzzle one level down. Same-day
+ * double-breaks no-op via `tasksCreate`'s existence check; cross-day breaks get
+ * a fresh child. The title is deliberately NOT fingerprinted by stderr content
+ * (flaky output would proliferate children). The failures excerpt is embedded
+ * in the child's `## Context` section so the episode is actionable without
+ * cross-referencing `mag/test-health.json`.
+ */
+function createEpisodeChild(projectName: string, failures: string | undefined, parentId: string): void {
+  const today = new Date().toISOString().slice(0, 10);
+  const child = tasksCreate(`Fix broken test suite: ${projectName} — ${today}`, projectName, "A");
+  // Same-day double-break: the dated child already exists → no-op (don't
+  // re-link or append divergent failure text). The existing open child keeps
+  // the active-episode signal.
+  if (!child.created) return;
+  // Link to the container so containerCompletionSweep discovers the child.
+  setDependencyScalar(child.path, "subtask_of", parentId);
+  if (failures && failures.trim().length > 0) {
+    appendToSection(child.path, "Context", `Failing tests (${today}):\n\n\`\`\`\n${failures.trim()}\n\`\`\``);
+  }
 }
 
 /**

--- a/src/health.ts
+++ b/src/health.ts
@@ -276,10 +276,20 @@ function hasActiveChild(parentId: string): boolean {
 function createEpisodeChild(projectName: string, failures: string | undefined, parentId: string): void {
   const today = new Date().toISOString().slice(0, 10);
   const child = tasksCreate(`Fix broken test suite: ${projectName} — ${today}`, projectName, "A");
-  // Same-day double-break: the dated child already exists → no-op (don't
-  // re-link or append divergent failure text). The existing open child keeps
-  // the active-episode signal.
-  if (!child.created) return;
+  if (!child.created) {
+    // Today's dated child already exists. In the no-active-child paths that
+    // reach here, that child is necessarily RESOLVED. If it was marked
+    // done/merged but the suite is still red — a claimed fix that didn't hold,
+    // or a forced/second same-day run — reopen it so the episode stays
+    // actionable today (don't leave the container open with no active child
+    // until the UTC date rolls over). A fresh same-day child under a
+    // non-colliding title would reintroduce the proliferation date-stamping
+    // exists to avoid, so reopen in place instead. transitionStatus no-ops for
+    // abandoned/stale, deliberately respecting a same-day set-aside (a fresh
+    // child is filed tomorrow under a new date).
+    transitionStatus(child.path, ["done", "merged"], "ready");
+    return;
+  }
   // Link to the container so containerCompletionSweep discovers the child.
   setDependencyScalar(child.path, "subtask_of", parentId);
   if (failures && failures.trim().length > 0) {

--- a/src/tasks/markdown.test.ts
+++ b/src/tasks/markdown.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { addFrontmatterField, appendToSection, frontmatterBounds, removeFrontmatterField, updateDependencyArray, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize, VALID_STATUSES, TERMINAL_STATUSES, READY_QUEUE_ELIGIBLE_STATUSES, BLOCKED_RECONCILE_SKIP_STATUSES } from "./markdown.ts";
+import { addFrontmatterField, appendToSection, frontmatterBounds, removeFrontmatterField, updateDependencyArray, setDependencyScalar, updateFrontmatterField, transitionStatus, parseTaskFrontmatter, writeTaskFile, _resetParseTaskFrontmatterCache, _parseTaskFrontmatterCacheSize, VALID_STATUSES, TERMINAL_STATUSES, READY_QUEUE_ELIGIBLE_STATUSES, BLOCKED_RECONCILE_SKIP_STATUSES } from "./markdown.ts";
 
 const TMP_DIR = join(import.meta.dir, ".test-tmp");
 
@@ -681,6 +681,40 @@ describe("updateDependencyArray", () => {
     expect(result).toContain("dependencies: none");
     const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
     expect(fmMatch![1]).toContain("blocks: [z]");
+  });
+});
+
+describe("setDependencyScalar (gh-ludics-605)", () => {
+  test("replaces an existing nested scalar in place", () => {
+    const f = tmpFile("dep-scalar-update.md", "---\nid: task-1\ndependencies:\n  blocks: []\n  subtask_of: null\n---\n\n# Title\n");
+    setDependencyScalar(f, "subtask_of", "task-parent");
+    const fm = parseTaskFrontmatter(readFileSync(f, "utf-8"));
+    expect(fm.dependencies?.subtask_of).toBe("task-parent");
+  });
+
+  test("inserts a missing nested scalar after the dependency block", () => {
+    const f = tmpFile("dep-scalar-insert.md", "---\nid: task-1\ndependencies:\n  blocks: []\n---\n\n# Title\n");
+    setDependencyScalar(f, "subtask_of", "task-parent");
+    const result = readFileSync(f, "utf-8");
+    const fmMatch = result.match(/^---\n([\s\S]*?)\n---/);
+    expect(fmMatch![1]).toContain("subtask_of: task-parent");
+    expect(parseTaskFrontmatter(result).dependencies?.subtask_of).toBe("task-parent");
+  });
+
+  test("null clears the link (renders canonical YAML null)", () => {
+    const f = tmpFile("dep-scalar-clear.md", "---\nid: task-1\ndependencies:\n  blocks: []\n  subtask_of: task-parent\n---\n\n# Title\n");
+    setDependencyScalar(f, "subtask_of", null);
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("subtask_of: null");
+    expect(parseTaskFrontmatter(result).dependencies?.subtask_of).toBeNull();
+  });
+
+  test("does not touch body content matching the subfield name", () => {
+    const f = tmpFile("dep-scalar-body.md", "---\nid: task-1\ndependencies:\n  blocks: []\n---\n\nsubtask_of: prose\n");
+    setDependencyScalar(f, "subtask_of", "task-parent");
+    const result = readFileSync(f, "utf-8");
+    expect(result).toContain("subtask_of: prose"); // body untouched
+    expect(parseTaskFrontmatter(result).dependencies?.subtask_of).toBe("task-parent");
   });
 });
 

--- a/src/tasks/markdown.ts
+++ b/src/tasks/markdown.ts
@@ -418,6 +418,68 @@ export function updateDependencyArray(filePath: string, subfield: string, values
   atomicWriteFileSync(filePath, output.join("\n"));
 }
 
+/**
+ * Set a scalar subfield within the `dependencies:` block of a task file
+ * (e.g. `subtask_of: <parent-id>`). Mirrors `updateDependencyArray` but for a
+ * single scalar value rather than a YAML list. If the subfield already exists
+ * inside the dependencies block it is replaced in place; otherwise it is
+ * inserted after the last dependency line. A `null` value renders as the
+ * canonical YAML null token (clearing the link). No-ops if the file is missing
+ * or has no frontmatter.
+ *
+ * `subtask_of` lives nested under `dependencies:`, so it cannot be written by
+ * the top-level `updateFrontmatterField`/`addFrontmatterField` writers (those
+ * would inject a top-level `subtask_of:` key the parser ignores). The
+ * `containerCompletionSweep` reads `dependencies.subtask_of`, so the link must
+ * be written into the nested block.
+ */
+export function setDependencyScalar(filePath: string, subfield: string, value: string | null): void {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const bounds = frontmatterBounds(lines);
+  if (!bounds) return;
+
+  const formatted = `  ${subfield}: ${renderFrontmatterValue(value)}`;
+
+  let inDeps = false;
+  let found = false;
+  let lastDepsLineIdx = -1;
+  const output: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (i === bounds.closeLine) {
+      if (!found && lastDepsLineIdx >= 0) {
+        output.splice(lastDepsLineIdx + 1, 0, formatted);
+      }
+      output.push(line);
+      continue;
+    }
+    if (i > bounds.openLine && i < bounds.closeLine) {
+      if (line.startsWith("dependencies:")) {
+        inDeps = true;
+        lastDepsLineIdx = output.length;
+        output.push(line);
+        continue;
+      }
+      if (inDeps && line.match(/^\s{2}\w/)) {
+        lastDepsLineIdx = output.length;
+        if (line.trimStart().startsWith(`${subfield}:`)) {
+          output.push(formatted);
+          found = true;
+          continue;
+        }
+      } else if (inDeps && !line.match(/^\s/)) {
+        inDeps = false;
+      }
+    }
+    output.push(line);
+  }
+
+  atomicWriteFileSync(filePath, output.join("\n"));
+}
+
 export function writeTaskFile(
   dir: string,
   id: string,

--- a/src/tasks/sync.test.ts
+++ b/src/tasks/sync.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { contentFingerprint, formatYamlScalar, setFrontmatterScalar, tasksNeedsElaborationList, tasksQueuePreemptions, tasksReconcileBlockedStatus } from "./sync.ts";
-import { renderFrontmatterValue } from "./markdown.ts";
+import { renderFrontmatterValue, TERMINAL_STATUSES } from "./markdown.ts";
 import { emptySlotData, writeSlotJson } from "../slots/json.ts";
 
 const TMP = join(import.meta.dir, ".test-tmp-sync");
@@ -428,6 +428,50 @@ describe("containerCompletionSweep", () => {
     tasksReconcileBlockedStatus(tasksDir);
     entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion");
     expect(entries).toHaveLength(1);
+  });
+
+  test("merged child counts as terminal → all-terminal {done, merged} enqueues verify (gh-ludics-605)", () => {
+    // A `merged` child does no further work, so it must satisfy the
+    // all-children-terminal predicate. Mutation: with TERMINAL_FOR_CHILD =
+    // {done, abandoned} only, allTerminal stays false and the container is
+    // never queued — it can never auto-complete.
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent-merged", [
+      { id: "task-cm-a", status: "done" },
+      { id: "task-cm-b", status: "merged" },
+    ]);
+
+    tasksReconcileBlockedStatus(tasksDir);
+    const entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent-merged");
+    expect(entries).toHaveLength(1);
+  });
+
+  test("stale child counts as terminal → all-terminal {abandoned, stale} enqueues verify (gh-ludics-605)", () => {
+    const { tasksDir, queueFile } = setupContainerWithChildren("task-parent-stale", [
+      { id: "task-cs-a", status: "abandoned" },
+      { id: "task-cs-b", status: "stale" },
+    ]);
+
+    tasksReconcileBlockedStatus(tasksDir);
+    const entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === "task-parent-stale");
+    expect(entries).toHaveLength(1);
+  });
+
+  test("every TERMINAL_STATUSES value, as the sole child, queues verify — sweep child-terminal set ⊇ TERMINAL_STATUSES (gh-ludics-605 drift guard)", () => {
+    // Regression guard for the cross-site definition mismatch: health.ts's
+    // `hasActiveChild` treats every TERMINAL_STATUSES state as resolved, so this
+    // sweep MUST also treat every one of them as child-terminal — otherwise a
+    // merged/stale child leaves the container permanently un-completable. By
+    // exercising each terminal status as a sole child here, we assert the
+    // sweep's child-terminal membership covers all of TERMINAL_STATUSES.
+    for (const status of TERMINAL_STATUSES) {
+      const parent = `task-tdrift-${status}`;
+      const { tasksDir, queueFile } = setupContainerWithChildren(parent, [
+        { id: `task-tdrift-child-${status}`, status },
+      ]);
+      tasksReconcileBlockedStatus(tasksDir);
+      const entries = readQueueActions(queueFile).filter(e => e.action === "verify-container-completion" && e.task === parent);
+      expect(entries, `child status '${status}' should count as terminal`).toHaveLength(1);
+    }
   });
 
   test("vacuous parent (no children with subtask_of) does not enqueue (AC6 edge case)", () => {

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -748,7 +748,16 @@ function containerCompletionSweep(taskMap: TaskMap): void {
     "done", "abandoned", "merged", "stale", "needs-confirmation",
     "in-progress", "deferred", "preempt-queued", "preempted",
   ]);
-  const TERMINAL_FOR_CHILD = new Set(["done", "abandoned"]);
+  // A child does no further work once it reaches any TERMINAL_STATUSES state.
+  // Must match health.ts's `CHILD_RESOLVED_STATUSES` (also = TERMINAL_STATUSES):
+  // if `hasActiveChild` treats a `merged`/`stale` child as resolved but this
+  // sweep required {done, abandoned} only, the container's `allTerminal` would
+  // never become true and `verify-container-completion` would never re-queue —
+  // leaving the container permanently un-completable (gh-ludics-605). Sourcing
+  // both sites from `TERMINAL_STATUSES` prevents that drift. Distinct from
+  // `TERMINAL_FOR_PARENT` above, which additionally treats active/needs-
+  // confirmation parent states as "already decided".
+  const TERMINAL_FOR_CHILD = new Set<string>(TERMINAL_STATUSES);
 
   // Single pass to index children by parent.
   const childrenByParent = new Map<string, Array<{ id: string; status: string }>>();


### PR DESCRIPTION
Fixes #605

## Problem

The test-health auto-filer (`finalizeExecutedRun` in `src/health.ts`) called `tasksCreate("Fix broken test suite: <proj>", …)` on every failing run, but `tasksCreate` dedups by a **status-blind fingerprint existence check**. Once that single per-project task reached a terminal status (`done`/`abandoned`/`stale`/`merged`), every future auto-file became a **silent no-op** — the suite could break forever and nothing was re-filed.

## Fix

`tasksCreate` stays **pure** (idempotent fingerprint create, unchanged). All new policy lives in `finalizeExecutedRun` → `fileTestFailureEpisode`, a container/child state machine reusing the existing `leaf: false` container subsystem:

```
res = tasksCreate("Fix broken test suite: <proj>", proj, "A")   // pure
if res.created:        promote to container (leaf:false, stays ready) + first dated child
else terminal:         revive container → ready, ensure leaf:false, fresh child
else non-terminal + open child:   NO-OP (episode in flight)
else non-terminal + no open child: fresh child   ← self-heal guard
```

- **Episode-unique child title** `Fix broken test suite: <proj> — <YYYY-MM-DD>` — a stable title would reintroduce the same fingerprint muzzle one level down. Same-day double-breaks no-op via `tasksCreate`'s existence check; cross-day breaks get a fresh child. Not fingerprinted by stderr (flaky output would proliferate children).
- **Failures excerpt** embedded in the child's `## Context` via `appendToSection` (chosen over a `tasksCreate` body param — keeps `tasksCreate` untouched and matches the existing post-create-edit pattern).
- **`subtask_of` wiring**: added a small `setDependencyScalar(filePath, "subtask_of", parentId)` helper in `src/tasks/markdown.ts`. The nested `dependencies.subtask_of` link can't be written by the top-level `addFrontmatterField`/`updateFrontmatterField` writers (they'd inject an ignored top-level key); `setDependencyScalar` mirrors `updateDependencyArray` but for a scalar. `containerCompletionSweep` reads `dependencies.subtask_of`, so the link must live in the nested block.

## Self-heal verification (`verify-container-completion`)

**Finding: the two-cycle self-heal as literally described in the issue does NOT hold as-is — and the fix needed a guard, which I added.**

`containerCompletionSweep` (`src/tasks/sync.ts:746`) only **queues** `verify-container-completion` when all children are terminal and the container isn't — it does not blind-close. But the `verify-container-completion` **skill itself does NOT transition the container** (skill step 6: "Do **not** transition the parent's status. The user decides."). It only notifies.

Consequence: after children resolve while the suite is still red, the container sits `ready` (verify never closes it) with no open child. A no-op keyed purely on container status (`ready`/`in-progress`) — as the issue's first sketch had it — would then **lose the failing-suite signal indefinitely** until the user manually closes the container.

**Guard added:** the active-episode no-op is keyed on the presence of an **open (non-terminal) child** (`hasActiveChild`), not on container status. So:
1. Children resolved, suite still red, container still `ready` → `fileTestFailureEpisode` sees no open child → files a **fresh dated child** (signal preserved).
2. If an open child exists → no-op (don't pile up).

This is strictly more robust than the issue's two-cycle expectation and doesn't depend on the verify skill ever closing the container. Bounded: still at most one child per day.

## Tests

`src/health.test.ts` — new `container/child auto-filer (gh-ludics-605)` describe block:
- first failure → container (`leaf:false`, `ready`) + one dated child `subtask_of` it, child carries the failures excerpt (container does not).
- active episode (open child) → no new task.
- same-day double-break → no duplicate child.
- re-break after container terminal (`done`/`abandoned`/`stale`) → container revived to `ready` + fresh child (3 cases).
- self-heal guard: container `ready` but child already resolved → fresh child filed (signal not lost).
- existing AC4 capability test updated: a failing run now files **2** tasks (container + child).

`src/tasks/markdown.test.ts` — `setDependencyScalar` coverage (replace / insert / null-clear / body-untouched).

Results: `health.test.ts` 51 pass / 0 fail; `tasks/markdown.test.ts` 91 pass; full suite **3313 pass, 2 fail** — the 2 are the pre-existing KNOWN-RED federation failures (`remote slotStop (non-force)`, `slotAssign machine default in federated setup`), untouched. `typecheck` clean, `lint` + `lint:no-mock-module` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)