### PR TITLE
fire @codex review immediately at pr-comments entry with a configurable delay knob (gh-ludics-604)

### DIFF
--- a/scripts/snapshots/state.shape.snapshot.json
+++ b/scripts/snapshots/state.shape.snapshot.json
@@ -22,6 +22,7 @@
     "autoFinish",
     "autoFinishTimeout",
     "autoRecoverWrongFilename",
+    "codexReviewRequestDelay",
     "enableClarify",
     "enableGather",
     "enablePlan",

--- a/src/adapters/t3code-orchestration-config.test.ts
+++ b/src/adapters/t3code-orchestration-config.test.ts
@@ -14,6 +14,8 @@ import {
   defaultOrchestrationConfig,
   DEFAULT_SUBSTANTIVE_STALL_CONFIG,
   parseSubstantiveStallOverrides,
+  parseCodexReviewRequestDelay,
+  type OrchestrationConfig,
 } from "../orchestration/state.ts";
 import { withSyntheticHarness } from "../test-utils.ts";
 
@@ -87,5 +89,50 @@ describe("adapter substantive_stall wiring (task-a670cdbf)", () => {
       .toBe(DEFAULT_SUBSTANTIVE_STALL_CONFIG.thresholdSeconds);
     expect(finalConfig.substantiveStall.minPct)
       .toBe(DEFAULT_SUBSTANTIVE_STALL_CONFIG.minPct);
+  });
+});
+
+// gh-ludics-604 — adapter wiring regression: mag.orchestration.codex_review_request_delay
+// reaches orchestration.config.codexReviewRequestDelay via the guarded merge shared by
+// src/adapters/t3code.ts and tmux-adapter.ts. The guard (`=== undefined`) is what makes an
+// explicit --codex-review-request-delay adapter arg win over YAML — the precedence the
+// merged plan requires. We reproduce the exact adapter merge here.
+describe("adapter codex_review_request_delay wiring (gh-ludics-604)", () => {
+  // Mirrors the guarded merge in both adapters:
+  //   const d = parseCodexReviewRequestDelay(orchCfg?.codex_review_request_delay);
+  //   if (d !== undefined && config.codexReviewRequestDelay === undefined) config.codexReviewRequestDelay = d;
+  function applyAdapterMerge(
+    config: Partial<OrchestrationConfig>,
+    yamlValue: unknown,
+  ): Partial<OrchestrationConfig> {
+    const d = parseCodexReviewRequestDelay(yamlValue);
+    if (d !== undefined && config.codexReviewRequestDelay === undefined) {
+      config.codexReviewRequestDelay = d;
+    }
+    return config;
+  }
+
+  test("YAML value flows through when no adapter arg set the field", () => {
+    const config = applyAdapterMerge({}, 120);
+    expect(defaultOrchestrationConfig(config).codexReviewRequestDelay).toBe(120);
+  });
+
+  test("explicit adapter arg WINS over YAML (guarded merge does not clobber)", () => {
+    // arg already populated config.codexReviewRequestDelay = 30 before the YAML merge runs.
+    const config = applyAdapterMerge({ codexReviewRequestDelay: 30 }, 120);
+    expect(config.codexReviewRequestDelay).toBe(30);
+    expect(defaultOrchestrationConfig(config).codexReviewRequestDelay).toBe(30);
+  });
+
+  test("malformed YAML value is dropped → falls through to default 0", () => {
+    const config = applyAdapterMerge({}, "soon");
+    expect(config.codexReviewRequestDelay).toBeUndefined();
+    expect(defaultOrchestrationConfig(config).codexReviewRequestDelay).toBe(0);
+  });
+
+  test("absent YAML key leaves the field unset → default 0", () => {
+    const config = applyAdapterMerge({}, undefined);
+    expect(config.codexReviewRequestDelay).toBeUndefined();
+    expect(defaultOrchestrationConfig(config).codexReviewRequestDelay).toBe(0);
   });
 });

--- a/src/adapters/t3code.test.ts
+++ b/src/adapters/t3code.test.ts
@@ -167,6 +167,34 @@ describe("parseOrchestrationAdapterArgs", () => {
     // adapter parser does NOT silently force the field to false.
     expect(parsed.orchestration?.config.autoRecoverWrongFilename).not.toBe(false);
   });
