### PR TITLE
fix(test): never run real launchctl/systemctl during tests (kills the live dashboard)

### DIFF
--- a/src/spawn.test.ts
+++ b/src/spawn.test.ts
@@ -36,4 +36,34 @@ describe("safeSyncOutput", () => {
     const r = safeSyncOutput(["echo", "hi"]);
     expect(r.timedOut).toBe(false);
   });
+
+  // Regression guard: service-manager commands (launchctl/systemctl) address
+  // the live launchd/systemd domain by uid and ignore the HOME sandbox, so
+  // running them for real in a test would mutate the developer/controller's
+  // actual jobs (e.g. bootout com.ludics.dashboard). They must be skipped under
+  // LUDICS_TEST_MODE — set by the src/test-setup.ts preload for every test run.
+  describe("service-manager isolation under LUDICS_TEST_MODE", () => {
+    test("preload set LUDICS_TEST_MODE for this test run", () => {
+      expect(process.env.LUDICS_TEST_MODE).toBe("1");
+    });
+
+    test("launchctl is skipped, never spawned (no live-domain mutation)", () => {
+      const r = safeSyncOutput(["launchctl", "bootout", "gui/0/com.ludics.dashboard"]);
+      expect(r.ok).toBe(false);
+      expect(r.exitCode).toBe(-1);
+      expect(r.stderr).toBe("skipped under LUDICS_TEST_MODE");
+    });
+
+    test("systemctl is skipped, never spawned", () => {
+      const r = safeSyncOutput(["systemctl", "--user", "disable", "--now", "ludics-dashboard.service"]);
+      expect(r.ok).toBe(false);
+      expect(r.stderr).toBe("skipped under LUDICS_TEST_MODE");
+    });
+
+    test("guard is targeted — unrelated commands still run in test mode", () => {
+      const r = safeSyncOutput(["echo", "still-runs"]);
+      expect(r.ok).toBe(true);
+      expect(r.stdout).toBe("still-runs");
+    });
+  });
 });

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -9,6 +9,13 @@ export interface SyncResult {
   timedOut: boolean;
 }
 
+/** Service-manager binaries that address the user's launchd/systemd domain by
+ *  uid and therefore ESCAPE the HOME sandbox tests rely on. Running them for
+ *  real during a test would mutate the live machine's actual jobs (e.g.
+ *  bootout the controller's com.ludics.dashboard). They are skipped under
+ *  LUDICS_TEST_MODE (set by src/test-setup.ts). */
+const TEST_BLOCKED_BINARIES = new Set(["launchctl", "systemctl"]);
+
 /** Run a command synchronously. Never throws.
  *  Returns { ok: false, exitCode: -1 } on ENOENT or missing cwd.
  *  stdout/stderr are trimmed by default; pass { trim: false } to preserve raw output.
@@ -17,6 +24,15 @@ export function safeSyncOutput(
   cmd: string[],
   opts?: { cwd?: string; env?: Record<string, string>; trim?: boolean; timeout?: number },
 ): SyncResult {
+  // In test runs, never execute real service-manager commands against the live
+  // host — they ignore HOME and hit the user's actual launchd/systemd domain.
+  // Return the same benign "not available" shape callers already tolerate on a
+  // platform without the binary (every launchctl/systemctl call site treats it
+  // as best-effort), so the trigger functions' file-level effects still run and
+  // their tests stay green while the live domain is left untouched.
+  if (process.env.LUDICS_TEST_MODE && TEST_BLOCKED_BINARIES.has(cmd[0])) {
+    return { ok: false, exitCode: -1, stdout: "", stderr: "skipped under LUDICS_TEST_MODE", timedOut: false };
+  }
   try {
     const result = Bun.spawnSync(cmd, {
       cwd: opts?.cwd,

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -18,3 +18,14 @@ if (!process.env.LUDICS_HARNESS_DIR) {
 // preload runs and restore it in their own afterEach/finally, so they are
 // unaffected.
 delete process.env.LUDICS_CLUSTER_MACHINE_NAME;
+
+// Mark the process as a test run so safeSyncOutput refuses to execute real
+// service-manager commands (`launchctl`/`systemctl`) against the live machine.
+// Those binaries address the user's launchd/systemd domain by uid and ignore
+// the HOME sandbox that test setups rely on, so a test exercising the trigger
+// teardown path (e.g. triggers.test.ts "darwin: deletes com.ludics.dashboard.plist")
+// would `launchctl disable`+`bootout` the developer/controller's REAL
+// com.ludics.dashboard job — taking the live dashboard down. CI never saw it
+// (Linux has no launchctl, so the call failed harmlessly); only a darwin
+// controller running the suite was hit. See safeSyncOutput in src/spawn.ts.
+process.env.LUDICS_TEST_MODE = "1";


### PR DESCRIPTION
## Problem

Running the test suite on a **darwin controller** (mac-studio) repeatedly takes down the live `com.ludics.dashboard` launchd job — observed many times this session while slot 3 ran the suite for AC verification.

Root cause: `src/triggers.test.ts`'s `"darwin: deletes com.ludics.dashboard.plist"` calls `removeControllerTriggerUnits(..., "darwin")`, which shells out to **real** `launchctl disable` + `launchctl bootout` on `gui/$uid/com.ludics.dashboard` (`src/triggers.ts:102-103`). `setup()` sandboxes **`HOME`** to a tmpdir, but **`launchctl` ignores `HOME`** — it addresses the live user launchd domain by uid. So the test disables + bootouts the operator's **real** dashboard job. The `disable` is persistent, which is why `KeepAlive=true` can't revive it.

- **CI stayed green** because Linux has no `launchctl` (`safeSyncOutput` fails harmlessly).
- Only a **live darwin controller** running the suite was hit.

This is a second test-isolation leak adjacent to the `LUDICS_CLUSTER_MACHINE_NAME` env leak fixed in #612-era work — same class (the suite isn't hermetic from the live machine).

## Fix

- `src/test-setup.ts` (global test preload) sets `LUDICS_TEST_MODE=1`.
- `safeSyncOutput` (`src/spawn.ts`) skips `launchctl`/`systemctl` under that flag, returning the same benign "not available" shape every call site already tolerates on a platform without the binary. The trigger functions' **file-level** effects (sandboxed `unlinkSync`) still run, so their assertions stay green — only the live service-manager domain is left untouched.
- Targeted, not blanket: other spawns (git, gh, echo, …) still run in test mode. No test asserts on real `launchctl`/`systemctl` output (verified), so nothing else breaks.

## Verification

- `bun test src/triggers.test.ts src/spawn.test.ts` → **74 pass / 0 fail**.
- Ran `bun test src/triggers.test.ts` **preload-driven (no explicit env)** and confirmed the controller's `com.ludics.dashboard` stays **up (HTTP 200)** afterward — before this change the same run took it down.
- `typecheck`, `eslint`, `lint:test-isolation`, `lint:no-mock-module` all clean.
- Added `spawn.test.ts` regression tests (preload flag set; launchctl/systemctl skipped; unrelated commands still run).

## Follow-up (not in this PR)

Consider a lint rule flagging real `launchctl`/`systemctl` invocation reachable from `*.test.ts` so this can't regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)