### PR TITLE
Add cluster.disable_console_workers (reverse gh-602's console-routing half; preserve controller-exclusion)

### DIFF
--- a/src/cluster.test.ts
+++ b/src/cluster.test.ts
@@ -346,15 +346,15 @@ slots:
     expect(clusterConfig().disableConsoleWorkers).toBe(false);
   });
 
-  // (b) selection excludes / includes the console per the flag
-  it("excludes the console node from a ludics self-task when the flag is ON", () => {
+  // (b) selection excludes the console for a non-ludics task, but the
+  // controller stays available to it (controller-exclusion is gh-602-only).
+  it("excludes the console node but keeps the controller for a NON-ludics task when the flag is ON", () => {
     setup("  disable_console_workers: true\n");
     writeHeartbeat("macbook-pro", 10); // console fresh
     writeHeartbeat("mac-studio", 10);  // controller online
-    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
-    // With the flag ON the console is removed from `eligible`, so the
-    // gh-ludics-602 console-preference branch can't fire — the self-task falls
-    // back to the always_on controller instead of the console.
+    const result = selectMachineForSlot({ project: "ocannl", effort: "medium" });
+    // Console is forbidden for every task; the controller (leader) is NOT —
+    // controller-exclusion applies only to ludics self-tasks (gh-602 half 1).
     expect(result).not.toBe("macbook-pro");
     expect(result).toBe("mac-studio");
   });
@@ -366,6 +366,66 @@ slots:
     const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
     // Back-compat: with the flag OFF a live console still wins for self-tasks.
     expect(result).toBe("macbook-pro");
+  });
+
+  // gh-602 controller-exclusion half (1): a ludics self-task with the flag ON
+  // must be excluded from BOTH the console AND the controller/leader — never
+  // falling back to the controller. With only leader+console available it
+  // blocks (null) rather than running self-orchestration on the controller.
+  const LEADER_AND_CONSOLE_ONLY = `state_repo: test/state
+state_path: harness
+cluster:
+  transport: tailscale
+  disable_console_workers: true
+  machines:
+    - name: mac-studio
+      host: mac-studio.ts.net
+      role: leader
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+    - name: macbook-pro
+      host: macbook-pro.ts.net
+      role: console
+      os: macos
+      gpu: apple-silicon
+      always_on: false
+slots:
+  count: 6
+`;
+
+  it("BLOCKS (null) a ludics self-task with the flag ON when only the controller + console are available — never picks the controller", () => {
+    writeFileSync(join(TMP, "config.yaml"), LEADER_AND_CONSOLE_ONLY);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // current = the leader
+    writeHeartbeat("mac-studio", 10);  // controller online
+    writeHeartbeat("macbook-pro", 10); // console online
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // Invariant: console forbidden (flag) AND controller forbidden (gh-602 half 1)
+    // → empty candidate set → null. Mutation: dropping the leader-exclusion
+    // returns "mac-studio" (the controller).
+    expect(result).toBeNull();
+    expect(result).not.toBe("mac-studio");
+  });
+
+  it("keeps the controller forbidden for a ludics self-task even when the console is down (no escape-hatch fallback)", () => {
+    writeFileSync(join(TMP, "config.yaml"), LEADER_AND_CONSOLE_ONLY);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio";
+    writeHeartbeat("mac-studio", 10); // controller online; console absent (down)
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // Even with the console offline (gh-602 escape hatch unavailable), the
+    // self-task must NOT fall back to the controller — it blocks.
+    expect(result).toBeNull();
+  });
+
+  it("still routes a ludics self-task with the flag ON to a non-console / non-controller worker when one exists", () => {
+    setup("  disable_console_workers: true\n");
+    // 3-machine config (mac-studio leader, macbook-pro console, minipc-wsl worker)
+    writeHeartbeat("minipc-wsl", 10); // a real worker is online
+    writeHeartbeat("mac-studio", 10);
+    writeHeartbeat("macbook-pro", 10);
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // The worker is neither console nor leader → it survives both exclusions.
+    expect(result).toBe("minipc-wsl");
   });
 
   // (c) no-eligible-machine path must NOT fall back to the console

--- a/src/cluster.test.ts
+++ b/src/cluster.test.ts
@@ -262,6 +262,143 @@ slots:
 });
 
 // ---------------------------------------------------------------------------