+
+  test("--codex-review-request-delay parses seconds into config.codexReviewRequestDelay (gh-ludics-604)", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pair --codex-review-request-delay 120");
+    expect(parsed.orchestration?.config.codexReviewRequestDelay).toBe(120);
+  });
+
+  test("--codex-review-request-delay 0 is honored (not treated as unset)", () => {
+    const parsed = parseOrchestrationAdapterArgs("--pair --codex-review-request-delay 0");
+    expect(parsed.orchestration?.config.codexReviewRequestDelay).toBe(0);
+  });
+
+  test("--codex-review-request-delay without a value throws", () => {
+    expect(() => parseOrchestrationAdapterArgs("--pair --codex-review-request-delay")).toThrow(
+      /--codex-review-request-delay requires seconds/,
+    );
+  });
+
+  test("--codex-review-request-delay with a non-numeric value throws", () => {
+    expect(() => parseOrchestrationAdapterArgs("--pair --codex-review-request-delay soon")).toThrow(
+      /non-negative number/,
+    );
+  });
+
+  test("--codex-review-request-delay with a negative value throws", () => {
+    expect(() => parseOrchestrationAdapterArgs("--pair --codex-review-request-delay -5")).toThrow(
+      /non-negative number/,
+    );
+  });
 });
 
 describe("orchestratedThreadTitle", () => {

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -36,6 +36,7 @@ import {
   defaultOrchestrationConfig,
   DEFAULT_SUBSTANTIVE_STALL_CONFIG,
   parseSubstantiveStallOverrides,
+  parseCodexReviewRequestDelay,
   initAgentRuntimeState,
   persistState,
   readOrchestrationState,
@@ -459,6 +460,17 @@ export function parseOrchestrationAdapterArgs(raw: string): ParsedAdapterArgs {
         const reviewSecs = parseInt(next, 10);
         if (isNaN(reviewSecs)) throw new Error(`orchestration adapter args: --review-timeout requires a valid number, got "${next}"`);
         orchestrationConfig.timeouts = { ...orchestrationConfig.timeouts, review: reviewSecs };
+        i++;
+        break;
+      }
+      case "--codex-review-request-delay": {
+        // gh-ludics-604: per-task override for the @codex review request delay (seconds).
+        if (!next) throw new Error("orchestration adapter args: --codex-review-request-delay requires seconds");
+        const codexDelaySecs = parseInt(next, 10);
+        if (isNaN(codexDelaySecs) || codexDelaySecs < 0) {
+          throw new Error(`orchestration adapter args: --codex-review-request-delay requires a non-negative number, got "${next}"`);
+        }
+        orchestrationConfig.codexReviewRequestDelay = codexDelaySecs;
         i++;
         break;
       }
@@ -1078,6 +1090,14 @@ async function startOrchestratedThreads(
       ...(orchestration.config.substantiveStall ?? {}),
       ...substantiveStallOverrides,
     };
+  }
+
+  // gh-ludics-604: wire mag.orchestration.codex_review_request_delay into config.
+  // Guarded on `=== undefined` so an explicit --codex-review-request-delay adapter
+  // arg (already in orchestration.config by this point) wins over YAML.
+  const codexReviewDelay = parseCodexReviewRequestDelay(orchCfg?.codex_review_request_delay);
+  if (codexReviewDelay !== undefined && orchestration.config.codexReviewRequestDelay === undefined) {
+    orchestration.config.codexReviewRequestDelay = codexReviewDelay;
   }
 
   // Resolve models up-front, BEFORE createWorktrees, so a missing/blank

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_SUBSTANTIVE_STALL_CONFIG,
   initAgentRuntimeState,
   parseSubstantiveStallOverrides,
+  parseCodexReviewRequestDelay,
   isWorkerContext,
   persistState,
   readOrchestrationState,
@@ -834,6 +835,14 @@ async function start(ctx: AdapterContext): Promise<string> {
       ...(orchestration.config.substantiveStall ?? {}),
       ...substantiveStallOverrides,
     };
+  }
+
+  // gh-ludics-604: wire mag.orchestration.codex_review_request_delay into config.
+  // Guarded on `=== undefined` so an explicit --codex-review-request-delay adapter
+  // arg (already in orchestration.config by this point) wins over YAML.
+  const codexReviewDelay = parseCodexReviewRequestDelay(orchCfg?.codex_review_request_delay);
+  if (codexReviewDelay !== undefined && orchestration.config.codexReviewRequestDelay === undefined) {
+    orchestration.config.codexReviewRequestDelay = codexReviewDelay;
   }
 
   // Resolve models up-front, BEFORE createWorktrees / tmux sessions, so a

--- a/src/orchestration/phases.test.ts
+++ b/src/orchestration/phases.test.ts
@@ -11,6 +11,7 @@ import {
   initAgentRuntimeState,
   migrateState,
   parseSubstantiveStallOverrides,
+  parseCodexReviewRequestDelay,
   type OrchestrationState,
 } from "./state.ts";
 
@@ -1698,6 +1699,61 @@ describe("parseSubstantiveStallOverrides — YAML→config (task-a670cdbf)", () 
       nudgeCooldownSeconds: 180,
       maxNudgeAttempts: 2,
     });
