### PR TITLE
Re-check condition-gated enqueues at delivery time (drop stale queued skills)

### DIFF
--- a/src/mag-delivery-confirmation.test.ts
+++ b/src/mag-delivery-confirmation.test.ts
@@ -879,3 +879,202 @@ describe("listInFlight — skips malformed records (A11 robustness)", () => {
     expect(readInFlight("req-MISSING")).toBeNull();
   });
 });
+
+// --- task-c16f71b5: delivery-time staleness gate -----------------------------
+//
+// An autonomously enqueued, condition-gated request (carrying `enqueueSource`)
+// whose motivating predicate no longer holds at pop time is consumed without
+// sending: no `send`, no in-flight record, a `skipped-stale` skip-marker (Tier-2
+// only), and a `mag_queue_skipped_stale` event. Records without `enqueueSource`
+// always deliver.
+
+describe("deliverPoppedSkill — delivery-time staleness gate (task-c16f71b5)", () => {
+  function tasksDir(): string {
+    return join(harnessDir(), "tasks");
+  }
+  function writeTask(id: string, frontmatter: string): void {
+    mkdirSync(tasksDir(), { recursive: true });
+    writeFileSync(join(tasksDir(), `${id}.md`), `---\nid: ${id}\n${frontmatter}---\n\n# ${id}\n`);
+  }
+  function readResult(id: string): Record<string, unknown> | null {
+    if (!existsSync(resultFile(id))) return null;
+    return JSON.parse(readFileSync(resultFile(id), "utf-8")) as Record<string, unknown>;
+  }
+  function skippedStaleEvents(): Record<string, unknown>[] {
+    return readEvents().filter((e) => e.event_type === "mag_queue_skipped_stale");
+  }
+
+  // AC8(a): a stale autonomous elaborate is dropped — no send, skip-marker
+  // written, event emitted, no in-flight record. (The gh-ludics-609 replay.)
+  test("stale autonomous elaborate (already elaborated) is dropped without sending", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-stale", "status: ready\nleaf: true\nelaborated: 2026-06-25\n");
+    const line = JSON.stringify({ id: "req-EL", action: "elaborate", task: "task-stale", enqueueSource: "keepalive" });
+
+    let sendCalls = 0;
+    const sent = deliverPoppedSkill(
+      { requestId: "req-EL", command: "/ludics-elaborate task-stale", line, expectsResult: true },
+      { send: () => { sendCalls++; return true; } },
+    );
+
+    // The pop is consumed (return true) but the skill is NOT sent — the
+    // invariant that would break under the old behaviour (no-op Mag round-trip).
+    expect(sent).toBe(true);
+    expect(sendCalls).toBe(0);
+    expect(existsSync(inFlightFilePath("req-EL"))).toBe(false);
+    const marker = readResult("req-EL");
+    expect(marker?.status).toBe("skipped-stale");
+    expect(marker?.action).toBe("elaborate");
+    expect(marker?.task).toBe("task-stale");
+    expect(typeof marker?.reason).toBe("string");
+    expect(String(marker?.reason)).toContain("elaborated");
+    expect(skippedStaleEvents().length).toBe(1);
+  });
+
+  // AC8(b): a non-stale autonomous record delivers normally.
+  test("non-stale autonomous elaborate (not yet elaborated) delivers normally", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-fresh", "status: ready\nleaf: true\n");
+    const line = JSON.stringify({ id: "req-EL2", action: "elaborate", task: "task-fresh", enqueueSource: "keepalive" });
+
+    let sendCalls = 0;
+    const sent = deliverPoppedSkill(
+      { requestId: "req-EL2", command: "/ludics-elaborate task-fresh", line, expectsResult: true },
+      { send: () => { sendCalls++; return true; } },
+    );
+
+    expect(sent).toBe(true);
+    expect(sendCalls).toBe(1);
+    expect(existsSync(inFlightFilePath("req-EL2"))).toBe(true); // delivered → in-flight written
+    expect(readResult("req-EL2")).toBeNull(); // no skip-marker
+    expect(skippedStaleEvents().length).toBe(0);
+  });
+
+  // AC8(c): a record WITHOUT enqueueSource always delivers, even when its
+  // predicate would report stale. Proves the drop is gated on the field, not
+  // the predicate alone — mutation guard against dropping user/CLI records.
+  test("record lacking enqueueSource delivers even when the predicate would say stale", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-stale-cli", "status: ready\nleaf: true\nelaborated: 2026-06-25\n");
+    // Same already-elaborated task as (a) but no enqueueSource on the line.
+    const line = JSON.stringify({ id: "req-CLI", action: "elaborate", task: "task-stale-cli" });
+
+    let sendCalls = 0;
+    const sent = deliverPoppedSkill(
+      { requestId: "req-CLI", command: "/ludics-elaborate task-stale-cli", line, expectsResult: true },
+      { send: () => { sendCalls++; return true; } },
+    );
+
+    expect(sent).toBe(true);
+    expect(sendCalls).toBe(1);
+    expect(existsSync(inFlightFilePath("req-CLI"))).toBe(true);
+    expect(readResult("req-CLI")).toBeNull();
+    expect(skippedStaleEvents().length).toBe(0);
+  });
+
+  // AC8(d): a Tier-3 drop (expectsResult:false) writes NO result file but still
+  // emits the event.
+  test("Tier-3 stale drop emits the event but writes no result file", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-stale-t3", "status: ready\nleaf: true\nelaborated: 2026-06-25\n");
+    const line = JSON.stringify({ id: "req-T3", action: "elaborate", task: "task-stale-t3", enqueueSource: "keepalive" });
+
+    let sendCalls = 0;
+    const sent = deliverPoppedSkill(
+      { requestId: "req-T3", command: "/ludics-elaborate task-stale-t3", line, expectsResult: false },
+      { send: () => { sendCalls++; return true; } },
+    );
+
+    expect(sent).toBe(true);
+    expect(sendCalls).toBe(0);
+    expect(readResult("req-T3")).toBeNull(); // Tier-3 → no skip-marker
+    expect(skippedStaleEvents().length).toBe(1); // …but the event still fires
+  });
+
+  // Per-action predicate coverage. Each pair instantiates one drop condition and
+  // its non-stale control, observed at the delivery seam.
+  test("draft-proposal drops when a proposal already exists, delivers when absent", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+
+    writeTask("task-dp1", "status: ready\nleaf: true\nproposal: docs/proposals/x.md\n");
+    const dropLine = JSON.stringify({ id: "req-DP1", action: "draft-proposal", task: "task-dp1", enqueueSource: "keepalive" });
+    let dropped = 0;
+    deliverPoppedSkill({ requestId: "req-DP1", command: "/ludics-draft-proposal task-dp1", line: dropLine, expectsResult: true },
+      { send: () => { dropped++; return true; } });
+    expect(dropped).toBe(0);
+    expect(readResult("req-DP1")?.status).toBe("skipped-stale");
+
+    writeTask("task-dp2", "status: ready\nleaf: true\n");
+    const okLine = JSON.stringify({ id: "req-DP2", action: "draft-proposal", task: "task-dp2", enqueueSource: "keepalive" });
+    let okSends = 0;
+    deliverPoppedSkill({ requestId: "req-DP2", command: "/ludics-draft-proposal task-dp2", line: okLine, expectsResult: true },
+      { send: () => { okSends++; return true; } });
+    expect(okSends).toBe(1);
+    expect(readResult("req-DP2")).toBeNull();
+  });
+
+  test("draft-proposal drops when has_questions is set", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-dpq", "status: ready\nleaf: true\nhas_questions: true\n");
+    const line = JSON.stringify({ id: "req-DPQ", action: "draft-proposal", task: "task-dpq", enqueueSource: "keepalive" });
+    let sends = 0;
+    deliverPoppedSkill({ requestId: "req-DPQ", command: "/ludics-draft-proposal task-dpq", line, expectsResult: true },
+      { send: () => { sends++; return true; } });
+    expect(sends).toBe(0);
+    expect(String(readResult("req-DPQ")?.reason)).toContain("questions");
+  });
+
+  test("preempt delivers on preempt-queued, drops once the task is in-progress", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+
+    writeTask("task-pre1", "status: preempt-queued\nleaf: true\n");
+    const okLine = JSON.stringify({ id: "req-PRE1", action: "preempt", task: "task-pre1", autonomy: "auto", enqueueSource: "sync" });
+    let okSends = 0;
+    deliverPoppedSkill({ requestId: "req-PRE1", command: "/ludics-preempt task-pre1", line: okLine, expectsResult: true },
+      { send: () => { okSends++; return true; } });
+    expect(okSends).toBe(1);
+
+    writeTask("task-pre2", "status: in-progress\nleaf: true\n");
+    const dropLine = JSON.stringify({ id: "req-PRE2", action: "preempt", task: "task-pre2", autonomy: "auto", enqueueSource: "sync" });
+    let dropSends = 0;
+    deliverPoppedSkill({ requestId: "req-PRE2", command: "/ludics-preempt task-pre2", line: dropLine, expectsResult: true },
+      { send: () => { dropSends++; return true; } });
+    expect(dropSends).toBe(0);
+    expect(readResult("req-PRE2")?.status).toBe("skipped-stale");
+  });
+
+  test("verify-container-completion drops on a reopened child and on a terminal container", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+
+    // Reopened child: container not terminal but a child is back to in-progress.
+    writeTask("task-cont", "status: ready\nleaf: false\n");
+    writeTask("task-child", "status: in-progress\nleaf: true\ndependencies:\n  subtask_of: task-cont\n");
+    const childLine = JSON.stringify({ id: "req-VC1", action: "verify-container-completion", task: "task-cont", enqueueSource: "sync" });
+    let vc1 = 0;
+    deliverPoppedSkill({ requestId: "req-VC1", command: "/ludics-verify-container task-cont", line: childLine, expectsResult: true },
+      { send: () => { vc1++; return true; } });
+    expect(vc1).toBe(0);
+    expect(String(readResult("req-VC1")?.reason)).toContain("children");
+
+    // Container already terminal.
+    writeTask("task-cont2", "status: done\nleaf: false\n");
+    const termLine = JSON.stringify({ id: "req-VC2", action: "verify-container-completion", task: "task-cont2", enqueueSource: "sync" });
+    let vc2 = 0;
+    deliverPoppedSkill({ requestId: "req-VC2", command: "/ludics-verify-container task-cont2", line: termLine, expectsResult: true },
+      { send: () => { vc2++; return true; } });
+    expect(vc2).toBe(0);
+    expect(String(readResult("req-VC2")?.reason)).toContain("terminal");
+  });
+
+  test("verify-container-completion delivers when every child is terminal", async () => {
+    const { deliverPoppedSkill } = await import("./mag.ts");
+    writeTask("task-cont3", "status: ready\nleaf: false\n");
+    writeTask("task-child3", "status: done\nleaf: true\ndependencies:\n  subtask_of: task-cont3\n");
+    const line = JSON.stringify({ id: "req-VC3", action: "verify-container-completion", task: "task-cont3", enqueueSource: "sync" });
+    let sends = 0;
+    deliverPoppedSkill({ requestId: "req-VC3", command: "/ludics-verify-container task-cont3", line, expectsResult: true },
+      { send: () => { sends++; return true; } });
+    expect(sends).toBe(1);
+    expect(readResult("req-VC3")).toBeNull();
+  });
+});

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -11,7 +11,7 @@ import { atomicWriteFileSync, isPlainObject, writeJsonFile, writeJsonFileCompact
 import { listStashes } from "./slots/preempt.ts";
 import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
-import { queueRequest, queueRequestAtHead, queueHasCompactForTrigger, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults, parseQueueLines } from "./queue.ts";
+import { queueRequest, queueRequestAtHead, queueHasCompactForTrigger, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults, parseQueueLines, writeResult } from "./queue.ts";
 import { getUrl } from "./network.ts";
 import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName, clusterDoctor, wslPersistenceStatus } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
