### PR TITLE
gh-ludics-609: fail loud on stale/missing worker task content + plug worker→harness write leaks

### DIFF
--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync } from "fs";
 import { parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { resolveTaskContentForSetup } from "./task-launch.ts";
 import { basename, join, resolve } from "path";
 import {
   getGitBranch,
@@ -1113,10 +1114,14 @@ async function startOrchestratedThreads(
     ),
   );
 
-  // Read proposal path for the reachability guard (AC1–AC5).
-  const taskFilePath_ = join(ctx.harnessDir, "tasks", `${taskId}.md`);
-  const taskContent_ = existsSync(taskFilePath_) ? readFileSync(taskFilePath_, "utf-8") : null;
-  const proposalPath_ = taskContent_ ? (parseTaskFrontmatter(taskContent_).proposal ?? "") : "";
+  // Resolve task content + proposal path, failing loudly on a missing/stale task
+  // file (gh-ludics-609 (b)) instead of silently degrading to an empty spec. The
+  // throw surfaces through the same `slot_setup_failed` path as the proposal-
+  // reachability and project-checkout guards. `expectedTaskIntroCommit` is set on
+  // a worker from the controller's start-intent fingerprint (AC2); unset locally.
+  const { proposalPath: proposalPath_ } = resolveTaskContentForSetup(
+    ctx.harnessDir, taskId, ctx.expectedTaskIntroCommit,
+  );
 
   const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode, proposalPath_);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);

--- a/src/adapters/t3code.ts
+++ b/src/adapters/t3code.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { parseTaskFrontmatter } from "../tasks/markdown.ts";
 import { resolveTaskContentForSetup } from "./task-launch.ts";
-import { basename, join, resolve } from "path";
+import { basename, resolve } from "path";
 import {
   getGitBranch,
   getMainRepoFromWorktree,

--- a/src/adapters/task-launch.test.ts
+++ b/src/adapters/task-launch.test.ts
@@ -1,7 +1,30 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
-import { assertRepoRelativeProposalPath, readProposalLaunchMetadata } from "./task-launch.ts";
+import {
+  assertRepoRelativeProposalPath,
+  readProposalLaunchMetadata,
+  resolveTaskContentForSetup,
+  taskFileIntroCommit,
+} from "./task-launch.ts";
+
+/** Initialize a throwaway git repo at `dir` and return a committer that stages all
+ *  and commits, returning the new HEAD sha. Used for the freshness-fingerprint tests. */
+function gitRepo(dir: string): (msg: string) => string {
+  const git = (args: string[]) => {
+    const r = Bun.spawnSync(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    return r.stdout.toString().trim();
+  };
+  git(["init", "-q"]);
+  git(["config", "user.email", "t@t"]);
+  git(["config", "user.name", "t"]);
+  git(["config", "commit.gpgsign", "false"]);
+  return (msg: string) => {
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", msg]);
+    return git(["rev-parse", "HEAD"]);
+  };
+}
 
 const TMP = join(import.meta.dir, ".test-tmp-task-launch");
 
@@ -118,6 +141,66 @@ describe("readProposalLaunchMetadata", () => {
     const meta = readProposalLaunchMetadata("agent-claude", harnessDir, "task-105", projectDir);
     expect(meta?.launchFeature).toBe("add-filter");
     expect(meta?.proposalFile).toBe(join(projectDir, "docs", "proposals", "add-filter.md"));
+  });
+});
+
+describe("resolveTaskContentForSetup (gh-ludics-609 (b))", () => {
+  test("AC1: throws naming the missing task file when tasks/<id>.md is absent", () => {
+    const harnessDir = join(TMP, "harness");
+    mkdirSync(join(harnessDir, "tasks"), { recursive: true });
+    // No task file written.
+    const expectedPath = join(harnessDir, "tasks", "task-missing.md");
+    expect(() => resolveTaskContentForSetup(harnessDir, "task-missing")).toThrow(
+      `slot setup blocked: assigned task file not found at ${expectedPath}`,
+    );
+  });
+
+  test("present file with no fingerprint returns the parsed proposal path (AC2 fallback)", () => {
+    const harnessDir = join(TMP, "harness");
+    mkdirSync(join(harnessDir, "tasks"), { recursive: true });
+    writeFileSync(
+      join(harnessDir, "tasks", "task-present.md"),
+      ["---", "id: task-present", "proposal: docs/proposals/foo.md", "---", "", "# Task"].join("\n"),
+    );
+    const out = resolveTaskContentForSetup(harnessDir, "task-present");
+    expect(out.proposalPath).toBe("docs/proposals/foo.md");
+    expect(out.taskContent).toContain("# Task");
+  });
+
+  test("AC2: throws on intro-commit fingerprint mismatch (present-but-stale)", () => {
+    const harnessDir = join(TMP, "harness-git");
+    mkdirSync(join(harnessDir, "tasks"), { recursive: true });
+    const commit = gitRepo(harnessDir);
+    writeFileSync(
+      join(harnessDir, "tasks", "task-fp.md"),
+      ["---", "id: task-fp", "proposal: docs/p.md", "---", ""].join("\n"),
+    );
+    const localSha = commit("add task");
+    // A non-matching expected fingerprint (controller has a newer commit) → refuse.
+    expect(() => resolveTaskContentForSetup(harnessDir, "task-fp", "0".repeat(40))).toThrow(
+      /task file .* is stale — expected intro-commit 0{40}, local checkout has/,
+    );
+    // The matching fingerprint passes (no throw) and returns the proposal path.
+    const out = resolveTaskContentForSetup(harnessDir, "task-fp", localSha);
+    expect(out.proposalPath).toBe("docs/p.md");
+  });
+});
+
+describe("taskFileIntroCommit (gh-ludics-609 (c))", () => {
+  test("returns the latest commit touching tasks/<id>.md; '' when untracked", () => {
+    const harnessDir = join(TMP, "harness-fp");
+    mkdirSync(join(harnessDir, "tasks"), { recursive: true });
+    const commit = gitRepo(harnessDir);
+    writeFileSync(join(harnessDir, "tasks", "task-z.md"), "v1\n");
+    const sha1 = commit("v1");
+    expect(taskFileIntroCommit(harnessDir, "task-z")).toBe(sha1);
+    // A later edit moves the fingerprint forward — freshness semantics.
+    writeFileSync(join(harnessDir, "tasks", "task-z.md"), "v2\n");
+    const sha2 = commit("v2");
+    expect(sha2).not.toBe(sha1);
+    expect(taskFileIntroCommit(harnessDir, "task-z")).toBe(sha2);
+    // Unknown task / not git-tracked → "".
+    expect(taskFileIntroCommit(harnessDir, "task-none")).toBe("");
   });
 });
 