+  });
+});
+
+// gh-ludics-604 — codexReviewRequestDelay knob: default, migration backfill triple,
+// and YAML parser. The migration backfill is mandatory: without it, a legacy state
+// file deserializes with codexReviewRequestDelay === undefined and the fire site's
+// `elapsed >= undefined` (NaN) never fires the explicit request.
+describe("codexReviewRequestDelay — default + migration (gh-ludics-604)", () => {
+  test("defaultOrchestrationConfig defaults the knob to 0; override is honored", () => {
+    expect(defaultOrchestrationConfig().codexReviewRequestDelay).toBe(0);
+    expect(defaultOrchestrationConfig({ codexReviewRequestDelay: 120 }).codexReviewRequestDelay).toBe(120);
+  });
+
+  test("legacy state without codexReviewRequestDelay backfills config default (0)", () => {
+    const state = makeSoloState();
+    delete (state.config as { codexReviewRequestDelay?: number }).codexReviewRequestDelay;
+    const result = migrateState(state, 1);
+    expect(result.config.codexReviewRequestDelay).toBe(0);
+  });
+
+  test("negative control: a non-default value is NOT overwritten by the backfill", () => {
+    const state = makeSoloState();
+    state.config.codexReviewRequestDelay = 90;
+    const result = migrateState(state, 1);
+    expect(result.config.codexReviewRequestDelay).toBe(90);
+  });
+
+  test("user override survives migration round-trip (serialize → deserialize → migrate)", () => {
+    const state = makeSoloState();
+    state.config.codexReviewRequestDelay = 120;
+    const round = migrateState(JSON.parse(JSON.stringify(migrateState(state, 1))), 1);
+    expect(round.config.codexReviewRequestDelay).toBe(120);
+  });
+});
+
+describe("parseCodexReviewRequestDelay — YAML→config (gh-ludics-604)", () => {
+  test("accepts a finite non-negative number (and floors fractional seconds)", () => {
+    expect(parseCodexReviewRequestDelay(0)).toBe(0);
+    expect(parseCodexReviewRequestDelay(120)).toBe(120);
+    expect(parseCodexReviewRequestDelay(90.7)).toBe(90);
+  });
+
+  test("drops invalid values — typo-resilient (returns undefined)", () => {
+    expect(parseCodexReviewRequestDelay("120")).toBeUndefined();   // string
+    expect(parseCodexReviewRequestDelay(-5)).toBeUndefined();       // negative
+    expect(parseCodexReviewRequestDelay(NaN)).toBeUndefined();      // NaN
+    expect(parseCodexReviewRequestDelay(Infinity)).toBeUndefined(); // non-finite
+    expect(parseCodexReviewRequestDelay(null)).toBeUndefined();
+    expect(parseCodexReviewRequestDelay({ x: 1 })).toBeUndefined();
+    expect(parseCodexReviewRequestDelay(undefined)).toBeUndefined();
+  });
+
+  test("a dropped value flows through defaultOrchestrationConfig to the default (0)", () => {
+    const parsed = parseCodexReviewRequestDelay("not a number");
+    expect(defaultOrchestrationConfig({ codexReviewRequestDelay: parsed }).codexReviewRequestDelay).toBe(0);
   });
 });
 

--- a/src/orchestration/runner.pr-comments.test.ts
+++ b/src/orchestration/runner.pr-comments.test.ts
@@ -269,6 +269,34 @@ describe("checkAndRedispatchPrComments deferred review fallback", () => {
     expect(state.prCodexReviewFallbackPosted).toBe(true);
   });
 