@@ -507,6 +507,122 @@ export function deliveryGateBlocked(): boolean {
   return listInFlight().some(r => !existsSync(magResultFile(r.requestId)));
 }
 
+// ---------------------------------------------------------------------------
+// Delivery-time staleness re-check (task-c16f71b5).
+//
+// A condition-gated request can be correct when enqueued yet stale by the time
+// it is popped: the keepalive queues `elaborate <task>` because the task had no
+// `elaborated:` field, the field lands before the pop, and the stale pop is then
+// delivered as a no-op "already-elaborated" round-trip (the gh-ludics-609
+// incident). The gate below re-evaluates the motivating predicate at pop time
+// and drops the request when it no longer applies.
+//
+// The gate is SOURCE-keyed, not action-keyed: the same action can be enqueued
+// autonomously OR via manual CLI, and only the autonomous copy carries
+// `enqueueSource`. A record without `enqueueSource` is never dropped here.
+// ---------------------------------------------------------------------------
+
+/** A per-action staleness predicate. Returns `true` when the request still
+ *  applies (deliver), or `false` / a non-empty reason string when the request
+ *  is stale (drop — the string carries the human-readable reason). Synchronous
+ *  and file-read-only, matching `deliverPoppedSkill`'s sync body. */
+type StillApplicable = (record: Record<string, unknown>) => boolean | string;
+
+/** Read a task file's content, or `null` when missing/unreadable. */
+function readTaskFileContent(taskId: string): string | null {
+  if (!taskId) return null;
+  const file = join(harnessDir(), "tasks", `${taskId}.md`);
+  if (!existsSync(file)) return null;
+  try {
+    return readFileSync(file, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/** True iff every child task (`dependencies.subtask_of === containerId`) is in a
+ *  terminal status. Mirrors `containerCompletionSweep` in tasks/sync.ts — both
+ *  read `dependencies.subtask_of` and treat `TERMINAL_STATUSES` as the
+ *  child-resolved set, so the delivery re-check and the enqueue sweep cannot
+ *  drift. A container with zero matching children returns `true` (no open work).
+ */
+function containerChildrenAllTerminal(containerId: string): boolean {
+  const tasksDir = join(harnessDir(), "tasks");
+  let files: string[];
+  try {
+    files = readdirSync(tasksDir).filter((f: string) => f.endsWith(".md"));
+  } catch {
+    return true;
+  }
+  for (const f of files) {
+    let fm;
+    try {
+      fm = parseTaskFrontmatter(readFileSync(join(tasksDir, f), "utf-8"));
+    } catch {
+      continue;
+    }
+    if (fm.dependencies?.subtask_of !== containerId) continue;
+    if (!TERMINAL_STATUSES.includes(fm.status ?? "")) return false;
+  }
+  return true;
+}
+
+/** Per-action delivery-time staleness predicates. An action absent from this
+ *  registry defaults to "always applicable" (deliver) — adding a new gated
+ *  action is a single entry. `process-suggestions` is intentionally absent: its
+ *  "already processed" condition has no cheap synchronous marker (the skill's
+ *  idempotency is relates_to-overlap based), so it is tagged for provenance but
+ *  left to the in-skill guard. */
+const STILL_APPLICABLE: Record<string, StillApplicable> = {
+  // gh-ludics-609 incident predicate: drop once the task is gone, no longer
+  // ready, a non-leaf container, or already elaborated.
+  elaborate: (record) => {
+    const task = String(record.task ?? "");
+    const content = readTaskFileContent(task);
+    if (content === null) return "task file gone";
+    const fm = parseTaskFrontmatter(content);
+    if (fm.status !== undefined && fm.status !== "ready") return `not ready (status: ${fm.status})`;
+    if (fm.leaf === false) return "task is a non-leaf container";
+    if (isElaborated(content)) return "already elaborated";
+    return true;
+  },
+  // Drop once a proposal exists, questions reopened, the task left ready, or a
+  // second draft-proposal for the same task is already pending/in-flight.
+  "draft-proposal": (record) => {
+    const task = String(record.task ?? "");
+    const content = readTaskFileContent(task);
+    if (content === null) return "task file gone";
+    if (content.includes("\nproposal:")) return "proposal already exists";
+    if (content.includes("\nhas_questions:")) return "has unanswered questions";
+    const fm = parseTaskFrontmatter(content);
+    if (fm.status !== undefined && fm.status !== "ready") return `not ready (status: ${fm.status})`;
+    if (draftProposalAlreadyPendingOrInFlight(task)) return "draft-proposal already pending/in-flight";
+    return true;
+  },
+  // Sync flips the task to `preempt-queued` immediately on enqueue, so a valid
+  // pending preempt reads `ready` or `preempt-queued`; anything else means the
+  // priority task already got slotted or moved on.
+  preempt: (record) => {
+    const task = String(record.task ?? "");
+    const content = readTaskFileContent(task);
+    if (content === null) return "task file gone";
+    const status = parseTaskFrontmatter(content).status ?? "";
+    if (status === "ready" || status === "preempt-queued") return true;
+    return `no longer preemptable (status: ${status})`;
+  },
+  // Drop once the container is gone, already terminal, or a child reopened
+  // (children no longer all-terminal).
+  "verify-container-completion": (record) => {
+    const task = String(record.task ?? "");
+    const content = readTaskFileContent(task);
+    if (content === null) return "container file gone";
+    const status = parseTaskFrontmatter(content).status ?? "";
+    if (TERMINAL_STATUSES.includes(status)) return "container already terminal";
+    if (!containerChildrenAllTerminal(task)) return "children no longer all terminal";
+    return true;
+  },
+};
+
 /**
  * Deliver one popped skill item into the Mag pane (gh-ludics-535).
  *
@@ -549,6 +665,37 @@ export function deliverPoppedSkill(
       message: `skipped: ${delivered}`,
     });
     return true;
+  }
+  // Delivery-time staleness gate (task-c16f71b5): an autonomously enqueued,
+  // condition-gated request (carrying `enqueueSource`) whose motivating
+  // predicate no longer holds is consumed without sending — same
+  // consume-without-send shape as A6. Records lacking `enqueueSource`
+  // (user/event-driven items + every current record) fall straight through.
+  const rec = parseQueueLines(popped.line)[0];
+  if (rec && typeof rec.enqueueSource === "string") {
+    const action = String(rec.action ?? "");
+    const predicate = STILL_APPLICABLE[action];
+    if (predicate) {
+      const verdict = predicate(rec);
+      if (verdict !== true) {
+        const reason = (typeof verdict === "string" && verdict) ? verdict : `${action} no longer applicable`;
+        const task = String(rec.task ?? "");
+        // Tier-2 (expectsResult !== false): leave a durable, inspectable
+        // skip-marker result (A10 shape). Tier-3 items have no result-file
+        // contract — emit the event only. Never writeInFlight: the item never
+        // went out, so nothing must be left awaiting.
+        if (popped.expectsResult !== false) {
+          writeResult(popped.requestId, "skipped-stale", undefined, { action, task, reason });
+        }
+        emitEvent({
+          event_type: "mag_queue_skipped_stale",
+          source: "keepalive",
+          scope: "mag",
+          message: `dropped stale (${reason}): ${delivered}`,
+        });
+        return true;
+      }
+    }
   }
   const sent = send(MAG_SESSION_NAME, delivered);
   if (sent) {
@@ -3007,7 +3154,7 @@ function maybeUnstickAssignedSlots(): void {
     // Not elaborated — needs elaboration first
     if (!isElaborated(content)) {
       if (!autoProposalDebounced(taskId) && !queueHasPendingActionForTask("elaborate", taskId)) {
-        queueRequest({ action: "elaborate", task: taskId });
+        queueRequest({ action: "elaborate", task: taskId }, { enqueueSource: "keepalive" });
         markAutoProposalQueued(taskId);
         emitEvent({ event_type: "slot_unstick", source: "keepalive", scope: "slot", slot: slotNum, task: taskId, message: `queued elaboration for stuck slot ${slotNum}` });
         console.error(`ludics: slot ${slotNum} stuck — queued elaboration for ${taskId}`);
@@ -3019,7 +3166,7 @@ function maybeUnstickAssignedSlots(): void {
     // Skip if already queued for this specific task (prevents spam when
     // the orchestrator skips in-progress tasks without writing a proposal)
     if (!autoProposalDebounced(taskId) && !draftProposalAlreadyPendingOrInFlight(taskId)) {
-      queueRequest({ action: "draft-proposal", task: taskId });
+      queueRequest({ action: "draft-proposal", task: taskId }, { enqueueSource: "keepalive" });
       markAutoProposalQueued(taskId);
       emitEvent({ event_type: "slot_unstick", source: "keepalive", scope: "slot", slot: slotNum, task: taskId, message: `re-queued draft-proposal for stuck slot ${slotNum}` });
       console.error(`ludics: slot ${slotNum} stuck — re-queued draft-proposal for ${taskId}`);
@@ -3065,7 +3212,7 @@ export function maybeQueueProposals(config?: LudicsFullConfig): void {
     // invisible to it — share the predicate so the in-flight arm is authoritative.
     if (draftProposalAlreadyPendingOrInFlight(task.id)) continue;
 
-    queueRequest({ action: "draft-proposal", task: task.id });
+    queueRequest({ action: "draft-proposal", task: task.id }, { enqueueSource: "keepalive" });
     markAutoProposalQueued(task.id);
     console.error(`ludics: auto-queued draft-proposal for ${task.id} (ready queue position)`);
     return; // one per cycle
@@ -3470,7 +3617,7 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
   const topCandidate = candidates[0]!;
   if (!topCandidate.elaborated) {
     if (!autoProposalDebounced(topCandidate.id)) {
-      queueRequest({ action: "elaborate", task: topCandidate.id });
+      queueRequest({ action: "elaborate", task: topCandidate.id }, { enqueueSource: "keepalive" });
       markAutoProposalQueued(topCandidate.id); // reuse debounce to avoid re-queuing
       emitEvent({ event_type: "task_elaborate_queued", source: "keepalive", scope: "task", task: topCandidate.id, message: `top candidate needs elaboration` });
       console.error(`ludics: top candidate ${topCandidate.id} needs elaboration — queued`);
@@ -3494,7 +3641,7 @@ export async function maybeFillEmptySlots(config?: LudicsFullConfig): Promise<vo
         if (topContent.includes("\nhas_questions:")) {
           // Can't generate proposal yet — skip this candidate entirely
         } else {
-          queueRequest({ action: "draft-proposal", task: topTask.id });
+          queueRequest({ action: "draft-proposal", task: topTask.id }, { enqueueSource: "keepalive" });
           markAutoProposalQueued(topTask.id);
           console.error(`ludics: top candidate ${topTask.id} needs proposal — queued draft-proposal`);
         }

--- a/src/queue-event-payload.test.ts
+++ b/src/queue-event-payload.test.ts
@@ -118,3 +118,62 @@ describe("queue record — bypassGate field (gh-ludics-538 AC 11)", () => {
     expect("bypassGate" in ev).toBe(false);
   });
 });
+
+// task-c16f71b5: the additive `enqueueSource` field opts an autonomous,
+// condition-gated record into the delivery-time staleness re-check. Mirrors the
+// bypassGate provenance idiom — set-when-on-the-allow-list, omitted otherwise.
+describe("queue record — enqueueSource field (task-c16f71b5)", () => {
+  const getStateDir = withSyntheticHarness(beforeEach, afterEach);
+
+  test("queueRequest persists a valid enqueueSource on the record", () => {
+    queueRequest({ action: "elaborate", task: "task-es" }, { enqueueSource: "keepalive" });
+    const rec = readLastQueueRecord(getStateDir());
+    expect(rec.action).toBe("elaborate");
+    // Invariant: an autonomous record carries its provenance, so the delivery
+    // gate can distinguish it from a user/CLI enqueue. Without this the gate
+    // never fires and stale pops reach Mag again.
+    expect(rec.enqueueSource).toBe("keepalive");
+  });
+
+  test("queueRequest without extras omits enqueueSource (user/CLI records never gated)", () => {
+    queueRequest({ action: "elaborate", task: "task-es" });
+    const rec = readLastQueueRecord(getStateDir());
+    expect(rec.action).toBe("elaborate");
+    expect("enqueueSource" in rec).toBe(false);
+  });
+
+  test("queueRequest with an off-allow-list enqueueSource omits the field", () => {
+    // Only keepalive/sync/retrospective are persisted — a stray value (cast to
+    // bypass tsc, mimicking malformed input) must never land on the record.
+    queueRequest(
+      { action: "elaborate", task: "task-es" },
+      { enqueueSource: "manual" as unknown as "keepalive" },
+    );
+    const rec = readLastQueueRecord(getStateDir());
+    expect("enqueueSource" in rec).toBe(false);
+  });
+
+  test("queueRequestAtHead persists a valid enqueueSource", () => {
+    queueRequestAtHead({ action: "elaborate", task: "task-es" }, { enqueueSource: "sync" });
+    const rec = readFirstQueueRecord(getStateDir());
+    expect(rec.enqueueSource).toBe("sync");
+  });
+
+  test("enqueueSource survives a JSON round-trip on the queue record", () => {
+    queueRequest({ action: "preempt", task: "task-rt", autonomy: "auto" }, { enqueueSource: "sync" });
+    const rec = readLastQueueRecord(getStateDir());
+    // Re-serialize and re-parse to prove the field is not dropped by the
+    // record's own JSON encoding (deliverPoppedSkill re-parses the raw line).
+    const roundTripped = JSON.parse(JSON.stringify(rec)) as Record<string, unknown>;
+    expect(roundTripped.action).toBe("preempt");
+    expect(roundTripped.task).toBe("task-rt");
+    expect(roundTripped.enqueueSource).toBe("sync");
+  });
+
+  test("enqueueSource is NOT mirrored onto the queue_request event payload", () => {
+    queueRequest({ action: "elaborate", task: "task-es" }, { enqueueSource: "keepalive" });
+    const ev = readLastEvent(getStateDir());
+    expect(ev.event_type).toBe("queue_request");
+    expect("enqueueSource" in ev).toBe(false);
+  });
+});

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -158,10 +158,25 @@ export type QueueAction =
  *  `triggeredBy` records the request id that caused a follow-up enqueue
  *  (e.g. the briefing/health-check that gated a /compact) so retried
  *  dispatches can dedup against an already-queued follow-up (PR #552 review
- *  by Codex: send-failure rollback used to double-queue /compact). */
+ *  by Codex: send-failure rollback used to double-queue /compact).
+ *  `enqueueSource` records that an autonomous, condition-gated request was
+ *  enqueued by the keepalive / sync sweep / retrospective writer (task-c16f71b5).
+ *  Like `bypassGate`, it is side-band provenance set at enqueue and read at
+ *  dispatch: `deliverPoppedSkill` re-checks the motivating predicate at pop time
+ *  and drops the request if it went stale. Absence of the field is the
+ *  unconditional-deliver signal — every user-/event-driven item omits it and is
+ *  never re-checked. */
 export interface QueueRequestExtras {
   bypassGate?: boolean;
   triggeredBy?: string;
+  enqueueSource?: "keepalive" | "sync" | "retrospective";
+}
+
+/** True for the three autonomous enqueue provenances that opt a record into the
+ *  delivery-time staleness re-check. An explicit allow-list (not a bare
+ *  `typeof === "string"`) so a stray value can never land on a record. */
+function isEnqueueSource(v: unknown): v is "keepalive" | "sync" | "retrospective" {
+  return v === "keepalive" || v === "sync" || v === "retrospective";
 }
 
 export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): string {
@@ -177,6 +192,7 @@ export function queueRequest(req: QueueAction, extras?: QueueRequestExtras): str
   if (typeof extras?.triggeredBy === "string" && extras.triggeredBy.length > 0) {
     baseRecord.triggeredBy = extras.triggeredBy;
   }
+  if (isEnqueueSource(extras?.enqueueSource)) baseRecord.enqueueSource = extras.enqueueSource;
   withQueueLock(() => {
     appendFileSync(file, JSON.stringify(baseRecord) + "\n");
   });
@@ -239,6 +255,7 @@ export function queueRequestAtHead(req: QueueAction, extras?: QueueRequestExtras
   if (typeof extras?.triggeredBy === "string" && extras.triggeredBy.length > 0) {
     baseRecord.triggeredBy = extras.triggeredBy;
   }
+  if (isEnqueueSource(extras?.enqueueSource)) baseRecord.enqueueSource = extras.enqueueSource;
   queueReinsertHead(JSON.stringify(baseRecord));
   emitEvent(buildQueueRequestEvent(req, requestId));
   return requestId;

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -449,7 +449,7 @@ export function writeRetrospective(data: RetrospectiveData): void {
   const hasRequestChanges = data.reviews?.some(r => r.verdict === "request_changes") ?? false;
   if (data.suggestRefactorSummary || Object.keys(data.workflowFeedback).length > 0 || hasRequestChanges) {
     try {
-      queueRequest({ action: "process-suggestions", task: data.taskId });
+      queueRequest({ action: "process-suggestions", task: data.taskId }, { enqueueSource: "retrospective" });
     } catch {
       // Non-critical: don't fail retrospective write if queue append fails
     }

--- a/src/tasks/sync.ts
+++ b/src/tasks/sync.ts
@@ -794,7 +794,7 @@ function containerCompletionSweep(taskMap: TaskMap): void {
     if (fpUnchanged && containerCompletionDebounced(parentId)) continue;
     if (queueHasPendingActionForTask("verify-container-completion", parentId)) continue;
 
-    queueRequest({ action: "verify-container-completion", task: parentId });
+    queueRequest({ action: "verify-container-completion", task: parentId }, { enqueueSource: "sync" });
     markContainerCompletionQueued(parentId);
     writeContainerCompletionFingerprint(parentId, currentFingerprint);
     emitEvent({
@@ -911,7 +911,7 @@ function tasksQueueElaborations(): void {
 
     if (alreadyQueuedElaborateTasks.has(taskId)) continue;
 
-    queueRequest({ action: "elaborate", task: taskId });
+    queueRequest({ action: "elaborate", task: taskId }, { enqueueSource: "sync" });
     emitEvent({ event_type: "task_elaborate_queued", source: "sync", scope: "task", task: taskId });
     count++;
   }
@@ -998,7 +998,7 @@ function tasksQueuePreemptions(): void {
     if (alreadyQueuedPreemptTasks.has(id)) continue;
 
     const autonomy = preemptAutonomy();
-    queueRequest({ action: "preempt", task: id, autonomy });
+    queueRequest({ action: "preempt", task: id, autonomy }, { enqueueSource: "sync" });
     emitEvent({ event_type: "task_preempt_queued", source: "sync", scope: "task", task: id, message: `priority project: ${project}` });
     // Mark task immediately so subsequent syncs won't re-queue it
     // (closes the race window between queue-pop and actual slot assignment)

--- a/templates/dashboard/dashboard.test.ts
+++ b/templates/dashboard/dashboard.test.ts
@@ -298,4 +298,76 @@ describe("mag.html renderQueue — Unresolved deliveries section (gh-ludics-535)
     ]);
     expect(listEl.innerHTML).toContain('<span class="mag-queue-badge">3</span>');
   });
+
+  // task-c16f71b5: skipped-stale result markers render in their own
+  // "Recently dropped (stale)" section, NOT in "Recent".
+  test("a skipped-stale result renders under 'Recently dropped (stale)' with action/task/reason/timestamp", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [
+      { id: "req-d", status: "skipped-stale", action: "elaborate", task: "task-x", reason: "already elaborated", timestamp: "2026-06-25T07:44:00Z" },
+    ], []);
+    const html = listEl.innerHTML;
+    const droppedIdx = html.indexOf("Recently dropped (stale)");
+    // Invariant: a stale-drop is visible in its own section — the whole point of
+    // the observability surface. If it fell through to "Recent" or vanished,
+    // this lookup would fail.
+    expect(droppedIdx).toBeGreaterThanOrEqual(0);
+    expect(html).toContain("dropped-stale");
+    expect(html).toContain("elaborate");
+    expect(html).toContain("task-x");
+    expect(html).toContain("already elaborated");
+    expect(html).toContain("2026-06-25T07:44:00Z");
+  });
+
+  test("a completed result stays in 'Recent', not in the dropped section", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [
+      { id: "req-ok", status: "completed", action: "elaborate", task: "task-ok" },
+      { id: "req-d", status: "skipped-stale", action: "preempt", task: "task-d", reason: "no longer preemptable" },
+    ], []);
+    const html = listEl.innerHTML;
+    const droppedIdx = html.indexOf("Recently dropped (stale)");
+    const recentIdx = html.indexOf("Recent</div>");
+    // Both sections present; the completed item lives under Recent, the stale
+    // drop under its own header.
+    expect(droppedIdx).toBeGreaterThanOrEqual(0);
+    expect(recentIdx).toBeGreaterThan(droppedIdx);
+    expect(html).toContain("no longer preemptable");
+  });
+
+  test("escapes the dropped reason (XSS guard)", () => {
+    const listEl = { innerHTML: "" };
+    const renderQueue = makeRenderQueue(listEl);
+    renderQueue([], [
+      { id: "req-x", status: "skipped-stale", action: "elaborate", task: "t", reason: "<script>evil</script>" },
+    ], []);
+    expect(listEl.innerHTML).toContain("&lt;script&gt;evil&lt;/script&gt;");
+    expect(listEl.innerHTML).not.toContain("<script>evil");
+  });
+});
+
+// task-c16f71b5: the dropped-stale row styling must be theme-aware (amber
+// `--warning`), not a hardcoded blue literal that reads low-contrast on dark
+// themes (memory feedback_blue_low_luminosity).
+describe("style.css — .dropped-stale theme-aware accent (task-c16f71b5)", () => {
+  const style = readFileSync(join(import.meta.dir, "style.css"), "utf-8");
+
+  test(".dropped-stale rule exists and references the --warning theme var", () => {
+    const ruleIdx = style.indexOf(".mag-queue-item.dropped-stale");
+    expect(ruleIdx).toBeGreaterThanOrEqual(0);
+    // The rule block must use var(--warning); absence would mean the drop styling
+    // is either missing or pinned to a non-theme color.
+    const block = style.slice(ruleIdx, ruleIdx + 400);
+    expect(block).toContain("var(--warning)");
+  });
+
+  test(".dropped-stale does not hardcode a blue hex literal", () => {
+    const ruleIdx = style.indexOf(".mag-queue-item.dropped-stale");
+    const block = style.slice(ruleIdx, ruleIdx + 400);
+    // Guard the load-bearing-contrast invariant: no #..ff / blue() in the rule.
+    expect(block.toLowerCase()).not.toMatch(/#[0-9a-f]{0,4}ff\b/);
+    expect(block.toLowerCase()).not.toContain("blue");
+  });
 });

--- a/templates/dashboard/mag.html
+++ b/templates/dashboard/mag.html
@@ -153,9 +153,26 @@
                 }
             }
 
