### PR TITLE
fix(test): per-process fixture dir for worktrees.test.ts (concurrent runs collide)

### DIFF
--- a/src/orchestration/worktrees.test.ts
+++ b/src/orchestration/worktrees.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { autoCommitWorktree, classifyOrphanDir, cleanupWorktrees, clearGhResolvedMarkers, createWorktrees, deleteBranches, ensureGitExcludes, ensureProposalReachable, ensureUpstreamRemote, GIT_EXCLUDE_ENTRIES, maybeGit, ORPHAN_RECOVERY_ALLOWLIST, orchBranchName, orchWorktreeStem, parseRegisteredWorktreeMatches, proposalReachableFromRef, purgeOrphanDirIfRecoverable, refreshMainBranchFromRemote, removeWorktreeByPath, seedGhResolvedToOrigin, symlinkPeerSync } from "./worktrees.ts";
 import { captureConsoleError, withSyntheticHarness } from "../test-utils.ts";
 import * as spawnMod from "../spawn.ts";
 
-const TMP = join(import.meta.dir, ".test-tmp-worktrees");
+const TMP = realpathSync(mkdtempSync(join(tmpdir(), "ludics-worktrees-test-")));
 
 function run(cmd: string[], cwd: string): void {
   const result = Bun.spawnSync(cmd, {


### PR DESCRIPTION
## Problem

`src/orchestration/worktrees.test.ts` keyed its fixture root onto a **fixed in-source path**:

```ts
const TMP = join(import.meta.dir, ".test-tmp-worktrees");
```

torn down by a top-level `afterEach(() => rmSync(TMP, { recursive: true, force: true }))`. Two concurrent `bun test` processes (e.g. CI shards, or a federation node running the suite while another invocation runs) key onto the **same on-disk directory**, so one process's teardown wipes the other's fixtures mid-run and both spuriously fail.

## Fix

Switch `TMP` to a **per-process** temp dir, mirroring the existing `withHarnessDir` pattern already in this file (`mkdtempSync(join(tmpdir(), "ludics-test-harness-"))`):

```ts
const TMP = realpathSync(mkdtempSync(join(tmpdir(), "ludics-worktrees-test-")));
```

`realpathSync` normalizes the macOS `/var` → `/private/var` symlink so `TMP` still matches the realpaths git emits in `git worktree list` output (several tests assert on those paths). `TMP` is module-load-evaluated once, so all ~140 `join(TMP, …)` references and the `mkdirSync(TMP, { recursive: true })` / `rmSync(TMP)` lifecycle stay correct.

## Verification

- `bun test src/orchestration/worktrees.test.ts` → **105 pass / 0 fail**
- **Concurrency evidence** — two invocations of just this file run concurrently:
  - **post-fix**: both **105 pass / 0 fail**
  - **pre-fix** (same concurrent pair): **75 fail** and **77 fail** — the collision reproduced
- `bun run typecheck`, `bunx eslint src/orchestration/worktrees.test.ts`, `bun run lint:test-isolation` → all clean

Relates to task-61b5ace9; follow-up from task-f48d9c98 / PR #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)