+  test("does NOT redispatch the coder for its own @codex review trigger counted this tick (gh-ludics-604)", async () => {
+    // Codex review #608: at delay 0 the trigger is posted this tick; GitHub is
+    // read-your-writes so fetchNewPrCommentCount returns that fresh trigger as a
+    // "new comment". It must be discounted, not treated as coder-facing feedback.
+    reviewSpy.mockReturnValue(false);
+    commentSpy.mockReturnValue(false);
+    commentCountSpy.mockReturnValue(1); // the self-trigger, counted by the API
+    const state = makePrCommentsState({ prCodexReviewDeferredSince: nowSec });
+    await checkAndRedispatchPrComments(state, dummyTransport);
+    expect(postSpy).toHaveBeenCalledTimes(1);               // trigger posted
+    expect(state.prCommentsRedispatchCount).toBeUndefined(); // coder NOT redispatched
+    // Quiet path taken. Mutation: without the discount, totalNewComments is 1, the
+    // redispatch branch runs and sets prCommentsQuietSince = 0 — this assertion fails.
+    expect(state.prCommentsQuietSince).toBeGreaterThan(0);
+  });
+
+  test("still redispatches when a real comment arrives alongside the @codex trigger (only our own is discounted)", async () => {
+    reviewSpy.mockReturnValue(false);
+    commentSpy.mockReturnValue(false);
+    commentCountSpy.mockReturnValue(2); // 1 = our trigger, 1 = a genuine new comment
+    const state = makePrCommentsState({ prCodexReviewDeferredSince: nowSec });
+    await checkAndRedispatchPrComments(state, dummyTransport);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    // 2 − 1(our trigger) = 1 > 0 ⇒ the genuine comment still redispatches the coder.
+    expect(state.prCommentsRedispatchCount).toBe(1);
+    expect(state.prCommentsQuietSince).toBe(0);
+  });
+
   test("does not re-post fallback once already posted, keeps waiting for review", async () => {
     reviewSpy.mockReturnValue(false);
     const state = makePrCommentsState({

--- a/src/orchestration/runner.pr-comments.test.ts
+++ b/src/orchestration/runner.pr-comments.test.ts
@@ -9,7 +9,7 @@ import * as notify from "../notify.ts";
 import * as events from "../events.ts";
 import * as github from "./github.ts";
 import * as worktrees from "./worktrees.ts";
-import { type OrchestrationState } from "./state.ts";
+import { defaultOrchestrationConfig, type OrchestrationState } from "./state.ts";
 import {
   makeTmpDir,
   makeState,
@@ -243,45 +243,48 @@ describe("checkAndRedispatchPrComments deferred review fallback", () => {
     eventSpy.mockRestore();
   });
 
-  test("clears deferral early when all PRs have submitted reviews", async () => {
+  test("clears deferral early (no request) when a Codex review is already present at entry", async () => {
+    // gh-ludics-604: review-present-at-entry → no double-spend even at default delay 0.
     reviewSpy.mockReturnValue(true);
     const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 60, // armed 60s ago (within window)
+      prCodexReviewDeferredSince: nowSec, // just armed; default delay 0 ⇒ checked immediately
     });
     await checkAndRedispatchPrComments(state, dummyTransport);
     expect(state.prCodexReviewDeferredSince).toBeUndefined();
     expect(postSpy).not.toHaveBeenCalled();
   });
 
-  test("posts fallback after deadline when no review exists, keeps deferral armed", async () => {
+  test("default delay 0: posts the explicit request immediately when no review exists, keeps deferral armed", async () => {
+    // gh-ludics-604: the request fires on the first eligible poll after entry — no ~10-min wait.
     reviewSpy.mockReturnValue(false);
     const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 700, // 700s ago, past 600s deadline
+      prCodexReviewDeferredSince: nowSec, // just armed this poll
     });
+    expect(state.config.codexReviewRequestDelay).toBe(0); // harness precondition: default knob
     await checkAndRedispatchPrComments(state, dummyTransport);
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(postSpy.mock.calls[0]![0]).toBe("https://github.com/test/repo/pull/42");
     // Deferral stays armed — blocks shortcut until review actually arrives
-    expect(state.prCodexReviewDeferredSince).toBe(nowSec - 700);
+    expect(state.prCodexReviewDeferredSince).toBe(nowSec);
     expect(state.prCodexReviewFallbackPosted).toBe(true);
   });
 
   test("does not re-post fallback once already posted, keeps waiting for review", async () => {
     reviewSpy.mockReturnValue(false);
     const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 800,
+      prCodexReviewDeferredSince: nowSec,
       prCodexReviewFallbackPosted: true,
     });
     await checkAndRedispatchPrComments(state, dummyTransport);
     expect(postSpy).not.toHaveBeenCalled();
     // Still armed — waiting for review
-    expect(state.prCodexReviewDeferredSince).toBe(nowSec - 800);
+    expect(state.prCodexReviewDeferredSince).toBe(nowSec);
   });
 
   test("clears deferral after fallback posted and review arrives", async () => {
     reviewSpy.mockReturnValue(true);
     const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 800,
+      prCodexReviewDeferredSince: nowSec - 30,
       prCodexReviewFallbackPosted: true,
     });
     await checkAndRedispatchPrComments(state, dummyTransport);
@@ -289,23 +292,35 @@ describe("checkAndRedispatchPrComments deferred review fallback", () => {
     expect(state.prCodexReviewFallbackPosted).toBeUndefined();
   });
 
-  test("keeps waiting within deferral window when no review yet", async () => {
+  test("positive delay (120s) honors the grace: within grace → no request; past grace → posts", async () => {
+    // gh-ludics-604: the knob lets a grace be dialed in without a code change.
     reviewSpy.mockReturnValue(false);
-    const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 60, // only 60s, well within 600s window
+    // Within the 120s grace (armed 60s ago) → not yet posted, deferral unchanged.
+    const within = makePrCommentsState({
+      prCodexReviewDeferredSince: nowSec - 60,
+      config: defaultOrchestrationConfig({ codexReviewRequestDelay: 120 }),
     });
-    await checkAndRedispatchPrComments(state, dummyTransport);
+    await checkAndRedispatchPrComments(within, dummyTransport);
     expect(postSpy).not.toHaveBeenCalled();
-    expect(state.prCodexReviewDeferredSince).toBe(nowSec - 60); // unchanged
+    expect(within.prCodexReviewDeferredSince).toBe(nowSec - 60); // unchanged
+
+    // Past the 120s grace (armed 200s ago) → posts for the missing-review PR.
+    const past = makePrCommentsState({
+      prCodexReviewDeferredSince: nowSec - 200,
+      config: defaultOrchestrationConfig({ codexReviewRequestDelay: 120 }),
+    });
+    await checkAndRedispatchPrComments(past, dummyTransport);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(past.prCodexReviewFallbackPosted).toBe(true);
   });
 
-  test("posts fallback only for PRs missing review (per-PR resolution)", async () => {
+  test("posts request only for PRs missing review (per-PR resolution) at default delay 0", async () => {
     // PR 42 has review, PR 43 does not
     reviewSpy.mockImplementation((url: string) =>
       url.includes("pull/42")
     );
     const state = makePrCommentsState({
-      prCodexReviewDeferredSince: nowSec - 700,
+      prCodexReviewDeferredSince: nowSec,
       mode: "duo",
       agents: [
         { name: "coder", provider: "claude-code", role: "coder", model: "opus-4", branch: "a", worktreePath: "/tmp/a" },
@@ -328,7 +343,7 @@ describe("checkAndRedispatchPrComments deferred review fallback", () => {
     expect(postSpy).toHaveBeenCalledTimes(1);
     expect(postSpy.mock.calls[0]![0]).toBe("https://github.com/test/repo/pull/43");
     // Still armed — PR 43 review hasn't arrived yet
-    expect(state.prCodexReviewDeferredSince).toBe(nowSec - 700);
+    expect(state.prCodexReviewDeferredSince).toBe(nowSec);
     expect(state.prCodexReviewFallbackPosted).toBe(true);
   });
 
@@ -351,13 +366,17 @@ describe("checkAndRedispatchPrComments deferred review fallback", () => {
     expect(postSpy).not.toHaveBeenCalled();
   });
 
-  test("keeps deferral armed when no Codex review or comment", async () => {
+  test("keeps deferral armed within the configured grace when no Codex review or comment", async () => {
+    // With a positive grace the marker survives an early poll without posting,
+    // so it still blocks the shortcut transition until the grace elapses.
     reviewSpy.mockReturnValue(false);
     commentSpy.mockReturnValue(false);
     const state = makePrCommentsState({
       prCodexReviewDeferredSince: nowSec - 60,
+      config: defaultOrchestrationConfig({ codexReviewRequestDelay: 120 }),
     });
     await checkAndRedispatchPrComments(state, dummyTransport);
+    expect(postSpy).not.toHaveBeenCalled();
     expect(state.prCodexReviewDeferredSince).toBe(nowSec - 60);
   });
 });

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1737,7 +1737,11 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
 
   // --- Deferred Codex review request (per-PR resolution) ---
   if (state.prCodexReviewDeferredSince) {
-    const deferralTimeout = Math.min(600, Math.floor(state.config.prCommentsTimeout / 2));
+    // gh-ludics-604: delay sourced from the dedicated codexReviewRequestDelay knob
+    // (default 0 = post on the first eligible poll after the pr-comments transition),
+    // decoupled from prCommentsTimeout. The per-PR urlsMissingReview partition below
+    // provides the point-in-time "already reviewed?" dedup that prevents a double-spend.
+    const deferralTimeout = state.config.codexReviewRequestDelay;
     const elapsed = now - state.prCodexReviewDeferredSince;
     const deadlineReached = elapsed >= deferralTimeout;
 
@@ -2454,11 +2458,13 @@ export function applyPhaseSideEffects(state: OrchestrationState, next: Orchestra
 }
 
 /**
- * Arm deferred Codex review request on initial entry to pr-comments.
- * Instead of posting `@codex review` immediately, sets
- * `prCodexReviewDeferredSince` so that `checkAndRedispatchPrComments()`
- * can check for an auto-triggered review first and only post the
- * explicit request as a fallback after `min(10m, quiet_period/2)`.
+ * Mark the explicit Codex review request as pending on initial entry to
+ * pr-comments. Sets `prCodexReviewDeferredSince` to the entry timestamp so that
+ * `checkAndRedispatchPrComments()` performs a point-in-time check for an
+ * already-present Codex review and, when none is found, posts the explicit
+ * `@codex review` request after `state.config.codexReviewRequestDelay` seconds
+ * (gh-ludics-604; default 0 = on the next eligible poll). The field is a
+ * "request pending / not yet resolved" marker, not a hard-coded 10-minute timer.
  *
  * Only fires on initial pr-comments entry paths (pr-create, update-docs,
  * review), NOT on merge-loop re-entries (merge-review -> pr-comments).
@@ -2479,7 +2485,8 @@ export function maybePostCodexReviewRequests(
   const hasAnyPrUrl = state.agents.some((a) => !!state.agentStates[a.name]?.prUrl);
   if (!hasAnyPrUrl) return;
 
-  // Arm deferral — use nowEpoch() because phaseStartedAt hasn't been updated yet
+  // Mark the request pending — use nowEpoch() because phaseStartedAt hasn't been
+  // updated yet. checkAndRedispatchPrComments resolves it after codexReviewRequestDelay.
   state.prCodexReviewDeferredSince = nowEpoch();
 }
 

--- a/src/orchestration/runner.ts
+++ b/src/orchestration/runner.ts
@@ -1735,6 +1735,12 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
     return;
   }
 
+  // PRs we post an explicit `@codex review` trigger to on THIS tick (gh-ludics-604).
+  // Our own trigger is an issue comment that fetchNewPrCommentCount would otherwise
+  // count as fresh coder-facing feedback; we discount it below so the coder is not
+  // redispatched to "address" the trigger instead of waiting for the Codex review.
+  const codexTriggeredThisTick = new Set<string>();
+
   // --- Deferred Codex review request (per-PR resolution) ---
   if (state.prCodexReviewDeferredSince) {
     // gh-ludics-604: delay sourced from the dedicated codexReviewRequestDelay knob
@@ -1770,7 +1776,11 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
       const projectEntry = findProjectConfig(state.projectDir);
       const customPrompt = projectEntry?.codex_review_prompt ?? undefined;
       for (const prUrl of urlsMissingReview) {
-        postCodexReviewComment(prUrl, customPrompt);
+        // Only mark the PR as triggered when the comment actually posted, so a
+        // failed post does not wrongly discount a real new comment below.
+        if (postCodexReviewComment(prUrl, customPrompt)) {
+          codexTriggeredThisTick.add(prUrl);
+        }
       }
       state.prCodexReviewFallbackPosted = true;
     }
@@ -1780,7 +1790,13 @@ export async function checkAndRedispatchPrComments(state: OrchestrationState, tr
   // Count new comments since the last check.
   let totalNewComments = 0;
   for (const agent of agentsWithPr) {
-    totalNewComments += fetchNewPrCommentCount(state.agentStates[agent.name]!.prUrl!, lastCheck);
+    const prUrl = state.agentStates[agent.name]!.prUrl!;
+    let newComments = fetchNewPrCommentCount(prUrl, lastCheck);
+    // gh-ludics-604: subtract our own @codex review trigger posted this tick (the
+    // GitHub API is read-your-writes, so the fresh trigger is in this count) so it
+    // does not read as new coder-facing feedback and spuriously redispatch the coder.
+    if (codexTriggeredThisTick.has(prUrl)) newComments = Math.max(0, newComments - 1);
+    totalNewComments += newComments;
   }
 
   state.prCommentsLastCheckAt = now;

--- a/src/orchestration/state.ts
+++ b/src/orchestration/state.ts
@@ -154,6 +154,12 @@ export interface OrchestrationConfig {
   /** Seconds since the last redispatch after which a quiet pr-comments phase with an
    *  unaddressed review on the PR triggers a one-shot orchestration_warning. Default 600. */
   prCommentsStuckThreshold: number;
+  /** Seconds to wait after the initial pr-comments transition before posting the explicit
+   *  `@codex review` request, when no Codex review/comment is present at that point.
+   *  Decoupled from prCommentsTimeout (the human-comment window) — gh-ludics-604. Default 0
+   *  = post on the first eligible poll after entry. Raise to 60-120 only if redundant remote
+   *  reviews appear. */
+  codexReviewRequestDelay: number;
   /** Gates the wrong-filename auto-cp branch only. When false, whitelisted suspects
    *  fall through to the targeted-nudge branch instead of being auto-copied. */
   autoRecoverWrongFilename: boolean;
@@ -218,6 +224,19 @@ export function parseSubstantiveStallOverrides(
     out.maxNudgeAttempts = yaml.max_nudge_attempts;
   }
   return out;
+}
+
+/**
+ * Parse `mag.orchestration.codex_review_request_delay` (seconds) into a number
+ * for `orchestration.config.codexReviewRequestDelay` (gh-ludics-604). Validated
+ * as a finite non-negative `number` (per
+ * `feedback_narrowing_needs_boundary_validators`); a hand-edited typo or negative
+ * value is dropped silently (returns `undefined`) so it falls through to its
+ * default rather than crashing slot init.
+ */
+export function parseCodexReviewRequestDelay(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return undefined;
+  return Math.floor(raw);
 }
 
 export interface OrchestrationState {
@@ -355,6 +374,7 @@ export const DEFAULT_TIMEOUTS: Record<string, number> = {
 export const DEFAULT_PR_COMMENTS_TIMEOUT = 1800; // 30 min quiet before auto-merging
 export const DEFAULT_PR_COMMENTS_CHECK_INTERVAL = 60; // poll GitHub every 60 s
 export const DEFAULT_PR_COMMENTS_STUCK_THRESHOLD = 600; // 10 min quiet-after-redispatch before stuck warning
+export const DEFAULT_CODEX_REVIEW_REQUEST_DELAY = 0; // post the @codex review request immediately (gh-ludics-604)
 
 export const DEFAULT_POLL_INTERVAL = 10;
 export const DEFAULT_LEARNING_INTERVAL = 3600;
@@ -382,6 +402,8 @@ export function defaultOrchestrationConfig(
       overrides.prCommentsCheckInterval ?? DEFAULT_PR_COMMENTS_CHECK_INTERVAL,
     prCommentsStuckThreshold:
       overrides.prCommentsStuckThreshold ?? DEFAULT_PR_COMMENTS_STUCK_THRESHOLD,
+    codexReviewRequestDelay:
+      overrides.codexReviewRequestDelay ?? DEFAULT_CODEX_REVIEW_REQUEST_DELAY,
     autoRecoverWrongFilename: overrides.autoRecoverWrongFilename ?? true,
     substantiveStall: {
       thresholdSeconds:
@@ -624,6 +646,12 @@ export function migrateState(state: OrchestrationState, slot: number): Orchestra
   // gh-bce80781: backfill new config field for legacy state files.
   if (state.config && state.config.prCommentsStuckThreshold === undefined) {
     state.config.prCommentsStuckThreshold = DEFAULT_PR_COMMENTS_STUCK_THRESHOLD;
+  }
+  // gh-ludics-604: backfill new config field for legacy state files. Without this,
+  // the fire site reads `undefined` and `elapsed >= undefined` is NaN-false, so a
+  // mid-flight upgraded slot would never post the explicit @codex review request.
+  if (state.config && state.config.codexReviewRequestDelay === undefined) {
+    state.config.codexReviewRequestDelay = DEFAULT_CODEX_REVIEW_REQUEST_DELAY;
   }
   // task-a670cdbf: backfill substantive-stall config for legacy state files.
   // Per-leaf so a partial override doesn't drop the missing leaves.

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -170,6 +170,13 @@ mag:
     #   xhigh    | xhigh                | high
     #   max      | max                  | xhigh
     # Legacy aliases (still accepted): coder_thinking_effort, reviewer_thinking_effort
+    # Seconds to wait after the initial pr-comments transition before posting the
+    # explicit `@codex review` request, when no Codex review/comment is already present
+    # at that point (gh-ludics-604). 0 (default) posts immediately on the first eligible
+    # poll; a positive value adds a grace period (e.g. 120) if redundant remote reviews
+    # appear. Decoupled from the human-comment quiet window. Per-task override:
+    # `-A "--codex-review-request-delay <seconds>"`.
+    codex_review_request_delay: 0
     phase_timeouts:              # Per-phase timeout overrides in seconds (unset phases use built-in defaults)
       work: 7200
       review: 3600


### PR DESCRIPTION
## Summary

Closes the ~10-minute dead latency before the explicit `@codex review` request. On the initial `pr-comments` transition the orchestrator previously **armed a ~10-min deferral** (`Math.min(600, prCommentsTimeout/2)`) and only posted the request when that timer expired. This replaces the arm-and-wait with a **point-in-time check at the transition**, gated by a new **decoupled config knob `codexReviewRequestDelay` defaulting to 0**:

- No Codex review/comment present at entry → the explicit `@codex review` is posted on the **first eligible poll** (immediately, at the default).
- A Codex review already present → **no request** (no double-spend of the remote review).
- The delay is now its own knob, decoupled from `prCommentsTimeout` — the human-comment quiet window and the reviewer-nag delay are no longer the same number. A `60–120 s` grace can be dialed in via config or `-A` **without a code change**.

The anchor deliberately **stays at the `pr-comments` transition** (not re-anchored to PR creation — issue fix 1/2 were explicitly out of scope): that transition is reached only after the local review phase approved, so the cheap/abundant local approval is always banked before the precious remote review is spent. All dedup guards are preserved: initial-entry-only arm, leave-`pr-comments` cleanup, per-PR `urlsMissingReview` partition, and the `prCodexReviewFallbackPosted` one-shot.

Proposal: `docs/proposals/codex-review-request-immediate-with-knob.md` · Issue: #604

## Changes

1. **`state.ts`** — new `codexReviewRequestDelay` field (`DEFAULT_CODEX_REVIEW_REQUEST_DELAY = 0`), `parseCodexReviewRequestDelay` YAML validator, `defaultOrchestrationConfig` wiring, and a `migrateState` backfill (legacy on-disk state lacking the field would otherwise NaN-compare at the fire site and never post).
2. **`runner.ts`** — fire-site delay sourced from the knob (`deferralTimeout = state.config.codexReviewRequestDelay`); arm-site docstring/comment refreshed to "pending request" semantics.
3. **`state.shape.snapshot.json`** — record the new persisted field.
4. **`t3code.ts` + `tmux-adapter.ts`** — read `mag.orchestration.codex_review_request_delay`, **guarded on `=== undefined`** so an explicit `--codex-review-request-delay` adapter arg wins over YAML; the literal read also satisfies `lint:config-reference`. Shared `--codex-review-request-delay <seconds>` arg added (covers both adapters).
5. **`config.reference.yaml`** — document `codex_review_request_delay: 0`.

## Tests (18 new)

- Fire site (`runner.pr-comments.test.ts`): default-0 immediate post; review-present no-double-spend; positive-grace within/past; per-PR partition at default 0. Old 600 s magic-number tests rewritten to the knob.
- Config (`phases.test.ts`): default 0, migration triple (backfill / negative-control / round-trip), `parseCodexReviewRequestDelay` units.
- Adapters (`t3code.test.ts`, `t3code-orchestration-config.test.ts`): arg parse (valid/0/missing/non-numeric/negative) and guarded-merge precedence (YAML flows through when unset; explicit arg wins; malformed dropped).

## Validation

`bun run typecheck` ✓ · `lint:state-migration` ✓ · `lint:config-reference` ✓ · `lint:cli-readme` ✓ · `lint:test-isolation` ✓ (pinned). Full suite: **3343 pass / 2 fail** — both failures pre-existing federation/cluster baseline in `src/slots/index.test.ts`, unrelated to this change.

## Follow-up (Codex review on this PR)

Codex flagged that at the new default (`codexReviewRequestDelay=0`) the `@codex review` trigger is posted on the first `pr-comments` poll, then the same tick's `fetchNewPrCommentCount` — GitHub being read-your-writes — counts that fresh trigger as a new PR comment and wakes the coder to "address" it instead of waiting for the review. Fixed in `a9b0f43`: the runner tracks PRs it triggered this tick and discounts its own trigger from each PR's new-comment count (floored at 0); genuine concurrent comments still redispatch (2 − 1 = 1). Covered by two new tests (trigger-only → no redispatch, mutation-checked; trigger + real comment → still redispatches).

## Open implementation note

Whether an explicit `@codex review` issued while Codex's auto-review is in-flight self-dedups (proposal lines 119–123) was not empirically confirmed — requires a live Codex run, out of a coding worktree's reach. The accepted residual is bounded by the new knob (dial in a grace without a code change if redundant remote reviews appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