-            if (results.length > 0) {
+            // Recently dropped (stale): condition-gated requests consumed at
+            // delivery time because their predicate went stale (task-c16f71b5).
+            // Read-only observability list, not an actionable queue.
+            const dropped = results.filter(r => r && r.status === 'skipped-stale').slice(0, 10);
+            const completed = results.filter(r => !r || r.status !== 'skipped-stale');
+
+            if (dropped.length > 0) {
+                html += '<div class="mag-queue-section-title">Recently dropped (stale)</div>';
+                for (const item of dropped) {
+                    const action = escapeHtml(String(item.action || 'unknown'));
+                    const task = item.task ? ' ' + escapeHtml(String(item.task)) : '';
+                    const reason = item.reason ? ' — ' + escapeHtml(String(item.reason)) : '';
+                    const ts = item.timestamp ? `<div class="timestamp">${escapeHtml(String(item.timestamp))}</div>` : '';
+                    html += `<div class="mag-queue-item dropped-stale"><span class="action">[dropped]</span> ${action}${task}${reason}${ts}</div>`;
+                }
+            }
+
+            if (completed.length > 0) {
                 html += '<div class="mag-queue-section-title">Recent</div>';
-                for (const item of results) {
+                for (const item of completed) {
                     if (item.error) {
                         html += `<div class="mag-queue-item"><span class="action">[parse error]</span></div>`;
                         continue;

--- a/templates/dashboard/style.css
+++ b/templates/dashboard/style.css
@@ -2191,6 +2191,15 @@ footer a:hover {
 .mag-queue-item .action { font-weight: 600; }
 .mag-queue-item .timestamp { color: var(--text-muted); font-size: 0.72rem; }
 
+/* Recently dropped (stale) requests (task-c16f71b5). Amber `--warning` accent
+   is theme-aware across all three themes; deliberately not blue, which reads as
+   low-contrast on dark backgrounds (memory feedback_blue_low_luminosity). */
+.mag-queue-item.dropped-stale {
+    border-left: 2px solid var(--warning);
+    color: var(--text-muted);
+}
+.mag-queue-item.dropped-stale .action { color: var(--warning); }
+
 .mag-queue-actions {
     display: inline-flex;
     gap: 4px;


### PR DESCRIPTION
## Summary

A condition-gated Mag request can be correct *when enqueued* yet stale *when delivered*. In the `gh-ludics-609` incident (2026-06-25), the keepalive queued `elaborate <task>` because the task had no `elaborated:` field; the field landed before the pop; the stale pop was then delivered to Mag twice as a no-op "already-elaborated" round-trip.

This re-evaluates the predicate that motivated an **autonomously** enqueued, condition-gated request **at pop/delivery time**, just before sending the skill to Mag. When the condition no longer holds, the pop is consumed without sending — a durable skip-marker is written and an observability event emitted — and recent drops are surfaced on the Mag dashboard tab. User-/event-driven requests are never re-checked and always deliver.

Implements `task-c16f71b5` (proposal: `docs/proposals/recheck-condition-gated-enqueues-at-delivery.md`). Relates to `gh-ludics-609`.

## Changes

- **`enqueueSource` provenance** (`src/queue.ts`): new `enqueueSource?: "keepalive" | "sync" | "retrospective"` on `QueueRequestExtras`, persisted in both `queueRequest` and `queueRequestAtHead` via an allow-listed guard (mirrors the `bypassGate` idiom; record-only, not mirrored onto the event). Tagged the 9 autonomous condition-gated enqueue sites (`mag.ts` ×5, `tasks/sync.ts` ×3, `retrospective.ts` ×1); CLI/user sites stay untagged.
- **Delivery-time gate** (`src/mag.ts` `deliverPoppedSkill`): re-parses the raw popped line beside the A6 dedup; when the record carries `enqueueSource` and a registered `STILL_APPLICABLE` predicate reports stale, consumes the pop without sending — writes a Tier-2 `skipped-stale` skip-marker result (`action`/`task`/`reason`) and emits `mag_queue_skipped_stale`; never `writeInFlight`. Records without `enqueueSource` always deliver.
- **Predicate registry**: per-action synchronous, file-read-only predicates for `elaborate` (the incident), `draft-proposal`, `preempt`, `verify-container-completion`. `process-suggestions` is tagged but intentionally unregistered (no cheap synchronous processed-marker — left to its in-skill guard). Unregistered action ⇒ always deliver.
- **Dashboard** (`templates/dashboard/mag.html` + `style.css`): a read-only "Recently dropped (stale)" Mag-tab section (newest-first, bounded to 10) showing `action`/`task`/`reason`/`timestamp`, styled with the theme-aware `--warning` accent (not blue). Reuses the existing `recentResults` → `/api/queue` → `renderQueue` pipeline.

In-skill precondition guards are untouched (the delivery re-check only avoids the wasted round-trip; the in-skill guards remain the correctness backstop).

## Tests

- `src/queue-event-payload.test.ts` — `enqueueSource` persistence (valid / absent / off-allow-list), JSON round-trip, not mirrored onto the event.
- `src/mag-delivery-confirmation.test.ts` — AC8 (a) stale autonomous `elaborate` dropped (no send, skip-marker, event, no in-flight); (b) non-stale delivers; (c) record lacking `enqueueSource` always delivers; (d) Tier-3 drop writes no result file but emits the event; plus per-predicate coverage for `draft-proposal` / `preempt` / `verify-container-completion`.
- `templates/dashboard/dashboard.test.ts` — dropped-stale render section, separation from "Recent", XSS escaping, and `--warning` theme-var styling.

## Validation

- `bun run typecheck`, `bun run build`, `bun run lint`, `lint:state-migration`, `lint:no-nul-bytes` — all clean.
- Full `bun test`: 3363 pass / 2 fail. The 2 failures are the pre-existing env-dependent cluster-machine tests (unrelated; unchanged from baseline). +20 net new passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)