+// cluster.disable_console_workers — config parse + console-exclusion routing.
+// When set, console-role machines are never selected to run worker slots and
+// (in mag's keepalive) are never auto-started. Default false for back-compat.
+// ---------------------------------------------------------------------------
+
+describe("cluster.disable_console_workers — parsing + console exclusion", () => {
+  const ORIGINAL_HOME = process.env.HOME;
+  const ORIGINAL_CONFIG = process.env.LUDICS_CONFIG;
+  const ORIGINAL_HARNESS = process.env.LUDICS_HARNESS_DIR;
+  const ORIGINAL_MACHINE = process.env.LUDICS_CLUSTER_MACHINE_NAME;
+  let TMP = "";
+
+  // `${flagLine}` is spliced in to toggle the option (or omit it entirely).
+  function config(flagLine: string): string {
+    return `state_repo: test/state
+state_path: harness
+cluster:
+  transport: tailscale
+${flagLine}  machines:
+    - name: mac-studio
+      host: mac-studio.ts.net
+      role: leader
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+    - name: macbook-pro
+      host: macbook-pro.ts.net
+      role: console
+      os: macos
+      gpu: apple-silicon
+      always_on: false
+    - name: minipc-wsl
+      host: minipc-wsl.ts.net
+      role: worker
+      os: linux
+      gpu: nvidia
+slots:
+  count: 6
+`;
+  }
+
+  function writeHeartbeat(name: string, ageSeconds: number): void {
+    const dir = heartbeatsDir();
+    mkdirSync(dir, { recursive: true });
+    const epoch = Math.floor(Date.now() / 1000) - ageSeconds;
+    writeFileSync(join(dir, `${name}.json`), JSON.stringify({ node: name, epoch }));
+  }
+
+  function setup(flagLine: string): void {
+    writeFileSync(join(TMP, "config.yaml"), config(flagLine));
+  }
+
+  beforeEach(() => {
+    TMP = mkdtempSync(join(tmpdir(), "ludics-disable-console-"));
+    process.env.HOME = TMP;
+    process.env.LUDICS_HARNESS_DIR = join(TMP, "harness");
+    process.env.LUDICS_CONFIG = join(TMP, "config.yaml");
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "mac-studio"; // current = leader
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIGINAL_HOME;
+    if (ORIGINAL_CONFIG === undefined) delete process.env.LUDICS_CONFIG; else process.env.LUDICS_CONFIG = ORIGINAL_CONFIG;
+    if (ORIGINAL_HARNESS === undefined) delete process.env.LUDICS_HARNESS_DIR; else process.env.LUDICS_HARNESS_DIR = ORIGINAL_HARNESS;
+    if (ORIGINAL_MACHINE === undefined) delete process.env.LUDICS_CLUSTER_MACHINE_NAME; else process.env.LUDICS_CLUSTER_MACHINE_NAME = ORIGINAL_MACHINE;
+    rmSync(TMP, { recursive: true, force: true });
+  });
+
+  // (a) parse
+  it("parses disable_console_workers: true", () => {
+    setup("  disable_console_workers: true\n");
+    expect(clusterConfig().disableConsoleWorkers).toBe(true);
+  });
+
+  it("parses disable_console_workers: false", () => {
+    setup("  disable_console_workers: false\n");
+    expect(clusterConfig().disableConsoleWorkers).toBe(false);
+  });
+
+  it("defaults disable_console_workers to false when absent", () => {
+    setup("");
+    expect(clusterConfig().disableConsoleWorkers).toBe(false);
+  });
+
+  // (b) selection excludes / includes the console per the flag
+  it("excludes the console node from a ludics self-task when the flag is ON", () => {
+    setup("  disable_console_workers: true\n");
+    writeHeartbeat("macbook-pro", 10); // console fresh
+    writeHeartbeat("mac-studio", 10);  // controller online
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // With the flag ON the console is removed from `eligible`, so the
+    // gh-ludics-602 console-preference branch can't fire — the self-task falls
+    // back to the always_on controller instead of the console.
+    expect(result).not.toBe("macbook-pro");
+    expect(result).toBe("mac-studio");
+  });
+
+  it("includes the console node (gh-ludics-602 routing) when the flag is OFF", () => {
+    setup("  disable_console_workers: false\n");
+    writeHeartbeat("macbook-pro", 10); // console fresh
+    writeHeartbeat("mac-studio", 10);  // controller online
+    const result = selectMachineForSlot({ project: "ludics", effort: "medium" });
+    // Back-compat: with the flag OFF a live console still wins for self-tasks.
+    expect(result).toBe("macbook-pro");
+  });
+
+  // (c) no-eligible-machine path must NOT fall back to the console
+  it("returns null (no fallback to console) when excluding the console empties the candidate set", () => {
+    // Config with ONLY a console machine; flag ON. current = a non-listed name
+    // so the console is the sole candidate, then excluded → no machine left.
+    const onlyConsole = `state_repo: test/state
+state_path: harness
+cluster:
+  transport: tailscale
+  disable_console_workers: true
+  machines:
+    - name: macbook-pro
+      host: macbook-pro.ts.net
+      role: console
+      os: macos
+      gpu: apple-silicon
+      always_on: true
+slots:
+  count: 6
+`;
+    writeFileSync(join(TMP, "config.yaml"), onlyConsole);
+    process.env.LUDICS_CLUSTER_MACHINE_NAME = "macbook-pro";
+    writeHeartbeat("macbook-pro", 10); // fresh — must NOT rescue the assignment
+    const result = selectMachineForSlot({ project: "ocannl", effort: "medium" });
+    // Invariant: console-only + flag ON blocks assignment rather than running
+    // on the console. Mutation: dropping the empty-after-exclusion guard returns
+    // "macbook-pro".
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // selectOnlineCapableMachine — capability + online filter for test-health
 // routing (gh-ludics-578). Mirrors selectMachineForSlot's per-key filter +
 // heartbeatIsFresh gate but returns the full ClusterMachine for SSH routing.

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -28,6 +28,11 @@ interface ClusterConfig {
   transport: string;
   domain: string;
   machines: ClusterMachine[];
+  // When true, machines with role "console" are never selected to run worker
+  // slots and are never auto-started by the keepalive — frees the console box
+  // for interactive/SSH use. Maps from YAML `cluster.disable_console_workers`.
+  // Defaults to false for back-compat.
+  disableConsoleWorkers: boolean;
 }
 
 export function clusterConfig(): ClusterConfig {
@@ -56,10 +61,21 @@ export function clusterConfig(): ClusterConfig {
       transport,
       domain: String(fed?.domain ?? ""),
       machines,
+      disableConsoleWorkers: Boolean(fed?.disable_console_workers ?? false),
     };
   } catch {
-    return { transport: "local", domain: "", machines: [] };
+    return { transport: "local", domain: "", machines: [], disableConsoleWorkers: false };
   }
+}
+
+/**
+ * Whether console-role machines are barred from running worker slots.
+ * Reads `cluster.disable_console_workers` (default false). Used by
+ * `selectMachineForSlot` (excludes console from the candidate set) and the
+ * keepalive auto-start path (skips slots assigned to a console machine).
+ */
+export function disableConsoleWorkers(): boolean {
+  return clusterConfig().disableConsoleWorkers;
 }
 
 export function clusterEnabled(): boolean {
@@ -398,6 +414,22 @@ export function selectMachineForSlot(
     if (reqs.gpu) eligible = eligible.filter((m) => m.gpu === reqs.gpu);
     if (eligible.length === 0) {
       console.error(`ludics: no cluster machine meets requirements (os=${reqs.os ?? "any"}, gpu=${reqs.gpu ?? "any"}) — ${machines.length} machines checked`);
+      return null;
+    }
+  }
+
+  // disable_console_workers: when set, console-role machines are never eligible
+  // to run worker slots (frees the console box for interactive use). Applied
+  // AFTER the requirement filter so a requirement-driven empty set keeps its
+  // specific message. If excluding the console empties the candidate set, BLOCK
+  // the assignment (return null) rather than silently falling back onto the
+  // console. This also neutralizes the gh-ludics-602 console-preference branch
+  // below (an excluded console can't be in `online`), so ludics self-tasks fall
+  // through to the controller fallback instead of routing to the console.
+  if (clusterConfig().disableConsoleWorkers) {
+    eligible = eligible.filter((m) => m.role !== "console");
+    if (eligible.length === 0) {
+      console.error(`ludics: disable_console_workers is set and no non-console machine is eligible — blocking assignment`);
       return null;
     }
   }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -418,18 +418,34 @@ export function selectMachineForSlot(
     }
   }
 
-  // disable_console_workers: when set, console-role machines are never eligible
-  // to run worker slots (frees the console box for interactive use). Applied
-  // AFTER the requirement filter so a requirement-driven empty set keeps its
-  // specific message. If excluding the console empties the candidate set, BLOCK
-  // the assignment (return null) rather than silently falling back onto the
-  // console. This also neutralizes the gh-ludics-602 console-preference branch
-  // below (an excluded console can't be in `online`), so ludics self-tasks fall
-  // through to the controller fallback instead of routing to the console.
+  // gh-ludics-602 predicate — a ludics SELF-modifying task. Hoisted so the
+  // disable_console_workers block below can preserve gh-602's controller-
+  // exclusion half while the console-preference branch further down keeps using
+  // the same set. Matches gh-602 exactly (project name == "ludics", case-insensitive).
+  const isLudicsSelfTask = (_task.project ?? "").toLowerCase() === "ludics";
+
+  // disable_console_workers: a faithful 180° of gh-ludics-602's console-routing
+  // half. gh-602 has two halves — (1) keep ludics self-modifying tasks OFF the
+  // controller/leader (self-orchestration there repoints the global `ludics`
+  // symlink + boots the dashboard), and (2) PREFER/route them to the console as
+  // the escape hatch. This flag reverses ONLY half (2): the console flips from
+  // preferred to FORBIDDEN for ALL worker slots (frees the console box for
+  // interactive/SSH use). Half (1) stays. Net for a ludics self-task with the
+  // flag on: console AND controller/leader are both forbidden, so if no other
+  // eligible worker exists the candidate set empties and we BLOCK (return null)
+  // rather than ever falling back to the controller. Applied AFTER the
+  // requirement filter so a requirement-driven empty set keeps its specific
+  // message.
   if (clusterConfig().disableConsoleWorkers) {
+    // Half (2) reversed: console is forbidden for every task.
     eligible = eligible.filter((m) => m.role !== "console");
+    // Half (1) preserved: ludics self-tasks additionally stay off the
+    // controller/leader — never let them fall back onto it.
+    if (isLudicsSelfTask) {
+      eligible = eligible.filter((m) => m.role !== "leader");
+    }
     if (eligible.length === 0) {
-      console.error(`ludics: disable_console_workers is set and no non-console machine is eligible — blocking assignment`);
+      console.error(`ludics: disable_console_workers is set — no eligible machine for ${isLudicsSelfTask ? "ludics self-task (console + controller forbidden)" : "task (console forbidden)"} — blocking assignment`);
       return null;
     }
   }
@@ -459,7 +475,11 @@ export function selectMachineForSlot(
   // the requirement filter + online gate, so it composes with — never overrides
   // — hard requirements: a console node that fails the requirement filter is
   // absent from `online` and cannot be resurrected here.
-  const isLudicsSelfTask = (_task.project ?? "").toLowerCase() === "ludics";
+  //
+  // When disable_console_workers is on, the console was already removed from
+  // `eligible`/`online` above, so this branch is inert for that case (the
+  // controller-exclusion half is enforced upstream); it remains the active
+  // gh-602 path only with the flag OFF (default, full back-compat).
   if (isLudicsSelfTask) {
     const consolePref = online.filter((m) => m.role !== "leader" && m.role === "console");
     if (consolePref.length > 0) return consolePref[0]!.name;

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,7 @@ export interface LudicsFullConfig {
     transport?: string;
     domain?: string;
     secret?: string;
+    disable_console_workers?: boolean;
     machines?: Array<Record<string, unknown>>;
   };
 }

--- a/src/mag.ts
+++ b/src/mag.ts
@@ -13,7 +13,7 @@ import { readAllSlotJson, readSlotJson } from "./slots/json.ts";
 import type { SlotData } from "./slots/types.ts";
 import { queueRequest, queueRequestAtHead, queueHasCompactForTrigger, queuePending, queueHasPendingAction, queueHasPendingActionForTask, queueHasPendingFeedbackDigest, queueReinsertHead, queuePopExpected, queueList, recentResults, parseQueueLines, writeResult } from "./queue.ts";
 import { getUrl } from "./network.ts";
-import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName, clusterDoctor, wslPersistenceStatus } from "./cluster.ts";
+import { clusterShouldRunMag, clusterIsController, selectMachineForSlot, clusterCurrentMachineName, clusterDoctor, wslPersistenceStatus, disableConsoleWorkers, clusterMachine } from "./cluster.ts";
 // cluster-http imports are lazy to avoid import cycles
 import { isRemoteMachine } from "./remote.ts";
 // slot-intents.ts deleted — intents use in-memory store via cluster-http.ts
@@ -3068,9 +3068,16 @@ async function maybeAutoStartSlots(): Promise<void> {
     const sessionStarted = data.sessionStarted ?? "";
     if (sessionStarted) continue;
 
+    // disable_console_workers: never auto-start a slot assigned to a console
+    // machine when the flag is set — the console box is reserved for
+    // interactive/SSH use.
+    const slotMachine = data.machine ?? "";
+    if (disableConsoleWorkers() && slotMachine && clusterMachine(slotMachine)?.role === "console") {
+      continue;
+    }
+
     // Skip remote slots that already have a fresh pending start intent —
     // prevents re-recording the intent every keepalive.
-    const slotMachine = data.machine ?? "";
     if (slotMachine && isRemoteMachine(slotMachine)) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy to avoid import cycle: mag.ts → cluster-http.ts → (journal/events chain back into mag)

--- a/templates/config.reference.yaml
+++ b/templates/config.reference.yaml
@@ -348,6 +348,9 @@ cluster:
   secret: ""                  # Shared Bearer secret for HTTP cluster endpoints. Empty = unauthenticated over
                               # the Tailscale tailnet (the tailnet is the trust boundary). Set a value to
                               # require Bearer auth on every /cluster/* request.
+  disable_console_workers: false  # When true, machines with role "console" are never selected to run
+                              # worker slots and are never auto-started by the keepalive — frees the
+                              # console box for interactive/SSH use. Default false (back-compat).
   machines: []
     # - name: desktop
     #   host: desktop.your-tailnet.ts.net


### PR DESCRIPTION
## Goal

Add a `cluster.disable_console_workers` boolean config option (default `false`, full back-compat). When `true`, machines whose `role` is `console` are **never** selected to run worker slots, and the keepalive **never** auto-starts slots on them — freeing the console machine (currently `macbook-pro`) for interactive/SSH use.

## Policy: a faithful 180° of gh-ludics-602's console-routing half

[gh-ludics-602](https://github.com/lukstafi/ludics/issues/602) ("self-orchestration breaks the controller") has **two halves** for ludics self-modifying tasks:

1. **Keep them OFF the controller/leader** — self-orchestration there repoints the global `ludics` symlink and boots the dashboard. **This MUST stay.**
2. **Prefer/route them to the console** — the escape hatch.

This flag reverses **only half (2)**: the console flips from *preferred* to *forbidden* for all worker slots. **Half (1) stays.**

Net effect with the flag on:
- **ludics self-modifying tasks** (gh-602's exact predicate, `project == "ludics"` case-insensitive) are excluded from **both** the console **and** the controller/leader. If no other eligible worker exists, `selectMachineForSlot` returns `null` — it **blocks** (awaits manual/SSH handling) rather than ever falling back to the controller.
- **non-ludics tasks** only lose the console; the controller stays available to them.
- **flag off (default):** gh-602 behavior is unchanged — console-preferred, controller-protected.

## What changed

- **Config schema/types + parsing** (`src/config.ts`, `templates/config.reference.yaml`): added `disable_console_workers` (YAML snake_case) to the cluster reference schema and the `LudicsFullConfig.cluster` interface. Parsed in `clusterConfig()` (`src/cluster.ts`) into `ClusterConfig.disableConsoleWorkers` (camelCase TS), default `false`. New `disableConsoleWorkers()` helper.
- **Machine selection** (`selectMachineForSlot`, `src/cluster.ts`): hoisted gh-602's `isLudicsSelfTask` predicate; when the flag is on, console-role machines are removed from the candidate set for every task, and for ludics self-tasks the leader/controller is additionally removed. Empties-to-`null` (blocks) rather than falling back onto the console **or** the controller. Applied after the requirement filter.
- **Keepalive auto-start** (`maybeAutoStartSlots`, `src/mag.ts`): skips auto-starting any slot whose assigned machine has role `console` when the flag is on.
- **Tests** (`src/cluster.test.ts`): parse of `true`/`false`/absent; non-ludics task keeps the controller but loses the console; ludics self-task with flag ON and only leader+console available returns `null` (asserts it does **not** pick the controller), incl. a console-down variant; ludics self-task still routes to a real non-console/non-leader worker; flag-off gh-602 console routing stays green; the no-eligible-machine path returns `null` without falling back to the console.

## Activating config

The federation controller harness already sets `cluster.disable_console_workers: true` in its `config.yaml` (currently inert until this merges + deploys).

## Operational consequence

With the flag on and the console as the only otherwise-eligible online machine, assignments block rather than running on the console. For **ludics self-modifying tasks** specifically, when neither a non-console/non-leader worker nor the (forbidden) console/controller is available, the task blocks and awaits manual/SSH handling — by design, this is preferable to re-triggering the gh-602 controller-disruption.

## Validation

- `bun run build` — ✅
- `bun run typecheck` — ✅
- `bun run lint` — ✅
- `bun run lint:config-reference` — ✅
- `bun test src/cluster.test.ts` — ✅ 41 pass / 0 fail
- `bun test src/mag-remote-dispatch-path.test.ts` — ✅ 3 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)