### PR TITLE
fix(cluster): route ludics self-tasks off the watched controller (gh-ludics-602)

### DIFF
--- a/src/cluster.test.ts
+++ b/src/cluster.test.ts
@@ -103,7 +103,14 @@ cluster:
       host: mac-studio.ts.net
       role: leader
       os: macos
+      gpu: apple-silicon
       always_on: true
+    - name: macbook-pro
+      host: macbook-pro.ts.net
+      role: console
+      os: macos
+      gpu: apple-silicon
+      always_on: false
     - name: minipc-wsl
       host: minipc-wsl.ts.net
       role: worker
@@ -176,6 +183,81 @@ slots:
   it("honors LUDICS_CLUSTER_MACHINE_NAME for current-machine resolution", () => {
     process.env.LUDICS_CLUSTER_MACHINE_NAME = "minipc-wsl";
     expect(clusterCurrentMachineName()).toBe("minipc-wsl");
+  });
+
+  // gh-ludics-602: ludics SELF-task routing preference — keep self-modification
+  // off the watched controller when a live console node exists. Current machine
+  // is pinned to mac-studio (the leader) by beforeEach.
+
+  it("AC(a): routes a no-requirements ludics self-task to the live console node, not the always_on controller", () => {
+    writeHeartbeat("macbook-pro", 10); // console fresh
+    writeHeartbeat("mac-studio", 10);  // controller also online
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // Invariant: a fresh console node wins over the online always_on controller.
+    // Mutation: deleting the self-task branch returns "mac-studio".
+    expect(result).toBe("macbook-pro");
+  });
+
+  it("AC(b): falls back to the controller (not null) when the console node has no heartbeat", () => {
+    writeHeartbeat("mac-studio", 10); // controller online; console absent (down)
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // Invariant: self-task stays assignable; empty consolePref falls through to
+    // the always_on ranking (mac-studio), never null.
+    expect(result).not.toBeNull();
+    expect(result).toBe("mac-studio");
+  });
+
+  it("AC(b): treats a stale console heartbeat as down and falls back to the controller", () => {
+    writeHeartbeat("macbook-pro", 1000); // stale (> 900s timeout) → not in `online`
+    writeHeartbeat("mac-studio", 10);
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    expect(result).toBe("mac-studio");
+  });
+
+  it("AC(c): leaves a non-ludics no-requirements task on the always_on controller even when the console is live", () => {
+    writeHeartbeat("macbook-pro", 10);
+    writeHeartbeat("mac-studio", 10);
+    const result = selectMachineForSlot({ project: "ocannl", effort: "medium" });
+    // Invariant: the self-task branch must not perturb other projects.
+    // Mutation: making isLudicsSelfTask always-true returns "macbook-pro".
+    expect(result).toBe("mac-studio");
+  });
+
+  it("AC(c): matches the self-task project name case-insensitively", () => {
+    writeHeartbeat("macbook-pro", 10);
+    writeHeartbeat("mac-studio", 10);
+    const result = selectMachineForSlot({ project: "LUDICS", effort: "medium" });
+    // Invariant: case-insensitive match via .toLowerCase().
+    // Mutation: dropping .toLowerCase() returns "mac-studio".
+    expect(result).toBe("macbook-pro");
+  });
+
+  it("AC(d)/(e): a ludics self-task with a hard gpu requirement routes to the eligible worker, never the console", () => {
+    writeHeartbeat("macbook-pro", 10); // console fresh but gpu-ineligible (apple-silicon)
+    writeHeartbeat("minipc-wsl", 10);  // nvidia worker fresh
+    const result = selectMachineForSlot({
+      project: "ludics",
+      effort: "medium",
+      requirements: { gpu: "nvidia" },
+    });
+    // Invariant: the console preference re-ranks only WITHIN the requirement-
+    // filtered online pool; a requirement-ineligible console is unreachable.
+    // Mutation: filtering `pool`/all-machines instead of `online` returns
+    // "macbook-pro".
+    expect(result).toBe("minipc-wsl");
+  });
+
+  it("AC(d): a ludics self-task with a hard gpu requirement is still blocked (null) when the eligible worker is offline, even with a live console", () => {
+    writeHeartbeat("macbook-pro", 10); // console fresh — must NOT rescue the requirement
+    // minipc-wsl absent → offline
+    const result = selectMachineForSlot({
+      project: "ludics",
+      effort: "medium",
+      requirements: { gpu: "nvidia" },
+    });
+    // Invariant: the AC10 online gate fires before the self-task branch; a fresh
+    // console cannot resurrect a requirement-ineligible/offline assignment.
+    expect(result).toBeNull();
   });
 });
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -418,6 +418,22 @@ export function selectMachineForSlot(
   // Pick from online if available, otherwise from all eligible (task will wait for machine to come online)
   const pool = online.length > 0 ? online : eligible;
 
+  // gh-ludics-602: keep ludics SELF-tasks off the watched controller. When a
+  // live (fresh-heartbeat) console node exists, route there so a per-worktree
+  // `ludics init` can't bootout the controller's dashboard / repoint its global
+  // binary. Restrict to `online` (NOT `pool`, which may have fallen back to
+  // offline `eligible`): only route off the controller when a worker is truly
+  // up; otherwise fall through to the controller fallback below. Applied AFTER
+  // the requirement filter + online gate, so it composes with — never overrides
+  // — hard requirements: a console node that fails the requirement filter is
+  // absent from `online` and cannot be resurrected here.
+  const isLudicsSelfTask = (_task.project ?? "").toLowerCase() === "ludics";
+  if (isLudicsSelfTask) {
+    const consolePref = online.filter((m) => m.role !== "leader" && m.role === "console");
+    if (consolePref.length > 0) return consolePref[0]!.name;
+    // else: fall through to the always_on ranking below → controller fallback.
+  }
+
   // Primary signal: prefer always_on machines; tiebreak: prefer non-current for load balance
   const alwaysOn = pool.filter((m) => m.always_on);
   if (alwaysOn.length > 0) {


### PR DESCRIPTION
## Problem

Orchestrating a **ludics self-task** (`project == ludics`) on the **controller node** (mac-studio) takes the live controller's dashboard offline. The per-task worktree runs `ludics init`, which boots out the controller's launchd dashboard unit and repoints the global `~/.local/bin/ludics` symlink — and mac-studio is the node the user watches. Diagnosed live 2026-06-24 ([#602](https://github.com/lukstafi/ludics/issues/602)).

## Fix (proposal fix 2 — conditional machine routing)

Add a self-task routing preference inside `selectMachineForSlot` (`src/cluster.ts`). When `project == ludics` (case-insensitive) and a live console node (`role: console`, fresh heartbeat) exists, route there instead of the `always_on` controller; otherwise fall through to today's behaviour.

The branch is inserted **after** the requirement filter + AC10 online gate and **before** the existing `always_on` ranking, and filters `online` (not the offline-fallback `pool`). So it:
- composes with — never overrides — hard requirements (a requirement-ineligible console is absent from `online` and unreachable);
- only diverts off the controller when a worker is **truly up**; falls back to the controller when the console is down/stale (user is away — accepted residual per the proposal).

Out of scope (per proposal): worktree-aware `ludics init` (fix 1), idempotent unit re-bootstrap (fix 3), CLAUDE.md build-sequence changes.

## Tests (`src/cluster.test.ts`)

Extended the existing `selectMachineForSlot — online gating + routing` block (added a `macbook-pro` console node to its CONFIG) with cases for AC (a)–(e): live-console routing, controller fallback on console-down/stale, non-ludics unchanged, case-insensitive match, and requirement-subordination (gpu:nvidia ludics task routes to / blocks on the eligible worker, never the console).

- `bun test src/cluster.test.ts` → **32 pass / 0 fail**
- Mutation-confirmed: disabling the branch fails AC(a) and the case-insensitive test (sole enforcer); fall-through ACs stay green.
- typecheck / eslint / `lint:test-isolation` / `lint:config-reference` clean; `bun run build` compiles.
- Full adjacent suite: only the 2 pre-existing, environment-dependent baseline failures in `src/slots/index.test.ts` remain (unrelated to cluster routing).

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)