--- a/src/adapters/task-launch.ts
+++ b/src/adapters/task-launch.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "fs";
 import { join, normalize, resolve } from "path";
 import { parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { safeSyncOutput } from "../spawn.ts";
 
 /** Throws if `rawPath` is not repo-relative (absolute, home-relative, or escapes tree). */
 export function assertRepoRelativeProposalPath(rawPath: string): void {
@@ -28,6 +29,80 @@ export function proposalFeatureName(proposalPath: string): string {
   const name = base.replace(/\.md$/i, "").trim();
   if (!name) throw new Error(`invalid proposal path "${proposalPath}"`);
   return name;
+}
+
+/**
+ * The most-recent commit SHA that touched `tasks/<taskId>.md` in the harness repo,
+ * or `""` if the file is absent / not git-tracked / git is unavailable.
+ *
+ * Used as the task-content freshness fingerprint for gh-ludics-609 (b)+(c):
+ *  - the controller computes it at dispatch (`slotStart` remote branch) and threads
+ *    it through the start intent (`PendingIntent.taskIntroCommit`);
+ *  - the worker compares its local value against the controller's (content gate, AC2)
+ *    and requires the SHA to be an ancestor of its harness HEAD (freshness gate, AC5).
+ *
+ * `log -1` is the latest commit touching the path — the right freshness semantics:
+ * a worker whose checkout is missing later edits to the task file resolves an earlier
+ * SHA (or `""`), so the comparison catches stale content, not just an absent file.
+ */
+export function taskFileIntroCommit(harnessDir: string, taskId: string): string {
+  if (!taskId) return "";
+  const r = safeSyncOutput(
+    ["git", "log", "-1", "--format=%H", "--", join("tasks", `${taskId}.md`)],
+    { cwd: harnessDir },
+  );
+  return r.ok ? r.stdout.trim() : "";
+}
+
+export interface TaskSetupContent {
+  taskFilePath: string;
+  taskContent: string;
+  proposalPath: string;
+}
+
+/**
+ * Resolve the assigned task file's content + proposal path at adapter setup,
+ * failing loudly instead of silently degrading to an empty spec (gh-ludics-609 (b)).
+ *
+ * Replaces the former inline
+ *   `taskContent_ = existsSync(p) ? readFileSync(p) : null; proposalPath_ = ...`
+ * block in both adapters' `start(ctx)`. A missing file used to yield
+ * `taskContent = null` → `proposalPath = ""`, which disarmed the
+ * proposal-reachability guard (gated on `if (proposalPath)`) and launched the
+ * agent against a bare task ID. This throws via the existing adapter
+ * setup-failure surface (`slot_setup_failed`) instead.
+ *
+ * @param expectedIntroCommit Optional controller-supplied freshness fingerprint
+ *   (the `taskFileIntroCommit` of the controller's authoritative checkout, threaded
+ *   on the start intent). When present, a mismatch against the local file's
+ *   `taskFileIntroCommit` throws (AC2 — catches present-but-stale content). When
+ *   absent (legacy/local/standalone dispatch), only existence is checked (AC1).
+ */
+export function resolveTaskContentForSetup(
+  harnessDir: string,
+  taskId: string,
+  expectedIntroCommit?: string,
+): TaskSetupContent {
+  const taskFilePath = join(harnessDir, "tasks", `${taskId}.md`);
+  if (!existsSync(taskFilePath)) {
+    throw new Error(
+      `slot setup blocked: assigned task file not found at ${taskFilePath} ` +
+      `(stale/missing harness checkout — refusing to launch against an empty task spec; gh-ludics-609)`,
+    );
+  }
+  if (expectedIntroCommit) {
+    const localIntro = taskFileIntroCommit(harnessDir, taskId);
+    if (localIntro !== expectedIntroCommit) {
+      throw new Error(
+        `slot setup blocked: task file ${taskFilePath} is stale — expected intro-commit ` +
+        `${expectedIntroCommit}, local checkout has ${localIntro || "none"} ` +
+        `(harness behind controller; refusing to launch against divergent content; gh-ludics-609)`,
+      );
+    }
+  }
+  const taskContent = readFileSync(taskFilePath, "utf-8");
+  const proposalPath = parseTaskFrontmatter(taskContent).proposal ?? "";
+  return { taskFilePath, taskContent, proposalPath };
 }
 
 export interface ProposalLaunchMetadata {

--- a/src/adapters/tmux-adapter.ts
+++ b/src/adapters/tmux-adapter.ts
@@ -36,7 +36,7 @@ import {
 import { initPeerSync, writeAgentMarkerFiles } from "../orchestration/peer-sync.ts";
 import { claudeEffort, codexEffort, normaliseEffortLevel } from "../orchestration/effort.ts";
 import { createWorktrees, symlinkPeerSync } from "../orchestration/worktrees.ts";
-import { parseTaskFrontmatter } from "../tasks/markdown.ts";
+import { resolveTaskContentForSetup } from "./task-launch.ts";
 import { recordDeferredCleanup, buildCleanupEntry } from "../orchestration/deferred-cleanup.ts";
 import { isoNow, nowEpoch } from "../orchestration/util.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
@@ -857,10 +857,14 @@ async function start(ctx: AdapterContext): Promise<string> {
     ),
   );
 
-  // Read proposal path for the reachability guard (AC1–AC5).
-  const taskFilePath_ = join(ctx.harnessDir, "tasks", `${taskId}.md`);
-  const taskContent_ = existsSync(taskFilePath_) ? readFileSync(taskFilePath_, "utf-8") : null;
-  const proposalPath_ = taskContent_ ? (parseTaskFrontmatter(taskContent_).proposal ?? "") : "";
+  // Resolve task content + proposal path, failing loudly on a missing/stale task
+  // file (gh-ludics-609 (b)) instead of silently degrading to an empty spec. The
+  // throw surfaces through the same `slot_setup_failed` path as the proposal-
+  // reachability and project-checkout guards. `expectedTaskIntroCommit` is set on
+  // a worker from the controller's start-intent fingerprint (AC2); unset locally.
+  const { proposalPath: proposalPath_ } = resolveTaskContentForSetup(
+    ctx.harnessDir, taskId, ctx.expectedTaskIntroCommit,
+  );
 
   const setup = createWorktrees(projectDir, taskId, orchestration.agents, undefined, ctx.slot, orchestration.mode, proposalPath_);
   symlinkPeerSync(setup.peerSyncDir, setup.agentWorktrees);

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -13,6 +13,13 @@ export interface AdapterContext {
   harnessDir: string;
   stateRepoDir: string;
   startTtyd?: boolean;
+  /** Controller-supplied task-content freshness fingerprint (gh-ludics-609 (b)/AC2):
+   *  the `taskFileIntroCommit` of the controller's authoritative harness checkout,
+   *  threaded from the start intent via the worker's per-slot fingerprint override.
+   *  When set, the adapter setup refuses on a local task file whose intro-commit
+   *  differs (present-but-stale). Unset on controller-local / standalone runs, where
+   *  the local harness is authoritative and only existence is checked (AC1). */
+  expectedTaskIntroCommit?: string;
 }
 
 /** Allow adapter methods to return sync or async results. */

--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -474,6 +474,33 @@ describe("parsePendingIntent", () => {
     expect(parsePendingIntent({ ...valid, adapterArgs: null })?.adapterArgs).toBeUndefined();
   });
 
+  test("preserves optional taskIntroCommit and round-trips the freshness SHA (gh-ludics-609)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    const sha = "a".repeat(40);
+    const out = parsePendingIntent({ ...valid, taskId: "task-99", taskIntroCommit: sha });
+    // Invariant: the controller-authored task-content freshness fingerprint survives
+    // the parse boundary verbatim. If this dropped/mangled it, the worker's (c)
+    // ancestry gate and (b) content gate would both go vacuous (undefined → skipped).
+    expect(out).toEqual({ action: "start", epoch: NOW, machine: "host-a", taskId: "task-99", taskIntroCommit: sha });
+  });
+
+  test("legacy intent without taskIntroCommit still validates (optional field; gh-ludics-609)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid })?.taskIntroCommit).toBeUndefined();
+  });
+
+  test("string-coerces non-string taskIntroCommit; drops/trims empty after coercion (gh-ludics-609)", async () => {
+    const { parsePendingIntent } = await import("./cluster-http.ts");
+    expect(parsePendingIntent({ ...valid, taskIntroCommit: 42 })?.taskIntroCommit).toBe("42");
+    // Empty / whitespace-only is dropped so a worker with no fingerprint falls back
+    // to the existence-only gate (AC2 fallback), not a vacuous mismatch on "".
+    expect(parsePendingIntent({ ...valid, taskIntroCommit: "" })?.taskIntroCommit).toBeUndefined();
+    expect(parsePendingIntent({ ...valid, taskIntroCommit: "   " })?.taskIntroCommit).toBeUndefined();
+    expect(parsePendingIntent({ ...valid, taskIntroCommit: null })?.taskIntroCommit).toBeUndefined();
+    // Surrounding whitespace is trimmed so the ancestry compare uses a bare SHA.
+    expect(parsePendingIntent({ ...valid, taskIntroCommit: "  abc123  " })?.taskIntroCommit).toBe("abc123");
+  });
+
   test("rejects non-bool preserveState (no sensible coercion target)", async () => {
     const { parsePendingIntent } = await import("./cluster-http.ts");
     expect(parsePendingIntent({ ...valid, preserveState: "yes" })).toBeNull();

--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -256,6 +256,42 @@ describe("handleSignal dispatch", () => {
 
 import { existsSync, readFileSync } from "fs";
 
+// gh-ludics-609 write-leak closure: the controller-side endpoints workers POST to.
+// Reuses the TMP/harnessDir/config fixture from the handleSignal suite above.
+describe("POST /api/cluster/retrospective + /api/cluster/feedback (gh-ludics-609)", () => {
+  test("retrospective: writes harness/retrospectives/<id>.json on the controller", async () => {
+    const req = makeRequest("/api/cluster/retrospective", { taskId: "task-abc", data: { taskId: "task-abc", title: "T" } });
+    const resp = await handleClusterRequest(req, "/api/cluster/retrospective");
+    expect(resp.status).toBe(200);
+    const file = join(harnessDir, "retrospectives", "task-abc.json");
+    expect(existsSync(file)).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf-8")).title).toBe("T");
+  });
+
+  test("retrospective: rejects an invalid task id (traversal guard) with 400 and writes nothing", async () => {
+    const req = makeRequest("/api/cluster/retrospective", { taskId: "../evil", data: { x: 1 } });
+    const resp = await handleClusterRequest(req, "/api/cluster/retrospective");
+    expect(resp.status).toBe(400);
+    expect(existsSync(join(harnessDir, "retrospectives"))).toBe(false);
+  });
+
+  test("feedback: writes harness/feedback/<id>--<file>.md on the controller", async () => {
+    const req = makeRequest("/api/cluster/feedback", { taskId: "task-fb", filename: "workflow-feedback-coder.md", content: "body\n" });
+    const resp = await handleClusterRequest(req, "/api/cluster/feedback");
+    expect(resp.status).toBe(200);
+    const file = join(harnessDir, "feedback", "task-fb--workflow-feedback-coder.md");
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, "utf-8")).toBe("body\n");
+  });
+
+  test("feedback: rejects a filename with path separators (traversal) with 400", async () => {
+    const req = makeRequest("/api/cluster/feedback", { taskId: "task-fb", filename: "../../etc/passwd", content: "x" });
+    const resp = await handleClusterRequest(req, "/api/cluster/feedback");
+    expect(resp.status).toBe(400);
+    expect(existsSync(join(harnessDir, "feedback"))).toBe(false);
+  });
+});
+
 // Reuses the TMP/harnessDir/config fixture from the handleSignal suite above.
 describe("atomic writes for intent/heartbeat/orchestration-state", () => {
   test("recordIntent writes a round-trippable file with no .tmp leftover", async () => {

--- a/src/cluster-http.test.ts
+++ b/src/cluster-http.test.ts
@@ -275,6 +275,17 @@ describe("POST /api/cluster/retrospective + /api/cluster/feedback (gh-ludics-609
     expect(existsSync(join(harnessDir, "retrospectives"))).toBe(false);
   });
 
+  test("retrospective: ACCEPTS a dotted task id matching the shared TASK_ID_RE (PR #611 P2)", async () => {
+    // Invariant: the endpoint validator must equal the authoritative TASK_ID_RE
+    // (which allows '.'), else a worker's retrospective for a dotted id is silently
+    // dropped (callers discard POST failures). An inline /^[a-z0-9_-]+$/i mirror
+    // would 400 here. '/' is still rejected (traversal) — see the test above.
+    const req = makeRequest("/api/cluster/retrospective", { taskId: "task-1.2.3", data: { taskId: "task-1.2.3", title: "Dotted" } });
+    const resp = await handleClusterRequest(req, "/api/cluster/retrospective");
+    expect(resp.status).toBe(200);
+    expect(existsSync(join(harnessDir, "retrospectives", "task-1.2.3.json"))).toBe(true);
+  });
+
   test("feedback: writes harness/feedback/<id>--<file>.md on the controller", async () => {
     const req = makeRequest("/api/cluster/feedback", { taskId: "task-fb", filename: "workflow-feedback-coder.md", content: "body\n" });
     const resp = await handleClusterRequest(req, "/api/cluster/feedback");

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -145,6 +145,13 @@ export interface PendingIntent {
    *  `freshSlots` snapshot raced the controller's two-slot publish. Optional, so
    *  legacy `stop`/`resume` intents and older on-disk files remain valid. */
   adapterArgs?: string;
+  /** Assigned task file's freshness fingerprint (gh-ludics-609 (c)): the SHA of the
+   *  commit that last touched `tasks/<taskId>.md` in the controller's authoritative
+   *  harness (`git log -1 --format=%H -- tasks/<id>.md`). Carried on `start` intents
+   *  so the worker requires it to be an ancestor of its harness HEAD before launching
+   *  and refuses a present-but-stale local task file. Optional, so legacy/local
+   *  dispatch and older on-disk files remain valid. */
+  taskIntroCommit?: string;
 }
 
 /** Validate an untrusted intent payload (file-on-disk read, HTTP body) into
@@ -195,6 +202,15 @@ export function parsePendingIntent(raw: unknown): PendingIntent | null {
   if (r.adapterArgs !== undefined && r.adapterArgs !== null) {
     const adapterArgs = typeof r.adapterArgs === "string" ? r.adapterArgs : String(r.adapterArgs);
     if (adapterArgs.trim() !== "") out.adapterArgs = adapterArgs;
+  }
+
+  // taskIntroCommit (gh-ludics-609): same string-coerce + drop-when-empty contract as
+  // taskId/adapterArgs. An empty/whitespace value is dropped so legacy/local dispatch
+  // (no fingerprint) falls back to the worker's existence-only gate; a non-empty value
+  // carries the controller's task-content freshness SHA.
+  if (r.taskIntroCommit !== undefined && r.taskIntroCommit !== null) {
+    const taskIntroCommit = typeof r.taskIntroCommit === "string" ? r.taskIntroCommit : String(r.taskIntroCommit);
+    if (taskIntroCommit.trim() !== "") out.taskIntroCommit = taskIntroCommit.trim();
   }
 
   if (r.preserveState !== undefined) {

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -3,7 +3,7 @@
 // Server handlers are called by dashboard-server routing.
 // Client helper is used by slots, cluster, and worker-signal modules.
 
-import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync, appendFileSync } from "fs";
+import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync, appendFileSync, writeFileSync } from "fs";
 import { writeJsonFile, writeJsonFileCompact } from "./json.ts";
 import { join } from "path";
 import { harnessDir, loadConfigSync, slotsCount, stateRepoDir } from "./config.ts";
@@ -360,6 +360,18 @@ export async function clusterPostTaskSectionAppend(taskId: string, section: stri
   return resolveAndPost("/api/cluster/task-section-append", { taskId, section, line });
 }
 
+/** Worker→controller: deliver a retrospective JSON for the controller to write into
+ *  its authoritative harness (gh-ludics-609 write-leak closure). */
+export async function clusterPostRetrospective(taskId: string, data: object): Promise<{ ok: boolean }> {
+  return resolveAndPost("/api/cluster/retrospective", { taskId, data });
+}
+
+/** Worker→controller: deliver a single workflow-feedback markdown file for the
+ *  controller to copy into its harness feedback/ dir (gh-ludics-609). */
+export async function clusterPostFeedback(taskId: string, filename: string, content: string): Promise<{ ok: boolean }> {
+  return resolveAndPost("/api/cluster/feedback", { taskId, filename, content });
+}
+
 export async function clusterGetTask(taskId: string): Promise<{ ok: boolean; data?: string }> {
   const result = await resolveAndGet(`/api/cluster/task/${taskId}`);
   return { ok: result.ok, data: typeof result.data === "string" ? result.data : undefined };
@@ -492,6 +504,8 @@ const taskMatch = pathname.match(/^\/api\/cluster\/task\/(.+)$/);
     case "/api/cluster/task-update": return handlePostTaskUpdate(body);
     case "/api/cluster/task-section-append": return handlePostTaskSectionAppend(body);
     case "/api/cluster/slot-update": return handlePostSlotUpdate(body);
+    case "/api/cluster/retrospective": return handlePostRetrospective(body);
+    case "/api/cluster/feedback": return handlePostFeedback(body);
     default:
       return jsonResponse(404, { error: "not found" });
   }
@@ -764,6 +778,44 @@ function handlePostSlotUpdate(body: Record<string, unknown>): Response {
   if (typeof body.git === "string") data.git = body.git;
 
   writeSlotJson(slot, data);
+  return jsonResponse(200, { ok: true });
+}
+
+// gh-ludics-609 write-leak closure: workers POST their retrospective JSON and
+// workflow-feedback files to the controller instead of writing the tracked harness
+// directly (which would dirty the worker checkout and wedge the next git pull).
+// The controller writes them into its authoritative harness here.
+const RETRO_TASK_ID_RE = /^[a-z0-9_-]+$/i;
+
+function handlePostRetrospective(body: Record<string, unknown>): Response {
+  const taskId = String(body.taskId ?? "");
+  if (!taskId || !RETRO_TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
+  if (!body.data || typeof body.data !== "object") return jsonResponse(400, { error: "data object required" });
+  try {
+    const dir = join(harnessDir(), "retrospectives");
+    mkdirSync(dir, { recursive: true });
+    writeJsonFile(join(dir, `${taskId}.json`), body.data);
+  } catch (err) {
+    return jsonResponse(500, { error: String(err) });
+  }
+  return jsonResponse(200, { ok: true });
+}
+
+function handlePostFeedback(body: Record<string, unknown>): Response {
+  const taskId = String(body.taskId ?? "");
+  const filename = String(body.filename ?? "");
+  const content = String(body.content ?? "");
+  if (!taskId || !RETRO_TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
+  // Only workflow-feedback markdown, no path separators (traversal guard).
+  if (!/^workflow-feedback[\w.-]*\.md$/.test(filename)) return jsonResponse(400, { error: "invalid filename" });
+  try {
+    const dir = join(harnessDir(), "feedback");
+    mkdirSync(dir, { recursive: true });
+    // Mirror persistWorkflowFeedback's <taskId>--<original> collision-avoidance naming.
+    writeFileSync(join(dir, `${taskId}--${filename}`), content);
+  } catch (err) {
+    return jsonResponse(500, { error: String(err) });
+  }
   return jsonResponse(200, { ok: true });
 }
 

--- a/src/cluster-http.ts
+++ b/src/cluster-http.ts
@@ -12,7 +12,7 @@ import { parseSlotLiveness, type SlotData } from "./slots/types.ts";
 import { slotClear } from "./slots/index.ts";
 import { emitEvent } from "./events.ts";
 import { journalAppend } from "./journal.ts";
-import { updateFrontmatterField, appendToSection } from "./tasks/markdown.ts";
+import { updateFrontmatterField, appendToSection, TASK_ID_RE } from "./tasks/markdown.ts";
 import type { ClusterMachine } from "./cluster.ts";
 
 // --- Config helpers ---
@@ -784,12 +784,15 @@ function handlePostSlotUpdate(body: Record<string, unknown>): Response {
 // gh-ludics-609 write-leak closure: workers POST their retrospective JSON and
 // workflow-feedback files to the controller instead of writing the tracked harness
 // directly (which would dirty the worker checkout and wedge the next git pull).
-// The controller writes them into its authoritative harness here.
-const RETRO_TASK_ID_RE = /^[a-z0-9_-]+$/i;
+// The controller writes them into its authoritative harness here. Task IDs are
+// validated against the authoritative shared TASK_ID_RE (which allows dots, e.g.
+// GitHub-sourced ids) rather than a stricter inline mirror — a mismatch would
+// silently drop retrospectives/feedback for dotted ids since worker callers discard
+// POST failures. TASK_ID_RE forbids "/" so it still blocks path traversal.
 
 function handlePostRetrospective(body: Record<string, unknown>): Response {
   const taskId = String(body.taskId ?? "");
-  if (!taskId || !RETRO_TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
+  if (!taskId || !TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
   if (!body.data || typeof body.data !== "object") return jsonResponse(400, { error: "data object required" });
   try {
     const dir = join(harnessDir(), "retrospectives");
@@ -805,7 +808,7 @@ function handlePostFeedback(body: Record<string, unknown>): Response {
   const taskId = String(body.taskId ?? "");
   const filename = String(body.filename ?? "");
   const content = String(body.content ?? "");
-  if (!taskId || !RETRO_TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
+  if (!taskId || !TASK_ID_RE.test(taskId)) return jsonResponse(400, { error: "invalid task id" });
   // Only workflow-feedback markdown, no path separators (traversal guard).
   if (!/^workflow-feedback[\w.-]*\.md$/.test(filename)) return jsonResponse(400, { error: "invalid filename" });
   try {

--- a/src/mag.test.ts
+++ b/src/mag.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick, maybeResumeDeadOrchestrators, fillBlankSnapshotArgsFromIntent } from "./mag.ts";
+import { normalizeLaunchAdapter, evaluateAutoStartDecisionPure, resolveQueueRequestCommand, orchPidForSlotMode, mergeRequirements, briefingPrecomputeContext, clearStaleSettled, setQueueHold, isQueueHeld, applyQueueFeedPrefix, runMag, clearAutoProposalDebounce, autoProposalDebounceFile, runStagingOutboundPushTick, maybeResumeDeadOrchestrators, fillBlankSnapshotArgsFromIntent, startFreshnessRefusal } from "./mag.ts";
 import { emptySlotData, writeSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
 import type { RunGit } from "./git-runner.ts";
@@ -2039,5 +2039,39 @@ describe("fillBlankSnapshotArgsFromIntent (gh-ludics-589 Part B)", () => {
     expect(fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "resume", adapterArgs: duoArgs })).toBeNull();
     expect(fillBlankSnapshotArgsFromIntent(snap(4, ""), { action: "start" })).toBeNull();
     expect(fillBlankSnapshotArgsFromIntent(undefined, { action: "start", adapterArgs: duoArgs })).toBeNull();
+  });
+});
+
+describe("startFreshnessRefusal (gh-ludics-609 (c)/AC5)", () => {
+  const sha = "f".repeat(40);
+
+  test("REFUSES a start whose fingerprint fails the ancestry check", () => {
+    // Harness condition: worker HEAD does not contain the intro-commit (checker→false).
+    // Invariant: a stale-harness start is refused — the returned reason is the signal
+    // the loop uses to skip dispatch + leave the intent unacked. If the gate were
+    // removed (always proceed), this would return null and the agent would launch
+    // against stale content (the gh-ludics-609 incident).
+    const reason = startFreshnessRefusal({ action: "start", taskId: "task-7d2", taskIntroCommit: sha }, () => false);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain("task-7d2");
+    expect(reason).toContain(sha);
+  });
+
+  test("PROCEEDS when the fingerprint is an ancestor (checker→true)", () => {
+    // Post-fetch the worker HEAD contains the intro-commit → no refusal → dispatch.
+    expect(startFreshnessRefusal({ action: "start", taskId: "task-7d2", taskIntroCommit: sha }, () => true)).toBeNull();
+  });
+
+  test("PROCEEDS (existence-only fallback) when the start carries no fingerprint", () => {
+    // Legacy/local dispatch: the checker must NOT even be consulted — a throwing
+    // checker proves the no-fingerprint branch short-circuits before calling it.
+    const boom = () => { throw new Error("checker should not run"); };
+    expect(startFreshnessRefusal({ action: "start", taskId: "t" }, boom)).toBeNull();
+  });
+
+  test("never gates stop/resume intents", () => {
+    const boom = () => { throw new Error("checker should not run for stop/resume"); };
+    expect(startFreshnessRefusal({ action: "stop", taskIntroCommit: sha }, boom)).toBeNull();
+    expect(startFreshnessRefusal({ action: "resume", taskIntroCommit: sha }, boom)).toBeNull();
   });
 });

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -3968,6 +3968,37 @@ export function fillBlankSnapshotArgsFromIntent(
   return { ...snap, adapterArgs: intent.adapterArgs };
 }
 
+/**
+ * Dispatch decision for the gh-ludics-609 (c)/AC5 freshness gate. Returns a
+ * non-null refusal reason when a `start` intent carrying a task freshness
+ * fingerprint must be REFUSED (harness stale — leave the intent unacked, surface
+ * a setup failure), or `null` to PROCEED. Only `start` intents with a fingerprint
+ * are gated; `stop`/`resume` and fingerprint-less (legacy/local) starts proceed
+ * (the worker falls back to the adapter's existence-only check).
+ *
+ * Pure given an injected freshness checker — exported as a test seam (the live
+ * `processSlotIntents` is not unit-reachable without the controller HTTP stack).
+ * The default checker is the real `ensureHarnessFreshForCommit` (fetch + ancestry).
+ */
+export function startFreshnessRefusal(
+  intent: { action: string; taskId?: string; taskIntroCommit?: string },
+  freshChecker: (introCommit: string) => boolean = ensureHarnessFreshForCommitDefault,
+): string | null {
+  if (intent.action !== "start" || !intent.taskIntroCommit) return null;
+  if (freshChecker(intent.taskIntroCommit)) return null;
+  return `task ${intent.taskId ?? "?"} intro-commit ${intent.taskIntroCommit} ` +
+    `not an ancestor of harness HEAD after fetch (gh-ludics-609)`;
+}
+
+// Indirection so the seam's default arg references a stable symbol even though the
+// real implementation is imported lazily inside processSlotIntents (circular-dep
+// avoidance). Tests inject their own checker, so this default is only the live path.
+function ensureHarnessFreshForCommitDefault(introCommit: string): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ensureHarnessFreshForCommit } = require("./state.ts") as typeof import("./state.ts");
+  return ensureHarnessFreshForCommit(introCommit);
+}
+
 async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Promise<void> {
   const currentMachine = clusterCurrentMachineName();
   if (!currentMachine) return;
@@ -3977,7 +4008,7 @@ async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Pro
     if (!clusterIsController()) {
       if (!freshSlots) return; // no fresh state — skip
       const { clusterGetIntents, clusterDeleteIntent } = await import("./cluster-http.ts");
-      const { setWorkerSlotsOverride } = await import("./slots/index.ts");
+      const { setWorkerSlotsOverride, setPendingStartFingerprint } = await import("./slots/index.ts");
       const result = await clusterGetIntents();
       if (!result.ok || !result.data) return;
       // result.data is Record<number, PendingIntent> validated by
@@ -4002,8 +4033,30 @@ async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Pro
           // stale local slot-N.json).
           const filled = fillBlankSnapshotArgsFromIntent(freshSlots.get(slotNum), intent);
           if (filled) freshSlots.set(slotNum, filled);
+
+          // gh-ludics-609 (c)/AC5: before launching a start, refresh the harness and
+          // require the assigned task's freshness fingerprint to be an ancestor of
+          // HEAD. A stale checkout (missing/old tasks/<id>.md) is refused loudly —
+          // intent left unacked, surfaced as a setup failure — instead of launching
+          // an agent against an empty/divergent task spec. Fetch precedes the
+          // ancestry test (worker-deploy stale-ref trap). Skipped when the intent
+          // carries no fingerprint (legacy/local dispatch — existence-only gate).
+          const refusal = startFreshnessRefusal(intent);
+          if (refusal) {
+            emitEvent({
+              event_type: "slot_setup_failed", source: "keepalive", scope: "slot", slot: slotNum,
+              message: `refused start: harness stale — ${refusal}`,
+            });
+            shouldAck = false; // leave unacked → controller retry / TTL sweep
+            continue; // do NOT dispatch slotStart against stale content
+          }
+
           // Set fresh controller state so slot operations use it instead of stale local harness
           setWorkerSlotsOverride(freshSlots);
+          // Thread the content fingerprint so the adapter setup re-checks the local
+          // task file (AC2 — catches present-but-stale that the ancestry gate's
+          // post-fetch reset already healed but a racing edit could re-introduce).
+          setPendingStartFingerprint(slotNum, intent.action === "start" ? intent.taskIntroCommit : undefined);
           try {
             switch (intent.action) {
               case "start": await slotStart(slotNum); break;
@@ -4012,6 +4065,7 @@ async function processSlotIntents(freshSlots: Map<number, SlotData> | null): Pro
             }
           } finally {
             setWorkerSlotsOverride(null);
+            setPendingStartFingerprint(slotNum, undefined);
           }
           emitEvent({ event_type: `slot_intent_${intent.action}`, source: "keepalive", scope: "slot", slot: slotNum, message: `processed ${intent.action} intent` });
         } catch (err) {

--- a/src/retrospective.test.ts
+++ b/src/retrospective.test.ts
@@ -145,8 +145,101 @@ describe("extractReviews", () => {
   });
 });
 
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import type { RetrospectiveData } from "./retrospective.ts";
+import { persistWorkflowFeedback } from "./retrospective.ts";
+
+// gh-ludics-609 write-leak closure (AC6/AC8): a worker run must NOT drop untracked
+// files into its tracked harness (retrospectives/<id>.json, feedback/<id>--*.md) —
+// those wedge the next `git pull --ff-only`. Driven via real cluster config +
+// LUDICS_CLUSTER_MACHINE_NAME (the queue.test pattern), with a controller positive
+// control. No HTTP server runs in-test, so the worker POSTs are fire-and-forget
+// no-ops — the assertion is purely that the harness gains no files.
+describe("write-leak closure: worker retrospective/feedback never dirty the harness (gh-ludics-609)", () => {
+  const SAVED_HOME = process.env.HOME;
+  const SAVED_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  const SAVED_CONFIG = process.env.LUDICS_CONFIG;
+  const SAVED_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  let wtmp = "";
+
+  function writeClusterConfig(homeDir: string): string {
+    const configPath = join(homeDir, "config.yaml");
+    writeFileSync(configPath, `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: leader-box
+      host: leader-box.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: minipc-wsl
+      host: minipc-wsl.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    return configPath;
+  }
+
+  function setup(machine: string): { harness: string; peerSync: string } {
+    wtmp = mkdtempSync(join(tmpdir(), "ludics-retro-leak-"));
+    process.env.HOME = wtmp;
+    const harness = join(wtmp, "harness");
+    process.env.LUDICS_HARNESS_DIR = harness;
+    process.env.LUDICS_CONFIG = writeClusterConfig(wtmp);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = machine;
+    mkdirSync(harness, { recursive: true });
+    const peerSync = join(wtmp, "peer-sync");
+    mkdirSync(peerSync, { recursive: true });
+    writeFileSync(join(peerSync, "workflow-feedback-coder.md"), "feedback body\n");
+    return { harness, peerSync };
+  }
+
+  function minimalData(taskId: string): RetrospectiveData {
+    return {
+      taskId, title: "t", status: "done", completedAt: "2026-06-25T00:00:00Z", startedAt: null,
+      slot: null, mode: null, proposalPath: null, prUrl: null, githubUrl: null, phases: [],
+      rounds: 1, mergeRound: 0, planMergeRound: 0, agents: [], verdicts: [], reviews: [],
+      threads: [], turns: [], missingThreads: [], suggestRefactorSummary: null,
+      workflowFeedback: {}, workflowFeedbackSummary: null, collectedAt: "2026-06-25T00:00:00Z",
+    };
+  }
+
+  afterEach(() => {
+    if (SAVED_HOME === undefined) delete process.env.HOME; else process.env.HOME = SAVED_HOME;
+    if (SAVED_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = SAVED_HARNESS;
+    if (SAVED_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = SAVED_CONFIG;
+    if (SAVED_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = SAVED_MACHINE;
+    try { rmSync(wtmp, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("worker: writeRetrospective + persistWorkflowFeedback leave retrospectives/ and feedback/ EMPTY", () => {
+    const { harness, peerSync } = setup("minipc-wsl"); // role: worker → isWorkerContext()
+    // Invariant: zero new files under the two tracked dirs. Removing either
+    // isWorkerContext() guard makes the corresponding write land here → fails.
+    writeRetrospective(minimalData("task-worker-leak"));
+    persistWorkflowFeedback(peerSync, "task-worker-leak");
+    expect(existsSync(join(harness, "retrospectives", "task-worker-leak.json"))).toBe(false);
+    const feedbackDir = join(harness, "feedback");
+    const feedbackFiles = existsSync(feedbackDir) ? readdirSync(feedbackDir) : [];
+    expect(feedbackFiles).toHaveLength(0);
+  });
+
+  test("controller positive control: leader-box DOES write both retrospective and feedback", () => {
+    const { harness, peerSync } = setup("leader-box"); // role: leader → controller
+    writeRetrospective(minimalData("task-ctrl-leak"));
+    persistWorkflowFeedback(peerSync, "task-ctrl-leak");
+    expect(existsSync(join(harness, "retrospectives", "task-ctrl-leak.json"))).toBe(true);
+    expect(existsSync(join(harness, "feedback", "task-ctrl-leak--workflow-feedback-coder.md"))).toBe(true);
+  });
+});
 
 describe("writeRetrospective - review-only auto-queue path", () => {
   let harness: string;

--- a/src/retrospective.ts
+++ b/src/retrospective.ts
@@ -9,6 +9,8 @@ import { harnessDir } from "./config.ts";
 import { emitEvent } from "./events.ts";
 import { parseReviewFilename } from "./orchestration/review-files.ts";
 import { queueRequest } from "./queue.ts";
+import { isWorkerContext } from "./orchestration/state.ts";
+import { clusterPostRetrospective, clusterPostFeedback } from "./cluster-http.ts";
 import type { OrchestrationState } from "./orchestration/state.ts";
 import type { T3Thread, T3ThreadMessage } from "./t3code/types.ts";
 import { threadModel } from "./t3code/types.ts";
@@ -341,13 +343,26 @@ function extractAllWorkflowFeedback(peerSyncDir: string): Record<string, string>
   return result;
 }
 
-/** Copy workflow feedback files to harness/feedback/ for the digest pipeline. */
-function persistWorkflowFeedback(peerSyncDir: string, taskId: string): void {
+/** Copy workflow feedback files to harness/feedback/ for the digest pipeline.
+ *  On a worker (gh-ludics-609 write-leak closure) POST each file to the controller
+ *  instead of writing the tracked harness — an untracked feedback/<id>--*.md would
+ *  dirty the worker checkout and wedge the next git pull.
+ *  @internal exported for tests only */
+export function persistWorkflowFeedback(peerSyncDir: string, taskId: string): void {
   if (!existsSync(peerSyncDir)) return;
 
   try {
     const files = readdirSync(peerSyncDir).filter((f: string) => /^workflow-feedback.*\.md$/.test(f));
     if (files.length === 0) return;
+
+    if (isWorkerContext()) {
+      for (const f of files) {
+        const content = readFileSync(join(peerSyncDir, f), "utf-8");
+        // Fire-and-forget: the controller writes its authoritative harness.
+        void clusterPostFeedback(taskId, f, content).catch(() => {});
+      }
+      return;
+    }
 
     const feedbackDir = join(harnessDir(), "feedback");
     mkdirSync(feedbackDir, { recursive: true });
@@ -408,9 +423,18 @@ function readTaskFrontmatter(taskId: string): TaskFrontmatter | null {
 
 /** @internal exported for tests only */
 export function writeRetrospective(data: RetrospectiveData): void {
-  const dir = join(harnessDir(), "retrospectives");
-  mkdirSync(dir, { recursive: true });
-  writeJsonFile(join(dir, `${data.taskId}.json`), data);
+  // gh-ludics-609 write-leak closure: on a worker, POST the retrospective to the
+  // controller (which writes its authoritative harness) instead of dropping an
+  // untracked retrospectives/<id>.json into the worker's tracked checkout — that
+  // would dirty the harness and wedge the next git pull. The event + suggestion
+  // queueing below still run (emitEvent POSTs on a worker; queueRequest no-ops).
+  if (isWorkerContext()) {
+    void clusterPostRetrospective(data.taskId, data).catch(() => {});
+  } else {
+    const dir = join(harnessDir(), "retrospectives");
+    mkdirSync(dir, { recursive: true });
+    writeJsonFile(join(dir, `${data.taskId}.json`), data);
+  }
 
   emitEvent({
     event_type: "retrospective_written",

--- a/src/slots/index.test.ts
+++ b/src/slots/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, setDefaultTimeout, spyOn, test
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { hostname as osHostname, tmpdir } from "os";
 import { join } from "path";
-import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride, persistSlotLiveness, slotIsDuoMember } from "./index.ts";
+import { slotAssign, slotClear, slotResume, slotStart, slotSetMode, slotStop, runSlot, markSlotSetupFailed, autoFillAdapterArgs, makeAdapterContext, slotPreempt, slotReset, slotRestore, validateAssignAdapter, VALID_ASSIGN_ADAPTERS, reinitTtydPid, setWorkerSlotsOverride, persistSlotLiveness, slotIsDuoMember, setPendingStartFingerprint, getPendingStartFingerprint } from "./index.ts";
 import * as clusterHttpMod from "../cluster-http.ts";
 import * as tmuxAdapterMod from "../adapters/tmux-adapter.ts";
 import * as t3codeServerMod from "../t3code/server.ts";
@@ -908,6 +908,27 @@ describe("makeAdapterContext taskId normalization", () => {
   test("preserves a real task id", () => {
     const ctx = makeAdapterContext(1, buildSlotData("task-abc123"));
     expect(ctx.taskId).toBe("task-abc123");
+  });
+
+  test("threads the per-slot start fingerprint onto ctx.expectedTaskIntroCommit (gh-ludics-609 AC2)", () => {
+    // Harness condition: processSlotIntents set a fingerprint for this slot before
+    // dispatching slotStart. makeAdapterContext must surface it so the adapter setup
+    // can refuse a present-but-stale local task file. Absent override → undefined
+    // (controller-local/standalone run, existence-only gate).
+    expect(makeAdapterContext(1, buildSlotData("task-abc123")).expectedTaskIntroCommit).toBeUndefined();
+    setPendingStartFingerprint(1, "deadbeef".repeat(5));
+    try {
+      const ctx = makeAdapterContext(1, buildSlotData("task-abc123"));
+      // Invariant: the exact fingerprint reaches ctx. If makeAdapterContext dropped
+      // the read, resolveTaskContentForSetup would get undefined and the AC2
+      // stale-content limb would go vacuous.
+      expect(ctx.expectedTaskIntroCommit).toBe("deadbeef".repeat(5));
+      // Scoped per slot — a different slot has no fingerprint.
+      expect(makeAdapterContext(2, buildSlotData("task-abc123")).expectedTaskIntroCommit).toBeUndefined();
+    } finally {
+      setPendingStartFingerprint(1, undefined);
+    }
+    expect(getPendingStartFingerprint(1)).toBeUndefined();
   });
 });
 
@@ -2237,6 +2258,79 @@ describe("remote slot dispatch via HTTP", () => {
     expect(data.sessionStarted).toBe("2026-04-04T20:00Z");
 
     clearIntent(1);
+  });
+
+  test("remote slotStart records a start intent carrying the task intro-commit fingerprint (gh-ludics-609 AC4)", async () => {
+    // Pin the controller machine via a named cluster entry + LUDICS_CLUSTER_MACHINE_NAME
+    // rather than includeSelf's osHostname() match, which is host-dependent in this
+    // worktree (see reference_slots_tests_pin_cluster_machine_env).
+    const SAVED_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+    const cfgDir = join(TMP, ".config", "ludics");
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.yaml"), `state_repo: owner/ludics-state
+state_path: harness
+slots:
+  count: 2
+cluster:
+  transport: http
+  domain: test.local
+  machines:
+    - name: ctrl-node
+      host: ctrl-node.test.local
+      os: macos
+      role: leader
+      always_on: true
+      gpu: ""
+    - name: worker-a
+      host: worker-a.test.local
+      os: linux
+      role: worker
+      always_on: false
+      gpu: ""
+`);
+    process.env.LUDICS_CONFIG = join(cfgDir, "config.yaml");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "ctrl-node"; // this host = the controller
+
+    const harness = join(TMP, "ludics-state", "harness");
+    const tasksDir = join(harness, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeSlotJson(1, emptySlotData(1), harness);
+    writeSlotJson(2, emptySlotData(2), harness);
+    writeTask(tasksDir, "task-fp-intent", "Fingerprint intent test");
+
+    // git-init the harness and commit the task file so taskFileIntroCommit resolves a
+    // real SHA (the controller's authoritative checkout). Without git this would be
+    // "" and the field would be (correctly) dropped — here we want the populated path.
+    const git = (args: string[]) => Bun.spawnSync(["git", ...args], { cwd: harness, stdout: "pipe", stderr: "pipe" });
+    git(["init", "-q"]);
+    git(["config", "user.email", "t@t"]);
+    git(["config", "user.name", "t"]);
+    git(["config", "commit.gpgsign", "false"]);
+    git(["add", "-A"]);
+    git(["commit", "-q", "-m", "add task"]);
+    const expectedSha = git(["rev-parse", "HEAD"]).stdout.toString().trim();
+
+    const hbDir = getHeartbeatsDir();
+    mkdirSync(hbDir, { recursive: true });
+    writeFileSync(join(hbDir, "worker-a.json"), JSON.stringify({ epoch: Math.floor(Date.now() / 1000) }));
+
+    try {
+      void slotAssign(1, "task-fp-intent", "tmux", "", "", "", "worker-a");
+      await slotStart(1);
+
+      // Invariant: the controller threads the freshness fingerprint to the worker. If
+      // dropped, the worker's (c) ancestry gate and (b) content gate both go vacuous and
+      // a stale harness could again run the wrong task silently.
+      const intent = getIntentForDashboard(1);
+      expect(intent).not.toBeNull();
+      expect(intent!.action).toBe("start");
+      expect(intent!.machine).toBe("worker-a");
+      expect(intent!.taskIntroCommit).toBe(expectedSha);
+      clearIntent(1);
+    } finally {
+      if (SAVED_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+      else process.env.LUDICS_CLUSTER_MACHINE_NAME = SAVED_MACHINE;
+    }
   });
 
   test("remote slotStop with --force does not write intent, clears state", async () => {

--- a/src/slots/index.ts
+++ b/src/slots/index.ts
@@ -22,6 +22,7 @@ import { readSlotState, writeSlotState, processAlive } from "../t3code/server.ts
 import { agentCliCommand, isAgentAlive, readTmuxSlotState, startTtyd, tmuxSessionName, ttydPort, writeTmuxOrchestrationSiblingState, writeTmuxSlotState } from "../adapters/tmux-adapter.ts";
 import { tmuxHasSession, tmuxNewSession, tmuxSendCommand, tmuxSendKeys } from "../adapters/tmux.ts";
 import { selectOrchestrationFlagsForTask, isT3codeIntegrationPausedError } from "../adapters/t3code.ts";
+import { taskFileIntroCommit } from "../adapters/task-launch.ts";
 import { readOrchestrationState, persistState, removeOrchestrationState } from "../orchestration/state.ts";
 import { startOrchestrationProcess } from "../orchestration/process.ts";
 import { isRemoteMachine } from "../remote.ts";
@@ -71,6 +72,24 @@ let workerSlotsOverride: Map<number, SlotData> | null = null;
  *  Call with null to clear. */
 export function setWorkerSlotsOverride(data: Map<number, SlotData> | null): void {
   workerSlotsOverride = data;
+}
+
+// Worker-side per-slot task-content freshness fingerprint (gh-ludics-609 (b)/AC2).
+// Set by processSlotIntents from the start intent's `taskIntroCommit` just before
+// dispatching slotStart, so makeAdapterContext can thread it onto the AdapterContext
+// and the adapter setup refuses on present-but-stale task content. Cleared after.
+const pendingStartFingerprint = new Map<number, string>();
+
+/** Record the controller-supplied task intro-commit fingerprint for a slot's
+ *  imminent worker-side start. Pass an empty/undefined commit to clear the slot. */
+export function setPendingStartFingerprint(slot: number, introCommit: string | undefined): void {
+  if (introCommit && introCommit.trim()) pendingStartFingerprint.set(slot, introCommit.trim());
+  else pendingStartFingerprint.delete(slot);
+}
+
+/** Read the pending task intro-commit fingerprint for a slot, or undefined. */
+export function getPendingStartFingerprint(slot: number): string | undefined {
+  return pendingStartFingerprint.get(slot);
 }
 
 /** Mutator-only liveness writer: structural mirror of `parseSlotLiveness` on
@@ -960,6 +979,7 @@ export function makeAdapterContext(slotNum: number, data: SlotData): AdapterCont
     machine: data.machine ?? "",
     harnessDir: harnessDir(),
     stateRepoDir: stateRepoDir(),
+    expectedTaskIntroCommit: getPendingStartFingerprint(slotNum),
   };
 }
 
@@ -1151,9 +1171,14 @@ export async function slotStart(slotNum: number, { startTtyd: shouldStartTtyd = 
     // --duo-peer-slot) even if its up-front freshSlots snapshot raced the
     // controller's two-slot publish. The controller's slot state is authoritative
     // here. Pass undefined (not "") when empty so parsePendingIntent drops it.
+    // gh-ludics-609 (c): thread the assigned task file's freshness fingerprint (the
+    // commit that last touched tasks/<id>.md in the controller's authoritative
+    // harness) so the worker can (1) require it to be an ancestor of its harness
+    // HEAD before launching and (2) refuse a present-but-stale local task file.
     await ensureRemoteMachineReachable(slotNum, ctx.machine, "start", ctx.mode, {
       taskId: ctx.taskId,
       adapterArgs: ctx.adapterArgs.trim() ? ctx.adapterArgs : undefined,
+      taskIntroCommit: ctx.taskId ? (taskFileIntroCommit(harnessDir(), ctx.taskId) || undefined) : undefined,
     });
     return;
   }

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -1,9 +1,10 @@
 // State checkpoint tests
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { existsSync, unlinkSync } from "fs";
+import { existsSync, unlinkSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
-import { stateMarkDirty, stateIsDirty, stateCommit } from "./state.ts";
+import { stateMarkDirty, stateIsDirty, stateCommit, ensureHarnessFreshForCommit } from "./state.ts";
 
 describe("dirty flag", () => {
   const flagPath = join(process.env.HOME ?? "/tmp", ".ludics-state-dirty");
@@ -37,5 +38,101 @@ describe("dirty flag", () => {
     } catch {
       // Expected if stateRepoDir() fails in test env
     }
+  });
+});
+
+describe("ensureHarnessFreshForCommit (gh-ludics-609 (c)/AC5)", () => {
+  const SAVED_HOME = process.env.HOME;
+  const SAVED_CONFIG = process.env.LUDICS_CONFIG;
+  let home = "";
+
+  function git(dir: string, args: string[]): string {
+    const r = Bun.spawnSync(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+    return r.stdout.toString().trim();
+  }
+  function commitFile(repo: string, rel: string, body: string, msg: string): string {
+    const abs = join(repo, rel);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, body);
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-q", "-m", msg]);
+    return git(repo, ["rev-parse", "HEAD"]);
+  }
+  function initRepo(dir: string): void {
+    mkdirSync(dir, { recursive: true });
+    git(dir, ["init", "-q", "-b", "main"]);
+    git(dir, ["config", "user.email", "t@t"]);
+    git(dir, ["config", "user.name", "t"]);
+    git(dir, ["config", "commit.gpgsign", "false"]);
+  }
+
+  afterEach(() => {
+    if (SAVED_HOME === undefined) delete process.env.HOME; else process.env.HOME = SAVED_HOME;
+    if (SAVED_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = SAVED_CONFIG;
+    if (home) rmSync(home, { recursive: true, force: true });
+  });
+
+  // Build an origin (bare) + a worker clone whose stateRepoDir() resolves to it.
+  // state_repo tail "myrepo" → stateRepoDir = $HOME/myrepo.
+  function setup(): { origin: string; clone: string } {
+    home = mkdtempSync(join(tmpdir(), "ludics-fresh-"));
+    process.env.HOME = home;
+    const cfgPath = join(home, "config.yaml");
+    writeFileSync(cfgPath, "state_repo: test/myrepo\nstate_path: harness\n");
+    process.env.LUDICS_CONFIG = cfgPath;
+
+    const work = join(home, "origin-work");
+    initRepo(work);
+    commitFile(work, "harness/README.md", "base\n", "base");
+    const origin = join(home, "origin.git");
+    git(work, ["clone", "-q", "--bare", work, origin]);
+
+    const clone = join(home, "myrepo");
+    git(home, ["clone", "-q", origin, "myrepo"]);
+    git(clone, ["config", "user.email", "t@t"]);
+    git(clone, ["config", "user.name", "t"]);
+    return { origin, clone };
+  }
+
+  it("returns true when the intro-commit is reachable only after fetch (pre-fetch lie)", () => {
+    const { origin, clone } = setup();
+    // origin advances with the assigned task file; the worker clone has NOT fetched.
+    const work2 = join(home, "origin-work2");
+    git(home, ["clone", "-q", origin, "origin-work2"]);
+    git(work2, ["config", "user.email", "t@t"]);
+    git(work2, ["config", "user.name", "t"]);
+    const introCommit = commitFile(work2, "harness/tasks/task-x.md", "spec\n", "add task-x");
+    git(work2, ["push", "-q", "origin", "main"]);
+
+    // Pre-fetch the clone does not have the intro-commit at all.
+    const preCat = Bun.spawnSync(["git", "cat-file", "-e", introCommit], { cwd: clone, stdout: "pipe", stderr: "pipe" });
+    expect(preCat.exitCode).not.toBe(0);
+
+    // The gate fetches first, then tests ancestry → fresh.
+    expect(ensureHarnessFreshForCommit(introCommit)).toBe(true);
+    // And the worker HEAD now contains it.
+    const postCat = Bun.spawnSync(["git", "merge-base", "--is-ancestor", introCommit, "HEAD"], { cwd: clone, stdout: "pipe", stderr: "pipe" });
+    expect(postCat.exitCode).toBe(0);
+  });
+
+  it("returns false when the intro-commit is not an ancestor of origin/main after fetch", () => {
+    const { origin, clone } = setup();
+    // A commit that lives only on a divergent branch, never merged to main.
+    const work2 = join(home, "origin-work2");
+    git(home, ["clone", "-q", origin, "origin-work2"]);
+    git(work2, ["config", "user.email", "t@t"]);
+    git(work2, ["config", "user.name", "t"]);
+    git(work2, ["checkout", "-q", "-b", "divergent"]);
+    const orphanCommit = commitFile(work2, "harness/tasks/task-y.md", "spec\n", "divergent task-y");
+    git(work2, ["push", "-q", "origin", "divergent"]);
+
+    // After statePull resets to origin/main, the divergent commit is NOT an ancestor → refuse.
+    expect(ensureHarnessFreshForCommit(orphanCommit)).toBe(false);
+    void clone;
+  });
+
+  it("returns true with empty fingerprint (no gate when controller supplied none)", () => {
+    // No git/config needed — empty string short-circuits before any side effect.
+    expect(ensureHarnessFreshForCommit("")).toBe(true);
   });
 });

--- a/src/state.ts
+++ b/src/state.ts
@@ -132,6 +132,41 @@ export function statePull(): boolean {
   return true;
 }
 
+/**
+ * Worker-side dispatch-time freshness gate (gh-ludics-609 (c)/AC5).
+ *
+ * Refresh the local state repo from origin, then verify the controller-supplied
+ * task introducing-commit is an ancestor of the worker's harness HEAD. Returns
+ * true if the harness is fresh enough to launch, false to refuse.
+ *
+ * Fetch-before-ancestry is load-bearing: a 0-behind `HEAD..origin/main` lies if
+ * the worker has not fetched, and pre-fetch the worker may not even hold the
+ * commit object — `merge-base --is-ancestor` would then report "not an ancestor"
+ * for a commit that IS reachable post-fetch (the worker-deploy stale-ref trap).
+ * So we always `statePull()` (fetch + reset --hard origin/main) first. The reset
+ * is safe because worker runs no longer dirty the harness (gh-ludics-609 write-leak
+ * closure) — a clean checkout always fast-forwards.
+ *
+ * An empty `introCommit` means the controller had no fingerprint (legacy/local
+ * dispatch); callers treat that as "no gate" and should not call this.
+ */
+export function ensureHarnessFreshForCommit(introCommit: string): boolean {
+  if (!introCommit) return true; // no fingerprint supplied → nothing to gate on
+  if (!statePull()) {
+    console.error("ludics: harness freshness gate: fetch/reset failed — refusing start");
+    return false;
+  }
+  const repoDir = stateRepoDir();
+  const r = run(["git", "merge-base", "--is-ancestor", introCommit, "HEAD"], repoDir);
+  if (!r.success) {
+    console.error(
+      `ludics: harness freshness gate: task intro-commit ${introCommit} is not an ancestor ` +
+      `of harness HEAD after fetch — refusing start (stale worker harness)`,
+    );
+  }
+  return r.success;
+}
+
 export function statePush(): void {
   const repoDir = stateRepoDir();
 


### PR DESCRIPTION
Resolves https://github.com/lukstafi/ludics/issues/609.

Closes the silent-failure path where a worker running orchestration against a **stale local harness checkout** (missing or divergent assigned task file) launched an agent against an **empty/ID-only task spec** — and ran whatever sibling work its project checkout carried, commits still tagged with the assigned ID. Ships **(b)+(c), not (a)** per the user-resolved direction (git stays the content channel; fix freshness + plug leaks).

## (b) — Loud refusal at the adapter setup site (AC1-3)
- Extracted the inline `taskContent_`/`proposalPath_` read from both adapters' `start(ctx)` into `resolveTaskContentForSetup` (`src/adapters/task-launch.ts`), which **throws** (via the existing `slot_setup_failed` surface) when `tasks/<id>.md` is absent (AC1) and on **intro-commit fingerprint mismatch** when the controller supplies one (AC2). Fires once per setup before any worktree fork → uniform across solo/duo/pair (AC3).
- Fingerprint reaches the adapter via `ctx.expectedTaskIntroCommit`, set by a per-slot override (`setPendingStartFingerprint`) read in `makeAdapterContext`.

## (c) — Dispatch-time freshness precondition (AC4-5)
- `PendingIntent.taskIntroCommit` + `parsePendingIntent` (optional / string-coerce / drop-when-empty, mirroring `taskId`/`adapterArgs`); controller `slotStart` populates it via `taskFileIntroCommit` (`git log -1 --format=%H -- tasks/<id>.md`).
- `ensureHarnessFreshForCommit` (`src/state.ts`): `statePull()` (fetch + reset --hard origin/main) **then** `git merge-base --is-ancestor` — fetch precedes the ancestry test (worker-deploy stale-ref trap). `processSlotIntents` refuses a stale start loudly (emit `slot_setup_failed`, leave unacked, skip dispatch) via the pure `startFreshnessRefusal` seam.

## Write-leak closure (AC6-8)
- `writeRetrospective` + `persistWorkflowFeedback` (`src/retrospective.ts`) are now `isWorkerContext()`-guarded: a worker POSTs to new `POST /api/cluster/retrospective` / `/api/cluster/feedback` endpoints (validate task id + filename against traversal) instead of dirtying its tracked harness — so a worker run leaves a clean checkout and `git pull --ff-only` can never wedge. Controller/standalone unchanged.
- AC7 audit: the two retrospective sites were the only orchestration-runner-reachable ungated `harnessDir()` writes; everything else is controller/Mag-only or already redirected. Remaining set is empty.

## Tests / checks
- New regression tests in `task-launch.test.ts`, `cluster-http.test.ts`, `state.test.ts`, `mag.test.ts`, `retrospective.test.ts`, `slots/index.test.ts` (each AC has a falsifier + mutation note; worker tests have controller positive controls).
- Full suite: **3366 pass / 2 fail** (+1 test: dotted-task-id acceptance, PR review P2) — both pre-existing baseline failures in `src/slots/index.test.ts` (host-name dependent, ⊂ the 5-failure pre-change baseline). All 17 CI lints + typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)