### PR TITLE
fix(tests): neutralize ambient LUDICS_CLUSTER_MACHINE_NAME; isolate notify config

### DIFF
--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -118,11 +118,23 @@ describe("notify ntfy.sh suppression under bun test", () => {
   const ORIGINAL_HARNESS_DIR = process.env.LUDICS_HARNESS_DIR;
   const ORIGINAL_BUN_TEST = process.env.BUN_TEST;
   const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "ludics-notify-suppress-"));
     mkdirSync(join(tmpDir, "journal"), { recursive: true });
     process.env.LUDICS_HARNESS_DIR = tmpDir;
+    // Isolate the config: without this, loadConfigSync resolves the developer's
+    // real ~/config.yaml. On a federation controller that config self-matches
+    // the local hostname, so notifyLog's isWorkerContext() guard spawns
+    // safeSyncOutput (git/hostname) during cluster-identity resolution and
+    // defeats the "0 safeSyncOutput" assertions below. A minimal config with no
+    // cluster section makes clusterCurrentMachineName() return falsy, so
+    // isWorkerContext() short-circuits without spawning — and no topics keeps
+    // the notify* calls on the "topic not configured" path.
+    const configPath = join(tmpDir, "config.yaml");
+    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\nslots:\n  count: 2\n");
+    process.env.LUDICS_CONFIG = configPath;
     // Set BUN_TEST explicitly: bun-test does not always populate it. The
     // guard's primary signal is BUN_TEST; assert from the test that the
     // value the suppression check sees matches what the runner / wrapper
@@ -138,6 +150,8 @@ describe("notify ntfy.sh suppression under bun test", () => {
     else process.env.BUN_TEST = ORIGINAL_BUN_TEST;
     if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
     else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG;
+    else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
   });
 
   test("notifyAgents writes to journal but does NOT invoke safeSyncOutput under BUN_TEST", async () => {

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -132,8 +132,15 @@ describe("notify ntfy.sh suppression under bun test", () => {
     // cluster section makes clusterCurrentMachineName() return falsy, so
     // isWorkerContext() short-circuits without spawning — and no topics keeps
     // the notify* calls on the "topic not configured" path.
+    //
+    // The config MUST be terminal: omit `state_repo`. resolveConfigPath() treats
+    // a pointer config carrying `state_repo`/`state_path` as a redirect to
+    // $HOME/<repoName>/<statePath>/config.yaml and, when that file exists (the
+    // real harness clone on a controller — exactly the env we're neutralizing),
+    // loads it instead. Without `state_repo` the redirect branch is skipped and
+    // our synthetic config is used directly, independent of $HOME.
     const configPath = join(tmpDir, "config.yaml");
-    writeFileSync(configPath, "state_repo: owner/ludics-state\nstate_path: harness\nslots:\n  count: 2\n");
+    writeFileSync(configPath, "slots:\n  count: 2\n");
     process.env.LUDICS_CONFIG = configPath;
     // Set BUN_TEST explicitly: bun-test does not always populate it. The
     // guard's primary signal is BUN_TEST; assert from the test that the

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -7,3 +7,14 @@ import { tmpdir } from "os";
 if (!process.env.LUDICS_HARNESS_DIR) {
   process.env.LUDICS_HARNESS_DIR = mkdtempSync(join(tmpdir(), "ludics-test-"));
 }
+
+// Safety net: neutralize an ambient cluster-machine override leaked from the
+// launching shell. The federation controller exports
+// LUDICS_CLUSTER_MACHINE_NAME=<node> into its interactive shell, which bleeds
+// into the Bun test process and breaks hostname-based self-match tests
+// (clusterCurrentMachine() short-circuits on the override and returns undefined
+// when that name is absent from a test's synthetic cluster config). Tests that
+// exercise the override set it explicitly in their own bodies after this
+// preload runs and restore it in their own afterEach/finally, so they are
+// unaffected.
+delete process.env.LUDICS_CLUSTER_MACHINE_NAME;


### PR DESCRIPTION
## Summary

Fixes the broken test suite caused by an ambient `LUDICS_CLUSTER_MACHINE_NAME` leaking from the federation-controller shell. Proposal: `docs/proposals/fix-slots-test-cluster-machine-env-leak.md` (already on `main`).

Two `src/slots/index.test.ts` hostname-self-match tests failed when the suite was launched from the controller shell (which exports `LUDICS_CLUSTER_MACHINE_NAME=mac-studio`) but passed in CI. The ambient value short-circuits `clusterCurrentMachine()`'s override branch (`src/cluster.ts:104`), returning `undefined` for a synthetic config that doesn't name `mac-studio`, so the slot mis-defaults to the leader instead of the self-matched node.

## Changes

Two commits:

**`cbddbd1` — neutralize the ambient override + isolate the notify test config**
- `src/test-setup.ts` — the global Bun preload now `delete process.env.LUDICS_CLUSTER_MACHINE_NAME`, mirroring the existing `LUDICS_HARNESS_DIR` safety net. Makes the suite deterministic regardless of the launching shell; product logic in `src/cluster.ts` is untouched (the fail-closed override branch is intentional, AC4).
- `src/notify.test.ts` — the ntfy-suppression describe now isolates `LUDICS_CONFIG`. Forcing the override absent exposed a latent failure: `notifyLog → isWorkerContext() → clusterIsController()` spawns `safeSyncOutput` (hostname/git) during cluster-identity resolution when the controller's real `config.yaml` self-matches the local hostname, defeating the test's "0 safeSyncOutput" assertion.

**`2a5c3d8` — make the isolation config terminal (addresses Codex P2)**
- The first-pass isolation config carried `state_repo`/`state_path`, which `resolveConfigPath()` treats as a *redirect* to `$HOME/<repoName>/<statePath>/config.yaml` — on a controller that real harness clone exists, so the "isolated" config silently redirected back to the real clustered config. Dropping `state_repo` makes the config terminal (the `if (stateRepo)` redirect branch is skipped), independent of `$HOME`. `loadConfigSync` defaults `state_repo` to `""`, so nothing else needs it.

## Verification

- AC1 `LUDICS_CLUSTER_MACHINE_NAME=mac-studio bun test src/slots/index.test.ts` → **122 pass / 0 fail**
- AC2 `env -u LUDICS_CLUSTER_MACHINE_NAME bun test src/slots/index.test.ts` → **122 pass / 0 fail**
- AC3 full suite, sequential, both ways → **3388 pass / 0 fail** each
- AC4 `git diff -- src/cluster.ts` empty (override branch unchanged)
- `bun run typecheck` + `bun run lint` + targeted project lints → OK

Mutation-checked: reverting the preload `delete` reproduces the 2 slots failures (`self-match-node` → `leader-other`); reverting the `LUDICS_CONFIG` isolation reproduces the notify failure (`Expected 0 / Received 6`). For the `2a5c3d8` redirect fix, a sandbox-`HOME` probe planting `$SANDBOX/ludics-state/harness/config.yaml` (self-matching cluster) confirms the old `state_repo` config redirects (test fails) while the terminal config does not (13/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)